### PR TITLE
Exclude `None`s when serializing models

### DIFF
--- a/mcp_python/client/sse.py
+++ b/mcp_python/client/sse.py
@@ -104,7 +104,7 @@ async def sse_client(url: str, headers: dict[str, Any] | None = None, timeout: f
                                     logger.debug(f"Sending client message: {message}")
                                     response = await client.post(
                                         endpoint_url,
-                                        json=message.model_dump(by_alias=True, mode="json"),
+                                        json=message.model_dump(by_alias=True, mode="json", exclude_none=True),
                                     )
                                     response.raise_for_status()
                                     logger.debug(

--- a/mcp_python/client/stdio.py
+++ b/mcp_python/client/stdio.py
@@ -70,7 +70,7 @@ async def stdio_client(server: StdioServerParameters):
         try:
             async with write_stream_reader:
                 async for message in write_stream_reader:
-                    json = message.model_dump_json(by_alias=True)
+                    json = message.model_dump_json(by_alias=True, exclude_none=True)
                     await process.stdin.send((json + "\n").encode())
         except anyio.ClosedResourceError:
             await anyio.lowlevel.checkpoint()

--- a/mcp_python/server/sse.py
+++ b/mcp_python/server/sse.py
@@ -74,7 +74,7 @@ class SseServerTransport:
                     await sse_stream_writer.send(
                         {
                             "event": "message",
-                            "data": message.model_dump_json(by_alias=True),
+                            "data": message.model_dump_json(by_alias=True, exclude_none=True),
                         }
                     )
 

--- a/mcp_python/server/stdio.py
+++ b/mcp_python/server/stdio.py
@@ -48,7 +48,7 @@ async def stdio_server(
         try:
             async with write_stream_reader:
                 async for message in write_stream_reader:
-                    json = message.model_dump_json(by_alias=True)
+                    json = message.model_dump_json(by_alias=True, exclude_none=True)
                     await stdout.write(json + "\n")
                     await stdout.flush()
         except anyio.ClosedResourceError:

--- a/mcp_python/server/websocket.py
+++ b/mcp_python/server/websocket.py
@@ -47,7 +47,7 @@ async def websocket_server(scope: Scope, receive: Receive, send: Send):
         try:
             async with write_stream_reader:
                 async for message in write_stream_reader:
-                    obj = message.model_dump(by_alias=True, mode="json")
+                    obj = message.model_dump(by_alias=True, mode="json", exclude_none=True)
                     await websocket.send_json(obj)
         except anyio.ClosedResourceError:
             await websocket.close()

--- a/mcp_python/shared/session.py
+++ b/mcp_python/shared/session.py
@@ -132,7 +132,7 @@ class BaseSession(
         self._response_streams[request_id] = response_stream
 
         jsonrpc_request = JSONRPCRequest(
-            jsonrpc="2.0", id=request_id, **request.model_dump(by_alias=True, mode="json")
+            jsonrpc="2.0", id=request_id, **request.model_dump(by_alias=True, mode="json", exclude_none=True)
         )
 
         # TODO: Support progress callbacks
@@ -150,7 +150,7 @@ class BaseSession(
         Emits a notification, which is a one-way message that does not expect a response.
         """
         jsonrpc_notification = JSONRPCNotification(
-            jsonrpc="2.0", **notification.model_dump(by_alias=True, mode="json")
+            jsonrpc="2.0", **notification.model_dump(by_alias=True, mode="json", exclude_none=True)
         )
 
         await self._write_stream.send(JSONRPCMessage(jsonrpc_notification))
@@ -165,7 +165,7 @@ class BaseSession(
             jsonrpc_response = JSONRPCResponse(
                 jsonrpc="2.0",
                 id=request_id,
-                result=response.model_dump(by_alias=True, mode="json"),
+                result=response.model_dump(by_alias=True, mode="json", exclude_none=True),
             )
             await self._write_stream.send(JSONRPCMessage(jsonrpc_response))
 
@@ -180,7 +180,7 @@ class BaseSession(
                     await self._incoming_message_stream_writer.send(message)
                 elif isinstance(message.root, JSONRPCRequest):
                     validated_request = self._receive_request_type.model_validate(
-                        message.root.model_dump(by_alias=True, mode="json")
+                        message.root.model_dump(by_alias=True, mode="json", exclude_none=True)
                     )
                     responder = RequestResponder(
                         request_id=message.root.id,
@@ -196,7 +196,7 @@ class BaseSession(
                         await self._incoming_message_stream_writer.send(responder)
                 elif isinstance(message.root, JSONRPCNotification):
                     notification = self._receive_notification_type.model_validate(
-                        message.root.model_dump(by_alias=True, mode="json")
+                        message.root.model_dump(by_alias=True, mode="json", exclude_none=True)
                     )
 
                     await self._received_notification(notification)

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -35,7 +35,7 @@ async def test_client_session_initialize():
         jsonrpc_request = await client_to_server_receive.receive()
         assert isinstance(jsonrpc_request.root, JSONRPCRequest)
         request = ClientRequest.model_validate(
-            jsonrpc_request.model_dump(by_alias=True, mode="json")
+            jsonrpc_request.model_dump(by_alias=True, mode="json", exclude_none=True)
         )
         assert isinstance(request.root, InitializeRequest)
 
@@ -59,14 +59,14 @@ async def test_client_session_initialize():
                     JSONRPCResponse(
                         jsonrpc="2.0",
                         id=jsonrpc_request.root.id,
-                        result=result.model_dump(by_alias=True, mode="json"),
+                        result=result.model_dump(by_alias=True, mode="json", exclude_none=True),
                     )
                 )
             )
             jsonrpc_notification = await client_to_server_receive.receive()
             assert isinstance(jsonrpc_notification.root, JSONRPCNotification)
             initialized_notification = ClientNotification.model_validate(
-                jsonrpc_notification.model_dump(by_alias=True, mode="json")
+                jsonrpc_notification.model_dump(by_alias=True, mode="json", exclude_none=True)
             )
 
     async def listen_session():

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -18,7 +18,7 @@ async def test_stdio_server():
     ]
 
     for message in messages:
-        stdin.write(message.model_dump_json() + "\n")
+        stdin.write(message.model_dump_json(by_alias=True, exclude_none=True) + "\n")
     stdin.seek(0)
 
     async with stdio_server(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,7 +15,7 @@ def test_jsonrpc_request():
 
     request = JSONRPCMessage.model_validate(json_data)
     assert isinstance(request.root, JSONRPCRequest)
-    ClientRequest.model_validate(request.model_dump(by_alias=True))
+    ClientRequest.model_validate(request.model_dump(by_alias=True, exclude_none=True))
 
     assert request.root.jsonrpc == "2.0"
     assert request.root.id == 1


### PR DESCRIPTION
We don't have any `null`s in the spec, so right now the Python SDK serialization is not spec-compliant. This fixes it by removing all `None`s (which become `null`s).

Discovered via https://github.com/modelcontextprotocol/typescript-sdk/pull/5.

# Depends on

* https://github.com/modelcontextprotocol/python-sdk/pull/7