### PR TITLE
Introduce Initialization options that are passed to ServerSession

### DIFF
--- a/mcp_python/server/__main__.py
+++ b/mcp_python/server/__main__.py
@@ -1,10 +1,12 @@
 import logging
 import sys
-
+import importlib.metadata
 import anyio
 
 from mcp_python.server.session import ServerSession
+from mcp_python.server.types import InitializationOptions
 from mcp_python.server.stdio import stdio_server
+from mcp_python.types import ServerCapabilities
 
 if not sys.warnoptions:
     import warnings
@@ -26,8 +28,9 @@ async def receive_loop(session: ServerSession):
 
 
 async def main():
+    version = importlib.metadata.version("mcp_python")
     async with stdio_server() as (read_stream, write_stream):
-        async with ServerSession(read_stream, write_stream) as session, write_stream:
+        async with ServerSession(read_stream, write_stream, InitializationOptions(server_name="mcp_python", server_version=version, capabilities=ServerCapabilities())) as session, write_stream:
             await receive_loop(session)
 
 

--- a/mcp_python/server/session.py
+++ b/mcp_python/server/session.py
@@ -10,6 +10,7 @@ from mcp_python.shared.session import (
     BaseSession,
     RequestResponder,
 )
+from mcp_python.server.types import InitializationOptions
 from mcp_python.shared.version import SUPPORTED_PROTOCOL_VERSION
 from mcp_python.types import (
     ClientNotification,
@@ -52,9 +53,11 @@ class ServerSession(
         self,
         read_stream: MemoryObjectReceiveStream[JSONRPCMessage | Exception],
         write_stream: MemoryObjectSendStream[JSONRPCMessage],
+        init_options: InitializationOptions
     ) -> None:
         super().__init__(read_stream, write_stream, ClientRequest, ClientNotification)
         self._initialization_state = InitializationState.NotInitialized
+        self._init_options = init_options
 
     async def _received_request(
         self, responder: RequestResponder[ClientRequest, ServerResult]
@@ -66,15 +69,10 @@ class ServerSession(
                     ServerResult(
                         InitializeResult(
                             protocolVersion=SUPPORTED_PROTOCOL_VERSION,
-                            capabilities=ServerCapabilities(
-                                logging=None,
-                                resources=None,
-                                tools=None,
-                                experimental=None,
-                                prompts={},
-                            ),
+                            capabilities=self._init_options.capabilities,
                             serverInfo=Implementation(
-                                name="mcp_python", version="0.1.0"
+                                name=self._init_options.server_name,
+                                version=self._init_options.server_version
                             ),
                         )
                     )

--- a/mcp_python/server/types.py
+++ b/mcp_python/server/types.py
@@ -5,7 +5,8 @@ This module provides simpler types to use with the server for managing prompts.
 from dataclasses import dataclass
 from typing import Literal
 
-from mcp_python.types import Role
+from pydantic import BaseModel
+from mcp_python.types import Role, ServerCapabilities
 
 
 @dataclass
@@ -25,3 +26,9 @@ class Message:
 class PromptResponse:
     messages: list[Message]
     desc: str | None = None
+
+
+class InitializationOptions(BaseModel):
+    server_name: str
+    server_version: str
+    capabilities: ServerCapabilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,8 @@ target-version = "py38"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+
+[tool.uv]
+dev-dependencies = [
+    "trio>=0.26.2",
+]


### PR DESCRIPTION
**Depends on:**
- #15 

There is currently no way for server implementations to pass capabilities, server name and server version to the protocol. We now introduce an `InitializationOption` object that can be passed. Users of this are free to use the new `get_capabilities` to fill capabilities based on the defined handlers. This will allow patterns such as 

```
app = Server()

@app.list_prompts()
async def list_my_prompts(...):
   ...

app.run(..., InitializationOptions(..., capabilities=app.get_capabilities()))
```

This is mostly an RFC. I am not sold on the specific approach but want to get something going so that we can correctly negotiate capabilities between our Zed implementation of the protocol and Python servers.