### PR TITLE
`CallToolResult.isError` should be optional

### DIFF
--- a/mcp_python/types.py
+++ b/mcp_python/types.py
@@ -641,7 +641,7 @@ class CallToolResult(Result):
     """The server's response to a tool call."""
 
     content: list[TextContent | ImageContent | EmbeddedResource]
-    isError: bool
+    isError: bool = False
 
 
 class ToolListChangedNotification(Notification):


### PR DESCRIPTION
https://github.com/modelcontextprotocol/specification/pull/42