### PR TITLE
Return a specific server session instance of request context

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -84,7 +84,7 @@ async def sse_client(
 
                                     case "message":
                                         try:
-                                            message = types.JSONRPCMessage.model_validate_json( # noqa: E501
+                                            message = types.JSONRPCMessage.model_validate_json(  # noqa: E501
                                                 sse.data
                                             )
                                             logger.debug(

--- a/src/mcp/server/__init__.py
+++ b/src/mcp/server/__init__.py
@@ -16,8 +16,8 @@ from mcp.shared.session import RequestResponder
 
 logger = logging.getLogger(__name__)
 
-request_ctx: contextvars.ContextVar[RequestContext] = contextvars.ContextVar(
-    "request_ctx"
+request_ctx: contextvars.ContextVar[RequestContext[ServerSession]] = (
+    contextvars.ContextVar("request_ctx")
 )
 
 
@@ -115,7 +115,7 @@ class Server:
         )
 
     @property
-    def request_context(self) -> RequestContext:
+    def request_context(self) -> RequestContext[ServerSession]:
         """If called outside of a request context, this will raise a LookupError."""
         return request_ctx.get()
 


### PR DESCRIPTION
We currently return a generic instance of RequestContext without
a specialization on the Session type. This makes it impossible
for servers to typesafe call `list_roots()` and other methods.

We now return a specific instance of `RequestContext[ServerSession]`

Fixes #36 