### PR TITLE
server/sse: return response in handle_post_message

### DIFF
--- a/examples/servers/simple-prompt/mcp_simple_prompt/server.py
+++ b/examples/servers/simple-prompt/mcp_simple_prompt/server.py
@@ -107,7 +107,7 @@ def main(port: int, transport: str) -> int:
                 )
 
         async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
+            return await sse.handle_post_message(request.scope, request.receive)
 
         starlette_app = Starlette(
             debug=True,

--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -64,7 +64,7 @@ def main(port: int, transport: str) -> int:
                 )
 
         async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
+            return await sse.handle_post_message(request.scope, request.receive)
 
         starlette_app = Starlette(
             debug=True,

--- a/examples/servers/simple-tool/mcp_simple_tool/server.py
+++ b/examples/servers/simple-tool/mcp_simple_tool/server.py
@@ -78,7 +78,7 @@ def main(port: int, transport: str) -> int:
                 )
 
         async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
+            return await sse.handle_post_message(request.scope, request.receive)
 
         starlette_app = Starlette(
             debug=True,

--- a/uv.lock
+++ b/uv.lock
@@ -171,7 +171,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.0.0.dev0"
+version = "1.0.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Changes
- Modified `SseServerTransport.handle_post_message` to return `Response` objects instead of sending them directly via ASGI

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The current implementation directly sends ASGI responses, which breaks when used with Starlette because Starlette expects route handlers to return response objects. After the request is handled, Starlette tries to call the response object which currently fails because the `handle_post_message` method returns  None:
```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.scope, self.receive, self.send
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/routing.py", line 715, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/routing.py", line 735, in app
    await route.handle(scope, receive, send)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/artemm/Code/mcp_proxy/.venv/lib/python3.13/site-packages/starlette/routing.py", line 74, in app
    await response(scope, receive, send)
          ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not callable
```


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested the change with this code running locally:

```python
# server.py
import logging
from mcp.server import Server
from mcp.server.sse import SseServerTransport
import mcp.types as types
from starlette.applications import Starlette
from starlette.routing import Route

logging.basicConfig(level=logging.DEBUG)
logger = logging.getLogger("sse-server")

# Create SSE transport with endpoint
app = Server("example-server")
sse = SseServerTransport("/messages")


@app.list_tools()
async def handle_list_tools():
    return [
        types.Tool(
            name="hello",
            description="Says hello",
            inputSchema={},
        )
    ]


# Handler for SSE connections
async def handle_sse(request):
    async with sse.connect_sse(
        request.scope, request.receive, request._send
    ) as streams:
        await app.run(streams[0], streams[1], app.create_initialization_options())


# Handler for client messages
async def handle_messages(request):
    await sse.handle_post_message(request.scope, request.receive, request._send)


# Create Starlette app with routes
starlette_app = Starlette(
    debug=True,
    routes=[
        Route("/sse", endpoint=handle_sse),
        Route("/messages", endpoint=handle_messages, methods=["POST"]),
    ],
)

# Run with any ASGI server
import uvicorn

uvicorn.run(starlette_app, host="0.0.0.0", port=8000)
```

```python
# client.py
import asyncio
from mcp.client.sse import sse_client
from mcp.client.session import ClientSession

async def get_tools():
    async with sse_client("http://localhost:8000/sse") as streams:
        async with ClientSession(streams[0], streams[1]) as session:
            await session.initialize()

            # List available tools
            return await session.list_tools()

async def main():
    tools = await get_tools()
    print(tools.tools)

if __name__ == "__main__":
    asyncio.run(main())
``` 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Technically, the change is breaking because it removes on of the unused parameter but it didn't work anyway.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
