### PR TITLE
Added cancelled handler. Fixes #88

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, Optional, TypeVar
 
 from pydantic import BaseModel, ConfigDict, FileUrl, RootModel
 from pydantic.networks import AnyUrl
@@ -323,6 +323,21 @@ class ProgressNotificationParams(NotificationParams):
     total: float | None = None
     """Total number of items to process (or total progress required), if known."""
     model_config = ConfigDict(extra="allow")
+
+
+class CancelledParams(BaseModel):
+    requestId: Optional[int] = None
+    reason: Optional[str] = ""
+
+
+class CancellationNotification(Notification):
+    """
+    An out-of-band notification used to inform the receiver of a progress update for a
+    long-running request.
+    """
+
+    method: Literal["cancelled"]
+    params: CancelledParams
 
 
 class ProgressNotification(Notification):
@@ -997,7 +1012,10 @@ class ClientRequest(
 
 class ClientNotification(
     RootModel[
-        ProgressNotification | InitializedNotification | RootsListChangedNotification
+        ProgressNotification
+        | InitializedNotification
+        | RootsListChangedNotification
+        | CancellationNotification
     ]
 ):
     pass
@@ -1019,6 +1037,7 @@ class ServerNotification(
         | ResourceListChangedNotification
         | ToolListChangedNotification
         | PromptListChangedNotification
+        | CancellationNotification
     ]
 ):
     pass


### PR DESCRIPTION
CancellationNotification is missing in python sdk. On timeout the server would fail and not restart due to validation issue.


## Motivation and Context
https://github.com/modelcontextprotocol/python-sdk/issues/88

## How Has This Been Tested?
Tested on stdio server https://github.com/rusiaaman/wcgw

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Unsure if changes require elsewhere.