### PR TITLE
Fix bug: request_meta is not available in server.request_context

### DIFF
--- a/src/mcp/server/__init__.py
+++ b/src/mcp/server/__init__.py
@@ -439,12 +439,15 @@ class Server:
 
                                 token = None
                                 try:
-                                    # Set our global state that can be retrieved via
-                                    # app.get_request_context()
+                                    progress_token = None
+                                    if req.params.model_dump().get("_meta") is not None:
+                                        meta_dict = req.params.model_dump().get("_meta")
+                                        if "progressToken" in meta_dict:
+                                            progress_token = meta_dict["progressToken"]
                                     token = request_ctx.set(
                                         RequestContext(
                                             message.request_id,
-                                            message.request_meta,
+                                            types.RequestParams.Meta(progressToken=progress_token),
                                             session,
                                         )
                                     )

--- a/src/mcp/server/__init__.py
+++ b/src/mcp/server/__init__.py
@@ -440,7 +440,7 @@ class Server:
                                 token = None
                                 try:
                                     progress_token = None
-                                    if req.params.model_dump().get("_meta") is not None:
+                                    if req.params is not None and req.params.model_dump().get("_meta") is not None:
                                         meta_dict = req.params.model_dump().get("_meta")
                                         if "progressToken" in meta_dict:
                                             progress_token = meta_dict["progressToken"]

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -40,6 +40,7 @@ class RequestParams(BaseModel):
         model_config = ConfigDict(extra="allow")
 
     _meta: Meta | None = None
+    model_config = ConfigDict(extra="allow")
 
 
 class NotificationParams(BaseModel):


### PR DESCRIPTION
Fixes #103

Fix the issue where `server.request_context.meta` does not include the `progressToken`.

* **Extract `_meta` field**: Extract the `_meta` field from request parameters and assign it to `message.request_meta` in `src/mcp/server/__init__.py`.
* **Update `RequestContext`**: Update `RequestContext` instantiation to include `progressToken` in `src/mcp/server/__init__.py`.
* **Allow extra fields**: Update `RequestParams` instantiation to include `model_config = ConfigDict(extra="allow")` in `src/mcp/types.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/modelcontextprotocol/python-sdk/pull/104?shareId=047271d8-f203-40be-9c77-9e5ae7510d98).