### PR TITLE
Fix Bug: request_meta is not available in server.request_context #103

### DIFF
--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -102,9 +102,9 @@ class SseServerTransport:
         self._read_stream_writers[session_id] = read_stream_writer
         logger.debug(f"Created new session with ID: {session_id}")
 
-        sse_stream_writer, sse_stream_reader = anyio.create_memory_object_stream(
-            0, dict[str, Any]
-        )
+        sse_stream_writer, sse_stream_reader = anyio.create_memory_object_stream[
+            dict[str, Any]
+        ](0)
 
         async def sse_writer():
             logger.debug("Starting SSE writer")

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -221,7 +221,7 @@ class BaseSession(
                     )
                     responder = RequestResponder(
                         request_id=message.root.id,
-                        request_meta=validated_request.root.params._meta
+                        request_meta=validated_request.root.params.meta
                         if validated_request.root.params
                         else None,
                         request=validated_request,

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1,6 +1,6 @@
 from typing import Any, Generic, Literal, TypeVar
 
-from pydantic import BaseModel, ConfigDict, FileUrl, RootModel
+from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel
 from pydantic.networks import AnyUrl
 
 """
@@ -39,14 +39,14 @@ class RequestParams(BaseModel):
 
         model_config = ConfigDict(extra="allow")
 
-    _meta: Meta | None = None
+    meta: Meta | None = Field(alias="_meta", default=None)
 
 
 class NotificationParams(BaseModel):
     class Meta(BaseModel):
         model_config = ConfigDict(extra="allow")
 
-    _meta: Meta | None = None
+    meta: Meta | None = Field(alias="_meta", default=None)
     """
     This parameter name is reserved by MCP to allow clients and servers to attach
     additional metadata to their notifications.
@@ -86,7 +86,7 @@ class Result(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    _meta: dict[str, Any] | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
     This result property is reserved by the protocol to allow clients and servers to
     attach additional metadata to their responses.


### PR DESCRIPTION
## Summary
- Fixes **Bug: request_meta is not available in server.request_context #103**
- Pydantic fields starting with underscore are hidden/private and won't get deserialized. As a result, the `_meta` field was never available.

## Test plan
- Run pytest tests/server/test_request_context.py