### PR TITLE
fix mcp.types.Tool is not following python's naming convention snake_case 

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1,6 +1,6 @@
 from typing import Any, Generic, Literal, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel
+from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel, Field
 from pydantic.networks import AnyUrl
 
 """
@@ -657,7 +657,7 @@ class Tool(BaseModel):
     """The name of the tool."""
     description: str | None = None
     """A human-readable description of the tool."""
-    inputSchema: dict[str, Any]
+    input_schema: dict[str, Any] = Field(..., alias='inputSchema')
     """A JSON Schema object defining the expected parameters for the tool."""
     model_config = ConfigDict(extra="allow")
 

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1,6 +1,6 @@
 from typing import Any, Generic, Literal, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel, Field
+from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel
 from pydantic.networks import AnyUrl
 
 """


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Renamed the `inputSchema` field to `input_schema` in the `Tool` class to align with Python's naming conventions (snake_case). Added an alias `inputSchema` for backward compatibility.

## Motivation and Context
<!-- Why is This Change needed? What problem does it solve? -->
The name `inputSchema` does not follow Python's naming convention (PEP 8). This change improves code readability and consistency. Fix related: #97 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested locally by running existing tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
- [X] Yes. Users will need to update references to the `inputSchema` field to `input_schema`. Adding an alias is intended to ease the migration.

## Types of changes
<!-- What types of changes does your code introduce? Put an 'x' in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The addition of the `inputSchema` alias is intended to provide backward compatibility and facilitate the migration process for users.