### PR TITLE
[RFC] Silently skip non-json messages

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -213,6 +213,8 @@ class BaseSession(
             async for message in self._read_stream:
                 if isinstance(message, Exception):
                     await self._incoming_message_stream_writer.send(message)
+                elif not hasattr(message, "root"):
+                    continue
                 elif isinstance(message.root, JSONRPCRequest):
                     validated_request = self._receive_request_type.model_validate(
                         message.root.model_dump(

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -96,3 +96,66 @@ async def test_client_session_initialize():
     # Check that the client sent the initialized notification
     assert initialized_notification
     assert isinstance(initialized_notification.root, InitializedNotification)
+
+
+@pytest.mark.anyio
+async def test_client_session_non_jsonrpc_message():
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[
+        JSONRPCMessage
+    ](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[
+        JSONRPCMessage
+    ](1)
+
+    async def mock_server():
+        jsonrpc_request = await client_to_server_receive.receive()
+        assert isinstance(jsonrpc_request.root, JSONRPCRequest)
+        request = ClientRequest.model_validate(
+            jsonrpc_request.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )
+        assert isinstance(request.root, InitializeRequest)
+
+        result = ServerResult(
+            InitializeResult(
+                protocolVersion=LATEST_PROTOCOL_VERSION,
+                capabilities=ServerCapabilities(
+                    logging=None,
+                    resources=None,
+                    tools=None,
+                    experimental=None,
+                    prompts=None,
+                ),
+                serverInfo=Implementation(name="mock-server", version="0.1.0"),
+            )
+        )
+
+        async with server_to_client_send:
+            await server_to_client_send.send("invalid message")  # type: ignore[arg-type]
+
+            await server_to_client_send.send(
+                JSONRPCMessage(
+                    JSONRPCResponse(
+                        jsonrpc="2.0",
+                        id=jsonrpc_request.root.id,
+                        result=result.model_dump(
+                            by_alias=True, mode="json", exclude_none=True
+                        ),
+                    )
+                )
+            )
+
+            jsonrpc_notification = await client_to_server_receive.receive()
+            assert isinstance(jsonrpc_notification.root, JSONRPCNotification)
+
+    async def listen_session():
+        async for message in session.incoming_messages:
+            if isinstance(message, Exception):
+                raise message
+
+    async with (
+        ClientSession(server_to_client_receive, client_to_server_send) as session,
+        anyio.create_task_group() as tg,
+    ):
+        tg.start_soon(mock_server)
+        tg.start_soon(listen_session)
+        await session.initialize()


### PR DESCRIPTION
This change skips non-json server messages, for example: logs to standard out.

## Motivation and Context
Today if the client receives a non-json message from a local server, the receive loop is interrupted with an exception which causes the client to miss the next server json response. The way in which this fails is difficult to debug, there's nothing indicating that the server sent an invalid message which broke the client's receive loop. 

Although the documentation is clear that local servers should not log to standard out, clients are using servers that they may not have implemented themselves and they may not be aware that a server is logging to standard out by accident. Sometimes fixing the logging from a community-developed server is not straightforward for a client developer, and those logs will effectively break the client developer's application.

Since the client only cares about json RPC messages, any non-json RPC message should just be ignored and not cause the client to stop listening for a json rpc message that may be still be coming from the server.

## How Has This Been Tested?
I have added a test for the client session that shows the server sending an non-json message and the client session handling it gracefully by silently skipping it. Without the fix, the same test fails because an exception is thrown in the client session (because the received message does not have a root attribute), which seems to cause the client_to_server_receive io buffer to close. After that, the receive loop in the BaseSession class is stuck waiting since the buffer is empty.

The test failure messages can be seen here: https://gist.github.com/christopherhwood/bded0d8efb8c17656db9fc04ddd6c5d3.

## Breaking Changes
This change violates this section of the documentation, and requires updates to the typescript and maybe kotlin sdks: https://github.com/modelcontextprotocol/docs/blob/83a1e38d8b48a65eb608dd5d4f6b27b024c01fe9/docs/tools/debugging.mdx?plain=1#L152-L154

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x ] My code follows the repository's style guidelines
- [ x ] New and existing tests pass locally
- [ x ] I have added appropriate error handling
- [ x ] I have added or updated documentation as needed

## Additional context
I am putting this as a RFC since it is a breaking change of sorts to the documentation and it looks like it will require changes to the typescript sdk and maybe kotlin sdk as well. If we'd like to move forward with it then I am happy to update the documentation and other sdks.

If there are concerns about making server development more challenging due to silently handling malformed messages perhaps we can add debug logging or another mechanism to help server developers. Please share if there are other cases where treating non-json messages as errors instead of silently ignoring them is a feature and not a bug.