### PR TITLE
Update README to reflect that only RC version has FastMCP features

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ The Model Context Protocol allows applications to provide context for LLMs in a 
 
 We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects:
 
+FastMCP features are currently only available in the 1.2.0 release candidate version, which can be installed with:
+
 ```bash
-uv add "mcp[cli]"
+uv add "mcp[cli]===1.2.0rc1"
 ```
 
 Alternatively:
 ```bash
-pip install mcp
+pip install "mcp==1.2.0.rc1"
 ```
 
 ## Quickstart

--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -87,7 +87,7 @@ def update_claude_config(
         args = ["run"]
 
         # Collect all packages in a set to deduplicate
-        packages = {"fastmcp"}
+        packages = {"mcp"}
         if with_packages:
             packages.update(pkg for pkg in with_packages if pkg)
 
@@ -107,7 +107,7 @@ def update_claude_config(
             file_spec = str(Path(file_spec).resolve())
 
         # Add fastmcp run command
-        args.extend(["fastmcp", "run", file_spec])
+        args.extend(["mcp", "run", file_spec])
 
         server_config = {
             "command": "uv",

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mcp.cli.claude import update_claude_config
+
+
+@pytest.fixture
+def temp_config_dir(tmp_path):
+    """Create a temporary Claude config directory."""
+    config_dir = tmp_path / "Claude"
+    config_dir.mkdir()
+    return config_dir
+
+@pytest.fixture
+def mock_config_path(temp_config_dir):
+    """Mock get_claude_config_path to return our temporary directory."""
+    with patch('mcp.cli.claude.get_claude_config_path', return_value=temp_config_dir):
+        yield temp_config_dir
+
+def test_command_execution(mock_config_path):
+    """Test that the generated command can actually be executed."""
+    # Setup
+    server_name = "test_server"
+    file_spec = "test_server.py:app"
+    
+    # Update config
+    success = update_claude_config(
+        file_spec=file_spec,
+        server_name=server_name,
+    )
+    assert success
+    
+    # Read the generated config
+    config_file = mock_config_path / "claude_desktop_config.json"
+    config = json.loads(config_file.read_text())
+    
+    # Get the command and args
+    server_config = config["mcpServers"][server_name]
+    command = server_config["command"]
+    args = server_config["args"]
+
+    test_args = [command] + args + ["--help"]
+    
+    result = subprocess.run(
+        test_args,
+        capture_output=True,
+        text=True,
+        timeout=5
+    )
+    
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
As mentioned in issue #114 , the ReadMe is currently misleading as it specifies a version that does not have the functionality in the Quickstart and the rest of the documentation.

Adding a line in the README would be a quick hotfix while the MCP team works to release the FastMCP version.

## Motivation and Context
As mentioned in issue #114, users trying to install the Python SDK are being tripped up by the version's lack of features listed in the Quickstart section and the rest of the application.

The change suggested in issue #114 is to directly install the release candidate, where I have checked locally that the QuickStart functionality (from MCP.server.fastmcp import FastMCP) works.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
