### PR TITLE
Use mcp instead of fastmcp CLI as command in "mcp install"

### DIFF
--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -87,7 +87,7 @@ def update_claude_config(
         args = ["run"]
 
         # Collect all packages in a set to deduplicate
-        packages = {"fastmcp"}
+        packages = {"mcp"}
         if with_packages:
             packages.update(pkg for pkg in with_packages if pkg)
 
@@ -107,7 +107,7 @@ def update_claude_config(
             file_spec = str(Path(file_spec).resolve())
 
         # Add fastmcp run command
-        args.extend(["fastmcp", "run", file_spec])
+        args.extend(["mcp", "run", file_spec])
 
         server_config = {
             "command": "uv",

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mcp.cli.claude import update_claude_config
+
+
+@pytest.fixture
+def temp_config_dir(tmp_path):
+    """Create a temporary Claude config directory."""
+    config_dir = tmp_path / "Claude"
+    config_dir.mkdir()
+    return config_dir
+
+@pytest.fixture
+def mock_config_path(temp_config_dir):
+    """Mock get_claude_config_path to return our temporary directory."""
+    with patch('mcp.cli.claude.get_claude_config_path', return_value=temp_config_dir):
+        yield temp_config_dir
+
+def test_command_execution(mock_config_path):
+    """Test that the generated command can actually be executed."""
+    # Setup
+    server_name = "test_server"
+    file_spec = "test_server.py:app"
+    
+    # Update config
+    success = update_claude_config(
+        file_spec=file_spec,
+        server_name=server_name,
+    )
+    assert success
+    
+    # Read the generated config
+    config_file = mock_config_path / "claude_desktop_config.json"
+    config = json.loads(config_file.read_text())
+    
+    # Get the command and args
+    server_config = config["mcpServers"][server_name]
+    command = server_config["command"]
+    args = server_config["args"]
+
+    test_args = [command] + args + ["--help"]
+    
+    result = subprocess.run(
+        test_args,
+        capture_output=True,
+        text=True,
+        timeout=5
+    )
+    
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
Currently, when you run `mcp install ...`, it adds `uv run --with fastmcp fastmcp ...` to the Claude config file.
We don't need to do this anymore since fastmcp functionality has been merged into the main mcp python SDK.
Instead, we can make `mcp install ...` run `uv run --with mcp mcp ...`. 

## Motivation and Context
Running with `--with fastmcp fastmcp` continues to rely on an unnecessary external dependency when this functionality has been merged into the `mcp` cli command.

## How Has This Been Tested?
I added a test to check that the command added to the Claude config can run (with --help). This does pass with the fastmcp version but requires an additional external dependency.

## Breaking Changes
No, even previous installs will still work. All tests continue to pass. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed