### PR TITLE
docs: Update README to reflect that only RC version has FastMCP features

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ The Model Context Protocol allows applications to provide context for LLMs in a 
 
 We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects:
 
+FastMCP features are currently only available in the 1.2.0 release candidate version, which can be installed with:
+
 ```bash
-uv add "mcp[cli]"
+uv add "mcp[cli]===1.2.0rc1"
 ```
 
 Alternatively:
 ```bash
-pip install mcp
+pip install "mcp==1.2.0.rc1"
 ```
 
 ## Quickstart


### PR DESCRIPTION
> SORRY FOR REPEATED PR (I closed the previous one as I accidentally added other changes to that branch.)

As mentioned in issue #114 , the ReadMe is currently misleading as it specifies a version that does not have the functionality in the Quickstart and the rest of the documentation.

Adding a line in the README would be a quick hotfix while the MCP team works to release the FastMCP version.

## Motivation and Context
As mentioned in issue #114, users trying to install the Python SDK are being tripped up by the version's lack of features listed in the Quickstart section and the rest of the application.

The change suggested in issue #114 is to directly install the release candidate, where I have checked locally that the QuickStart functionality (from MCP.server.fastmcp import FastMCP) works.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
