### PR TITLE
add text encoding params to STDIO client

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -77,7 +77,8 @@ class StdioServerParameters(BaseModel):
     """
     The text encoding error handler.
 
-    See https://docs.python.org/3/library/codecs.html#codec-base-classes for explanations of possible values
+    See https://docs.python.org/3/library/codecs.html#codec-base-classes for
+    explanations of possible values
     """
 
 
@@ -108,7 +109,11 @@ async def stdio_client(server: StdioServerParameters):
         try:
             async with read_stream_writer:
                 buffer = ""
-                async for chunk in TextReceiveStream(process.stdout, encoding=server.encoding, errors=server.encoding_error_handler):
+                async for chunk in TextReceiveStream(
+                    process.stdout,
+                    encoding=server.encoding,
+                    errors=server.encoding_error_handler,
+                ):
                     lines = (buffer + chunk).split("\n")
                     buffer = lines.pop()
 
@@ -130,7 +135,12 @@ async def stdio_client(server: StdioServerParameters):
             async with write_stream_reader:
                 async for message in write_stream_reader:
                     json = message.model_dump_json(by_alias=True, exclude_none=True)
-                    await process.stdin.send((json + "\n").encode(encoding=server.encoding, errors=server.encoding_error_handler))
+                    await process.stdin.send(
+                        (json + "\n").encode(
+                            encoding=server.encoding,
+                            errors=server.encoding_error_handler,
+                        )
+                    )
         except anyio.ClosedResourceError:
             await anyio.lowlevel.checkpoint()
 

--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from contextlib import asynccontextmanager
+from typing import Literal
 
 import anyio
 import anyio.lowlevel
@@ -65,6 +66,20 @@ class StdioServerParameters(BaseModel):
     If not specified, the result of get_default_environment() will be used.
     """
 
+    encoding: str = "utf-8"
+    """
+    The text encoding used when sending/receiving messages to the server
+
+    defaults to utf-8
+    """
+
+    encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
+    """
+    The text encoding error handler.
+
+    See https://docs.python.org/3/library/codecs.html#codec-base-classes for explanations of possible values
+    """
+
 
 @asynccontextmanager
 async def stdio_client(server: StdioServerParameters):
@@ -93,7 +108,7 @@ async def stdio_client(server: StdioServerParameters):
         try:
             async with read_stream_writer:
                 buffer = ""
-                async for chunk in TextReceiveStream(process.stdout):
+                async for chunk in TextReceiveStream(process.stdout, encoding=server.encoding, errors=server.encoding_error_handler):
                     lines = (buffer + chunk).split("\n")
                     buffer = lines.pop()
 
@@ -115,7 +130,7 @@ async def stdio_client(server: StdioServerParameters):
             async with write_stream_reader:
                 async for message in write_stream_reader:
                     json = message.model_dump_json(by_alias=True, exclude_none=True)
-                    await process.stdin.send((json + "\n").encode())
+                    await process.stdin.send((json + "\n").encode(encoding=server.encoding, errors=server.encoding_error_handler))
         except anyio.ClosedResourceError:
             await anyio.lowlevel.checkpoint()
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR adds text encoding parameters to the STDIO Client. This allows the SDK user to configure how the text encoder will respond to errors and set the encoding used.

## Motivation and Context
Fixes #110

This fixes an issue I was encountering in some of my programs when handling text from the internet.

## How Has This Been Tested?
All of the included unit tests are passing with this (via `uv run pytest`)
Styling was checked via `ruff check`
I modified the example reproduction in #110 with an implementation of the new features (https://github.com/SecretiveShell/MCP-SDK-JSON-DECODE-ERROR/tree/test-fix)

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None, all default values remain the same.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

This was discussed in discord, and it was suggested that it would be beneficial to add extra test cases for this specific error. Currently this PR does not include this