### PR TITLE
Fix SSE server uncaught TypeError due to incorrect routing

### DIFF
--- a/examples/servers/simple-prompt/mcp_simple_prompt/server.py
+++ b/examples/servers/simple-prompt/mcp_simple_prompt/server.py
@@ -90,9 +90,9 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Route
+        from starlette.routing import Route, Mount
 
-        sse = SseServerTransport("/messages")
+        sse = SseServerTransport("/messages/")
 
         async def handle_sse(request):
             async with sse.connect_sse(
@@ -102,14 +102,11 @@ def main(port: int, transport: str) -> int:
                     streams[0], streams[1], app.create_initialization_options()
                 )
 
-        async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
-
         starlette_app = Starlette(
             debug=True,
             routes=[
                 Route("/sse", endpoint=handle_sse),
-                Route("/messages", endpoint=handle_messages, methods=["POST"]),
+                Mount("/messages/", app=sse.handle_post_message)
             ],
         )
 

--- a/examples/servers/simple-prompt/mcp_simple_prompt/server.py
+++ b/examples/servers/simple-prompt/mcp_simple_prompt/server.py
@@ -106,7 +106,7 @@ def main(port: int, transport: str) -> int:
             debug=True,
             routes=[
                 Route("/sse", endpoint=handle_sse),
-                Mount("/messages/", app=sse.handle_post_message)
+                Mount("/messages/", app=sse.handle_post_message),
             ],
         )
 

--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -47,9 +47,9 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Route
+        from starlette.routing import Route, Mount
 
-        sse = SseServerTransport("/messages")
+        sse = SseServerTransport("/messages/")
 
         async def handle_sse(request):
             async with sse.connect_sse(
@@ -59,14 +59,11 @@ def main(port: int, transport: str) -> int:
                     streams[0], streams[1], app.create_initialization_options()
                 )
 
-        async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
-
         starlette_app = Starlette(
             debug=True,
             routes=[
                 Route("/sse", endpoint=handle_sse),
-                Route("/messages", endpoint=handle_messages, methods=["POST"]),
+                Mount("/messages/", app=sse.handle_post_message),
             ],
         )
 

--- a/examples/servers/simple-tool/mcp_simple_tool/server.py
+++ b/examples/servers/simple-tool/mcp_simple_tool/server.py
@@ -60,9 +60,9 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Route
+        from starlette.routing import Route, Mount
 
-        sse = SseServerTransport("/messages")
+        sse = SseServerTransport("/messages/")
 
         async def handle_sse(request):
             async with sse.connect_sse(
@@ -72,14 +72,11 @@ def main(port: int, transport: str) -> int:
                     streams[0], streams[1], app.create_initialization_options()
                 )
 
-        async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
-
         starlette_app = Starlette(
             debug=True,
             routes=[
                 Route("/sse", endpoint=handle_sse),
-                Route("/messages", endpoint=handle_messages, methods=["POST"]),
+                Mount("/messages/", app=sse.handle_post_message),
             ],
         )
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -423,9 +423,9 @@ class FastMCP:
     async def run_sse_async(self) -> None:
         """Run the server using SSE transport."""
         from starlette.applications import Starlette
-        from starlette.routing import Route
+        from starlette.routing import Route, Mount
 
-        sse = SseServerTransport("/messages")
+        sse = SseServerTransport("/messages/")
 
         async def handle_sse(request):
             async with sse.connect_sse(
@@ -437,14 +437,11 @@ class FastMCP:
                     self._mcp_server.create_initialization_options(),
                 )
 
-        async def handle_messages(request):
-            await sse.handle_post_message(request.scope, request.receive, request._send)
-
         starlette_app = Starlette(
             debug=self.settings.debug,
             routes=[
                 Route("/sse", endpoint=handle_sse),
-                Route("/messages", endpoint=handle_messages, methods=["POST"]),
+                Mount("/messages/", app=sse.handle_post_message),
             ],
         )
 

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -11,7 +11,7 @@ Example usage:
     # Create Starlette routes for SSE and message handling
     routes = [
         Route("/sse", endpoint=handle_sse),
-        Mount("/messages", endpoint=handle_messages, methods=["POST"])
+        Mount("/messages", app=sse.handle_post_message),
     ]
 
     # Define handler functions
@@ -22,9 +22,6 @@ Example usage:
             await app.run(
                 streams[0], streams[1], app.create_initialization_options()
             )
-
-    async def handle_messages(request):
-        await sse.handle_post_message(request.scope, request.receive, request._send)
 
     # Create and run Starlette app
     starlette_app = Starlette(routes=routes)

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -11,7 +11,7 @@ Example usage:
     # Create Starlette routes for SSE and message handling
     routes = [
         Route("/sse", endpoint=handle_sse),
-        Route("/messages", endpoint=handle_messages, methods=["POST"])
+        Mount("/messages", endpoint=handle_messages, methods=["POST"])
     ]
 
     # Define handler functions

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -6,12 +6,12 @@ This module implements a Server-Sent Events (SSE) transport layer for MCP server
 Example usage:
 ```
     # Create an SSE transport at an endpoint
-    sse = SseServerTransport("/messages")
+    sse = SseServerTransport("/messages/")
 
     # Create Starlette routes for SSE and message handling
     routes = [
         Route("/sse", endpoint=handle_sse),
-        Mount("/messages", app=sse.handle_post_message),
+        Mount("/messages/", app=sse.handle_post_message),
     ]
 
     # Define handler functions


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Update SSE server and examples to fix an uncaught TypeError due to incorrect routing:
```
TypeError: 'NoneType' object is not callable
```
These have been updated based on the discussions in #83

Fixes #101 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested with the following approaches:
- Approach manually tested in another project in https://github.com/sparfenyuk/mcp-proxy/pull/8
- Tested `uv run mcp-simple-tool --transport sse --port 8000` manually

These examples do not currently have automated test coverage, tracked in #109.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
