### PR TITLE
fix: mcp install command with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ mcp install server.py
 mcp install server.py --name "My Analytics Server"
 
 # Environment variables
-mcp install server.py -e API_KEY=abc123 -e DB_URL=postgres://...
+mcp install server.py -v API_KEY=abc123 -v DB_URL=postgres://...
 mcp install server.py -f .env
 ```
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The `mcp install` command should use `-v` parameter to specify the environment variables.

![CleanShot 2025-01-13 at 20 17 01@2x](https://github.com/user-attachments/assets/035666f5-bccd-4bcc-a24d-a12d406807ef)


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
