### PR TITLE
feat: add instructions field to InitializeResult

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -86,9 +86,11 @@ class Settings(BaseSettings):
 
 
 class FastMCP:
-    def __init__(self, name: str | None = None, **settings: Any):
+    def __init__(
+        self, name: str | None = None, instructions: str | None = None, **settings: Any
+    ):
         self.settings = Settings(**settings)
-        self._mcp_server = MCPServer(name=name or "FastMCP")
+        self._mcp_server = MCPServer(name=name or "FastMCP", instructions=instructions)
         self._tool_manager = ToolManager(
             warn_on_duplicate_tools=self.settings.warn_on_duplicate_tools
         )
@@ -109,6 +111,10 @@ class FastMCP:
     @property
     def name(self) -> str:
         return self._mcp_server.name
+
+    @property
+    def instructions(self) -> str | None:
+        return self._mcp_server.instructions
 
     def run(self, transport: Literal["stdio", "sse"] = "stdio") -> None:
         """Run the FastMCP server. Note this is a synchronous function.

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -101,9 +101,12 @@ class NotificationOptions:
 
 
 class Server:
-    def __init__(self, name: str, version: str | None = None):
+    def __init__(
+        self, name: str, version: str | None = None, instructions: str | None = None
+    ):
         self.name = name
         self.version = version
+        self.instructions = instructions
         self.request_handlers: dict[
             type, Callable[..., Awaitable[types.ServerResult]]
         ] = {
@@ -139,6 +142,7 @@ class Server:
                 notification_options or NotificationOptions(),
                 experimental_capabilities or {},
             ),
+            instructions=self.instructions,
         )
 
     def get_capabilities(

--- a/src/mcp/server/models.py
+++ b/src/mcp/server/models.py
@@ -14,3 +14,4 @@ class InitializationOptions(BaseModel):
     server_name: str
     server_version: str
     capabilities: ServerCapabilities
+    instructions: str | None = None

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -135,6 +135,7 @@ class ServerSession(
                                 name=self._init_options.server_name,
                                 version=self._init_options.server_version,
                             ),
+                            instructions=self._init_options.instructions,
                         )
                     )
                 )

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -285,6 +285,8 @@ class InitializeResult(Result):
     """The version of the Model Context Protocol that the server wants to use."""
     capabilities: ServerCapabilities
     serverInfo: Implementation
+    instructions: str | None = None
+    """Instructions describing how to use the server and its features."""
 
 
 class InitializedNotification(Notification):

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -51,6 +51,7 @@ async def test_client_session_initialize():
                     prompts=None,
                 ),
                 serverInfo=Implementation(name="mock-server", version="0.1.0"),
+                instructions="The server instructions."
             )
         )
 
@@ -92,6 +93,7 @@ async def test_client_session_initialize():
     assert result.protocolVersion == LATEST_PROTOCOL_VERSION
     assert isinstance(result.capabilities, ServerCapabilities)
     assert result.serverInfo == Implementation(name="mock-server", version="0.1.0")
+    assert result.instructions == "The server instructions."
 
     # Check that the client sent the initialized notification
     assert initialized_notification

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -51,7 +51,7 @@ async def test_client_session_initialize():
                     prompts=None,
                 ),
                 serverInfo=Implementation(name="mock-server", version="0.1.0"),
-                instructions="The server instructions."
+                instructions="The server instructions.",
             )
         )
 

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -27,8 +27,9 @@ if TYPE_CHECKING:
 class TestServer:
     @pytest.mark.anyio
     async def test_create_server(self):
-        mcp = FastMCP()
+        mcp = FastMCP(instructions="Server instructions")
         assert mcp.name == "FastMCP"
+        assert mcp.instructions == "Server instructions"
 
     @pytest.mark.anyio
     async def test_non_ascii_description(self):


### PR DESCRIPTION
This adds the [instructions](https://github.com/modelcontextprotocol/specification/blob/ce55bba19fc1f5a343e45ef1b47f9ccf1801d318/schema/schema.ts#L175) field.

## Motivation and Context
The field is already in the MCP schema.

## How Has This Been Tested?
Added a test

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
