### PR TITLE
feat: add async resources for FastMCP

### DIFF
--- a/src/mcp/server/fastmcp/resources/types.py
+++ b/src/mcp/server/fastmcp/resources/types.py
@@ -1,5 +1,6 @@
 """Concrete resource implementations."""
 
+import inspect
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -53,7 +54,9 @@ class FunctionResource(Resource):
     async def read(self) -> str | bytes:
         """Read the resource by calling the wrapped function."""
         try:
-            result = self.fn()
+            result = (
+                await self.fn() if inspect.iscoroutinefunction(self.fn) else self.fn()
+            )
             if isinstance(result, Resource):
                 return await result.read()
             if isinstance(result, bytes):

--- a/tests/server/fastmcp/resources/test_function_resources.py
+++ b/tests/server/fastmcp/resources/test_function_resources.py
@@ -120,3 +120,19 @@ class TestFunctionResource:
         )
         content = await resource.read()
         assert isinstance(content, str)
+
+    @pytest.mark.anyio
+    async def test_async_read_text(self):
+        """Test reading text from async FunctionResource."""
+
+        async def get_data() -> str:
+            return "Hello, world!"
+
+        resource = FunctionResource(
+            uri=AnyUrl("function://test"),
+            name="test",
+            fn=get_data,
+        )
+        content = await resource.read()
+        assert content == "Hello, world!"
+        assert resource.mime_type == "text/plain"


### PR DESCRIPTION
This PR adds support for async resource endpoints for `fastmcp` servers.

## Motivation and Context
I noticed `fastmcp` doesn’t support asynchronous resources, even though the low-level API already has this functionality. 

## How Has This Been Tested?
- added unit test
- tested this on my private mcp server, which uses async resources

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
