### PR TITLE
fix: fastmcp debug logging

### DIFF
--- a/src/mcp/server/fastmcp/resources/resource_manager.py
+++ b/src/mcp/server/fastmcp/resources/resource_manager.py
@@ -34,7 +34,7 @@ class ResourceManager:
             extra={
                 "uri": resource.uri,
                 "type": type(resource).__name__,
-                "name": resource.name,
+                "resource_name": resource.name,
             },
         )
         existing = self._resources.get(str(resource.uri))


### PR DESCRIPTION
Fixes server crash when setting up the debug logging.

## Motivation and Context
FastMCP crashes when I set log level to `DEBUG`. Turns out there's a spot in the code where it overwrites the `LoggerRecord` `name` attribute, which happens to be a reserved keyword - https://docs.python.org/3/library/logging.html#logrecord-attributes.

## How Has This Been Tested?
Tried running the MCP server with the log level set to `DEBUG`.

```python
app = FastMCP("Demo", log_level="DEBUG")
```

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
