### PR TITLE
progress_token is 0 on first tool-call and the return is taken mistakenly

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -599,7 +599,7 @@ class Context(BaseModel):
             else None
         )
 
-        if not progress_token:
+        if progress_token == None:
             return
 
         await self.request_context.session.send_progress_notification(

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -599,7 +599,7 @@ class Context(BaseModel):
             else None
         )
 
-        if progress_token == None:
+        if progress_token is None:
             return
 
         await self.request_context.session.send_progress_notification(

--- a/tests/issues/test_176_progress_token.py
+++ b/tests/issues/test_176_progress_token.py
@@ -1,0 +1,46 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mcp.server.fastmcp import Context
+from mcp.shared.context import RequestContext
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_progress_token_zero_first_call():
+    """Test that progress notifications work when progress_token is 0 on first call."""
+
+    # Create mock session with progress notification tracking
+    mock_session = AsyncMock()
+    mock_session.send_progress_notification = AsyncMock()
+
+    # Create request context with progress token 0
+    mock_meta = MagicMock()
+    mock_meta.progressToken = 0  # This is the key test case - token is 0
+
+    request_context = RequestContext(
+        request_id="test-request", session=mock_session, meta=mock_meta
+    )
+
+    # Create context with our mocks
+    ctx = Context(request_context=request_context, fastmcp=MagicMock())
+
+    # Test progress reporting
+    await ctx.report_progress(0, 10)  # First call with 0
+    await ctx.report_progress(5, 10)  # Middle progress
+    await ctx.report_progress(10, 10)  # Complete
+
+    # Verify progress notifications
+    assert (
+        mock_session.send_progress_notification.call_count == 3
+    ), "All progress notifications should be sent"
+    mock_session.send_progress_notification.assert_any_call(
+        progress_token=0, progress=0.0, total=10.0
+    )
+    mock_session.send_progress_notification.assert_any_call(
+        progress_token=0, progress=5.0, total=10.0
+    )
+    mock_session.send_progress_notification.assert_any_call(
+        progress_token=0, progress=10.0, total=10.0
+    )

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -164,6 +164,7 @@ async def http_client(server, server_url) -> AsyncGenerator[httpx.AsyncClient, N
 async def test_raw_sse_connection(http_client: httpx.AsyncClient) -> None:
     """Test the SSE connection establishment simply with an HTTP client."""
     async with anyio.create_task_group():
+
         async def connection_test() -> None:
             async with http_client.stream("GET", "/sse") as response:
                 assert response.status_code == 200
@@ -209,7 +210,6 @@ async def initialized_sse_client_session(
         async with ClientSession(*streams) as session:
             await session.initialize()
             yield session
-
 
 
 @pytest.mark.anyio


### PR DESCRIPTION

<!-- Provide a brief summary of your changes -->

The first time a tool is called the progress_token is present, but its value is 0.  The way the conditional
is written the value of 0 is False and (not 0) is True.  What we want is to return if the value is not present (None).

## Motivation and Context
I had a small server that sent progress notifications and I noticed that on the first call to the tool, the
progress notifications were not sent.  On subsequent tool calls they were.

## How Has This Been Tested?
Yes.  I have tested with a small server and observed the progress notifications in Inspector.

## Breaking Changes
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

See console output of request sent on first call of tool.  The value of progressToken in the _meta is 0.  Thus
it is present.

![image](https://github.com/user-attachments/assets/06292def-aec1-403b-83f6-77590ecf0ddc)
