### PR TITLE
Relax pydantic, pydantic-settings, and uvicorn requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ dependencies = [
     "anyio>=4.5",
     "httpx>=0.27",
     "httpx-sse>=0.4",
-    "pydantic>=2.10.1,<3.0.0",
+    "pydantic>=2.7.2,<3.0.0",
     "starlette>=0.27",
     "sse-starlette>=1.6.1",
-    "pydantic-settings>=2.6.1",
-    "uvicorn>=0.30",
+    "pydantic-settings>=2.5.2",
+    "uvicorn>=0.23.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -237,26 +237,23 @@ async def test_lambda_function():
 def test_complex_function_json_schema():
     """Test JSON schema generation for complex function arguments.
     
-    Note: This test accepts two equivalent JSON Schema formats for models with defaults:
-    1. Pre-pydantic 2.7.2:
+    Note: Different versions of pydantic output slightly different
+    JSON Schema formats for model fields with defaults. The format changed in 2.9.0:
+
+    1. Before 2.9.0:
+       {
+         "allOf": [{"$ref": "#/$defs/Model"}],
+         "default": {}
+       }
+       
+    2. Since 2.9.0:
        {
          "$ref": "#/$defs/Model",
          "default": {}
        }
        
-    2. Pydantic 2.7.2+:
-       {
-         "allOf": [
-           {
-             "$ref": "#/$defs/Model"
-           }
-         ],
-         "default": {}
-       }
-       
-    Both formats are valid JSON Schema and represent the same validation rules.
-    The newer format using allOf is more correct according to the JSON Schema spec
-    as it properly composes the reference with additional properties.
+    Both formats are valid and functionally equivalent. This test accepts either format
+    to ensure compatibility across our supported pydantic versions.
     
     This change in format does not affect runtime behavior since:
     1. Both schemas validate the same way


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
This PR relaxes version constraints for several dependencies to improve compatibility, without changing functionality.

- `pydantic`: Changed from `>=2.10.1,<3.0.0` to `>=2.7.2,<3.0.0`
- `pydantic-settings`: Changed from `>=2.6.1` to `>=2.5.2`
- `uvicorn`: Changed from `>=0.30` to `>=0.23.1`

In addition to changing the version requirements, the main change in this PR is to fix a test that previously had been failing at pydantic 2.7.2, which had prompted @dsp-ant to upgrade the pydantic version. The relevant difference pre and post 2.7.2 pydantic was just in the JSON schema representation format. This fix was to make the test handle both pre-2.7.2 and post-2.7.2 pydantic JSON schema formats. Both schemas mean the same thing.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I tested this by running the test suite with both pydantic 2.7.2, and 2.10.1, to confirm the tests passed for both. For uvicorn and pydantic-settings, I examined the change log and the usage of these libraries in the code to make sure there were no breaking changes.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
There are no breaking changes here.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Relaxes dependency requirements, fixes a test that failed at an earlier dependency.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [x ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
