### PR TITLE
satisfy `pyright` untyped decorators in `mcp.server.fastmcp.server`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# vscode
+.vscode/

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, Callable, Generic, Literal, TypeAlias, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel
 from pydantic.networks import AnyUrl
@@ -27,6 +27,7 @@ ProgressToken = str | int
 Cursor = str
 Role = Literal["user", "assistant"]
 RequestId = str | int
+AnyFunction: TypeAlias = Callable[..., Any]
 
 
 class RequestParams(BaseModel):


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

### Motivation and Context
using a `.vscode/settings.json` like this
```json
{
    "python.analysis.typeCheckingMode": "strict"
}
```

the following example throws squiggles on `main`
```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("YouHaveBeenGoosed")

@mcp.tool()
def give_me_a_goose() -> str:
    return "goose"

if __name__ == "__main__":
    mcp.run()
```

![image](https://github.com/user-attachments/assets/eb272091-22eb-429e-9bb8-2622556a7734)

### How Has This Been Tested?
observing a marked lack of squiggles on this branch


### Breaking Changes
no

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Type nit

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
i purposefully wasn't so prescriptive with `_Function`, happy to be more specific if needed

if you're wondering how I got here: https://github.com/PrefectHQ/marvin/pull/1042