### PR TITLE
Enhancement: make stderr of server subprocess configurable

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -83,7 +83,7 @@ class StdioServerParameters(BaseModel):
 
 
 @asynccontextmanager
-async def stdio_client(server: StdioServerParameters):
+async def stdio_client(server: StdioServerParameters, errlog=sys.stderr):
     """
     Client transport for stdio: this will connect to a server by spawning a
     process and communicating with it over stdin/stdout.
@@ -100,7 +100,7 @@ async def stdio_client(server: StdioServerParameters):
     process = await anyio.open_process(
         [server.command, *server.args],
         env=server.env if server.env is not None else get_default_environment(),
-        stderr=sys.stderr,
+        stderr=errlog,
     )
 
     async def stdout_reader():


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This enhancement allows the creator of the stdio_client to pass a stream other than sys.stderr to become the stderr output.

## Motivation and Context
This change allows a client to implement something similar to that of Claude Desktop where the error log stream goes to a specific named output destination if desired.  (e.g. "mcp-server-XServer.log")  Without this, all subprocess servers can only write to the same stderr stream.

If there is a way to achieve the same effect without a code change that would be very acceptable, but I could not determine a way to do that.

## How Has This Been Tested?
This has been tested in a fork of "oterm", a terminal-based client.  Without this modification log and error messages from servers are written to the screen. 

## Breaking Changes
There should be no change to existing code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
I regret I do not have a self-contained test to submit, yet.