### PR TITLE
Enhance resource template to support values with slashes (Fix #159)

### DIFF
--- a/src/mcp/server/fastmcp/resources/templates.py
+++ b/src/mcp/server/fastmcp/resources/templates.py
@@ -55,7 +55,7 @@ class ResourceTemplate(BaseModel):
     def matches(self, uri: str) -> dict[str, Any] | None:
         """Check if URI matches template and extract parameters."""
         # Convert template to regex pattern
-        pattern = self.uri_template.replace("{", "(?P<").replace("}", ">[^/]+)")
+        pattern = self.uri_template.replace("{", "(?P<").replace("}", ">.+)")
         match = re.match(f"^{pattern}$", uri)
         if match:
             return match.groupdict()

--- a/tests/issues/test_141_resource_templates.py
+++ b/tests/issues/test_141_resource_templates.py
@@ -58,11 +58,6 @@ async def test_resource_template_edge_cases():
     with pytest.raises(ValueError, match="Unknown resource"):
         await mcp.read_resource("resource://users/123/posts")  # Missing post_id
 
-    with pytest.raises(ValueError, match="Unknown resource"):
-        await mcp.read_resource(
-            "resource://users/123/posts/456/extra"
-        )  # Extra path component
-
 
 @pytest.mark.anyio
 async def test_resource_template_client_interaction():

--- a/tests/server/fastmcp/resources/test_resource_template.py
+++ b/tests/server/fastmcp/resources/test_resource_template.py
@@ -46,6 +46,25 @@ class TestResourceTemplate:
         assert template.matches("test://foo") is None
         assert template.matches("other://foo/123") is None
 
+    def test_template_matches_slashes_in_value(self):
+        """Test matching URIs against a template, the value containing slashes."""
+
+        def my_func(path: str) -> dict:
+            return {"path": path}
+
+        template = ResourceTemplate.from_function(
+            fn=my_func,
+            uri_template="test://content/{path}",
+            name="test",
+        )
+
+        # Valid match
+        params = template.matches("test://content/path/with/slashes")
+        assert params == {"path": "path/with/slashes"}
+
+        # No match
+        assert template.matches("test://content/") is None
+
     @pytest.mark.anyio
     async def test_create_resource(self):
         """Test creating a resource from a template."""


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR enhances resource templates so that they can handle values containing slashes.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
### Motivation
This PR fixes the bug reported in #159 where the following example raises an error for paths containing slashes such as `resource://content/path/with/slashes`.

```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("My App")

@mcp.resource("resource://content/{path}")
def get_content(path: str) -> str:
    return f"Path: {path}"
```

Currently, this raises `mcp.shared.exceptions.McpError: Unknown resource: resource://content/path/with/slashes.`

Screenshot from MCP inspector:
<img width="867" alt="image" src="https://github.com/user-attachments/assets/eec2dcd5-22fc-4b0f-8c5c-4be4afc433d9" />

### Analysis
The root cause is in `ResourceTemplate.matches()` which explicitly excludes slashes from the regex matching:
https://github.com/modelcontextprotocol/python-sdk/blob/f10665db4c2f676da1131617ad67715952258712/src/mcp/server/fastmcp/resources/templates.py#L58

### Content of Fix
- Modified the regex pattern to allow slashes in parameter values
- Added test cases in `tests/server/fastmcp/resources/test_resource_template.py`
- Removed test case in `tests/issues/test_141_resource_templates.py` which expected errors for slash-containing values

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Unit testing: Added a test case in `tests/server/fastmcp/resources/test_resource_template.py`
- Integration testing: Verified the example from the Motivation section works correctly in MCP inspector

<img width="865" alt="image" src="https://github.com/user-attachments/assets/82751d84-1a6d-4c1e-b3b3-cffe1c5b7d0d" />


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
While this change primarily enhances functionality without breaking existing behavior, there might be edge cases where applications rely on the current error behavior for paths containing slashes. However, such cases are expected to be rare.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
While #159 marks this as a "bug," there is an existing test case suggesting this might have been intentional behavior:
https://github.com/modelcontextprotocol/python-sdk/blob/f10665db4c2f676da1131617ad67715952258712/tests/issues/test_141_resource_templates.py#L61-L64

I would appreciate maintainers' input on the intended behavior. If rejecting slash-containing values is the desired design, please close this PR.
