### PR TITLE
Force stdin/stdout encoding to UTF-8

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -20,6 +20,7 @@ Example usage:
 
 import sys
 from contextlib import asynccontextmanager
+from io import TextIOWrapper
 
 import anyio
 import anyio.lowlevel
@@ -38,11 +39,13 @@ async def stdio_server(
     from the current process' stdin and writing to stdout.
     """
     # Purposely not using context managers for these, as we don't want to close
-    # standard process handles.
+    # standard process handles. Encoding of stdin/stdout as text streams on
+    # python is platform-dependent (Windows is particularly problematic), so we
+    # re-wrap the underlying binary stream to ensure UTF-8.
     if not stdin:
-        stdin = anyio.wrap_file(sys.stdin)
+        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8"))
     if not stdout:
-        stdout = anyio.wrap_file(sys.stdout)
+        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
 
     read_stream: MemoryObjectReceiveStream[types.JSONRPCMessage | Exception]
     read_stream_writer: MemoryObjectSendStream[types.JSONRPCMessage | Exception]


### PR DESCRIPTION
The character encoding of the stdin/stdout streams in Python is platform- dependent. On Windows it will be something weird, like CP437 or CP1252, depending on the locale. This change ensures that no matter the platform, UTF-8 is used.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes

None known.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally (but see below)
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

Existing tests fail on Windows because of backslashes vs forward slashes in path names before my change. The same tests still fail on Windows with my change. Tests pass on Linux.

## Additional context

This enforces that stdin/stdout are UTF-8-encoded independent of platform; otherwise it's a grab-bag what you get on Windows. The JSON spec requires UTF-8, UTF-16, or UTF-32 encoding, and UTF-8 is by far the most common, so this seems safe.

A proper "fix" would be for the MCP specification to either specify an exact encoding or have a handshake where encoding is established before any other messages are exchanged. (I would lean toward requiring UTF-8.)