### PR TITLE
End to end logging

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -324,9 +324,9 @@ class BaseSession(
                                 await self._in_flight[cancelled_id].cancel()
                         else:
                             await self._received_notification(notification)
-                            await self._incoming_message_stream_writer.send(
-                                notification
-                            )
+#                            await self._incoming_message_stream_writer.send(
+#                                notification
+#                            )
                     except Exception as e:
                         # For other validation errors, log and continue
                         logging.warning(

--- a/tests/example_mcp_server.py
+++ b/tests/example_mcp_server.py
@@ -1,0 +1,33 @@
+#
+# Small Demo server using FastMCP and illustrating debugging and notification streams
+#
+
+import logging
+from mcp.server.fastmcp import FastMCP, Context
+import time
+import asyncio
+
+mcp = FastMCP("MCP EXAMPLE SERVER", debug=True, log_level="DEBUG")
+
+logger = logging.getLogger(__name__)
+
+logger.debug(f"MCP STARTING EXAMPLE SERVER")
+
+@mcp.resource("config://app")
+def get_config() -> str:
+    """Static configuration data"""
+    return "Test Server 2024-02-25"
+
+@mcp.tool()
+async def simple_tool(x:float, y:float, ctx:Context) -> str:
+    logger.debug("IN SIMPLE_TOOL")
+    await ctx.report_progress(1, 2)
+    return x*y
+
+@mcp.tool()
+async def simple_tool_with_logging(x:float, y:float, ctx:Context) -> str:
+    await ctx.info(f"Processing Simple Tool")
+    logger.debug("IN SIMPLE_TOOL")
+    await ctx.report_progress(1, 2)
+    return x*y
+

--- a/tests/example_mcp_server.py
+++ b/tests/example_mcp_server.py
@@ -5,7 +5,6 @@
 import logging
 from mcp.server.fastmcp import FastMCP, Context
 import time
-import asyncio
 
 mcp = FastMCP("MCP EXAMPLE SERVER", debug=True, log_level="DEBUG")
 

--- a/tests/mcp_stdio_client.py
+++ b/tests/mcp_stdio_client.py
@@ -1,0 +1,136 @@
+from mcp import ClientSession, ListToolsResult, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.types import CallToolResult
+from mcp import Tool as MCPTool
+
+from contextlib import AsyncExitStack
+from typing import Any
+import asyncio
+
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+
+class NotificationLoggingClientSession(ClientSession):
+
+    def __init__(self, read_stream, write_stream):
+        print(f"NOTIFICATION LOGGING CLIENT SESSION")
+        super().__init__(read_stream, write_stream)
+
+    # override base session to log incoming notifications
+    async def _received_notification(self, notification):
+        print(f"NOTIFICATION:{notification}")
+        print(f"NOTIFICATION-END")
+        
+    async def send_progress_notification(self, progress_token, progress, total):
+        print(f"PROGRESS:{progress_token}")
+        print(f"PROGRESS-END")
+        
+
+# adapted from mcp-python-sdk/examples/clients/simple-chatbot/mcp_simple_chatbot/main.py
+class MCPClient:
+    """Manages MCP server connections and tool execution."""
+
+    def __init__(self, name, server_params: StdioServerParameters, errlog=None):
+        self.name = name
+        self.server_params = server_params
+        self.errlog = errlog
+        self.stdio_context: Any | None = None
+        self.session: ClientSession | None = None
+        self._cleanup_lock: asyncio.Lock = asyncio.Lock()
+        self.exit_stack: AsyncExitStack = AsyncExitStack()
+
+    async def initialize(self) -> None:
+        """Initialize the server connection."""
+
+        try:
+            stdio_transport = await self.exit_stack.enter_async_context(
+                stdio_client(self.server_params)
+            )
+            read, write = stdio_transport
+            session = await self.exit_stack.enter_async_context(
+                # ClientSession(read, write)
+                NotificationLoggingClientSession(read, write)
+            )
+            await session.initialize()
+            self.session = session
+        except Exception as e:
+            logging.error(f"Error initializing server: {e}")
+            await self.cleanup()
+            raise
+
+    async def get_available_tools(self) -> list[MCPTool]:
+        """List available tools from the server.
+
+        Returns:
+            A list of available tools.
+
+        Raises:
+            RuntimeError: If the server is not initialized.
+        """
+        if not self.session:
+            raise RuntimeError(f"Server {self.name} not initialized")
+
+        tools_response = await self.session.list_tools()
+
+        # Let's just ignore pagination for now
+        return tools_response.tools
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        retries: int = 2,
+        delay: float = 1.0,
+    ) -> Any:
+        """Execute a tool with retry mechanism.
+
+        Args:
+            tool_name: Name of the tool to execute.
+            arguments: Tool arguments.
+            retries: Number of retry attempts.
+            delay: Delay between retries in seconds.
+
+        Returns:
+            Tool execution result.
+
+        Raises:
+            RuntimeError: If server is not initialized.
+            Exception: If tool execution fails after all retries.
+        """
+        if not self.session:
+            raise RuntimeError(f"Server {self.name} not initialized")
+
+        attempt = 0
+        while attempt < retries:
+            try:
+                logging.info(f"Executing {tool_name}...")
+                result = await self.session.call_tool(tool_name, arguments)
+
+                return result
+
+            except Exception as e:
+                attempt += 1
+                logging.warning(
+                    f"Error executing tool: {e}. Attempt {attempt} of {retries}."
+                )
+                if attempt < retries:
+                    logging.info(f"Retrying in {delay} seconds...")
+                    await asyncio.sleep(delay)
+                else:
+                    logging.error("Max retries reached. Failing.")
+                    raise
+
+    async def cleanup(self) -> None:
+        """Clean up server resources."""
+        async with self._cleanup_lock:
+            try:
+                await self.exit_stack.aclose()
+                self.session = None
+                self.stdio_context = None
+            except Exception as e:
+                logging.error(f"Error during cleanup of server {self.name}: {e}")
+
+

--- a/tests/test_mcp_tool.py
+++ b/tests/test_mcp_tool.py
@@ -28,7 +28,6 @@ servers_config = {
 }
 
 
-# @pytest.mark.asyncio
 @pytest.mark.anyio
 async def test_mcp():
 
@@ -55,7 +54,6 @@ async def test_mcp():
     await client.cleanup()
 
 
-# @pytest.mark.asyncio
 @pytest.mark.anyio
 async def test_mcp_with_logging():
 

--- a/tests/test_mcp_tool.py
+++ b/tests/test_mcp_tool.py
@@ -1,0 +1,83 @@
+import pytest
+
+import os
+import sys
+from .mcp_stdio_client import MCPClient
+
+from mcp import StdioServerParameters
+
+# locate the exmaple MCP server co-located in this directory
+
+mcp_server_dir = os.path.dirname(os.path.abspath(__file__))
+mcp_server_file = os.path.join(mcp_server_dir, "example_mcp_server.py")
+                           
+# mcpServers config in same syntax used by reference MCP
+
+servers_config = {
+    "mcpServers": {
+
+        "testMcpServer": {
+            "command": "mcp",   # be sure to . .venv/bin/activate so that mcp command is found
+            "args": [
+                "run",
+                mcp_server_file
+            ]
+        }
+
+    }
+}
+
+
+# @pytest.mark.asyncio
+@pytest.mark.anyio
+async def test_mcp():
+
+    servers = servers_config.get("mcpServers")
+
+    server0 = "testMcpServer"
+    config0 = servers[server0]
+    
+    client = MCPClient(
+        server0,
+        StdioServerParameters.model_validate(config0)
+    )
+    await client.initialize()
+    tools = await client.get_available_tools()
+
+    print(f"TOOLS:{tools}")
+    mcp_tool = tools[0]
+
+    res = await client.call_tool("simple_tool", {"x":5, "y":7})
+
+    print(f"RES:{res}")
+
+    # clients must be destroyed in reverse order
+    await client.cleanup()
+
+
+# @pytest.mark.asyncio
+@pytest.mark.anyio
+async def test_mcp_with_logging():
+
+    servers = servers_config.get("mcpServers")
+
+    server0 = "testMcpServer"
+    config0 = servers[server0]
+    
+    client = MCPClient(
+        server0,
+        StdioServerParameters.model_validate(config0)
+    )
+    await client.initialize()
+    tools = await client.get_available_tools()
+
+    print(f"TOOLS:{tools}")
+    mcp_tool = tools[0]
+
+    res = await client.call_tool("simple_tool_with_logging", {"x":5, "y":7})
+
+    print(f"RES:{res}")
+
+    # clients must be destroyed in reverse order
+    await client.cleanup()
+    


### PR DESCRIPTION
This addresses Issue #201 and provides a test and a fix.

## Motivation and Context
An MCP server may include logging messages (notifications/message) by using the ctx.{info,debug}() call.
Currently it seems that Claude Desktop and Inspector operate properly when an MCP server sends these
notifications, even if those clients do not do anything with them.

In the process of writing a Pure-Python client using the example given in simple-chatbot as a starting point,
if logging notifications are sent, they cause the client to hang.

There is an included fix in the shared/session.py file.  I believe the acknowledgement of the received notification is causing a deadlock.   Try running the test without the fix to observe server hanging.

The goal is to simply log the received notifications in the Client, and you can see that in the NotificationLoggingClientSession

## How Has This Been Tested?
The included test illustrates the pattern.

## Breaking Changes
possibly

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
