### PR TITLE
merge custom set env variables with default ones

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -99,7 +99,7 @@ async def stdio_client(server: StdioServerParameters):
 
     process = await anyio.open_process(
         [server.command, *server.args],
-        env=server.env if server.env is not None else get_default_environment(),
+        env={**get_default_environment(), **(server.env or {})},
         stderr=sys.stderr,
     )
 

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -1,6 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 
-from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.stdio import (
+    DEFAULT_INHERITED_ENV_VARS,
+    StdioServerParameters,
+    stdio_client,
+)
 from mcp.types import JSONRPCMessage, JSONRPCRequest, JSONRPCResponse
 
 
@@ -36,3 +42,30 @@ async def test_stdio_client():
         assert read_messages[1] == JSONRPCMessage(
             root=JSONRPCResponse(jsonrpc="2.0", id=2, result={})
         )
+
+@pytest.mark.anyio
+async def test_environment_merging():
+    captured_env = {}
+    
+    async def mock_open_process(*args, **kwargs):
+        # Just capture the env and return None - we don't care about the process
+        captured_env.update(kwargs.get('env', {}))
+        return None
+
+    custom_env = {"CUSTOM_VAR": "test_value", "PATH": "/custom/path"}
+    server = StdioServerParameters(command="test", env=custom_env)
+
+    with patch('anyio.open_process', side_effect=mock_open_process):
+        try:
+            async with stdio_client(server):
+                pass
+        except:  # noqa: E722
+            pass
+        
+    # Check default environment variables are there
+    for var in DEFAULT_INHERITED_ENV_VARS:
+        assert var in captured_env
+
+    # and check the custom ones
+    assert captured_env["CUSTOM_VAR"] == "test_value"
+    assert captured_env["PATH"] == "/custom/path"


### PR DESCRIPTION
## Motivation and Context
Fixes https://github.com/modelcontextprotocol/python-sdk/issues/213 -- the default env variables are not set if custom ones are provided.

## How Has This Been Tested?
unit test

## Breaking Changes
There is a behavior change where extra environment variables (default ones) will be set if users are providing their own.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

