### PR TITLE
enable http headers in sse in the context

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -526,6 +526,11 @@ class Server(Generic[LifespanResultT]):
             logger.debug(f"Dispatching request of type {type(req).__name__}")
 
             token = None
+            headers = {}
+            try:
+                headers = message.request.root.headers  # type: ignore
+            except Exception:
+                pass
             try:
                 # Set our global state that can be retrieved via
                 # app.get_request_context()
@@ -535,6 +540,7 @@ class Server(Generic[LifespanResultT]):
                         message.request_meta,
                         session,
                         lifespan_context,
+                        headers,
                     )
                 )
                 response = await handler(req)

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -528,6 +528,7 @@ class Server(Generic[LifespanResultT]):
             token = None
             headers = {}
             try:
+                # TODO: This try/catch and ignoring the type is wrong.
                 headers = message.request.root.headers  # type: ignore
             except Exception:
                 pass

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -160,7 +160,8 @@ class SseServerTransport:
         logger.debug(f"Received JSON: {json}")
 
         try:
-            message = types.JSONRPCMessage.model_validate(json)
+            message_with_headers = {**json, "headers": dict(request.headers)}
+            message = types.JSONRPCMessage.model_validate(message_with_headers)
             logger.debug(f"Validated client message: {message}")
         except ValidationError as err:
             logger.error(f"Failed to parse message: {err}")

--- a/src/mcp/shared/context.py
+++ b/src/mcp/shared/context.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 
 from mcp.shared.session import BaseSession
@@ -14,3 +14,4 @@ class RequestContext(Generic[SessionT, LifespanContextT]):
     meta: RequestParams.Meta | None
     session: SessionT
     lifespan_context: LifespanContextT
+    headers: dict[str, str] = field(default_factory=dict)

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -118,6 +118,7 @@ class JSONRPCRequest(Request):
     jsonrpc: Literal["2.0"]
     id: RequestId
     params: dict[str, Any] | None = None
+    headers: dict[str, str] | None = None
 
 
 class JSONRPCNotification(Notification):


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
In the server, it seems like a common case to need to access the raw HTTP headers (think a reverse proxy header, or some custom analytics headers).

Example use case, where we have two services that can possibly talk to the MCP server. The servers identify themselves through the `X-Client` HTTP header.

```python
from mcp.server.fastmcp import Context, FastMCP

mcp = FastMCP("test_w_headers", port=3001, debug=True)


@mcp.tool()
def add_sales_lead(lead: str, ctx: Context) -> str:
    """
	Adds a new sales lead. Tracks which app was the originator of 
	this request based on the X-Client custom header
	"""
	sales.add_lead(lead, tracking_attrs={"src": ctx.headers.get("X-Client")}
    return "Lead added successfully"

```


## How Has This Been Tested?
They were just tested manually locally

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
I'm not very familiar with the code. The `try/except` TODO should be done with proper type checking, but I just wanted to make it work to show the concept first.