### PR TITLE
Updated typing on request context for the server to use server session

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -34,6 +34,7 @@ from mcp.server.lowlevel.server import (
 from mcp.server.lowlevel.server import (
     lifespan as default_lifespan,
 )
+from mcp.server.session import ServerSession
 from mcp.server.sse import SseServerTransport
 from mcp.server.stdio import stdio_server
 from mcp.shared.context import RequestContext
@@ -597,7 +598,7 @@ class Context(BaseModel):
     The context is optional - tools that don't need it can omit the parameter.
     """
 
-    _request_context: RequestContext | None
+    _request_context: RequestContext[ServerSession, Any] | None
     _fastmcp: FastMCP | None
 
     def __init__(


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adding better type hinting for request context in fastmcp servers. This allows the IDE to provide autocomplete for things like `.list_roots()` and sampling.

## Motivation and Context
Was writing a server that called list_roots

## How Has This Been Tested?
Just a typing change, tests passing

## Breaking Changes
Nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
