### PR TITLE
Propagate Custom Request ID to use in cancel notification for call tool and get prompt

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -219,14 +219,19 @@ class ClientSession(
         )
 
     async def call_tool(
-        self, name: str, arguments: dict | None = None
+        self,
+        name: str,
+        arguments: dict | None = None,
+        request_id: types.ClientInitiatedRequestId | None = None,
     ) -> types.CallToolResult:
         """Send a tools/call request."""
         return await self.send_request(
             types.ClientRequest(
                 types.CallToolRequest(
                     method="tools/call",
-                    params=types.CallToolRequestParams(name=name, arguments=arguments),
+                    params=types.CallToolRequestParams(
+                        name=name, arguments=arguments, request_id=request_id
+                    ),
                 )
             ),
             types.CallToolResult,
@@ -244,14 +249,19 @@ class ClientSession(
         )
 
     async def get_prompt(
-        self, name: str, arguments: dict[str, str] | None = None
+        self,
+        name: str,
+        arguments: dict[str, str] | None = None,
+        request_id: types.ClientInitiatedRequestId | None = None,
     ) -> types.GetPromptResult:
         """Send a prompts/get request."""
         return await self.send_request(
             types.ClientRequest(
                 types.GetPromptRequest(
                     method="prompts/get",
-                    params=types.GetPromptRequestParams(name=name, arguments=arguments),
+                    params=types.GetPromptRequestParams(
+                        name=name, arguments=arguments, request_id=request_id
+                    ),
                 )
             ),
             types.GetPromptResult,

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -222,7 +222,7 @@ class ClientSession(
         self,
         name: str,
         arguments: dict | None = None,
-        request_id: types.ClientInitiatedRequestId | None = None,
+        request_id: types.CustomRequestId | None = None,
     ) -> types.CallToolResult:
         """Send a tools/call request."""
         return await self.send_request(
@@ -252,7 +252,7 @@ class ClientSession(
         self,
         name: str,
         arguments: dict[str, str] | None = None,
-        request_id: types.ClientInitiatedRequestId | None = None,
+        request_id: types.CustomRequestId | None = None,
     ) -> types.GetPromptResult:
         """Send a prompts/get request."""
         return await self.send_request(

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -21,11 +21,11 @@ from mcp.types import (
     JSONRPCNotification,
     JSONRPCRequest,
     JSONRPCResponse,
+    RequestId,
     RequestParams,
     ServerNotification,
     ServerRequest,
     ServerResult,
-    RequestId,
 )
 
 SendRequestT = TypeVar("SendRequestT", ClientRequest, ServerRequest)

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -34,9 +34,9 @@ LATEST_PROTOCOL_VERSION = "2024-11-05"
 ProgressToken = str | int
 Cursor = str
 Role = Literal["user", "assistant"]
-ClientInitiatedRequestId = str
-ServerInitiatedRequestId = int
-RequestId = ClientInitiatedRequestId | ServerInitiatedRequestId
+CustomRequestId = str
+AutomaticRequestId = int
+RequestId = CustomRequestId | AutomaticRequestId
 AnyFunction: TypeAlias = Callable[..., Any]
 
 
@@ -53,7 +53,7 @@ class RequestParams(BaseModel):
         model_config = ConfigDict(extra="allow")
 
     meta: Meta | None = Field(alias="_meta", default=None)
-    request_id: ClientInitiatedRequestId | None = Field(default=None)
+    request_id: CustomRequestId | None = Field(default=None)
 
 
 class NotificationParams(BaseModel):

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -34,7 +34,9 @@ LATEST_PROTOCOL_VERSION = "2024-11-05"
 ProgressToken = str | int
 Cursor = str
 Role = Literal["user", "assistant"]
-RequestId = str | int
+ClientInitiatedRequestId = str
+ServerInitiatedRequestId = int
+RequestId = ClientInitiatedRequestId | ServerInitiatedRequestId
 AnyFunction: TypeAlias = Callable[..., Any]
 
 
@@ -51,6 +53,7 @@ class RequestParams(BaseModel):
         model_config = ConfigDict(extra="allow")
 
     meta: Meta | None = Field(alias="_meta", default=None)
+    request_id: ClientInitiatedRequestId | None = Field(default=None)
 
 
 class NotificationParams(BaseModel):


### PR DESCRIPTION
Propagate Custom Request ID so that it can be used in cancel notification. The convention is that any Custom Request ID is a string, and int is for automatically incremented request IDs.

## Motivation and Context
(https://github.com/modelcontextprotocol/python-sdk/issues/230)

## How Has This Been Tested?
NA
## Breaking Changes
NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed


