### PR TITLE
Update sse client to follow redirects

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -43,7 +43,7 @@ async def sse_client(
     async with anyio.create_task_group() as tg:
         try:
             logger.info(f"Connecting to SSE endpoint: {remove_request_params(url)}")
-            async with httpx.AsyncClient(headers=headers) as client:
+            async with httpx.AsyncClient(headers=headers, follow_redirects=True) as client:
                 async with aconnect_sse(
                     client,
                     "GET",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

This solves the issue where server redirects to itself, ie for example when writing the sse server with nextjs and using "npm run dev". The endpoint redirects from localhost:3000/api/sse to /api/sse. Which should work fine.

## How Has This Been Tested?

Locally

## Breaking Changes

No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

