### PR TITLE
Enable context injection into resources

### DIFF
--- a/src/mcp/server/fastmcp/resources/resource_manager.py
+++ b/src/mcp/server/fastmcp/resources/resource_manager.py
@@ -1,12 +1,15 @@
 """Resource manager functionality."""
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from pydantic import AnyUrl
 
 from mcp.server.fastmcp.resources.base import Resource
 from mcp.server.fastmcp.resources.templates import ResourceTemplate
 from mcp.server.fastmcp.utilities.logging import get_logger
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp.server import Context
 
 logger = get_logger(__name__)
 
@@ -64,7 +67,9 @@ class ResourceManager:
         self._templates[template.uri_template] = template
         return template
 
-    async def get_resource(self, uri: AnyUrl | str) -> Resource | None:
+    async def get_resource(
+        self, uri: AnyUrl | str, context: "Context | None" = None
+    ) -> Resource | None:
         """Get resource by URI, checking concrete resources first, then templates."""
         uri_str = str(uri)
         logger.debug("Getting resource", extra={"uri": uri_str})
@@ -77,7 +82,9 @@ class ResourceManager:
         for template in self._templates.values():
             if params := template.matches(uri_str):
                 try:
-                    return await template.create_resource(uri_str, params)
+                    return await template.create_resource(
+                        uri_str, params, context=context
+                    )
                 except Exception as e:
                     raise ValueError(f"Error creating resource from template: {e}")
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -239,7 +239,8 @@ class FastMCP:
     async def read_resource(self, uri: AnyUrl | str) -> Iterable[ReadResourceContents]:
         """Read a resource by URI."""
 
-        resource = await self._resource_manager.get_resource(uri)
+        context = self.get_context()
+        resource = await self._resource_manager.get_resource(uri, context=context)
         if not resource:
             raise ResourceError(f"Unknown resource: {uri}")
 
@@ -336,6 +337,10 @@ class FastMCP:
         If the URI contains parameters (e.g. "resource://{param}") or the function
         has parameters, it will be registered as a template resource.
 
+        Resources can optionally request a Context object by adding a parameter with the
+        Context type annotation. The context provides access to MCP capabilities like
+        logging, progress reporting, and resource access.
+
         Args:
             uri: URI for the resource (e.g. "resource://my-resource" or "resource://{param}")
             name: Optional name for the resource
@@ -360,6 +365,12 @@ class FastMCP:
             async def get_weather(city: str) -> str:
                 data = await fetch_weather(city)
                 return f"Weather for {city}: {data}"
+
+            @server.resource("resource://{city}/weather")
+            async def get_weather(city: str, ctx: Context) -> str:
+                await ctx.info(f"Getting weather for {city}")
+                data = await fetch_weather(city)
+                return f"Weather for {city}: {data}"
         """
         # Check if user passed function directly instead of calling decorator
         if callable(uri):
@@ -376,7 +387,18 @@ class FastMCP:
             if has_uri_params or has_func_params:
                 # Validate that URI params match function params
                 uri_params = set(re.findall(r"{(\w+)}", uri))
-                func_params = set(inspect.signature(fn).parameters.keys())
+
+                # Get all function params except 'ctx' or any parameter of type Context
+                sig = inspect.signature(fn)
+                func_params = set()
+                for param_name, param in sig.parameters.items():
+                    # Skip context parameters
+                    if param_name == "ctx" or (
+                        hasattr(param.annotation, "__name__")
+                        and param.annotation.__name__ == "Context"
+                    ):
+                        continue
+                    func_params.add(param_name)
 
                 if uri_params != func_params:
                     raise ValueError(


### PR DESCRIPTION
## Motivation and Context
According to the readme it should be possible to pass a `Context` to a resource (like it is for tools), but that's currently throwing an error (https://github.com/modelcontextprotocol/python-sdk/issues/244)

## How Has This Been Tested?
Added pytests, and confirmed with inspector that the below demo server works as intended:
```
from mcp.server.fastmcp import FastMCP, Context

mcp = FastMCP("Demo")


@mcp.resource("identification://{name}")
def get_ids(name: str, ctx: Context) -> str:
    request_id = ctx.request_id
    client_id = ctx.client_id
    return str(f"{request_id},{client_id}")
```
## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
I tried to follow a similar structure to the way context is injected in tools