### PR TITLE
Fixed MCP Simple Chatbot README.MD API Key name

### DIFF
--- a/examples/clients/simple-chatbot/README.MD
+++ b/examples/clients/simple-chatbot/README.MD
@@ -23,7 +23,7 @@ This example demonstrates how to integrate the Model Context Protocol (MCP) into
    Create a `.env` file in the root directory and add your API key:
 
    ```plaintext
-   LLM_API_KEY=your_api_key_here
+   GROQ_API_KEY=your_api_key_here
    ```
 
 3. **Configure servers:**


### PR DESCRIPTION
README file has been updated to the correct API key name

## Motivation and Context

README.md file for the MCP Simple Chatbot has been updated to reflect that the application uses the `GROQ_API_KEY` instead of the `LLM_API_KEY` for the API key.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
