### PR TITLE
Changed default log level to error

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
 
     # Server settings
     debug: bool = False
-    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "ERROR"
 
     # HTTP settings
     host: str = "0.0.0.0"


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
I help support Roo Code, a fork of cline. 
There have had many users asking why they cant see the tool output in the MCP server tool window after creating a fastMCP server.
I think the default logging should be set to Error, if the user wants to see the INFO level, they can specify it. As a default, it's confusing a lot of people. 


## How Has This Been Tested?
It's a simple default value change. 

## Breaking Changes
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
