### PR TITLE
Add support for Linux configuration path in get_claude_config_path

### DIFF
--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -17,6 +17,8 @@ def get_claude_config_path() -> Path | None:
         path = Path(Path.home(), "AppData", "Roaming", "Claude")
     elif sys.platform == "darwin":
         path = Path(Path.home(), "Library", "Application Support", "Claude")
+    elif sys.platform.startswith("linux"):
+        path = Path(Path.home(), ".config", "Claude")
     else:
         return None
 

--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -19,7 +19,9 @@ def get_claude_config_path() -> Path | None:
     elif sys.platform == "darwin":
         path = Path(Path.home(), "Library", "Application Support", "Claude")
     elif sys.platform.startswith("linux"):
-        path = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"), "Claude")
+        path = Path(
+            os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"), "Claude"
+        )
     else:
         return None
 

--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -1,6 +1,7 @@
 """Claude app integration utilities."""
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -18,7 +19,7 @@ def get_claude_config_path() -> Path | None:
     elif sys.platform == "darwin":
         path = Path(Path.home(), "Library", "Application Support", "Claude")
     elif sys.platform.startswith("linux"):
-        path = Path(Path.home(), ".config", "Claude")
+        path = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
     else:
         return None
 

--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -19,7 +19,7 @@ def get_claude_config_path() -> Path | None:
     elif sys.platform == "darwin":
         path = Path(Path.home(), "Library", "Application Support", "Claude")
     elif sys.platform.startswith("linux"):
-        path = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+        path = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"), "Claude")
     else:
         return None
 

--- a/src/mcp/client/websocket.py
+++ b/src/mcp/client/websocket.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
-async def websocket_client(url: str) -> AsyncGenerator[
+async def websocket_client(
+    url: str,
+) -> AsyncGenerator[
     tuple[
         MemoryObjectReceiveStream[types.JSONRPCMessage | Exception],
         MemoryObjectSendStream[types.JSONRPCMessage],
@@ -59,7 +61,7 @@ async def websocket_client(url: str) -> AsyncGenerator[
 
         async def ws_writer():
             """
-            Reads JSON-RPC messages from write_stream_reader and 
+            Reads JSON-RPC messages from write_stream_reader and
             sends them to the server.
             """
             async with write_stream_reader:


### PR DESCRIPTION
## Motivation and Context
There's a community version of Claude desktop at:
https://github.com/emsi/claude-desktop (originally forked from https://github.com/aaddrick/claude-desktop-debian).

Unfortunately current version of MCP SDK does not support Linux yet there is nothing in the docs that indicate that and the `uv run mcp install server.py` command exits with a message "Claude app not found", while it's not actually looking for Claude Desktop app on Linux at all.
This patch addresses that and enables the SDK to install MCP servers in Claude desktop app on Linux.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
