### PR TITLE
Release on GitHub release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,14 +2,12 @@
 
 ## Bumping Dependencies
 
-1. Change dependency
-2. Upgrade lock with `uv lock --resolution lowest-direct
+1. Change dependency version in `pyproject.toml`
+2. Upgrade lock with `uv lock --resolution lowest-direct`
 
 ## Major or Minor Release
 
-1. Create a release branch named `vX.Y.Z` where `X.Y.Z` is the version.
-2. Bump version number on release branch.
-3. Create an annotated, signed tag: `git tag -s -a vX.Y.Z`
-4. Create a github release using `gh release create` and publish it.
-5. Have the release flow being reviewed.
-7. Bump version number on `main` to the next version followed by `.dev`, e.g. `v0.4.0.dev`.
+Create a GitHub release via UI with the tag being `vX.Y.Z` where `X.Y.Z` is the version,
+and the release title being the same. Then ask someone to review the release.
+
+The package version will be set automatically from the tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp"
-version = "1.4.0.dev0"
+dynamic = ["version"]
 description = "Model Context Protocol SDK"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -52,8 +52,16 @@ dev-dependencies = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+bump = true
 
 [project.urls]
 Homepage = "https://modelcontextprotocol.io"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [options]
@@ -78,7 +79,7 @@ name = "click"
 version = "8.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/2b/7ebad1e59a99207d417c0784f7fb67893465eef84b5b47c788324f1b4095/click-8.1.0.tar.gz", hash = "sha256:977c213473c7665d3aa092b41ff12063227751c41d7b17165013e10069cc5cd2", size = 329986 }
 wheels = [
@@ -191,7 +192,6 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -241,6 +241,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.23.1" },
     { name = "websockets", marker = "extra == 'ws'", specifier = ">=15.0.1" },
 ]
+provides-extras = ["cli", "rich", "ws"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
I'm not sure if you folks want this, but the release processed seemed a bit complicated.

The idea here is the version being set on tag. You can create a tag locally, and run `uv build` to check what I mean... Create a commit after, and build again to check how it would look like.