### PR TITLE
Update README to clarify installing mcp to project vs running mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,25 @@ The Model Context Protocol allows applications to provide context for LLMs in a 
 
 ## Installation
 
-We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects:
+### Adding MCP to your python project
+
+We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects. In a uv managed python project, add mcp to dependencies by:
 
 ```bash
 uv add "mcp[cli]"
 ```
 
-Alternatively:
+Alternatively, for projects using pip for dependencies:
 ```bash
 pip install mcp
+```
+
+### Running the standalone MCP development tools
+
+To run the mcp command with uv:
+
+```bash
+uv run mcp
 ```
 
 ## Quickstart


### PR DESCRIPTION
This change updates the README to avoid folks misunderstanding the uv add command.

## Motivation and Context
This is in response to issue #269 

## How Has This Been Tested?
I've tested the commands in this change (uv add and uv run) and it's in line with what the new wording suggests.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [N/A] My code follows the repository's style guidelines
- [N/A] New and existing tests pass locally
- [N/A] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None, this is just a README update.