### PR TITLE
add `cwd` to `StdioServerParameters`

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Literal
 
 import anyio
@@ -66,6 +67,9 @@ class StdioServerParameters(BaseModel):
     If not specified, the result of get_default_environment() will be used.
     """
 
+    cwd: str | Path | None = None
+    """The working directory to use when spawning the process."""
+
     encoding: str = "utf-8"
     """
     The text encoding used when sending/receiving messages to the server
@@ -101,6 +105,7 @@ async def stdio_client(server: StdioServerParameters):
         [server.command, *server.args],
         env=server.env if server.env is not None else get_default_environment(),
         stderr=sys.stderr,
+        cwd=server.cwd,
     )
 
     async def stdout_reader():


### PR DESCRIPTION
## Motivation and Context

self explanitory - I want to be able to set current working directory when running servers as subprocesses.

## How Has This Been Tested?

Yes locally

## Breaking Changes

nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
