### PR TITLE
Add end-to-end tests for server-client communication

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,65 @@
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from mcp import ClientSession, StdioServerParameters, stdio_client
+from mcp.server import FastMCP
+
+params = StdioServerParameters(command="uv", args=["run", __file__])
+
+
+def server() -> FastMCP:
+    mcp = FastMCP("Echo")
+
+    @mcp.resource("echo://{message}")
+    def echo_resource(message: str) -> str:
+        """Echo a message as a resource"""
+        return f"Resource echo: {message}"
+
+    @mcp.tool()
+    def echo_tool(message: str) -> str:
+        """Echo a message as a tool"""
+        return f"Tool echo: {message}"
+
+    @mcp.prompt()
+    def echo_prompt(message: str) -> str:
+        """Create an echo prompt"""
+        return f"Please process this message: {message}"
+
+    return mcp
+
+
+@pytest.fixture
+async def mcp_client_session() -> AsyncGenerator[ClientSession, None]:
+    async with stdio_client(params) as streams:
+        async with ClientSession(streams[0], streams[1]) as session:
+            await session.initialize()
+            yield session
+
+
+@pytest.mark.anyio
+async def test_list_resource_templates(mcp_client_session: ClientSession) -> None:
+    res = await mcp_client_session.list_resource_templates()
+    templates = set(template.name for template in res.resourceTemplates)
+
+    assert "echo_resource" in templates
+
+
+@pytest.mark.anyio
+async def test_list_tools(mcp_client_session: ClientSession) -> None:
+    res = await mcp_client_session.list_tools()
+    tools = set(tool.name for tool in res.tools)
+
+    assert "echo_tool" in tools
+
+
+@pytest.mark.anyio
+async def test_list_prompts(mcp_client_session: ClientSession) -> None:
+    res = await mcp_client_session.list_prompts()
+    prompts = set(prompt.name for prompt in res.prompts)
+
+    assert "echo_prompt" in prompts
+
+
+if __name__ == "__main__":
+    server().run()


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This PR introduces end-to-end tests to detect potential miscommunication issues between servers and clients (e.g. #280).

The implementation includes:
- Basic end-to-end test suite using an Echo server
- Verification of session initialization
- Testing of resource templates, tools, and prompts listing functionality

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
End-to-end testing is essential for validating reliable communication between servers and clients, ensuring system integrity and proper interaction across components.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

This PR only adds new tests and doesn't change any existing code.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
