### PR TITLE
fix: Add checks and better error messages on server object for mcp run

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ python server.py
 mcp run server.py
 ```
 
+Note that `mcp run` or `mcp dev` only supports server using FastMCP and not the low-level server variant.
+
 ### Streamable HTTP Transport
 
 > **Note**: Streamable HTTP transport is superseding SSE transport for production deployments.
@@ -693,6 +695,8 @@ if __name__ == "__main__":
 
     asyncio.run(run())
 ```
+
+Caution: The `mcp run` and `mcp dev` tool doesn't support low-level server.
 
 ### Writing MCP Clients
 


### PR DESCRIPTION
mcp run/dev command expects the server object in the python file to be a global variable, and it must be of the FastMCP type and not the low level Server type. The previous error messages may be confusing to users who are not aware of these facts.

## Motivation and Context
It is a bit confusing to users who tries to run an MCP server of the low level Server variant with the mcp run command and get unrelated error messages.

## How Has This Been Tested?
Run an MCP server of the low level Server variant and check that the correct error message is displayed.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A

