### PR TITLE
Feat/sse server parameters client

### DIFF
--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,5 +1,6 @@
 from .client.session import ClientSession
 from .client.stdio import StdioServerParameters, stdio_client
+from .client.sse import SseServerParameters, sse_client
 from .server.session import ServerSession
 from .server.stdio import stdio_server
 from .shared.exceptions import McpError
@@ -101,12 +102,14 @@ __all__ = [
     "ServerResult",
     "ServerSession",
     "SetLevelRequest",
+    "SseServerParameters",
     "StdioServerParameters",
     "StopReason",
     "SubscribeRequest",
     "Tool",
     "ToolsCapability",
     "UnsubscribeRequest",
+    "sse_client",
     "stdio_client",
     "stdio_server",
     "CompleteRequest",

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -61,16 +61,16 @@ async def sse_client(
             logger.info(f"Connecting to SSE endpoint: {remove_request_params(url)}")
             async with httpx.AsyncClient(headers=headers) as client:
                 async with aconnect_sse(
-                        client,
-                        "GET",
-                        url,
-                        timeout=httpx.Timeout(timeout, read=sse_read_timeout),
+                    client,
+                    "GET",
+                    url,
+                    timeout=httpx.Timeout(timeout, read=sse_read_timeout),
                 ) as event_source:
                     event_source.response.raise_for_status()
                     logger.debug("SSE connection established")
 
                     async def sse_reader(
-                            task_status: TaskStatus[str] = anyio.TASK_STATUS_IGNORED,
+                        task_status: TaskStatus[str] = anyio.TASK_STATUS_IGNORED,
                     ):
                         try:
                             async for sse in event_source.aiter_sse():
@@ -85,9 +85,9 @@ async def sse_client(
                                         url_parsed = urlparse(url)
                                         endpoint_parsed = urlparse(endpoint_url)
                                         if (
-                                                url_parsed.netloc != endpoint_parsed.netloc
-                                                or url_parsed.scheme
-                                                != endpoint_parsed.scheme
+                                            url_parsed.netloc != endpoint_parsed.netloc
+                                            or url_parsed.scheme
+                                            != endpoint_parsed.scheme
                                         ):
                                             error_msg = (
                                                 "Endpoint origin does not match "


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

I added the SseServerParameters class to client/sse.py


## Motivation and Context
I noticed that Stdio have StidoServerParameters, and it's a nice way to organize it. When I tried to use the same from SSE, I found that it doesn't export SseServerParameters. Hence the nature of this pull request. For reference, the typescript SDK does export different classes for Stdio and Sse. And the initial steps have been taken in the python sdk with StdioServerParameters. SseServerParameters class is a simple change that takes a step to a more maintainable codebase.

## How Has This Been Tested?
Tested with SSE servers in deployed application

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Yes, this is a breaking change because it changes how the Sse server is instantiated but 1) this should've been in the sdk, it's a pattern used in the stdioserver of this same repo, and in the typescript versions of the sdk. 2) it's early enough that barely anyone has written SSE servers since most people focusde on STDIO, so this is a good time to add this as it's still early.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [no tests for sse] New and existing tests pass locally
- [x] I have added appropriate error handling
- [] I have added or updated documentation as needed


