### PR TITLE
refactor: remove StdioServerParameters class

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,15 +521,8 @@ if __name__ == "__main__":
 The SDK provides a high-level client interface for connecting to MCP servers:
 
 ```python
-from mcp import ClientSession, StdioServerParameters, types
+from mcp import ClientSession, types
 from mcp.client.stdio import stdio_client
-
-# Create server parameters for stdio connection
-server_params = StdioServerParameters(
-    command="python",  # Executable
-    args=["example_server.py"],  # Optional command line arguments
-    env=None,  # Optional environment variables
-)
 
 
 # Optional: create a sampling callback
@@ -548,7 +541,12 @@ async def handle_sampling_message(
 
 
 async def run():
-    async with stdio_client(server_params) as (read, write):
+    # Connect to server using stdio transport
+    async with stdio_client(
+        command="python",  # Executable
+        args=["example_server.py"],  # Optional command line arguments
+        env=None,  # Optional environment variables
+    ) as (read, write):
         async with ClientSession(
             read, write, sampling_callback=handle_sampling_message
         ) as session:

--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,5 +1,5 @@
 from .client.session import ClientSession
-from .client.stdio import StdioServerParameters, stdio_client
+from .client.stdio import stdio_client
 from .server.session import ServerSession
 from .server.stdio import stdio_server
 from .shared.exceptions import McpError
@@ -101,7 +101,6 @@ __all__ = [
     "ServerResult",
     "ServerSession",
     "SetLevelRequest",
-    "StdioServerParameters",
     "StopReason",
     "SubscribeRequest",
     "Tool",

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -2,7 +2,7 @@ import shutil
 
 import pytest
 
-from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.stdio import stdio_client
 from mcp.types import JSONRPCMessage, JSONRPCRequest, JSONRPCResponse
 
 tee: str = shutil.which("tee")  # type: ignore
@@ -11,9 +11,7 @@ tee: str = shutil.which("tee")  # type: ignore
 @pytest.mark.anyio
 @pytest.mark.skipif(tee is None, reason="could not find tee command")
 async def test_stdio_client():
-    server_parameters = StdioServerParameters(command=tee)
-
-    async with stdio_client(server_parameters) as (read_stream, write_stream):
+    async with stdio_client(command=tee) as (read_stream, write_stream):
         # Test sending and receiving messages
         messages = [
             JSONRPCMessage(root=JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")),


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

client/stdio and client/sse use two different patterns for initialization, this PR tries to standardize it after discussions with @Kludex  by removing StdioServerParameters

## Motivation and Context
Continuation to the discussion here:  https://github.com/modelcontextprotocol/python-sdk/pull/300

## How Has This Been Tested?
Testing with Claude Desktop's config

## Breaking Changes
This is a breaking change to how Stdio is initialized, it is no longer done via StdioServerParameters

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
