### PR TITLE
Option to mount SSE server to existing ASGI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,11 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("My App")
 
 # Mount the SSE server to the existing ASGI server
-app = Starlette(routes=[
-    Mount('/', app=mcp.sse_app())
-])
+app = Starlette(
+    routes=[
+        Mount('/', app=mcp.sse_app()),
+    ]
+)
 
 # or dynamically mount as host
 app.router.routes.append(Host('mcp.acme.corp', app=mcp.sse_app()))

--- a/README.md
+++ b/README.md
@@ -352,15 +352,23 @@ mcp run server.py
 You can mount the SSE server to an existing ASGI server using the `sse_app` method. This allows you to integrate the SSE server with other ASGI applications.
 
 ```python
-from fastapi import FastAPI
+from starlette.applications import Starlette
+from starlette.routes import Mount, Host
 from mcp.server.fastmcp import FastMCP
 
-app = FastAPI()
+
 mcp = FastMCP("My App")
 
 # Mount the SSE server to the existing ASGI server
-app.mount('/', mcp.sse_app())
+app = Starlette(routes=[
+    Mount('/', app=mcp.sse_app())
+])
+
+# or dynamically mount as host
+app.router.routes.append(Host('mcp.acme.corp', app=mcp.sse_app()))
 ```
+
+For more information on mounting applications in Starlette, see the [Starlette documentation](https://www.starlette.io/routing/#submounting-routes).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
   - [Development Mode](#development-mode)
   - [Claude Desktop Integration](#claude-desktop-integration)
   - [Direct Execution](#direct-execution)
+  - [Mounting to an Existing ASGI Server](#mounting-to-an-existing-asgi-server)
 - [Examples](#examples)
   - [Echo Server](#echo-server)
   - [SQLite Explorer](#sqlite-explorer)
@@ -344,6 +345,21 @@ Run it with:
 python server.py
 # or
 mcp run server.py
+```
+
+### Mounting to an Existing ASGI Server
+
+You can mount the SSE server to an existing ASGI server using the `sse_app` method. This allows you to integrate the SSE server with other ASGI applications.
+
+```python
+from fastapi import FastAPI
+from mcp.server.fastmcp import FastMCP
+
+app = FastAPI()
+mcp = FastMCP("My App")
+
+# Mount the SSE server to the existing ASGI server
+app.mount('/', mcp.sse_app())
 ```
 
 ## Examples

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -19,6 +19,8 @@ import uvicorn
 from pydantic import BaseModel, Field
 from pydantic.networks import AnyUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
 
 from mcp.server.fastmcp.exceptions import ResourceError
 from mcp.server.fastmcp.prompts import Prompt, PromptManager

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -461,9 +461,6 @@ class FastMCP:
 
     async def run_sse_async(self) -> None:
         """Run the server using SSE transport."""
-        from starlette.applications import Starlette
-        from starlette.routing import Mount, Route
-
         starlette_app = self.sse_app()
 
         config = uvicorn.Config(
@@ -477,9 +474,6 @@ class FastMCP:
 
     def sse_app(self) -> Starlette:
         """Return an instance of the SSE server app."""
-        from starlette.applications import Starlette
-        from starlette.routing import Mount, Route
-
         sse = SseServerTransport("/messages/")
 
         async def handle_sse(request):


### PR DESCRIPTION
Fixes #311

Add option to mount SSE server to an existing ASGI server.

* Add a new method `sse_app` in `src/mcp/server/fastmcp/server.py` to return an instance of the SSE server app.
* Update the `run_sse_async` method in `src/mcp/server/fastmcp/server.py` to use the new `sse_app` method.
* Update the documentation in `README.md` to include instructions on how to mount the SSE server to an existing ASGI server.
* Fix the example in `README.md` to use `app.mount('/', mcp.sse_app())` instead.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/modelcontextprotocol/python-sdk/pull/312?shareId=80243589-c9c6-48c9-a9f3-d604c7bcb710).