### PR TITLE
docs(examples): fixing the prompts example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ async def fetch_weather(city: str) -> str:
 Prompts are reusable templates that help LLMs interact with your server effectively:
 
 ```python
-from mcp.server.fastmcp import FastMCP, types
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.prompts import base
 
 mcp = FastMCP("My App")
 
@@ -249,11 +250,11 @@ def review_code(code: str) -> str:
 
 
 @mcp.prompt()
-def debug_error(error: str) -> list[types.Message]:
+def debug_error(error: str) -> list[base.Message]:
     return [
-        types.UserMessage("I'm seeing this error:"),
-        types.UserMessage(error),
-        types.AssistantMessage("I'll help debug that. What have you tried so far?"),
+        base.UserMessage("I'm seeing this error:"),
+        base.UserMessage(error),
+        base.AssistantMessage("I'll help debug that. What have you tried so far?"),
     ]
 ```
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The example provided under the Prompts section in the Readme doesn't work due to `types` not being importable from `mcp.server.fastmcp`. If someone is using this library for the first time, seeing this error results in bad user/developer experience
<img width="657" alt="image" src="https://github.com/user-attachments/assets/32e1fc87-94de-44f9-beeb-25d0a745e75c" />

In this change, the existing example was corrected with the proper imports and tested by running locally. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
After the example was fixed, the example was run locally with the latest version of the library. 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
