### PR TITLE
Fix #201: Move incoming message stream from BaseSession to ServerSession

### DIFF
--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -92,7 +92,7 @@ class ServerSession(
         self._initialization_state = InitializationState.NotInitialized
         self._init_options = init_options
         self._incoming_message_stream_writer, self._incoming_message_stream_reader = (
-            anyio.create_memory_object_stream[ServerRequestResponder]()
+            anyio.create_memory_object_stream[ServerRequestResponder](0)
         )
         self._exit_stack.push_async_callback(
             lambda: self._incoming_message_stream_reader.aclose()
@@ -308,7 +308,7 @@ class ServerSession(
         )
 
     async def _handle_incoming(self, req: ServerRequestResponder) -> None:
-        return await self._incoming_message_stream_writer.send(req)
+        await self._incoming_message_stream_writer.send(req)
 
     @property
     def incoming_messages(

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -61,6 +61,12 @@ class InitializationState(Enum):
 
 ServerSessionT = TypeVar("ServerSessionT", bound="ServerSession")
 
+ServerRequestResponder = (
+    RequestResponder[types.ClientRequest, types.ServerResult]
+    | types.ClientNotification
+    | Exception
+)
+
 
 class ServerSession(
     BaseSession[
@@ -85,6 +91,15 @@ class ServerSession(
         )
         self._initialization_state = InitializationState.NotInitialized
         self._init_options = init_options
+        self._incoming_message_stream_writer, self._incoming_message_stream_reader = (
+            anyio.create_memory_object_stream[ServerRequestResponder]()
+        )
+        self._exit_stack.push_async_callback(
+            lambda: self._incoming_message_stream_reader.aclose()
+        )
+        self._exit_stack.push_async_callback(
+            lambda: self._incoming_message_stream_writer.aclose()
+        )
 
     @property
     def client_params(self) -> types.InitializeRequestParams | None:
@@ -291,3 +306,12 @@ class ServerSession(
                 )
             )
         )
+
+    async def _handle_incoming(self, req: ServerRequestResponder) -> None:
+        return await self._incoming_message_stream_writer.send(req)
+
+    @property
+    def incoming_messages(
+        self,
+    ) -> MemoryObjectReceiveStream[ServerRequestResponder]:
+        return self._incoming_message_stream_reader

--- a/src/mcp/shared/memory.py
+++ b/src/mcp/shared/memory.py
@@ -9,7 +9,13 @@ from typing import AsyncGenerator
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
-from mcp.client.session import ClientSession, ListRootsFnT, LoggingFnT, SamplingFnT
+from mcp.client.session import (
+    ClientSession,
+    ListRootsFnT,
+    LoggingFnT,
+    MessageHandlerFnT,
+    SamplingFnT,
+)
 from mcp.server import Server
 from mcp.types import JSONRPCMessage
 
@@ -57,6 +63,7 @@ async def create_connected_server_and_client_session(
     sampling_callback: SamplingFnT | None = None,
     list_roots_callback: ListRootsFnT | None = None,
     logging_callback: LoggingFnT | None = None,
+    message_handler: MessageHandlerFnT | None = None,
     raise_exceptions: bool = False,
 ) -> AsyncGenerator[ClientSession, None]:
     """Creates a ClientSession that is connected to a running MCP server."""
@@ -86,6 +93,7 @@ async def create_connected_server_and_client_session(
                     sampling_callback=sampling_callback,
                     list_roots_callback=list_roots_callback,
                     logging_callback=logging_callback,
+                    message_handler=message_handler,
                 ) as client_session:
                     await client_session.initialize()
                     yield client_session

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -378,4 +378,4 @@ class BaseSession(
         | Exception,
     ) -> None:
         """A generic handler for incoming messages. Overwritten by subclasses."""
-        await anyio.lowlevel.checkpoint()
+        pass

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -182,19 +182,6 @@ class BaseSession(
         self._in_flight = {}
 
         self._exit_stack = AsyncExitStack()
-        self._incoming_message_stream_writer, self._incoming_message_stream_reader = (
-            anyio.create_memory_object_stream[
-                RequestResponder[ReceiveRequestT, SendResultT]
-                | ReceiveNotificationT
-                | Exception
-            ]()
-        )
-        self._exit_stack.push_async_callback(
-            lambda: self._incoming_message_stream_reader.aclose()
-        )
-        self._exit_stack.push_async_callback(
-            lambda: self._incoming_message_stream_writer.aclose()
-        )
 
     async def __aenter__(self) -> Self:
         self._task_group = anyio.create_task_group()
@@ -300,11 +287,10 @@ class BaseSession(
         async with (
             self._read_stream,
             self._write_stream,
-            self._incoming_message_stream_writer,
         ):
             async for message in self._read_stream:
                 if isinstance(message, Exception):
-                    await self._incoming_message_stream_writer.send(message)
+                    await self._handle_incoming(message)
                 elif isinstance(message.root, JSONRPCRequest):
                     validated_request = self._receive_request_type.model_validate(
                         message.root.model_dump(
@@ -325,7 +311,7 @@ class BaseSession(
                     self._in_flight[responder.request_id] = responder
                     await self._received_request(responder)
                     if not responder._completed:
-                        await self._incoming_message_stream_writer.send(responder)
+                        await self._handle_incoming(responder)
 
                 elif isinstance(message.root, JSONRPCNotification):
                     try:
@@ -341,9 +327,7 @@ class BaseSession(
                                 await self._in_flight[cancelled_id].cancel()
                         else:
                             await self._received_notification(notification)
-                            await self._incoming_message_stream_writer.send(
-                                notification
-                            )
+                            await self._handle_incoming(notification)
                     except Exception as e:
                         # For other validation errors, log and continue
                         logging.warning(
@@ -355,7 +339,7 @@ class BaseSession(
                     if stream:
                         await stream.send(message.root)
                     else:
-                        await self._incoming_message_stream_writer.send(
+                        await self._handle_incoming(
                             RuntimeError(
                                 "Received response with an unknown "
                                 f"request ID: {message}"
@@ -387,12 +371,11 @@ class BaseSession(
         processed.
         """
 
-    @property
-    def incoming_messages(
+    async def _handle_incoming(
         self,
-    ) -> MemoryObjectReceiveStream[
-        RequestResponder[ReceiveRequestT, SendResultT]
+        req: RequestResponder[ReceiveRequestT, SendResultT]
         | ReceiveNotificationT
-        | Exception
-    ]:
-        return self._incoming_message_stream_reader
+        | Exception,
+    ) -> None:
+        """A generic handler for incoming messages. Overwritten by subclasses."""
+        await anyio.lowlevel.checkpoint()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,53 @@
+import logging
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.sse import sse_client
+from mcp.client.stdio import stdio_client
+
+# disable httpx logs
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("httpcore.http11").setLevel(logging.CRITICAL)
+logging.getLogger("httpx").setLevel(logging.CRITICAL)
+logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
+
+code = """
+import numpy
+a = numpy.array([1, 2, 3])
+print(a)
+a
+"""
+
+
+async def call_tools(session: ClientSession):
+    # await session.initialize()
+    await session.set_logging_level("debug")
+    tools = await session.list_tools()
+    print(f"{tools=}")
+    result = await session.call_tool("run_python_code", {"python_code": code})
+    print(f"{result=}")
+
+
+async def sse():
+    async with sse_client("http://localhost:3001/sse") as (read, write):
+        async with ClientSession(read, write) as session:
+            await call_tools(session)
+
+
+async def stdio():
+    server_params = StdioServerParameters(
+        command="npx",
+        args=[
+            "--registry=https://registry.npmjs.org",
+            "@pydantic/mcp-run-python",
+            "stdio",
+        ],
+    )
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await call_tools(session)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(sse())

--- a/tests/client/test_logging_callback.py
+++ b/tests/client/test_logging_callback.py
@@ -1,11 +1,12 @@
 from typing import List, Literal
 
-import anyio
 import pytest
 
+import mcp.types as types
 from mcp.shared.memory import (
     create_connected_server_and_client_session as create_session,
 )
+from mcp.shared.session import RequestResponder
 from mcp.types import (
     LoggingMessageNotificationParams,
     TextContent,
@@ -46,40 +47,37 @@ async def test_logging_callback():
         )
         return True
 
-    async with anyio.create_task_group() as tg:
-        async with create_session(
-            server._mcp_server, logging_callback=logging_collector
-        ) as client_session:
+    # Create a message handler to catch exceptions
+    async def message_handler(
+        message: RequestResponder[types.ServerRequest, types.ClientResult]
+        | types.ServerNotification
+        | Exception,
+    ) -> None:
+        if isinstance(message, Exception):
+            raise message
 
-            async def listen_session():
-                try:
-                    async for message in client_session.incoming_messages:
-                        if isinstance(message, Exception):
-                            raise message
-                except anyio.EndOfStream:
-                    pass
+    async with create_session(
+        server._mcp_server,
+        logging_callback=logging_collector,
+        message_handler=message_handler,
+    ) as client_session:
+        # First verify our test tool works
+        result = await client_session.call_tool("test_tool", {})
+        assert result.isError is False
+        assert isinstance(result.content[0], TextContent)
+        assert result.content[0].text == "true"
 
-            tg.start_soon(listen_session)
-
-            # First verify our test tool works
-            result = await client_session.call_tool("test_tool", {})
-            assert result.isError is False
-            assert isinstance(result.content[0], TextContent)
-            assert result.content[0].text == "true"
-
-            # Now send a log message via our tool
-            log_result = await client_session.call_tool(
-                "test_tool_with_log",
-                {
-                    "message": "Test log message",
-                    "level": "info",
-                    "logger": "test_logger",
-                },
-            )
-            assert log_result.isError is False
-            assert len(logging_collector.log_messages) == 1
-            assert logging_collector.log_messages[
-                0
-            ] == LoggingMessageNotificationParams(
-                level="info", logger="test_logger", data="Test log message"
-            )
+        # Now send a log message via our tool
+        log_result = await client_session.call_tool(
+            "test_tool_with_log",
+            {
+                "message": "Test log message",
+                "level": "info",
+                "logger": "test_logger",
+            },
+        )
+        assert log_result.isError is False
+        assert len(logging_collector.log_messages) == 1
+        assert logging_collector.log_messages[0] == LoggingMessageNotificationParams(
+            level="info", logger="test_logger", data="Test log message"
+        )

--- a/tests/issues/test_88_random_error.py
+++ b/tests/issues/test_88_random_error.py
@@ -6,6 +6,7 @@ from typing import Sequence
 
 import anyio
 import pytest
+from anyio.abc import TaskStatus
 
 from mcp.client.session import ClientSession
 from mcp.server.lowlevel import Server
@@ -54,15 +55,21 @@ async def test_notification_validation_error(tmp_path: Path):
             return [TextContent(type="text", text=f"fast {request_count}")]
         return [TextContent(type="text", text=f"unknown {request_count}")]
 
-    async def server_handler(read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            server.create_initialization_options(),
-            raise_exceptions=True,
-        )
+    async def server_handler(
+        read_stream,
+        write_stream,
+        task_status: TaskStatus[str] = anyio.TASK_STATUS_IGNORED,
+    ):
+        with anyio.CancelScope() as scope:
+            task_status.started(scope)  # type: ignore
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+                raise_exceptions=True,
+            )
 
-    async def client(read_stream, write_stream):
+    async def client(read_stream, write_stream, scope):
         # Use a timeout that's:
         # - Long enough for fast operations (>10ms)
         # - Short enough for slow operations (<200ms)
@@ -90,22 +97,13 @@ async def test_notification_validation_error(tmp_path: Path):
             # proving server is still responsive
             result = await session.call_tool("fast")
             assert result.content == [TextContent(type="text", text="fast 3")]
+        scope.cancel()
 
     # Run server and client in separate task groups to avoid cancellation
     server_writer, server_reader = anyio.create_memory_object_stream(1)
     client_writer, client_reader = anyio.create_memory_object_stream(1)
 
-    server_ready = anyio.Event()
-
-    async def wrapped_server_handler(read_stream, write_stream):
-        server_ready.set()
-        await server_handler(read_stream, write_stream)
-
     async with anyio.create_task_group() as tg:
-        tg.start_soon(wrapped_server_handler, server_reader, client_writer)
-        # Wait for server to start and initialize
-        with anyio.fail_after(1):  # Timeout after 1 second
-            await server_ready.wait()
+        scope = await tg.start(server_handler, server_reader, client_writer)
         # Run client in a separate task to avoid cancellation
-        async with anyio.create_task_group() as client_tg:
-            client_tg.start_soon(client, client_reader, server_writer)
+        tg.start_soon(client, client_reader, server_writer, scope)


### PR DESCRIPTION
## Summary
- Move the incoming message stream from BaseSession to ServerSession where it's actually needed
- Add message_handler callback to ClientSession for direct handling of incoming messages
- Simplify client code by removing need for separate receive loop tasks

## Test plan
- All existing tests pass
- Added message_handler to ClientSession for optional direct message handling
- Refactored tests to use the new message handler pattern instead of listening to incoming message stream

Fixes #201

🤖 Generated with [Claude Code](https://claude.ai/code)