### PR TITLE
Use default environment even when `env` is provided

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -103,7 +103,11 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
 
     process = await anyio.open_process(
         [server.command, *server.args],
-        env=server.env if server.env is not None else get_default_environment(),
+        env=(
+            {**get_default_environment(), **server.env}
+            if server.env is not None
+            else get_default_environment()
+        ),
         stderr=errlog,
         cwd=server.cwd,
     )


### PR DESCRIPTION
Fixed issue #326 - MCP client with npx not working when env parameter of StdioServerParameters is set

## Motivation and Context
See issue #326
Discarding the output of `get_default_environment()` when server.env has additional variables doesn't make sense. A reasonable assumption is that setting `env` variables adds to what was there otherwise.

## How Has This Been Tested?
I tested it and it fixed the issue for me.

## Breaking Changes
If somebody relied on setting the `env` parameter to clear default environment variables then they would need to change their code.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
`None`
