### PR TITLE
feat(client/sse): allow to set the timeout of `POST /messages`

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -120,6 +120,7 @@ async def sse_client(
                                             mode="json",
                                             exclude_none=True,
                                         ),
+                                        timeout=httpx.Timeout(timeout, read=sse_read_timeout),
                                     )
                                     response.raise_for_status()
                                     logger.debug(

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -120,7 +120,10 @@ async def sse_client(
                                             mode="json",
                                             exclude_none=True,
                                         ),
-                                        timeout=httpx.Timeout(timeout, read=sse_read_timeout),
+                                        timeout=httpx.Timeout(
+                                            timeout,
+                                            read=sse_read_timeout,
+                                        ),
                                     )
                                     response.raise_for_status()
                                     logger.debug(


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Hello. I'm writing a plugin for [langgenius/dify](https://github.com/langgenius/dify) that can export `workflows` on Dify as MCP Servers.  
Due to Dify's plugin mechanism, connecting to [Dify's cloud edition](https://cloud.dify.ai) via HTTP takes a longer time. The `GET /sse` endpoint can set a timeout through the parameters of the `sse_client` method, while the `POST /messages` endpoint cannot, which results in the handshake phase not functioning properly.  
So I reused the parameters `read` and `sse_read_timeout` of the `sse_cient` method as timeout settings for `POST/messages`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
before: failed fast in 5s for timeout

![image](https://github.com/user-attachments/assets/6b3e71e0-77f9-4687-9492-acc68f582ff7)

after: ok for handshake phase (404 for `/messages` endpoint not fully implemented)

![image](https://github.com/user-attachments/assets/04ff72ac-7eb9-4b78-aa2f-72d900fad20c)


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Although it works now, but I still wonder is this ok to just reuse the `sse_read_timeout` as timeout param for `/messages` endpoint, or should I add a new param like `messages_read_timeout` for `sse_client()`?