### PR TITLE
fix: prevent process hanging in stdio_client context manager

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -159,4 +159,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
     ):
         tg.start_soon(stdout_reader)
         tg.start_soon(stdin_writer)
-        yield read_stream, write_stream
+        try:
+            yield read_stream, write_stream
+        finally:
+            process.terminate()


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Fixes #360 

## How Has This Been Tested?
Tested minimal example:
```
import asyncio

from mcp import ClientSession, StdioServerParameters
from mcp.client.stdio import stdio_client


async def run():
    server_params = StdioServerParameters(
        command="claude",
        args=["mcp", "serve"],
    )
    async with stdio_client(server_params) as (read, write):   
        async with ClientSession(read, write) as _:
            pass
        print("exit ClientSession")
    print("exit stdio_client")

if __name__ == "__main__":
    asyncio.run(run())
```

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
