### PR TITLE
fix: support custom path when use sse server

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -75,6 +75,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     port: int = 8000
     sse_path: str = "/sse"
     message_path: str = "/messages/"
+    transport_message_path: str = "messages/"
 
     # resource settings
     warn_on_duplicate_resources: bool = True
@@ -479,7 +480,7 @@ class FastMCP:
 
     def sse_app(self) -> Starlette:
         """Return an instance of the SSE server app."""
-        sse = SseServerTransport(self.settings.message_path)
+        sse = SseServerTransport(self.settings.transport_message_path)
 
         async def handle_sse(request: Request) -> None:
             async with sse.connect_sse(


### PR DESCRIPTION
Support custom path when use sse server

## Motivation and Context
I think when I use the SSE Server, it should support customizing the prefix path. Example: if sse's url is http://localhost:8000/some/path/to/sse, it should request http://localhost:8000/some/path/to/messages when sending messages

## How Has This Been Tested?
I've tested in my application

## Breaking Changes
Not necessary

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
