### PR TITLE
Fix typo in starlette import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ You can mount the SSE server to an existing ASGI server using the `sse_app` meth
 
 ```python
 from starlette.applications import Starlette
-from starlette.routes import Mount, Host
+from starlette.routing import Mount, Host
 from mcp.server.fastmcp import FastMCP
 
 


### PR DESCRIPTION

<!-- Provide a brief summary of your changes -->

Small docs fix for https://github.com/modelcontextprotocol/python-sdk/pull/312.

The [actual code](https://github.com/comfuture/python-sdk/blob/d29e0e9ca33445285c04bc53bcebdda3b1986181/src/mcp/server/fastmcp/server.py#L22-L23) uses `starlette.routing` which is the correct package name.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Typo in README.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Using the updated README example works as expected.

## Breaking Changes

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
