### PR TITLE
Fixes incorrect casting into int for numbers in string format

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -88,7 +88,7 @@ class FuncMetadata(BaseModel):
                     pre_parsed = json.loads(data[field_name])
                 except json.JSONDecodeError:
                     continue  # Not JSON - skip
-                if isinstance(pre_parsed, str):
+                if isinstance(pre_parsed, (str, int, float)):
                     # This is likely that the raw value is e.g. `"hello"` which we
                     # Should really be parsed as '"hello"' in Python - but if we parse
                     # it as JSON it'll turn into just 'hello'. So we skip it.

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -399,3 +399,18 @@ def test_complex_function_json_schema():
         "title": "complex_arguments_fnArguments",
         "type": "object",
     }
+
+
+def test_str_vs_int():
+    """
+    Test that string values are kept as strings even when they contain numbers,
+    while numbers are parsed correctly.
+    """
+
+    def func_with_str_and_int(a: str, b: int):
+        return a
+
+    meta = func_metadata(func_with_str_and_int)
+    result = meta.pre_parse_json({"a": "123", "b": 123})
+    assert result["a"] == "123"
+    assert result["b"] == 123


### PR DESCRIPTION
Fixes #316 

When a parameter in fastMCP is a number, but the type of the tool is string, it is regardless casted into int, and thus the tool fails. This issue was solved in the original FastMCP repo but apparently it was lost. I just added the code back as suggested together with its test.

Original fix
- https://github.com/jlowin/fastmcp/commit/07fc1042b5d7a9db287d23da4d9cc5c7c9dbb792

Current Issue report:
- https://github.com/modelcontextprotocol/python-sdk/issues/316
 
## Motivation and Context

Fixes tool input numbers being cast into `int` when they are specified as `str`. 

## How Has This Been Tested?

I added back the original test. It matches the errors I'm seeing when using FastMCP 1.5.0 in my project. 

## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
