### PR TITLE
Docs: Change README to correct pip installation command for MCP CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ uv add "mcp[cli]"
 
 Alternatively, for projects using pip for dependencies:
 ```bash
-pip install mcp
+pip install "mcp[cli]"
 ```
 
 ### Running the standalone MCP development tools


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
When I followed the installation instructions in the README and used `pip install mcp`, it did install something. However, when I ran `mcp dev server.py`, I encountered the following error:
```
Error: typer is required. Install with 'pip install mcp[cli]'
```
I then removed the previous installation and tried `pip install mcp[cli]`, and it finally worked.

## How Has This Been Tested?
I only modified the README, so I just ran the tests mentioned in CONTRIBUTING.md, and they all passed successfully.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
