### PR TITLE
fix: Update context logging type hints to match MCP spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,20 @@ The Model Context Protocol allows applications to provide context for LLMs in a 
 
 ### Adding MCP to your python project
 
-We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects. In a uv managed python project, add mcp to dependencies by:
+We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects. 
 
-```bash
-uv add "mcp[cli]"
-```
+If you haven't created a uv-managed project yet, create one:
+
+   ```bash
+   uv init mcp-server-demo
+   cd mcp-server-demo
+   ```
+
+   Then add MCP to your project dependencies:
+
+   ```bash
+   uv add "mcp[cli]"
+   ```
 
 Alternatively, for projects using pip for dependencies:
 ```bash

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -660,7 +660,7 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT]):
     async def log(
         self,
         level: Literal["debug", "info", "warning", "error"],
-        message: str,
+        message: Any,
         *,
         logger_name: str | None = None,
     ) -> None:
@@ -696,18 +696,38 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT]):
         return self.request_context.session
 
     # Convenience methods for common log levels
-    async def debug(self, message: str, **extra: Any) -> None:
-        """Send a debug log message."""
+    async def debug(self, message: Any, **extra: Any) -> None:
+        """Send a debug log message.
+        
+        Args:
+            message: The message to log. Can be any JSON-serializable type.
+            **extra: Additional structured data to include
+        """
         await self.log("debug", message, **extra)
 
-    async def info(self, message: str, **extra: Any) -> None:
-        """Send an info log message."""
+    async def info(self, message: Any, **extra: Any) -> None:
+        """Send an info log message.
+        
+        Args:
+            message: The message to log. Can be any JSON-serializable type.
+            **extra: Additional structured data to include
+        """
         await self.log("info", message, **extra)
 
-    async def warning(self, message: str, **extra: Any) -> None:
-        """Send a warning log message."""
+    async def warning(self, message: Any, **extra: Any) -> None:
+        """Send a warning log message.
+        
+        Args:
+            message: The message to log. Can be any JSON-serializable type.
+            **extra: Additional structured data to include
+        """
         await self.log("warning", message, **extra)
 
-    async def error(self, message: str, **extra: Any) -> None:
-        """Send an error log message."""
+    async def error(self, message: Any, **extra: Any) -> None:
+        """Send an error log message.
+        
+        Args:
+            message: The message to log. Can be any JSON-serializable type.
+            **extra: Additional structured data to include
+        """
         await self.log("error", message, **extra)


### PR DESCRIPTION
## Motivation and Context
According to the MCP spec, context logging functions should accept any JSON-serializable type as the message parameter.
#397 

## How Has This Been Tested?
this has been tested with :
Integers (42)
Lists (["list", "of", "items"])
Dictionaries ({"key": "value"})
Floating point numbers (3.14)
string

## Breaking Changes
None
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
