### PR TITLE
Docs : Enhance README to suggest commands for creating a new UV project before adding mcp dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,20 @@ The Model Context Protocol allows applications to provide context for LLMs in a 
 
 ### Adding MCP to your python project
 
-We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects. In a uv managed python project, add mcp to dependencies by:
+We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects. 
 
-```bash
-uv add "mcp[cli]"
-```
+If you haven't created a uv-managed project yet, create one:
+
+   ```bash
+   uv init mcp-server-demo
+   cd mcp-server-demo
+   ```
+
+   Then add MCP to your project dependencies:
+
+   ```bash
+   uv add "mcp[cli]"
+   ```
 
 Alternatively, for projects using pip for dependencies:
 ```bash


### PR DESCRIPTION
Enhanced README to include suggestion for creating a uv project before adding mcp dependency.


<!-- Provide a brief summary of your changes -->

## Motivation and Context
Personally whenever I read docs, I go on executing series of commands to do initial setup. But here I found hyperlink to UV which had docs to install UV, but didnt had any mention about creation of project. Hence running `uv add "mcp[cli]"` was ending up with error.

Only once I did `$uv --help` to understand how to create a new project and then `uv add "mcp[cli]"` started working.
Might seem simple, but for many people with new tech stacks, will end up spending some time to realize this.
Hence adding it directly in the docs to help quickly setup MCP python sdk.

## How Has This Been Tested?
I have done a preview of README and verified changes
<img width="640" alt="image" src="https://github.com/user-attachments/assets/663ebf24-3ce1-4622-b254-3d814d23ddf1" />


## Breaking Changes
NA

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [x ] New and existing tests pass locally
- [x ] I have added appropriate error handling
- [x ] I have added or updated documentation as needed

## Additional context
NA
