### PR TITLE
Streamable HTTP client transport

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -97,6 +97,7 @@ class ClientSession(
         list_roots_callback: ListRootsFnT | None = None,
         logging_callback: LoggingFnT | None = None,
         message_handler: MessageHandlerFnT | None = None,
+        supported_protocol_versions: tuple[str | int, ...] | None = None,
     ) -> None:
         super().__init__(
             read_stream,
@@ -109,6 +110,9 @@ class ClientSession(
         self._list_roots_callback = list_roots_callback or _default_list_roots_callback
         self._logging_callback = logging_callback or _default_logging_callback
         self._message_handler = message_handler or _default_message_handler
+        self._supported_protocol_versions = (
+            supported_protocol_versions or SUPPORTED_PROTOCOL_VERSIONS
+        )
 
     async def initialize(self) -> types.InitializeResult:
         sampling = types.SamplingCapability()
@@ -137,7 +141,7 @@ class ClientSession(
             types.InitializeResult,
         )
 
-        if result.protocolVersion not in SUPPORTED_PROTOCOL_VERSIONS:
+        if result.protocolVersion not in self._supported_protocol_versions:
             raise RuntimeError(
                 "Unsupported protocol version from the server: "
                 f"{result.protocolVersion}"

--- a/src/mcp/client/streamable.py
+++ b/src/mcp/client/streamable.py
@@ -95,8 +95,11 @@ async def streamable_client(
                                         *headers,
                                     ),
                                 )
+                                content_type = response.headers.get("content-type")
                                 logger.debug(
-                                    f"response {url=} content-type={response.headers.get("content-type")} body={response.text}"
+                                    f"response {url=} "
+                                    f"content-type={content_type} "
+                                    f"body={response.text}"
                                 )
 
                                 response.raise_for_status()

--- a/src/mcp/client/streamable.py
+++ b/src/mcp/client/streamable.py
@@ -1,0 +1,178 @@
+import logging
+from contextlib import asynccontextmanager
+
+import anyio
+import httpx
+from httpx_sse import EventSource
+from pydantic import TypeAdapter
+
+import mcp.types as types
+from mcp.client.sse import sse_client
+
+logger = logging.getLogger(__name__)
+
+STREAMABLE_PROTOCOL_VERSION = "2025-03-26"
+SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
+    types.LATEST_PROTOCOL_VERSION,
+    STREAMABLE_PROTOCOL_VERSION,
+)
+
+
+@asynccontextmanager
+async def streamable_client(
+    url: str,
+    timeout: float = 5,
+):
+    """
+    Client transport for streamable HTTP, with fallback to SSE.
+    """
+    if await _is_old_sse_server(url, timeout):
+        async with sse_client(url) as (read_stream, write_stream):
+            yield read_stream, write_stream
+        return
+
+    read_stream_writer, read_stream = anyio.create_memory_object_stream[
+        types.JSONRPCMessage | Exception
+    ](0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream[
+        types.JSONRPCMessage
+    ](0)
+
+    async def handle_response(text: str) -> None:
+        items = _maybe_list_adapter.validate_json(text)
+        if isinstance(items, types.JSONRPCMessage):
+            items = [items]
+        for item in items:
+            await read_stream_writer.send(item)
+
+    headers: tuple[tuple[str, str], ...] = ()
+
+    async with anyio.create_task_group() as tg:
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+
+                async def sse_reader(event_source: EventSource):
+                    try:
+                        async for sse in event_source.aiter_sse():
+                            logger.debug(f"Received SSE event: {sse.event}")
+                            match sse.event:
+                                case "message":
+                                    try:
+                                        await handle_response(sse.data)
+                                        logger.debug(
+                                            f"Received server message: {sse.data}"
+                                        )
+                                    except Exception as exc:
+                                        logger.error(
+                                            f"Error parsing server message: {exc}"
+                                        )
+                                        await read_stream_writer.send(exc)
+                                        continue
+                                case _:
+                                    logger.warning(f"Unknown SSE event: {sse.event}")
+                    except Exception as exc:
+                        logger.error(f"Error in sse_reader: {exc}")
+                        await read_stream_writer.send(exc)
+                    finally:
+                        await read_stream_writer.aclose()
+
+                async def post_writer():
+                    nonlocal headers
+                    try:
+                        async with write_stream_reader:
+                            async for message in write_stream_reader:
+                                logger.debug(f"Sending client message: {message}")
+                                response = await client.post(
+                                    url,
+                                    json=message.model_dump(
+                                        by_alias=True,
+                                        mode="json",
+                                        exclude_none=True,
+                                    ),
+                                    headers=(
+                                        ("accept", "application/json"),
+                                        ("accept", "text/event-stream"),
+                                        *headers,
+                                    ),
+                                )
+                                logger.debug(
+                                    f"response {url=} content-type={response.headers.get("content-type")} body={response.text}"
+                                )
+
+                                response.raise_for_status()
+                                match response.headers.get("mcp-session-id"):
+                                    case str() as session_id:
+                                        headers = (("mcp-session-id", session_id),)
+                                    case _:
+                                        pass
+
+                                match response.headers.get("content-type"):
+                                    case "text/event-stream":
+                                        await sse_reader(EventSource(response))
+                                    case "application/json":
+                                        await handle_response(response.text)
+                                    case None:
+                                        pass
+                                    case unknown:
+                                        logger.warning(
+                                            f"Unknown content type: {unknown}"
+                                        )
+
+                                logger.debug(
+                                    "Client message sent successfully: "
+                                    f"{response.status_code}"
+                                )
+                    except Exception as exc:
+                        logger.error(f"Error in post_writer: {exc}", exc_info=True)
+                    finally:
+                        await write_stream.aclose()
+
+                tg.start_soon(post_writer)
+
+                try:
+                    yield read_stream, write_stream
+                finally:
+                    tg.cancel_scope.cancel()
+        finally:
+            await read_stream_writer.aclose()
+            await write_stream.aclose()
+
+
+_maybe_list_adapter: TypeAdapter[types.JSONRPCMessage | list[types.JSONRPCMessage]] = (
+    TypeAdapter(types.JSONRPCMessage | list[types.JSONRPCMessage])
+)
+
+
+async def _is_old_sse_server(url: str, timeout: float) -> bool:
+    """
+    Test whether this is an old SSE MCP server.
+
+    See: https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/#backwards-compatibility
+    """
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        test_initialize_request = types.InitializeRequest(
+            method="initialize",
+            params=types.InitializeRequestParams(
+                protocolVersion=STREAMABLE_PROTOCOL_VERSION,
+                capabilities=types.ClientCapabilities(),
+                clientInfo=types.Implementation(name="mcp", version="0.1.0"),
+            ),
+        )
+        response = await client.post(
+            url,
+            json=types.JSONRPCRequest(
+                jsonrpc="2.0",
+                id=1,
+                method=test_initialize_request.method,
+                params=test_initialize_request.params.model_dump(
+                    by_alias=True, mode="json", exclude_none=True
+                ),
+            ).model_dump(by_alias=True, mode="json", exclude_none=True),
+            headers=(
+                ("accept", "application/json"),
+                ("accept", "text/event-stream"),
+            ),
+        )
+        if 400 <= response.status_code < 500:
+            return True
+    return False

--- a/src/mcp/client/streamable.py
+++ b/src/mcp/client/streamable.py
@@ -75,8 +75,6 @@ async def streamable_client(
                     except Exception as exc:
                         logger.error(f"Error in sse_reader: {exc}")
                         await read_stream_writer.send(exc)
-                    finally:
-                        await read_stream_writer.aclose()
 
                 async def post_writer():
                     nonlocal headers

--- a/src/mcp/client/streamable.py
+++ b/src/mcp/client/streamable.py
@@ -29,7 +29,7 @@ async def streamable_client(
     Client transport for streamable HTTP, with fallback to SSE.
     """
     if await _is_old_sse_server(url, timeout):
-        async with sse_client(url) as (read_stream, write_stream):
+        async with sse_client(url, headers=headers) as (read_stream, write_stream):
             yield read_stream, write_stream
         return
 

--- a/src/mcp/client/streamable.py
+++ b/src/mcp/client/streamable.py
@@ -28,7 +28,7 @@ async def streamable_client(
     """
     Client transport for streamable HTTP, with fallback to SSE.
     """
-    if await _is_old_sse_server(url, timeout):
+    if await _is_old_sse_server(url, headers=headers, timeout=timeout):
         async with sse_client(url, headers=headers) as (read_stream, write_stream):
             yield read_stream, write_stream
         return
@@ -148,7 +148,11 @@ _maybe_list_adapter: TypeAdapter[types.JSONRPCMessage | list[types.JSONRPCMessag
 )
 
 
-async def _is_old_sse_server(url: str, timeout: float) -> bool:
+async def _is_old_sse_server(
+    url: str,
+    headers: dict[str, Any] | None,
+    timeout: float,
+) -> bool:
     """
     Test whether this is an old SSE MCP server.
 
@@ -176,6 +180,7 @@ async def _is_old_sse_server(url: str, timeout: float) -> bool:
             headers=(
                 ("accept", "application/json"),
                 ("accept", "text/event-stream"),
+                *(headers or {}).items(),
             ),
         )
         if 400 <= response.status_code < 500:


### PR DESCRIPTION
Client implementation of spec version 2025-03-26's new transport.

## Motivation and Context
The 2025-03-26 spec introduces a new HTTP transport mechanism (with fallback to the previous one). I didn't see a reference implementation available yet so we've made this experimental one.

## How Has This Been Tested?
We've tested with local and remote MCP servers in our product ([Lutra](https://lutra.ai)).

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
This is a draft. I'm not sure how the maintainers would like to handle updating `LATEST_PROTOCOL_VERSION` and `SUPPORTED_PROTOCOL_VERSIONS`. And I don't have automated tests for the new transport.