### PR TITLE
Fix: Use absolute path to uv executable in Claude Desktop config

### DIFF
--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 from typing import Any
+import shutil
 
 from mcp.server.fastmcp.utilities.logging import get_logger
 
@@ -30,6 +31,16 @@ def get_claude_config_path() -> Path | None:
         return path
     return None
 
+def get_uv_path() -> str:
+    """Get the full path to the uv executable."""
+    uv_path = shutil.which("uv")
+    if not uv_path:
+        logger.error(
+            "uv executable not found in PATH, falling back to 'uv'. "
+            "Please ensure uv is installed and in your PATH"
+        )
+        return "uv"  # Fall back to just "uv" if not found
+    return uv_path
 
 def update_claude_config(
     file_spec: str,
@@ -54,6 +65,7 @@ def update_claude_config(
             Claude Desktop may not be installed or properly set up.
     """
     config_dir = get_claude_config_path()
+    uv_path = get_uv_path()
     if not config_dir:
         raise RuntimeError(
             "Claude Desktop config directory not found. Please ensure Claude Desktop"
@@ -117,7 +129,7 @@ def update_claude_config(
         # Add fastmcp run command
         args.extend(["mcp", "run", file_spec])
 
-        server_config: dict[str, Any] = {"command": "uv", "args": args}
+        server_config: dict[str, Any] = {"command": uv_path, "args": args}
 
         # Add environment variables if specified
         if env_vars:


### PR DESCRIPTION
When calling 'mcp install', the Claude Desktop config is updated with just
'uv' as the command rather than the full path to the executable. This can
cause Claude Desktop to fail when it can't find uv in its PATH.

This change locates the absolute path of the uv executable and uses that
in the configuration, with a fallback to the plain 'uv' command if not found.


## Motivation and Context
This bug was causing significant frustration for developers using Claude Desktop integration with MCP servers. The problem was particularly difficult to diagnose for new users who might not understand why Claude Desktop couldn't find the uv command.
The fix ensures a more reliable developer experience by removing configuration-related obstacles that might block effective use of the MCP tools.

## How Has This Been Tested?
Yes tested it locally and it works properly.

## Breaking Changes
Nope

## Types of changes
- [✔ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ✔] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [✔ ] My code follows the repository's style guidelines
- [✔ ] New and existing tests pass locally
- [ ✔] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
