### PR TITLE
Add optional headers argument to websocket transport

### DIFF
--- a/src/mcp/client/websocket.py
+++ b/src/mcp/client/websocket.py
@@ -50,7 +50,9 @@ async def websocket_client(
     write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
 
     # Connect using websockets, requesting the "mcp" subprotocol
-    async with ws_connect(url, subprotocols=[Subprotocol("mcp")], additional_headers=headers) as ws:
+    async with ws_connect(
+        url, subprotocols=[Subprotocol("mcp")], additional_headers=headers
+    ) as ws:
 
         async def ws_reader():
             """

--- a/src/mcp/client/websocket.py
+++ b/src/mcp/client/websocket.py
@@ -2,6 +2,7 @@ import json
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Any
 
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def websocket_client(
     url: str,
+    headers: dict[str, Any] | None = None,
 ) -> AsyncGenerator[
     tuple[
         MemoryObjectReceiveStream[types.JSONRPCMessage | Exception],
@@ -48,7 +50,7 @@ async def websocket_client(
     write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
 
     # Connect using websockets, requesting the "mcp" subprotocol
-    async with ws_connect(url, subprotocols=[Subprotocol("mcp")]) as ws:
+    async with ws_connect(url, subprotocols=[Subprotocol("mcp")], additional_headers=headers) as ws:
 
         async def ws_reader():
             """


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This is a small PR to expose the additional_headers param on ws_connect through a new 'headers' argument in the websocket transport

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This enables users to pass through custom headers that the MCP server might require for auth, remote customization, version headers, or otherwise. Currently, the SSE transport supports settings headers, but the WS transport does not.

I am aware that the JS Websocket implementation only allows setting the Sec-WebSocket-Protocol header, so adding headers to all SDKs might be tricky, but I think it's better to expose the ability to set these headers where we can.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Will work the exact same as the current WS transport. The receiving server can now view the headers sent in the handshake request.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
