### PR TITLE
Upgrade types.py to 2025-03-26 protocol version

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -347,7 +347,9 @@ class BaseSession(
                             f"Failed to validate notification: {e}. "
                             f"Message was: {message.root}"
                         )
-                else:  # Response or error
+                elif isinstance(message.root, JSONRPCError) or isinstance(
+                    message.root, JSONRPCResponse
+                ):
                     stream = self._response_streams.pop(message.root.id, None)
                     if stream:
                         await stream.send(message.root)
@@ -358,6 +360,11 @@ class BaseSession(
                                 f"request ID: {message}"
                             )
                         )
+                else:
+                    # Couldn't be anything else.
+                    raise NotImplementedError(
+                        "Unhandled JSONRPCMessage type, message: " f"{message}"
+                    )
 
     async def _received_request(
         self, responder: RequestResponder[ReceiveRequestT, SendResultT]


### PR DESCRIPTION
This PR upgrades types.py to the 2025-03-26 protocol version.

## Motivation and Context
This is needed to support batch JSON RPC #444 

## How Has This Been Tested?
All tests and type check passed.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

