### PR TITLE
fix: fixed post writer error in long task tool

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -119,6 +119,8 @@ async def sse_client(
                                             by_alias=True,
                                             mode="json",
                                             exclude_none=True,
+                                            timeout=httpx.Timeout(timeout, read=sse_read_timeout),
+
                                         ),
                                     )
                                     response.raise_for_status()

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -120,7 +120,6 @@ async def sse_client(
                                             mode="json",
                                             exclude_none=True,
                                             timeout=httpx.Timeout(timeout, read=sse_read_timeout),
-
                                         ),
                                     )
                                     response.raise_for_status()


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
In tasks with a long duration, a post write error will occur. The reason is that the connection of the MCP has been disconnected. The timeout set in the application did not take effect. This is a bug.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
