### PR TITLE
Modify __init__ for sse_client when using thirdparty import

### DIFF
--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,4 +1,5 @@
 from .client.session import ClientSession
+from .client.sse import sse_client
 from .client.stdio import StdioServerParameters, stdio_client
 from .server.session import ServerSession
 from .server.stdio import stdio_server
@@ -107,6 +108,7 @@ __all__ = [
     "Tool",
     "ToolsCapability",
     "UnsubscribeRequest",
+    "sse_client",
     "stdio_client",
     "stdio_server",
     "CompleteRequest",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add sse_client import in top __init__.py file.
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When using mcp by lazy import in some Agent dev tools, cannot using sse_client as easily as stdio_client (mcp.client.sse.sse_client V.S. mcp.stdio_client), which is very uncomfortable and sometime may cause importing error.
After adding this change, user can import sse_client like stdio_client.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I have tested this using a open source framework called LazyLLM, after adding this change, bug wiil be fixed.
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No need to update, user can also use
``` from mcp import sse_client, stdio_client```
rather than
```
from mcp import stdio_client
from mcp.client.sse import sse_client
```
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
