### PR TITLE
fix: Update @mcp.resource to use function documentation as default descrip…

### DIFF
--- a/src/mcp/server/fastmcp/resources/types.py
+++ b/src/mcp/server/fastmcp/resources/types.py
@@ -76,7 +76,7 @@ class FunctionResource(Resource):
         name: str | None = None,
         description: str | None = None,
         mime_type: str | None = None,
-    ) -> Self:
+    ) -> "FunctionResource":
         """Create a FunctionResource from a function."""
         func_name = name or fn.__name__
         if func_name == "<lambda>":

--- a/src/mcp/server/fastmcp/resources/types.py
+++ b/src/mcp/server/fastmcp/resources/types.py
@@ -4,7 +4,7 @@ import inspect
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Self
+from typing import Any
 
 import anyio
 import anyio.to_thread

--- a/src/mcp/server/fastmcp/resources/types.py
+++ b/src/mcp/server/fastmcp/resources/types.py
@@ -77,7 +77,7 @@ class FunctionResource(Resource):
         description: str | None = None,
         mime_type: str | None = None,
     ) -> Self:
-        """Create a template from a function."""
+        """Create a FunctionResource from a function."""
         func_name = name or fn.__name__
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")

--- a/src/mcp/server/fastmcp/resources/types.py
+++ b/src/mcp/server/fastmcp/resources/types.py
@@ -4,7 +4,7 @@ import inspect
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 import anyio
 import anyio.to_thread
@@ -76,7 +76,7 @@ class FunctionResource(Resource):
         name: str | None = None,
         description: str | None = None,
         mime_type: str | None = None,
-    ):
+    ) -> Self:
         """Create a template from a function."""
         func_name = name or fn.__name__
         if func_name == "<lambda>":
@@ -87,7 +87,7 @@ class FunctionResource(Resource):
 
         return cls(
             uri=AnyUrl(uri),
-            name=name,
+            name=func_name,
             description=description or fn.__doc__ or "",
             mime_type=mime_type or "text/plain",
             fn=fn,

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -116,9 +116,11 @@ class FastMCP:
         self._mcp_server = MCPServer(
             name=name or "FastMCP",
             instructions=instructions,
-            lifespan=lifespan_wrapper(self, self.settings.lifespan)
-            if self.settings.lifespan
-            else default_lifespan,
+            lifespan=(
+                lifespan_wrapper(self, self.settings.lifespan)
+                if self.settings.lifespan
+                else default_lifespan
+            ),
         )
         self._tool_manager = ToolManager(
             warn_on_duplicate_tools=self.settings.warn_on_duplicate_tools
@@ -381,16 +383,16 @@ class FastMCP:
                     uri_template=uri,
                     name=name,
                     description=description,
-                    mime_type=mime_type or "text/plain",
+                    mime_type=mime_type,
                 )
             else:
                 # Register as regular resource
-                resource = FunctionResource(
-                    uri=AnyUrl(uri),
+                resource = FunctionResource.from_function(
+                    fn=fn,
+                    uri=uri,
                     name=name,
                     description=description,
-                    mime_type=mime_type or "text/plain",
-                    fn=fn,
+                    mime_type=mime_type,
                 )
                 self.add_resource(resource)
             return fn

--- a/tests/server/fastmcp/resources/test_function_resources.py
+++ b/tests/server/fastmcp/resources/test_function_resources.py
@@ -136,3 +136,22 @@ class TestFunctionResource:
         content = await resource.read()
         assert content == "Hello, world!"
         assert resource.mime_type == "text/plain"
+
+    @pytest.mark.anyio
+    async def test_from_function(self):
+        """Test creating a FunctionResource from a function."""
+
+        async def get_data() -> str:
+            """get_data returns a string"""
+            return "Hello, world!"
+
+        resource = FunctionResource.from_function(
+            fn=get_data,
+            uri="function://test",
+            name="test",
+        )
+
+        assert resource.description == "get_data returns a string"
+        assert resource.mime_type == "text/plain"
+        assert resource.name == "test"
+        assert resource.uri == AnyUrl("function://test")

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -348,6 +348,26 @@ class TestServerResources:
                 == base64.b64encode(b"Binary file data").decode()
             )
 
+    @pytest.mark.anyio
+    async def test_function_resource(self):
+        mcp = FastMCP()
+
+        @mcp.resource("function://test", name="test_get_data")
+        def get_data() -> str:
+            """get_data returns a string"""
+            return "Hello, world!"
+
+        async with client_session(mcp._mcp_server) as client:
+            resources = await client.list_resources()
+            assert len(resources.resources) == 1
+            resource = resources.resources[0]
+            assert resource.description == "get_data returns a string"
+            assert resource.uri == AnyUrl("function://test")
+            assert resource.name == "test_get_data"
+            assert resource.mimeType == "text/plain"
+            result = await client.read_resource(AnyUrl("function://test"))
+            assert result.contents[0].text == "Hello, world!"
+
 
 class TestServerResourceTemplates:
     @pytest.mark.anyio


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->
mcp.resource doesn't generate correctly description from func.doc.
see https://github.com/modelcontextprotocol/python-sdk/issues/488
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
generate correctly description from func.doc when param description is none.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
