### PR TITLE
Fix process termination in stdio client

### DIFF
--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -6,17 +6,16 @@ from typing import Literal, TextIO
 
 import anyio
 import anyio.lowlevel
-from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from anyio.streams.memory import (
+    MemoryObjectReceiveStream,
+    MemoryObjectSendStream,
+)
 from anyio.streams.text import TextReceiveStream
 from pydantic import BaseModel, Field
 
 import mcp.types as types
 
-from .win32 import (
-    create_windows_process,
-    get_windows_executable_command,
-    terminate_windows_process,
-)
+from .win32 import create_windows_process, get_windows_executable_command
 
 # Environment variables to inherit by default
 DEFAULT_INHERITED_ENV_VARS = (
@@ -173,10 +172,9 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
             yield read_stream, write_stream
         finally:
             # Clean up process to prevent any dangling orphaned processes
-            if sys.platform == "win32":
-                await terminate_windows_process(process)
-            else:
-                process.terminate()
+            tg.cancel_scope.cancel()
+            process.terminate()
+            await process.wait()
 
 
 def _get_executable_command(command: str) -> str:

--- a/src/mcp/client/stdio/win32.py
+++ b/src/mcp/client/stdio/win32.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TextIO
 
 import anyio
-from anyio.abc import Process
 
 
 def get_windows_executable_command(command: str) -> str:
@@ -86,24 +85,3 @@ async def create_windows_process(
             [command, *args], env=env, stderr=errlog, cwd=cwd
         )
         return process
-
-
-async def terminate_windows_process(process: Process):
-    """
-    Terminate a Windows process.
-
-    Note: On Windows, terminating a process with process.terminate() doesn't
-    always guarantee immediate process termination.
-    So we give it 2s to exit, or we call process.kill()
-    which sends a SIGKILL equivalent signal.
-
-    Args:
-        process: The process to terminate
-    """
-    try:
-        process.terminate()
-        with anyio.fail_after(2.0):
-            await process.wait()
-    except TimeoutError:
-        # Force kill if it doesn't terminate
-        process.kill()


### PR DESCRIPTION
**Github-Issue:** #391

- Added `tg.cancel_scope.cancel()` in the `finally` block of `stdio_client` to ensure that `stdin_writer` and `stdout_reader` tasks are properly cancelled  
- This ensures associated transports are closed before invoking `process.terminate()`  
- Removed the now-unnecessary `terminate_windows_process()` function

## Motivation and Context  
This change addresses a race condition specific to Windows' Proactor event loop, where ignored exceptions would occur during shutdown of the stdio client.  

The underlying problem was that subprocess transports (stdin/stdout) remained open when `process.terminate()` was called. On Windows, this could trigger a race during garbage collection and transport teardown, resulting in uncatchable exceptions.  

The previous workaround, `terminate_windows_process()`, attempted to mitigate this by waiting before forcefully terminating the process. However, on Windows, `kill()` is functionally identical to `terminate()`([https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.kill](url)), so the method provided no real benefit. Explicitly cancelling the stdio tasks ensures a clean and predictable shutdown.

## How Has This Been Tested?  
Tested on Windows 11 by repeatedly connecting and disconnecting multiple clients over stdio transport to multiple servers found both within the repository and using installed locally.  

The ignored exception could not be captured via standard exception handling (`try/except`, `sys.unraisablehook`, or pytest's `capsys` / `capfd`). As a result, an automated test was not feasible for this specific issue. All testing was conducted through repeated manual runs and verification of clean shutdown behavior.

## Breaking Changes  
No breaking changes are expected. The removed function, `terminate_windows_process()`, was internal and not designed for external use. Unless it was being used directly (which would be a misuse), no user code should be affected.

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update

## Checklist  
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)  
- [x] My code follows the repository's style guidelines  
- [ ] New and existing tests pass locally  
- [x] I have added appropriate error handling  
- [x] I have added or updated documentation as needed  

## Additional context  
There are two failing tests that predate this change:  
- `test_messages_are_executed_concurrently` fails with a timing difference of less than 5ms  
- `test_desktop` fails due to assumptions about POSIX-style file paths  

No changes to documentation or error handling were necessary for this fix.