### PR TITLE
Move uvicorn import to usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "starlette>=0.27",
     "sse-starlette>=1.6.1",
     "pydantic-settings>=2.5.2",
-    "uvicorn>=0.23.1",
+    "uvicorn>=0.23.1; sys_platform != 'emscripten'",
 ]
 
 [project.optional-dependencies]

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -15,7 +15,6 @@ from typing import Any, Generic, Literal
 
 import anyio
 import pydantic_core
-import uvicorn
 from pydantic import BaseModel, Field
 from pydantic.networks import AnyUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -466,6 +465,7 @@ class FastMCP:
 
     async def run_sse_async(self) -> None:
         """Run the server using SSE transport."""
+        import uvicorn
         starlette_app = self.sse_app()
 
         config = uvicorn.Config(

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
 
 [package.optional-dependencies]
@@ -540,7 +540,7 @@ requires-dist = [
     { name = "sse-starlette", specifier = ">=1.6.1" },
     { name = "starlette", specifier = ">=0.27" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.4" },
-    { name = "uvicorn", specifier = ">=0.23.1" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'", specifier = ">=0.23.1" },
     { name = "websockets", marker = "extra == 'ws'", specifier = ">=15.0.1" },
 ]
 provides-extras = ["cli", "rich", "ws"]


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
uvicorn is an optional dependency only used in one function but is imported at the global scope meaning mcp imports will fail if uvicorn is not available. This commit moves uvicorn import to usage in run_sse_async. It would be ideal to mark uvicorn as a default-on optional dependency but that isn't supported yet by pyproject.toml.

Pyodide and Emscripten don't support uvicorn but still work really well with the mcp package with this tiny change.

## How Has This Been Tested?
It was tested locally.

## Breaking Changes
Shouldn't be a breaking change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
