### PR TITLE
feat: use contextvar to pass process for easier access

### DIFF
--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -2,7 +2,7 @@ import shutil
 
 import pytest
 
-from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.stdio import PROCESS_VAR, StdioServerParameters, stdio_client
 from mcp.types import JSONRPCMessage, JSONRPCRequest, JSONRPCResponse
 
 tee: str = shutil.which("tee")  # type: ignore
@@ -33,6 +33,10 @@ async def test_stdio_client():
                 read_messages.append(message)
                 if len(read_messages) == 2:
                     break
+
+        process = PROCESS_VAR.get()
+        assert process is not None
+        assert process.returncode is None
 
         assert len(read_messages) == 2
         assert read_messages[0] == JSONRPCMessage(


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Sometimes, client developers need to check the status of the current process. This change makes it easier by allowing the process object to be accessed directly from anywhere in the code. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I have tested under stdio_client contextmanager to get process and process's return code

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
This change introduces no breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
