### PR TITLE
[Fix] SSE client to support MCP server mounted under a base path on a different ASGI server

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -20,9 +20,16 @@ def get_origin(url: str) -> str:
     return f"{parsed_url.scheme}://{parsed_url.netloc}"
 
 
-def get_path(url: str) -> str:
+def get_relative_path(url: str, remove_params: bool = False) -> str:
     parsed_url = urlparse(url)
-    return parsed_url.path
+    if remove_params:
+        return parsed_url.path
+    relative_path = parsed_url.path
+    if parsed_url.query:
+        relative_path += f"?{parsed_url.query}"
+    if parsed_url.fragment:
+        relative_path += f"#{parsed_url.fragment}"
+    return relative_path
 
 
 def get_endpoint_url(
@@ -30,7 +37,7 @@ def get_endpoint_url(
 ) -> str:
     endpoint_url = urljoin(base_url, sse_relative_url)
     if server_mount_path:
-        origin, path = get_origin(endpoint_url), get_path(endpoint_url)
+        origin, path = get_origin(endpoint_url), get_relative_path(endpoint_url)
         endpoint_url = urljoin(
             f"{origin}/{server_mount_path.strip('/')}/", path.lstrip("/")
         )
@@ -38,7 +45,7 @@ def get_endpoint_url(
 
 
 def remove_request_params(url: str) -> str:
-    return urljoin(url, get_path(url))
+    return urljoin(url, get_relative_path(url, remove_params=True))
 
 
 @asynccontextmanager


### PR DESCRIPTION
### What does this PR do?

- Fixes incorrect resolution of the `/messages` endpoint URL in the SSE client when the FastAPI app is mounted under a base path (e.g., `/mcp`).
- You can now provide a `server_mount_path` to ensure correct endpoint resolution.

## Motivation and Context
### Problem
```
# Create a FastAPI app
app = FastAPI()
# Create an MCP server and link it to the FastAPI app
server = FastMCP('test_app')
# Mount the server's SSE API on /mcp
app.mount('/mcp', server.sse_app())
```
- The server sends a relative endpoint like `/messages?session_id=...`,
- the client resolves it using `urljoin(base_url, relative_path)`
- When the app is mounted (e.g., `/mcp/sse`), this strips the subpath and constructs an invalid endpoint (e.g., `http://host/messages?session_id=...` instead of `http://host/mcp/messages?session_id=...`).

### Fix

This PR:
- Extracts the origin and mounted path prefix from the SSE base URL
- Correctly reassembles the endpoint URL using that prefix
```
        async with sse_client(base_url, server_mount_path='/mcp') as (read, write):
            async with ClientSession(read, write) as session:
                await session.initialize()  # Initialize the session
                print('✅ Connection established!')
```
## How Has This Been Tested?
server:
```
from fastapi import FastAPI
from models import User
from mcp.server.fastmcp import FastMCP

# Create a FastAPI app
app = FastAPI()

# Create an MCP server and link it to the FastAPI app
server = FastMCP('test_app')

# Mount the server's SSE API on /mcp
app.mount('/mcp', server.sse_app())

# Start the server when this file is run directly
if __name__ == "__main__":
    import uvicorn
    uvicorn.run(app, host="0.0.0.0", port=8000)
```

client:
```
import asyncio
from mcp import ClientSession
from mcp.client.sse import sse_client

async def run():
    base_url = 'http://0.0.0.0:8000/mcp/sse'  # Make sure the URL is correct for the SSE connection
    print(f'🔗 Connecting to SSE MCP server at {base_url}...')

    try:
        async with sse_client(base_url, server_mount_path='/mcp') as (read, write):
            async with ClientSession(read, write) as session:
                await session.initialize()  # Initialize the session
                print('✅ Connection established!')
    except Exception as e:
        print(f'[ERROR] Connection to SSE server failed: {e}')


# Run the test
if __name__ == '__main__':
    print('🚀 Running MCP SSE client tests...\n')
    asyncio.run(run())
```

This test should pass now.

## Breaking Changes
None identified, backward compatible

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
NA
