### PR TITLE
Fix sse_client timeout setting not works in post_writer

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -120,6 +120,7 @@ async def sse_client(
                                             mode="json",
                                             exclude_none=True,
                                         ),
+                                        timeout=timeout,
                                     )
                                     response.raise_for_status()
                                     logger.debug(


### PR DESCRIPTION
Currently timeout setting in sse_client are not works in post_writer function when it post a request to the server, which may cause some tool calls to raise a timeout error.

## Motivation and Context
Make some time consuming tool call works.

## How Has This Been Tested?
When i connect to a SSE MCP server and try to call a tool which usually takes 20 seconds to respond, it always failed.
`Error in post_writer:`
`meta=None content=[TextContent(type='text', text='Error executing request: Post "https://xxxxxxx": context canceled', annotations=None)] isError=False`
After pass the timeout from sse_client into the httpx post request, developers can take control as they need.
And this change solves my issue, tested in my case.

## Breaking Changes
Nothing changes but make it works correctly.

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x] My code follows the repository's style guidelines
- [ x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

