### PR TITLE
Add mount_path support for proper SSE endpoint routing with multiple FastMCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,33 @@ app = Starlette(
 app.router.routes.append(Host('mcp.acme.corp', app=mcp.sse_app()))
 ```
 
+When mounting multiple MCP servers under different paths, you need to configure the mount path for each server:
+
+```python
+from starlette.applications import Starlette
+from starlette.routing import Mount
+from mcp.server.fastmcp import FastMCP
+
+# Create multiple MCP servers
+github_mcp = FastMCP("GitHub API")
+browser_mcp = FastMCP("Browser")
+curl_mcp = FastMCP("Curl")
+
+# Configure mount paths for each server
+github_mcp.settings.mount_path = "/github"
+browser_mcp.settings.mount_path = "/browser"
+curl_mcp.settings.mount_path = "/curl"
+
+# Create Starlette app with multiple mounted servers
+app = Starlette(
+    routes=[
+        Mount("/github", app=github_mcp.sse_app()),
+        Mount("/browser", app=browser_mcp.sse_app()),
+        Mount("/curl", app=curl_mcp.sse_app()),
+    ]
+)
+```
+
 For more information on mounting applications in Starlette, see the [Starlette documentation](https://www.starlette.io/routing/#submounting-routes).
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -409,7 +409,6 @@ app = Starlette(
         # Using settings-based configuration
         Mount("/github", app=github_mcp.sse_app()),
         Mount("/browser", app=browser_mcp.sse_app()),
-        
         # Using direct mount path parameter
         Mount("/curl", app=curl_mcp.sse_app("/curl")),
         Mount("/search", app=search_mcp.sse_app("/search")),

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ app = Starlette(
 app.router.routes.append(Host('mcp.acme.corp', app=mcp.sse_app()))
 ```
 
-When mounting multiple MCP servers under different paths, you need to configure the mount path for each server:
+When mounting multiple MCP servers under different paths, you can configure the mount path in several ways:
 
 ```python
 from starlette.applications import Starlette
@@ -394,20 +394,31 @@ from mcp.server.fastmcp import FastMCP
 github_mcp = FastMCP("GitHub API")
 browser_mcp = FastMCP("Browser")
 curl_mcp = FastMCP("Curl")
+search_mcp = FastMCP("Search")
 
-# Configure mount paths for each server
+# Method 1: Configure mount paths via settings (recommended for persistent configuration)
 github_mcp.settings.mount_path = "/github"
 browser_mcp.settings.mount_path = "/browser"
-curl_mcp.settings.mount_path = "/curl"
+
+# Method 2: Pass mount path directly to sse_app (preferred for ad-hoc mounting)
+# This approach doesn't modify the server's settings permanently
 
 # Create Starlette app with multiple mounted servers
 app = Starlette(
     routes=[
+        # Using settings-based configuration
         Mount("/github", app=github_mcp.sse_app()),
         Mount("/browser", app=browser_mcp.sse_app()),
-        Mount("/curl", app=curl_mcp.sse_app()),
+        
+        # Using direct mount path parameter
+        Mount("/curl", app=curl_mcp.sse_app("/curl")),
+        Mount("/search", app=search_mcp.sse_app("/search")),
     ]
 )
+
+# Method 3: For direct execution, you can also pass the mount path to run()
+if __name__ == "__main__":
+    search_mcp.run(transport="sse", mount_path="/search")
 ```
 
 For more information on mounting applications in Starlette, see the [Starlette documentation](https://www.starlette.io/routing/#submounting-routes).

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -597,7 +597,7 @@ class FastMCP:
         # Combine paths
         return mount_path + endpoint
 
-    def sse_app(self, mount_path: str = "") -> Starlette:
+    def sse_app(self, mount_path: str | None = None) -> Starlette:
         """Return an instance of the SSE server app."""
         from starlette.middleware import Middleware
         from starlette.routing import Mount, Route

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -467,6 +467,7 @@ class FastMCP:
     async def run_sse_async(self) -> None:
         """Run the server using SSE transport."""
         import uvicorn
+
         starlette_app = self.sse_app()
 
         config = uvicorn.Config(
@@ -481,33 +482,35 @@ class FastMCP:
     def _normalize_path(self, mount_path: str, endpoint: str) -> str:
         """
         Combine mount path and endpoint to return a normalized path.
-        
+
         Args:
             mount_path: The mount path (e.g. "/github" or "/")
             endpoint: The endpoint path (e.g. "/messages/")
-            
+
         Returns:
             Normalized path (e.g. "/github/messages/")
         """
         # Special case: root path
         if mount_path == "/":
             return endpoint
-        
+
         # Remove trailing slash from mount path
         if mount_path.endswith("/"):
             mount_path = mount_path[:-1]
-        
+
         # Ensure endpoint starts with slash
         if not endpoint.startswith("/"):
             endpoint = "/" + endpoint
-        
+
         # Combine paths
         return mount_path + endpoint
-    
+
     def sse_app(self) -> Starlette:
         """Return an instance of the SSE server app."""
         # Create normalized endpoint considering the mount path
-        normalized_endpoint = self._normalize_path(self.settings.mount_path, self.settings.message_path)
+        normalized_endpoint = self._normalize_path(
+            self.settings.mount_path, self.settings.message_path
+        )
         sse = SseServerTransport(normalized_endpoint)
 
         async def handle_sse(request: Request) -> None:

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -556,7 +556,7 @@ class FastMCP:
                 self._mcp_server.create_initialization_options(),
             )
 
-    async def run_sse_async(self, mount_path: str = "") -> None:
+    async def run_sse_async(self, mount_path: str | None = None) -> None:
         """Run the server using SSE transport."""
         import uvicorn
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -180,7 +180,7 @@ class FastMCP:
         return self._mcp_server.instructions
 
     def run(
-        self, transport: Literal["stdio", "sse"] = "stdio", mount_path: str = ""
+        self, transport: Literal["stdio", "sse"] = "stdio", mount_path: str = None
     ) -> None:
         """Run the FastMCP server. Note this is a synchronous function.
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -186,7 +186,9 @@ class FastMCP:
         return self._mcp_server.instructions
 
     def run(
-        self, transport: Literal["stdio", "sse"] = "stdio", mount_path: str = None
+        self,
+        transport: Literal["stdio", "sse"] = "stdio",
+        mount_path: str | None = None,
     ) -> None:
         """Run the FastMCP server. Note this is a synchronous function.
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -607,13 +607,13 @@ class FastMCP:
             self.settings.mount_path = mount_path
 
         # Create normalized endpoint considering the mount path
-        normalized_endpoint = self._normalize_path(
+        normalized_message_endpoint = self._normalize_path(
             self.settings.mount_path, self.settings.message_path
         )
         
         # Set up auth context and dependencies
 
-        sse = SseServerTransport(normalized_endpoint)
+        sse = SseServerTransport(normalized_message_endpoint)
 
         async def handle_sse(scope: Scope, receive: Receive, send: Send):
             # Add client ID from auth context into request context if available

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -603,7 +603,7 @@ class FastMCP:
         from starlette.routing import Mount, Route
 
         # Update mount_path in settings if provided
-        if mount_path:
+        if mount_path is not None:
             self.settings.mount_path = mount_path
 
         # Create normalized endpoint considering the mount path

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -1,9 +1,11 @@
 import base64
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 from pydantic import AnyUrl
+from starlette.routing import Mount, Route
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.prompts.base import EmbeddedResource, Message, UserMessage
@@ -30,6 +32,69 @@ class TestServer:
         mcp = FastMCP(instructions="Server instructions")
         assert mcp.name == "FastMCP"
         assert mcp.instructions == "Server instructions"
+
+    @pytest.mark.anyio
+    async def test_normalize_path(self):
+        """Test path normalization for mount paths."""
+        mcp = FastMCP()
+
+        # Test root path
+        assert mcp._normalize_path("/", "/messages/") == "/messages/"
+
+        # Test path with trailing slash
+        assert mcp._normalize_path("/github/", "/messages/") == "/github/messages/"
+
+        # Test path without trailing slash
+        assert mcp._normalize_path("/github", "/messages/") == "/github/messages/"
+
+        # Test endpoint without leading slash
+        assert mcp._normalize_path("/github", "messages/") == "/github/messages/"
+
+        # Test both with trailing/leading slashes
+        assert mcp._normalize_path("/api/", "/v1/") == "/api/v1/"
+
+    @pytest.mark.anyio
+    async def test_sse_app_with_mount_path(self):
+        """Test SSE app creation with different mount paths."""
+        # Test with default mount path
+        mcp = FastMCP()
+        with patch.object(
+            mcp, "_normalize_path", return_value="/messages/"
+        ) as mock_normalize:
+            mcp.sse_app()
+            # Verify _normalize_path was called with correct args
+            mock_normalize.assert_called_once_with("/", "/messages/")
+
+        # Test with custom mount path
+        mcp = FastMCP()
+        mcp.settings.mount_path = "/custom"
+        with patch.object(
+            mcp, "_normalize_path", return_value="/custom/messages/"
+        ) as mock_normalize:
+            mcp.sse_app()
+            # Verify _normalize_path was called with correct args
+            mock_normalize.assert_called_once_with("/custom", "/messages/")
+
+    @pytest.mark.anyio
+    async def test_starlette_routes_with_mount_path(self):
+        """Test that Starlette routes are correctly configured with mount path."""
+        mcp = FastMCP()
+        mcp.settings.mount_path = "/api"
+        app = mcp.sse_app()
+
+        # Find routes by type
+        sse_routes = [r for r in app.routes if isinstance(r, Route)]
+        mount_routes = [r for r in app.routes if isinstance(r, Mount)]
+
+        # Verify routes exist
+        assert len(sse_routes) == 1, "Should have one SSE route"
+        assert len(mount_routes) == 1, "Should have one mount route"
+
+        # Verify path values
+        assert sse_routes[0].path == "/sse", "SSE route path should be /sse"
+        assert (
+            mount_routes[0].path == "/messages"
+        ), "Mount route path should be /messages"
 
     @pytest.mark.anyio
     async def test_non_ascii_description(self):
@@ -518,8 +583,6 @@ class TestContextInjection:
 
     @pytest.mark.anyio
     async def test_context_logging(self):
-        from unittest.mock import patch
-
         import mcp.server.session
 
         """Test that context logging methods work."""

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -74,7 +74,7 @@ class TestServer:
             mcp.sse_app()
             # Verify _normalize_path was called with correct args
             mock_normalize.assert_called_once_with("/custom", "/messages/")
-            
+
         # Test with mount_path parameter
         mcp = FastMCP()
         with patch.object(
@@ -105,19 +105,19 @@ class TestServer:
         assert (
             mount_routes[0].path == "/messages"
         ), "Mount route path should be /messages"
-        
+
         # Test with mount path as parameter
         mcp = FastMCP()
         app = mcp.sse_app(mount_path="/param")
-        
+
         # Find routes by type
         sse_routes = [r for r in app.routes if isinstance(r, Route)]
         mount_routes = [r for r in app.routes if isinstance(r, Mount)]
-        
+
         # Verify routes exist
         assert len(sse_routes) == 1, "Should have one SSE route"
         assert len(mount_routes) == 1, "Should have one mount route"
-        
+
         # Verify path values
         assert sse_routes[0].path == "/sse", "SSE route path should be /sse"
         assert (


### PR DESCRIPTION
Add mount_path capability to FastMCP for proper SSE endpoint handling when mounted under sub-paths

## Motivation and Context
When multiple FastMCP servers are mounted under different sub-paths in a single Starlette application, the session URIs were being generated incorrectly. FastMCP would create session URIs that didn't include the mount path, causing clients to send messages to the wrong endpoint. This change fixes the issue by
adding a `mount_path` setting that properly normalizes URIs.

## How Has This Been Tested?
- Added unit tests for the path normalization function
- Added unit tests for SSE app creation with different mount paths
- Tested with a real application mounting multiple FastMCP servers under different paths
- Manually verified session URI generation and message routing

## Breaking Changes
None. This is backwards compatible with existing code. The new `mount_path` setting defaults to "/".

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The issue occurs because the SseServerTransport class creates a session URI without considering that the server might be mounted under a sub-path. The fix adds a mount_path setting to FastMCP and implements a path normalization helper method that combines the mount path with the message path to ensure correct
URI generation.

This solution maintains clean separation between FastMCP and SseServerTransport without requiring changes to the SseServerTransport class itself.