### PR TITLE
replace inefficient use of `to_jsonable_python`

### DIFF
--- a/src/mcp/server/fastmcp/prompts/base.py
+++ b/src/mcp/server/fastmcp/prompts/base.py
@@ -1,7 +1,6 @@
 """Base classes for FastMCP prompts."""
 
 import inspect
-import json
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Literal
 
@@ -155,7 +154,9 @@ class Prompt(BaseModel):
                         content = TextContent(type="text", text=msg)
                         messages.append(UserMessage(content=content))
                     else:
-                        content = json.dumps(pydantic_core.to_jsonable_python(msg))
+                        content = pydantic_core.to_json(
+                            msg, fallback=str, indent=2
+                        ).decode()
                         messages.append(Message(role="user", content=content))
                 except Exception:
                     raise ValueError(

--- a/src/mcp/server/fastmcp/resources/types.py
+++ b/src/mcp/server/fastmcp/resources/types.py
@@ -9,7 +9,7 @@ from typing import Any
 import anyio
 import anyio.to_thread
 import httpx
-import pydantic.json
+import pydantic
 import pydantic_core
 from pydantic import Field, ValidationInfo
 
@@ -59,15 +59,12 @@ class FunctionResource(Resource):
             )
             if isinstance(result, Resource):
                 return await result.read()
-            if isinstance(result, bytes):
+            elif isinstance(result, bytes):
                 return result
-            if isinstance(result, str):
+            elif isinstance(result, str):
                 return result
-            try:
-                return json.dumps(pydantic_core.to_jsonable_python(result))
-            except (TypeError, pydantic_core.PydanticSerializationError):
-                # If JSON serialization fails, try str()
-                return str(result)
+            else:
+                return pydantic_core.to_json(result, fallback=str, indent=2).decode()
         except Exception as e:
             raise ValueError(f"Error reading resource {self.uri}: {e}")
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -3,7 +3,6 @@
 from __future__ import annotations as _annotations
 
 import inspect
-import json
 import re
 from collections.abc import AsyncIterator, Callable, Iterable, Sequence
 from contextlib import (
@@ -466,6 +465,7 @@ class FastMCP:
     async def run_sse_async(self) -> None:
         """Run the server using SSE transport."""
         import uvicorn
+
         starlette_app = self.sse_app()
 
         config = uvicorn.Config(
@@ -550,10 +550,7 @@ def _convert_to_content(
         return list(chain.from_iterable(_convert_to_content(item) for item in result))  # type: ignore[reportUnknownVariableType]
 
     if not isinstance(result, str):
-        try:
-            result = json.dumps(pydantic_core.to_jsonable_python(result))
-        except Exception:
-            result = str(result)
+        result = pydantic_core.to_json(result, fallback=str, indent=2).decode()
 
     return [TextContent(type="text", text=result)]
 

--- a/tests/server/fastmcp/resources/test_function_resources.py
+++ b/tests/server/fastmcp/resources/test_function_resources.py
@@ -100,7 +100,7 @@ class TestFunctionResource:
             fn=lambda: MyModel(name="test"),
         )
         content = await resource.read()
-        assert content == '{"name": "test"}'
+        assert content == '{\n  "name": "test"\n}'
 
     @pytest.mark.anyio
     async def test_custom_type_conversion(self):

--- a/tests/server/fastmcp/resources/test_resource_template.py
+++ b/tests/server/fastmcp/resources/test_resource_template.py
@@ -185,4 +185,4 @@ class TestResourceTemplate:
 
         assert isinstance(resource, FunctionResource)
         content = await resource.read()
-        assert content == "hello"
+        assert content == '"hello"'

--- a/tests/server/fastmcp/servers/test_file_server.py
+++ b/tests/server/fastmcp/servers/test_file_server.py
@@ -114,17 +114,13 @@ async def test_read_resource_file(mcp: FastMCP):
 
 @pytest.mark.anyio
 async def test_delete_file(mcp: FastMCP, test_dir: Path):
-    await mcp.call_tool(
-        "delete_file", arguments={"path": str(test_dir / "example.py")}
-    )
+    await mcp.call_tool("delete_file", arguments={"path": str(test_dir / "example.py")})
     assert not (test_dir / "example.py").exists()
 
 
 @pytest.mark.anyio
 async def test_delete_file_and_check_resources(mcp: FastMCP, test_dir: Path):
-    await mcp.call_tool(
-        "delete_file", arguments={"path": str(test_dir / "example.py")}
-    )
+    await mcp.call_tool("delete_file", arguments={"path": str(test_dir / "example.py")})
     res_iter = await mcp.read_resource("file://test_dir/example.py")
     res_list = list(res_iter)
     assert len(res_list) == 1


### PR DESCRIPTION
## Motivation and Context

Current approach of `json.dumps(pydantic_core.to_jsonable_python(result))` is much less efficient than serializing directly to JSON.

Also instead of letting one serialization failure cause fallback to `str()`, we use pydantic's `fallback` method.

## How Has This Been Tested?

yes.

## Breaking Changes

I would expect not.

NOTE: I did change the output from a single line JSON to `indent=2` to make the output more readable where it might be exposed to a user. Happy to revert that to compact JSON if it's never going to be read by a human.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] performance improvement and code cleanup 

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] ~~I have added or updated documentation as needed~~

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
