### PR TITLE
sse-pass-http-req

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -491,6 +491,7 @@ class FastMCP:
                     streams[0],
                     streams[1],
                     self._mcp_server.create_initialization_options(),
+                    extra_metadata={"http_request": request},
                 )
 
         return Starlette(
@@ -500,6 +501,15 @@ class FastMCP:
                 Mount(self.settings.message_path, app=sse.handle_post_message),
             ],
         )
+
+    def get_http_request(self) -> Request | None:
+        ctx = self.get_context()
+        if (ctx.request_context and
+            ctx.request_context.meta and
+            hasattr(ctx.request_context.meta, "extra_metadata")):
+            req: Request = ctx.request_context.meta.extra_metadata.get("http_request")  # type: ignore
+            return req
+        return None
 
     async def list_prompts(self) -> list[MCPPrompt]:
         """List all available prompts."""

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -492,6 +492,7 @@ class Server(Generic[LifespanResultT]):
                     logger.debug(f"Received message: {message}")
                     if (hasattr(message, "request_meta") and 
                         getattr(message, "request_meta")):
+                        message.request_meta = message.request_meta or types.RequestParams.Meta()   # type: ignore
                         message.request_meta.extra_metadata = extra_metadata  # type: ignore
                     tg.start_soon(
                         self._handle_message,

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -41,6 +41,7 @@ AnyFunction: TypeAlias = Callable[..., Any]
 class RequestParams(BaseModel):
     class Meta(BaseModel):
         progressToken: ProgressToken | None = None
+        extra_metadata: dict[str, Any] | None = None
         """
         If specified, the caller requests out-of-band progress notifications for
         this request (as represented by notifications/progress). The value of this


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When working with MCP tools, particularly over Server-Sent Events (SSE), it's important to access request metadata such as headers, IP addresses, and other context. This is crucial for features like authorization, tenant resolution, request tracing, and custom routing logic. By default, SSE provides limited context handling, which poses a challenge when such metadata is needed in downstream tools.

To solve this, I extended the MCP server to inject the request context into tool invocations. This allows tools to access request headers and additional metadata even in long-lived SSE streams. The implementation also abstracts transport-specific logic, making it easy to support future transport types like WebSockets or gRPC.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This change has been tested in a real MCP application with SSE transport. Scenarios tested:
Validating that tools correctly receive request headers (e.g., Authorization, X-Custom-Tenant-ID).
Injecting and accessing request query parameters within tools.
Ensuring SSE connections remain stable while context is being passed.
Fallback behavior when context is missing or malformed.
Regression tested for standard tool flows to ensure no breaking changes.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
