### PR TITLE
feat(func_metadata): expose skip_names argument

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -321,6 +321,7 @@ class FastMCP:
         name: str | None = None,
         description: str | None = None,
         annotations: ToolAnnotations | None = None,
+        skip_names: Sequence[str] = (),
     ) -> None:
         """Add a tool to the server.
 
@@ -332,9 +333,15 @@ class FastMCP:
             name: Optional name for the tool (defaults to function name)
             description: Optional description of what the tool does
             annotations: Optional ToolAnnotations providing additional tool information
+            skip_names: A list of parameter names to skip. These will not be included in
+                the model.
         """
         self._tool_manager.add_tool(
-            fn, name=name, description=description, annotations=annotations
+            fn,
+            name=name,
+            description=description,
+            annotations=annotations,
+            skip_names=skip_names,
         )
 
     def tool(
@@ -342,6 +349,7 @@ class FastMCP:
         name: str | None = None,
         description: str | None = None,
         annotations: ToolAnnotations | None = None,
+        skip_names: Sequence[str] = (),
     ) -> Callable[[AnyFunction], AnyFunction]:
         """Decorator to register a tool.
 
@@ -353,6 +361,8 @@ class FastMCP:
             name: Optional name for the tool (defaults to function name)
             description: Optional description of what the tool does
             annotations: Optional ToolAnnotations providing additional tool information
+            skip_names: A list of parameter names to skip. These will not be included in
+                the model.
 
         Example:
             @server.tool()
@@ -378,7 +388,11 @@ class FastMCP:
 
         def decorator(fn: AnyFunction) -> AnyFunction:
             self.add_tool(
-                fn, name=name, description=description, annotations=annotations
+                fn,
+                name=name,
+                description=description,
+                annotations=annotations,
+                skip_names=skip_names,
             )
             return fn
 

--- a/src/mcp/server/fastmcp/tools/base.py
+++ b/src/mcp/server/fastmcp/tools/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations as _annotations
 
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, get_origin
 
 from pydantic import BaseModel, Field
@@ -43,6 +43,7 @@ class Tool(BaseModel):
         description: str | None = None,
         context_kwarg: str | None = None,
         annotations: ToolAnnotations | None = None,
+        skip_names: Sequence[str] = (),
     ) -> Tool:
         """Create a Tool from a function."""
         from mcp.server.fastmcp.server import Context
@@ -64,10 +65,10 @@ class Tool(BaseModel):
                     context_kwarg = param_name
                     break
 
-        func_arg_metadata = func_metadata(
-            fn,
-            skip_names=[context_kwarg] if context_kwarg is not None else [],
-        )
+        if context_kwarg is not None:
+            skip_names = (context_kwarg, *skip_names)
+
+        func_arg_metadata = func_metadata(fn, skip_names=skip_names)
         parameters = func_arg_metadata.arg_model.model_json_schema()
 
         return cls(

--- a/src/mcp/server/fastmcp/tools/tool_manager.py
+++ b/src/mcp/server/fastmcp/tools/tool_manager.py
@@ -1,6 +1,6 @@
 from __future__ import annotations as _annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp.exceptions import ToolError
@@ -37,10 +37,15 @@ class ToolManager:
         name: str | None = None,
         description: str | None = None,
         annotations: ToolAnnotations | None = None,
+        skip_names: Sequence[str] = (),
     ) -> Tool:
         """Add a tool to the server."""
         tool = Tool.from_function(
-            fn, name=name, description=description, annotations=annotations
+            fn,
+            name=name,
+            description=description,
+            annotations=annotations,
+            skip_names=skip_names,
         )
         existing = self._tools.get(tool.name)
         if existing:

--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -130,12 +130,12 @@ def func_metadata(
     dynamic_pydantic_model_params: dict[str, Any] = {}
     globalns = getattr(func, "__globals__", {})
     for param in params.values():
+        if param.name in skip_names:
+            continue
         if param.name.startswith("_"):
             raise InvalidSignature(
                 f"Parameter {param.name} of {func.__name__} cannot start with '_'"
             )
-        if param.name in skip_names:
-            continue
         annotation = param.annotation
 
         # `x: None` / `x: None = None`

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -180,18 +180,26 @@ def test_skip_names():
     """Test that skipped parameters are not included in the model"""
 
     def func_with_many_params(
-        keep_this: int, skip_this: str, also_keep: float, also_skip: bool
+        keep_this: int,
+        skip_this: str,
+        also_keep: float,
+        also_skip: bool,
+        _skip_this_too: int = 0,
     ):
-        return keep_this, skip_this, also_keep, also_skip
+        return keep_this, skip_this, also_keep, also_skip, _skip_this_too
 
     # Skip some parameters
-    meta = func_metadata(func_with_many_params, skip_names=["skip_this", "also_skip"])
+    meta = func_metadata(
+        func_with_many_params,
+        skip_names=["skip_this", "also_skip", "_skip_this_too"],
+    )
 
     # Check model fields
     assert "keep_this" in meta.arg_model.model_fields
     assert "also_keep" in meta.arg_model.model_fields
     assert "skip_this" not in meta.arg_model.model_fields
     assert "also_skip" not in meta.arg_model.model_fields
+    assert "_skip_this_too" not in meta.arg_model.model_fields
 
     # Validate that we can call with only non-skipped parameters
     model: BaseModel = meta.arg_model.model_validate({"keep_this": 1, "also_keep": 2.5})  # type: ignore


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Expose `func_metadata`'s `skip_names` argument in the `@tool` decorator and move the `if param.name in skip_names:` check to the top.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
It allows users to ignore specific parameters, such as optional ones and especially those starting with an underscore.

My use case was to programmatically wrap a generated SDK for Spotify (from `openapi-generator-cli`) into an MCP server. However, the client methods included optional arguments that started with an underscore, which led to `InvalidSignature` exceptions.

<img width="616" alt="image" src="https://github.com/user-attachments/assets/5fa77120-23ee-4d95-a8c0-1c81df585a04" />

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
https://github.com/NextFire/spotify-mcp-server/tree/with-pr-fix

<img width="846" alt="image" src="https://github.com/user-attachments/assets/643a049e-5962-4891-9d56-391dfed35057" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
