### PR TITLE
Fix stdio_client kill process after timeout

### DIFF
--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -16,7 +16,6 @@ from mcp.shared.message import SessionMessage
 from .win32 import (
     create_windows_process,
     get_windows_executable_command,
-    terminate_windows_process,
 )
 
 # Environment variables to inherit by default
@@ -180,13 +179,15 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
         finally:
             # Clean up process to prevent any dangling orphaned processes
             try:
-                if sys.platform == "win32":
-                    await terminate_windows_process(process)
-                else:
-                    process.terminate()
+                process.terminate()
+                with anyio.fail_after(2.0):
+                    await process.wait()
             except ProcessLookupError:
                 # Process already exited, which is fine
                 pass
+            except TimeoutError:
+                # Force kill if it doesn't terminate
+                process.kill()
             await read_stream.aclose()
             await write_stream.aclose()
             await read_stream_writer.aclose()

--- a/src/mcp/client/stdio/win32.py
+++ b/src/mcp/client/stdio/win32.py
@@ -8,9 +8,7 @@ import sys
 from pathlib import Path
 from typing import BinaryIO, TextIO, cast
 
-import anyio
 from anyio import to_thread
-from anyio.abc import Process
 from anyio.streams.file import FileReadStream, FileWriteStream
 
 
@@ -158,25 +156,5 @@ async def create_windows_process(
             cwd=cwd,
             bufsize=0,
         )
+
         return FallbackProcess(popen_obj)
-
-
-async def terminate_windows_process(process: Process | FallbackProcess):
-    """
-    Terminate a Windows process.
-
-    Note: On Windows, terminating a process with process.terminate() doesn't
-    always guarantee immediate process termination.
-    So we give it 2s to exit, or we call process.kill()
-    which sends a SIGKILL equivalent signal.
-
-    Args:
-        process: The process to terminate
-    """
-    try:
-        process.terminate()
-        with anyio.fail_after(2.0):
-            await process.wait()
-    except TimeoutError:
-        # Force kill if it doesn't terminate
-        process.kill()


### PR DESCRIPTION
## Motivation and Context
Be consistent across platforms (Windows, Linux, etc). Some MCP Servers don't react to SIGTERM, so `stdio_client` will hang indefinitely when exiting the context manager.

Reference: https://github.com/modelcontextprotocol/python-sdk/pull/372

## How Has This Been Tested?
Yes

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

