### PR TITLE
Fix errors when mounting to non-root directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,13 @@ from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("My App")
 
+# Customize a mount path 
+mcp_mount_path = '/mcp'
+
 # Mount the SSE server to the existing ASGI server
 app = Starlette(
     routes=[
-        Mount('/', app=mcp.sse_app()),
+        Mount(mcp_mount_path, app=mcp.sse_app(mcp_mount_path=mcp_mount_path)),
     ]
 )
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -477,9 +477,9 @@ class FastMCP:
         server = uvicorn.Server(config)
         await server.serve()
 
-    def sse_app(self) -> Starlette:
+    def sse_app(self, mcp_mount_path: str = '') -> Starlette:
         """Return an instance of the SSE server app."""
-        sse = SseServerTransport(self.settings.message_path)
+        sse = SseServerTransport(mcp_mount_path + self.settings.message_path)
 
         async def handle_sse(request: Request) -> None:
             async with sse.connect_sse(


### PR DESCRIPTION
Fix errors when mounting MCP server to non-root directories.

## Motivation and Context
When I mounted sse_app to a different directory using the method in the readme, I found that the path of the messages returned by sse was wrong. My patch fixes this problem.

## How Has This Been Tested?
I tested the sse service in the n8n workflow and it works fine.

## Breaking Changes
If the user mounts sse_app to a non-root directory, the user needs to modify the code and provide the real path.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

