### PR TITLE
Preserve non-ASCII characters in JSON output for better multilingual support

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -552,7 +552,7 @@ def _convert_to_content(
 
     if not isinstance(result, str):
         try:
-            result = json.dumps(pydantic_core.to_jsonable_python(result))
+            result = json.dumps(pydantic_core.to_jsonable_python(result), ensure_ascii=False)
         except Exception:
             result = str(result)
 


### PR DESCRIPTION
## Motivation and Context

Add ensure_ascii=False parameter to json.dumps() when converting results  to JSON strings in _convert_to_content function. This prevents Unicode  characters (like Chinese) from being escaped as \uXXXX sequences, making  the output 
more readable and user-friendly for multilingual content.

Comprehension Barriers for LLMs: AI models frequently struggle to properly parse and understand Unicode escape sequences. For example, when Chinese text "你好" is encoded as "\u4f60\u597d", large language models often mistakenly interpret them as code or special instructions.

## How Has This Been Tested?
I have tested unicode characters and is working fine

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
