### PR TITLE
Private add_tool from Tool object instead of function

### DIFF
--- a/src/mcp/server/fastmcp/tools/tool_manager.py
+++ b/src/mcp/server/fastmcp/tools/tool_manager.py
@@ -38,25 +38,16 @@ class ToolManager:
     ) -> Tool:
         """Add a tool to the server."""
         tool = Tool.from_function(fn, name=name, description=description)
+        return self._add_tool(tool)
+
+    def _add_tool(self, tool: Tool) -> Tool:
         existing = self._tools.get(tool.name)
         if existing:
             if self.warn_on_duplicate_tools:
                 logger.warning(f"Tool already exists: {tool.name}")
-            return existing
+                return existing
         self._tools[tool.name] = tool
         return tool
-
-    def add_tool(
-        self,
-        tool: Tool
-    ) -> Tool:
-    existing = self._tools.get(tool.name)
-    if existing:
-        if self.warn_on_duplicate_tools:
-            logger.warning(f"Tool already exists: {tool.name}")
-            return existing
-    self._tools[tool.name] = tool
-    return tool
 
     async def call_tool(
         self,

--- a/src/mcp/server/fastmcp/tools/tool_manager.py
+++ b/src/mcp/server/fastmcp/tools/tool_manager.py
@@ -46,6 +46,18 @@ class ToolManager:
         self._tools[tool.name] = tool
         return tool
 
+    def add_tool(
+        self,
+        tool: Tool
+    ) -> Tool:
+    existing = self._tools.get(tool.name)
+    if existing:
+        if self.warn_on_duplicate_tools:
+            logger.warning(f"Tool already exists: {tool.name}")
+            return existing
+    self._tools[tool.name] = tool
+    return tool
+
     async def call_tool(
         self,
         name: str,


### PR DESCRIPTION
Add private method to add tools from tools. 

## Motivation and Context
There should be a way to add a tool without having to specify a function but constructing the tool directly. This can be handy when  one has the inputSchema but not the function. Creating a function given a schema programmatically is not trivial. 
The function is a private member just for backward compatibility, probably, the original add_tool should have been add_tool_from_fn. 

## How Has This Been Tested?
I ran tests.

## Breaking Changes
No br. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
