### PR TITLE
fix for SSE URL handling when a server name is specified

### DIFF
--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -1,0 +1,31 @@
+import pytest
+from urllib.parse import urlparse, urlunparse
+
+from mcp.client.sse import custom_url_join
+
+
+@pytest.mark.parametrize(
+    "base_url,endpoint,expected",
+    [        
+        # Additional test cases to verify behavior with different URL structures
+        (
+            "https://mcp.example.com/weather/sse", 
+            "/messages/?session_id=616df71373444d76bd566df4377c9629", 
+            "https://mcp.example.com/weather/messages/?session_id=616df71373444d76bd566df4377c9629"
+        ),
+        (
+            "https://mcp.example.com/weather/clarksburg/sse", 
+            "/messages/?session_id=616df71373444d76bd566df4377c9629", 
+            "https://mcp.example.com/weather/clarksburg/messages/?session_id=616df71373444d76bd566df4377c9629"
+        ),
+        (
+            "https://mcp.example.com/sse", 
+            "/messages/?session_id=616df71373444d76bd566df4377c9629", 
+            "https://mcp.example.com/messages/?session_id=616df71373444d76bd566df4377c9629"
+        ),
+    ],
+)
+def test_custom_url_join(base_url, endpoint, expected):
+    """Test the custom_url_join function with messages endpoint and session ID."""
+    result = custom_url_join(base_url, endpoint)
+    assert result == expected

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -6,22 +6,22 @@ from mcp.client.sse import custom_url_join
 
 @pytest.mark.parametrize(
     "base_url,endpoint,expected",
-    [        
+    [
         # Additional test cases to verify behavior with different URL structures
         (
-            "https://mcp.example.com/weather/sse", 
-            "/messages/?session_id=616df71373444d76bd566df4377c9629", 
-            "https://mcp.example.com/weather/messages/?session_id=616df71373444d76bd566df4377c9629"
+            "https://mcp.example.com/weather/sse",
+            "/messages/?session_id=616df71373444d76bd566df4377c9629",
+            "https://mcp.example.com/weather/messages/?session_id=616df71373444d76bd566df4377c9629",
         ),
         (
-            "https://mcp.example.com/weather/clarksburg/sse", 
-            "/messages/?session_id=616df71373444d76bd566df4377c9629", 
-            "https://mcp.example.com/weather/clarksburg/messages/?session_id=616df71373444d76bd566df4377c9629"
+            "https://mcp.example.com/weather/clarksburg/sse",
+            "/messages/?session_id=616df71373444d76bd566df4377c9629",
+            "https://mcp.example.com/weather/clarksburg/messages/?session_id=616df71373444d76bd566df4377c9629",
         ),
         (
-            "https://mcp.example.com/sse", 
-            "/messages/?session_id=616df71373444d76bd566df4377c9629", 
-            "https://mcp.example.com/messages/?session_id=616df71373444d76bd566df4377c9629"
+            "https://mcp.example.com/sse",
+            "/messages/?session_id=616df71373444d76bd566df4377c9629",
+            "https://mcp.example.com/messages/?session_id=616df71373444d76bd566df4377c9629",
         ),
     ],
 )

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mcp.client.sse import custom_url_join
 
 

--- a/tests/client/test_sse.py
+++ b/tests/client/test_sse.py
@@ -1,6 +1,4 @@
 import pytest
-from urllib.parse import urlparse, urlunparse
-
 from mcp.client.sse import custom_url_join
 
 


### PR DESCRIPTION
# Add custom URL join function for SSE endpoints

<!-- Provide a brief summary of your changes -->
This PR adds a custom URL join function to properly handle SSE endpoint URLs by correctly managing path segments regardless of trailing slashes.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When connecting to SSE endpoints, we need to reliably join base URLs with endpoint paths. For example if my SSE server lives at `https://mcp.example.com/weather/sse/` then I want to join the SSE event URL such as `/messages/?session_id=616df71373444d76bd566df4377c9629` to create `https://mcp.example.com/weather/messages/?session_id=616df71373444d76bd566df4377c9629` i.e. it includes the server name `weather`, the existing implementation does not include the server name. This custom function ensures paths are correctly joined including a server name if present in the path.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Added comprehensive unit tests covering multiple base URL patterns:
  - `https://mcp.example.com/weather/sse/` 
  - `https://mcp.example.com/weather/clarksburg/sse/`
  - `https://mcp.example.com/sse/`
- Tested with and without trailing slashes
- Tested with session ID query parameters
- Verified behavior with actual SSE connection endpoints

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
- [x] None. This is a new utility function that doesn't affect existing functionality.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [[MCP Documentation](https://modelcontextprotocol.io/)](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The function uses `urlparse` and `urlunparse` to properly handle all URL components, which ensures query parameters and fragments are preserved. We specifically handle the path joining logic to accommodate both trailing and non-trailing slash cases in base URLs.

Resolves #585