### PR TITLE
add a timeout arguments on per-request basis (as per MCP specifications)

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -254,7 +254,10 @@ class ClientSession(
         )
 
     async def call_tool(
-        self, name: str, arguments: dict[str, Any] | None = None
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        read_timeout_seconds: timedelta | None = None,
     ) -> types.CallToolResult:
         """Send a tools/call request."""
         return await self.send_request(
@@ -265,6 +268,7 @@ class ClientSession(
                 )
             ),
             types.CallToolResult,
+            request_read_timeout_seconds=read_timeout_seconds,
         )
 
     async def list_prompts(self) -> types.ListPromptsResult:

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -217,7 +217,8 @@ class BaseSession(
     ) -> ReceiveResultT:
         """
         Sends a request and wait for a response. Raises an McpError if the
-        response contains an error.
+        response contains an error. If a request read timeout is provided, it
+        will take precedence over the session read timeout.
 
         Do not use this method to emit notifications! Use send_notification()
         instead.

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -213,7 +213,7 @@ class BaseSession(
         self,
         request: SendRequestT,
         result_type: type[ReceiveResultT],
-        request_read_timeout_seconds: timedelta | None = None
+        request_read_timeout_seconds: timedelta | None = None,
     ) -> ReceiveResultT:
         """
         Sends a request and wait for a response. Raises an McpError if the

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -185,7 +185,7 @@ class BaseSession(
         self._request_id = 0
         self._receive_request_type = receive_request_type
         self._receive_notification_type = receive_notification_type
-        self._read_timeout_seconds = read_timeout_seconds
+        self._session_read_timeout_seconds = read_timeout_seconds
         self._in_flight = {}
 
         self._exit_stack = AsyncExitStack()
@@ -213,6 +213,7 @@ class BaseSession(
         self,
         request: SendRequestT,
         result_type: type[ReceiveResultT],
+        request_read_timeout_seconds: timedelta | None = None
     ) -> ReceiveResultT:
         """
         Sends a request and wait for a response. Raises an McpError if the
@@ -243,12 +244,15 @@ class BaseSession(
 
         await self._write_stream.send(JSONRPCMessage(jsonrpc_request))
 
+        # request read timeout takes precedence over session read timeout
+        timeout = None
+        if request_read_timeout_seconds is not None:
+            timeout = request_read_timeout_seconds.total_seconds()
+        elif self._session_read_timeout_seconds is not None:
+            timeout = self._session_read_timeout_seconds.total_seconds()
+
         try:
-            with anyio.fail_after(
-                None
-                if self._read_timeout_seconds is None
-                else self._read_timeout_seconds.total_seconds()
-            ):
+            with anyio.fail_after(timeout):
                 response_or_error = await response_stream_reader.receive()
         except TimeoutError:
             raise McpError(
@@ -257,7 +261,7 @@ class BaseSession(
                     message=(
                         f"Timed out while waiting for response to "
                         f"{request.__class__.__name__}. Waited "
-                        f"{self._read_timeout_seconds} seconds."
+                        f"{timeout} seconds."
                     ),
                 )
             )


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

The [MCP Specifications](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#timeouts) says:

> SDKs and other middleware SHOULD allow these timeouts to be configured on a per-request basis.

## How Has This Been Tested?
No regression on the test / test running locally.

## Breaking Changes
No it's a transparent change which enable to set timeout on per-request basis. If not set it default to the previous behavior of not having a timeout or using the session based timeout.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
### Notes:
I have added the capacity to set the read timeout only on the tool_call requests which is probably the most critical one but we might want to extend that to other calls from the client as well.
