### PR TITLE
Handle SSE Disconnects Properly

### DIFF
--- a/examples/servers/simple-prompt/mcp_simple_prompt/server.py
+++ b/examples/servers/simple-prompt/mcp_simple_prompt/server.py
@@ -2,8 +2,6 @@ import anyio
 import click
 import mcp.types as types
 from mcp.server.lowlevel import Server
-from starlette.responses import Response
-from starlette.routing import Route
 
 
 def create_messages(
@@ -92,7 +90,8 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Mount
+        from starlette.responses import Response
+        from starlette.routing import Mount, Route
 
         sse = SseServerTransport("/messages/")
 

--- a/examples/servers/simple-prompt/mcp_simple_prompt/server.py
+++ b/examples/servers/simple-prompt/mcp_simple_prompt/server.py
@@ -90,14 +90,12 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Mount, Route
+        from starlette.routing import Mount
 
         sse = SseServerTransport("/messages/")
 
-        async def handle_sse(request):
-            async with sse.connect_sse(
-                request.scope, request.receive, request._send
-            ) as streams:
+        async def handle_sse(scope, receive, send):
+            async with sse.connect_sse(scope, receive, send) as streams:
                 await app.run(
                     streams[0], streams[1], app.create_initialization_options()
                 )
@@ -105,7 +103,7 @@ def main(port: int, transport: str) -> int:
         starlette_app = Starlette(
             debug=True,
             routes=[
-                Route("/sse", endpoint=handle_sse),
+                Mount("/sse", app=handle_sse),
                 Mount("/messages/", app=sse.handle_post_message),
             ],
         )

--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -46,20 +46,24 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Mount
+        from starlette.responses import Response
+        from starlette.routing import Mount, Route
 
         sse = SseServerTransport("/messages/")
 
-        async def handle_sse(scope, receive, send):
-            async with sse.connect_sse(scope, receive, send) as streams:
+        async def handle_sse(request):
+            async with sse.connect_sse(
+                request.scope, request.receive, request._send
+            ) as streams:
                 await app.run(
                     streams[0], streams[1], app.create_initialization_options()
                 )
+            return Response()
 
         starlette_app = Starlette(
             debug=True,
             routes=[
-                Mount("/sse", app=handle_sse),
+                Route("/sse", endpoint=handle_sse, methods=["GET"]),
                 Mount("/messages/", app=sse.handle_post_message),
             ],
         )

--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -46,14 +46,12 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Mount, Route
+        from starlette.routing import Mount
 
         sse = SseServerTransport("/messages/")
 
-        async def handle_sse(request):
-            async with sse.connect_sse(
-                request.scope, request.receive, request._send
-            ) as streams:
+        async def handle_sse(scope, receive, send):
+            async with sse.connect_sse(scope, receive, send) as streams:
                 await app.run(
                     streams[0], streams[1], app.create_initialization_options()
                 )
@@ -61,7 +59,7 @@ def main(port: int, transport: str) -> int:
         starlette_app = Starlette(
             debug=True,
             routes=[
-                Route("/sse", endpoint=handle_sse),
+                Mount("/sse", app=handle_sse),
                 Mount("/messages/", app=sse.handle_post_message),
             ],
         )

--- a/examples/servers/simple-tool/mcp_simple_tool/server.py
+++ b/examples/servers/simple-tool/mcp_simple_tool/server.py
@@ -60,14 +60,12 @@ def main(port: int, transport: str) -> int:
     if transport == "sse":
         from mcp.server.sse import SseServerTransport
         from starlette.applications import Starlette
-        from starlette.routing import Mount, Route
+        from starlette.routing import Mount
 
         sse = SseServerTransport("/messages/")
 
-        async def handle_sse(request):
-            async with sse.connect_sse(
-                request.scope, request.receive, request._send
-            ) as streams:
+        async def handle_sse(scope, receive, send):
+            async with sse.connect_sse(scope, receive, send) as streams:
                 await app.run(
                     streams[0], streams[1], app.create_initialization_options()
                 )
@@ -75,7 +73,7 @@ def main(port: int, transport: str) -> int:
         starlette_app = Starlette(
             debug=True,
             routes=[
-                Route("/sse", endpoint=handle_sse),
+                Mount("/sse", app=handle_sse),
                 Mount("/messages/", app=sse.handle_post_message),
             ],
         )

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -19,8 +19,8 @@ from pydantic import BaseModel, Field
 from pydantic.networks import AnyUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from starlette.applications import Starlette
-from starlette.requests import Request
 from starlette.routing import Mount, Route
+from starlette.types import Receive, Scope, Send
 
 from mcp.server.fastmcp.exceptions import ResourceError
 from mcp.server.fastmcp.prompts import Prompt, PromptManager
@@ -481,12 +481,8 @@ class FastMCP:
         """Return an instance of the SSE server app."""
         sse = SseServerTransport(self.settings.message_path)
 
-        async def handle_sse(request: Request) -> None:
-            async with sse.connect_sse(
-                request.scope,
-                request.receive,
-                request._send,  # type: ignore[reportPrivateUsage]
-            ) as streams:
+        async def handle_sse(scope: Scope, receive: Receive, send: Send) -> None:
+            async with sse.connect_sse(scope, receive, send) as streams:
                 await self._mcp_server.run(
                     streams[0],
                     streams[1],

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -87,7 +87,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     # HTTP settings
     host: str = "0.0.0.0"
     port: int = 8000
-    sse_path: str = "/sse/"
+    sse_path: str = "/sse"
     message_path: str = "/messages/"
 
     # resource settings
@@ -589,6 +589,7 @@ class FastMCP:
                     streams[1],
                     self._mcp_server.create_initialization_options(),
                 )
+            return Response()
 
         # Create routes
         routes: list[Route | Mount] = []

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -87,7 +87,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     # HTTP settings
     host: str = "0.0.0.0"
     port: int = 8000
-    sse_path: str = "/sse"
+    sse_path: str = "/sse/"
     message_path: str = "/messages/"
 
     # resource settings

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -137,6 +137,10 @@ class ServerSession(
 
         return True
 
+    async def _receive_loop(self) -> None:
+        async with self._incoming_message_stream_writer:
+            await super()._receive_loop()
+
     async def _received_request(
         self, responder: RequestResponder[types.ClientRequest, types.ServerResult]
     ):

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -97,9 +97,6 @@ class ServerSession(
         self._exit_stack.push_async_callback(
             lambda: self._incoming_message_stream_reader.aclose()
         )
-        self._exit_stack.push_async_callback(
-            lambda: self._incoming_message_stream_writer.aclose()
-        )
 
     @property
     def client_params(self) -> types.InitializeRequestParams | None:

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -31,8 +31,8 @@ Example usage:
 ```
 
 Note: The handle_sse function must return a Response to avoid a "TypeError: 'NoneType'
-object is not callable" error when client disconnects. The example above shows the
-correct approach by returning an empty Response() after the SSE connection ends.
+object is not callable" error when client disconnects. The example above returns
+an empty Response() after the SSE connection ends to fix this.
 
 See SseServerTransport class documentation for more details.
 """

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -161,7 +161,7 @@ async def test_raw_sse_connection(http_client: httpx.AsyncClient) -> None:
     async with anyio.create_task_group():
 
         async def connection_test() -> None:
-            async with http_client.stream("GET", "/sse") as response:
+            async with http_client.stream("GET", "/sse/") as response:
                 assert response.status_code == 200
                 assert (
                     response.headers["content-type"]
@@ -185,7 +185,7 @@ async def test_raw_sse_connection(http_client: httpx.AsyncClient) -> None:
 
 @pytest.mark.anyio
 async def test_sse_client_basic_connection(server: None, server_url: str) -> None:
-    async with sse_client(server_url + "/sse") as streams:
+    async with sse_client(server_url + "/sse/") as streams:
         async with ClientSession(*streams) as session:
             # Test initialization
             result = await session.initialize()
@@ -201,7 +201,7 @@ async def test_sse_client_basic_connection(server: None, server_url: str) -> Non
 async def initialized_sse_client_session(
     server, server_url: str
 ) -> AsyncGenerator[ClientSession, None]:
-    async with sse_client(server_url + "/sse", sse_read_timeout=0.5) as streams:
+    async with sse_client(server_url + "/sse/", sse_read_timeout=0.5) as streams:
         async with ClientSession(*streams) as session:
             await session.initialize()
             yield session

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -9,6 +9,7 @@ import pytest
 import uvicorn
 from pydantic import AnyUrl
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Mount, Route
 
@@ -83,7 +84,7 @@ def make_server_app() -> Starlette:
     sse = SseServerTransport("/messages/")
     server = ServerTest()
 
-    async def handle_sse(request) -> None:
+    async def handle_sse(request: Request) -> Response:
         async with sse.connect_sse(
             request.scope, request.receive, request._send
         ) as streams:
@@ -189,7 +190,7 @@ async def test_raw_sse_connection(http_client: httpx.AsyncClient) -> None:
 
 @pytest.mark.anyio
 async def test_sse_client_basic_connection(server: None, server_url: str) -> None:
-    async with sse_client(server_url + "/sse/") as streams:
+    async with sse_client(server_url + "/sse") as streams:
         async with ClientSession(*streams) as session:
             # Test initialization
             result = await session.initialize()
@@ -205,7 +206,7 @@ async def test_sse_client_basic_connection(server: None, server_url: str) -> Non
 async def initialized_sse_client_session(
     server, server_url: str
 ) -> AsyncGenerator[ClientSession, None]:
-    async with sse_client(server_url + "/sse/", sse_read_timeout=0.5) as streams:
+    async with sse_client(server_url + "/sse", sse_read_timeout=0.5) as streams:
         async with ClientSession(*streams) as session:
             await session.initialize()
             yield session


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The `EventSourceResponse` from https://github.com/sysid/sse-starlette returns on SSE session disconnect. However, since we start this in a sub task group, the current implementation does nothing when a disconnect happens. This causes the session `Route` to stay open forever in these cases. 

This PR modifies this behavior to close the streams in the SSE server when EventSourceResponse wraps up, and updates `ServerSession` to properly wrap up and clean up its streams as well when the upstream streams close. 

This exposes a different error in that we have this set up as a `Route` in most cases which shouldn't return `None`. By fixing the 'running forever' issue we end up seeing exceptions related to this whenever a client disconnects. I updated `mount_sse` to return an empty response to fix this. 

## How Has This Been Tested?
Tested manually and ensured that the route was closed when clients close the connection.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
It isn't breaking, but users need to change the `handle_sse` function to a `Mount` to not get `"TypeError: 'NoneType' object is not callable"` errors when client disconnects.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
