### PR TITLE
When no authorization is required dont fail on missing user scope 401 Unauthorized 

### DIFF
--- a/src/mcp/server/auth/middleware/bearer_auth.py
+++ b/src/mcp/server/auth/middleware/bearer_auth.py
@@ -74,7 +74,7 @@ class RequireAuthMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         auth_user = scope.get("user")
-        if not isinstance(auth_user, AuthenticatedUser):
+        if not isinstance(auth_user, AuthenticatedUser) and self.required_scopes:
             raise HTTPException(status_code=401, detail="Unauthorized")
         auth_credentials = scope.get("auth")
 


### PR DESCRIPTION
While developing a mcp server that wil run locally I want to use the sse protocal and not stdio. Because im running local i dont need any authentication, but the default RequireAuthMiddleware will fail if if not isinstance(auth_user, AuthenticatedUser).

I want the solution to be
if not isinstance(auth_user, AuthenticatedUser) and self.required_scopes: so if there are no required scopes I wont have to do anything and i can just connect to the server withtout any autherization


## How Has This Been Tested?
I tested it locally to work with cursor


