### PR TITLE
Add support for sending cancellation in based on anyio.CancelScope status

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -140,7 +140,7 @@ class ClientSession(
                 )
             ),
             types.InitializeResult,
-            cancellable=False
+            cancellable=False,
         )
 
         if result.protocolVersion not in SUPPORTED_PROTOCOL_VERSIONS:

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -140,6 +140,7 @@ class ClientSession(
                 )
             ),
             types.InitializeResult,
+            cancellable=False
         )
 
         if result.protocolVersion not in SUPPORTED_PROTOCOL_VERSIONS:

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -601,14 +601,12 @@ class Server(Generic[LifespanResultT]):
             assert type(notify) in self.notification_handlers
 
             handler = self.notification_handlers[type(notify)]
-            print(f"Dispatching notification of type {type(notify).__name__}")
+            logger.debug(f"Dispatching notification of type {type(notify).__name__}")
 
             try:
                 await handler(notify)
             except Exception as err:
                 logger.error(f"Uncaught exception in notification handler: {err}")
-        else:
-            print(f"Not handling {notify}")
 
 
 async def _ping_handler(request: types.PingRequest) -> types.ServerResult:

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -445,7 +445,7 @@ class Server(Generic[LifespanResultT]):
         def decorator(
             func: Callable[[str | int, str | None], Awaitable[None]],
         ):
-            logger.debug("Registering handler for ProgressNotification")
+            logger.debug("Registering handler for CancelledNotification")
 
             async def handler(req: types.CancelledNotification):
                 await func(

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -448,15 +448,13 @@ class Server(Generic[LifespanResultT]):
             logger.debug("Registering handler for CancelledNotification")
 
             async def handler(req: types.CancelledNotification):
-                await func(
-                    req.params.requestId, req.params.reason
-                )
+                await func(req.params.requestId, req.params.reason)
 
             self.notification_handlers[types.CancelledNotification] = handler
             return func
 
         return decorator
-    
+
     def completion(self):
         """Provides completions for prompts and resource templates"""
 

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -216,6 +216,7 @@ class BaseSession(
         result_type: type[ReceiveResultT],
         request_read_timeout_seconds: timedelta | None = None,
         metadata: MessageMetadata = None,
+        cancellable: bool = True,
     ) -> ReceiveResultT:
         """
         Sends a request and wait for a response. Raises an McpError if the
@@ -260,7 +261,7 @@ class BaseSession(
                 with anyio.fail_after(timeout) as scope:
                     response_or_error = await response_stream_reader.receive()
 
-                    if scope.cancel_called:
+                    if cancellable and scope.cancel_called:
                         with anyio.CancelScope(shield=True):
                             notification = CancelledNotification(
                                 method="notifications/cancelled",

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -35,8 +35,10 @@ SendRequestT = TypeVar("SendRequestT", ClientRequest, ServerRequest)
 SendResultT = TypeVar("SendResultT", ClientResult, ServerResult)
 SendNotificationT = TypeVar("SendNotificationT", ClientNotification, ServerNotification)
 SendNotificationInternalT = TypeVar(
-    "SendNotificationInternalT", 
-    CancelledNotification, ClientNotification, ServerNotification
+    "SendNotificationInternalT",
+    CancelledNotification,
+    ClientNotification,
+    ServerNotification,
 )
 ReceiveRequestT = TypeVar("ReceiveRequestT", ClientRequest, ServerRequest)
 ReceiveResultT = TypeVar("ReceiveResultT", bound=BaseModel)
@@ -269,14 +271,13 @@ class BaseSession(
                             notification = CancelledNotification(
                                 method="notifications/cancelled",
                                 params=CancelledNotificationParams(
-                                    requestId=request_id, 
-                                    reason="cancelled"
-                                )
+                                    requestId=request_id, reason="cancelled"
+                                ),
                             )
                             await self._send_notification_internal(
                                 notification, request_id
                             )
-                            
+
                         raise McpError(
                             ErrorData(code=32601, message="Request cancelled")
                         )
@@ -292,7 +293,7 @@ class BaseSession(
                         ),
                     )
                 )
-            
+
             if isinstance(response_or_error, JSONRPCError):
                 raise McpError(response_or_error.error)
             else:

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -270,7 +270,9 @@ class BaseSession(
                                     reason="cancelled"
                                 )
                             )
-                            await self._send_notification_internal(notification, request_id)
+                            await self._send_notification_internal(
+                                notification, request_id
+                            )
                             
                         raise McpError(
                             ErrorData(code=32601, message="Request cancelled")

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -34,7 +34,10 @@ from mcp.types import (
 SendRequestT = TypeVar("SendRequestT", ClientRequest, ServerRequest)
 SendResultT = TypeVar("SendResultT", ClientResult, ServerResult)
 SendNotificationT = TypeVar("SendNotificationT", ClientNotification, ServerNotification)
-SendNotificationInternalT = TypeVar("SendNotificationInternalT", CancelledNotification, ClientNotification, ServerNotification)
+SendNotificationInternalT = TypeVar(
+    "SendNotificationInternalT", 
+    CancelledNotification, ClientNotification, ServerNotification
+)
 ReceiveRequestT = TypeVar("ReceiveRequestT", ClientRequest, ServerRequest)
 ReceiveResultT = TypeVar("ReceiveResultT", bound=BaseModel)
 ReceiveNotificationT = TypeVar(

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -272,7 +272,7 @@ class BaseSession(
                             await self._send_notification_internal(notification, request_id)
                             
                         raise McpError(
-                            ErrorData(code=32601, message="request cancelled")
+                            ErrorData(code=32601, message="Request cancelled")
                         )
 
             except TimeoutError:

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -9,9 +9,6 @@ from mcp.server.lowlevel.server import Server
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_connected_server_and_client_session
 from mcp.types import (
-    CancelledNotification,
-    CancelledNotificationParams,
-    ClientNotification,
     ClientRequest,
     EmptyResult,
 )

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -62,7 +62,7 @@ async def test_request_cancellation():
                 await anyio.sleep(10)  # Long enough to ensure we can cancel
                 return []
             raise ValueError(f"Unknown tool: {name}")
-        
+
         @server.cancel_notification()
         async def handle_cancel(requestId: str | int, reason: str | None):
             nonlocal ev_cancel_notified

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -989,7 +989,7 @@ async def test_streamablehttp_client_session_termination(
             # Attempt to make a request after termination
             with pytest.raises(
                 McpError,
-                match="Session terminated",
+                match="request cancelled",
             ):
                 await session.list_tools()
 

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -989,7 +989,7 @@ async def test_streamablehttp_client_session_termination(
             # Attempt to make a request after termination
             with pytest.raises(
                 McpError,
-                match="request cancelled",
+                match="Session terminated",
             ):
                 await session.list_tools()
 


### PR DESCRIPTION


## Motivation and Context
MCP 2025-03-26 introduces a cancellation notification https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/cancellation this patch implements this protocol for the ClientSession via integration with the anyio.CancelScope potential fix for https://github.com/modelcontextprotocol/python-sdk/issues/160

## How Has This Been Tested?
Added unit tests to assert behaviour and tidied up previous work around for lack of this behaviour in tests/shared/test_session.py#test_request_cancellation

## Breaking Changes
Not expected but tests with real world applications would be advisable prior to merge

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Documentation updates would be sensible, I'm happy to write something if this patch looks good. Also I debated whether it's possible to trigger a cancel on the server side when a client side cancel is received, I'll take a look at how feasible that is tomorrow
