### PR TITLE
Simplified client progress_callback support

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -250,28 +250,30 @@ class BaseSession(
         send_request = None
 
         if progress_callback is not None:
-            if request.root.params is not None:
+            if request.root.params is None:
+                progress_id = self._progress_id
+                new_params = RequestParams(
+                    _meta=RequestParams.Meta(progressToken=progress_id)
+                )
+            else:
                 if (
                     request.root.params.meta is None
                     or request.root.params.meta.progressToken is None
                 ):
                     progress_id = self._progress_id
-                    self._progress_id = progress_id + 1
                     new_params = request.root.params.model_copy(
                         update={"meta": RequestParams.Meta(progressToken=progress_id)}
                     )
-                    new_root = request.root.model_copy(update={"params": new_params})
-                    send_request = request.model_copy(update={"root": new_root})
-                    self._in_progress[progress_id] = progress_callback
                 else:
                     raise ValueError(
                         "Request has progressToken and progress_callback provided "
                         "via send_request method only one or other is supported"
                     )
-            else:
-                raise ValueError(
-                    f"{type(request.root).__name__} does not support progress"
-                )
+
+            new_root = request.root.model_copy(update={"params": new_params})
+            send_request = request.model_copy(update={"root": new_root})
+            self._progress_id = progress_id + 1
+            self._in_progress[progress_id] = progress_callback
 
         if send_request is None:
             send_request = request

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -251,14 +251,23 @@ class BaseSession(
 
         if progress_callback is not None:
             if request.root.params is not None:
-                progress_id = self._progress_id
-                self._progress_id = progress_id + 1
-                new_params = request.root.params.model_copy(
-                    update={"meta": RequestParams.Meta(progressToken=progress_id)}
-                )
-                new_root = request.root.model_copy(update={"params": new_params})
-                send_request = request.model_copy(update={"root": new_root})
-                self._in_progress[progress_id] = progress_callback
+                if (
+                    request.root.params.meta is None
+                    or request.root.params.meta.progressToken is None
+                ):
+                    progress_id = self._progress_id
+                    self._progress_id = progress_id + 1
+                    new_params = request.root.params.model_copy(
+                        update={"meta": RequestParams.Meta(progressToken=progress_id)}
+                    )
+                    new_root = request.root.model_copy(update={"params": new_params})
+                    send_request = request.model_copy(update={"root": new_root})
+                    self._in_progress[progress_id] = progress_callback
+                else:
+                    raise ValueError(
+                        "Request has progressToken and progress_callback provided "
+                        "via send_request method only one or other is supported"
+                    )
             else:
                 raise ValueError(
                     f"{type(request.root).__name__} does not support progress"

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -261,6 +261,8 @@ async def test_client_session_progress():
         SessionMessage
     ](1)
 
+    send_notification_count = 10
+
     async def mock_server():
         session_message = await client_to_server_receive.receive()
         jsonrpc_request = session_message.message
@@ -273,24 +275,16 @@ async def test_client_session_progress():
         assert request.root.params.meta.progressToken is not None
 
         progress_token = request.root.params.meta.progressToken
-
         notifications = [
             types.ServerNotification(
                 root=types.ProgressNotification(
                     params=types.ProgressNotificationParams(
-                        progressToken=progress_token, progress=1
+                        progressToken=progress_token, progress=i
                     ),
                     method="notifications/progress",
                 )
-            ),
-            types.ServerNotification(
-                root=types.ProgressNotification(
-                    params=types.ProgressNotificationParams(
-                        progressToken=progress_token, progress=2
-                    ),
-                    method="notifications/progress",
-                )
-            ),
+            )
+            for i in range(send_notification_count)
         ]
         result = ServerResult(types.CallToolResult(content=[]))
 
@@ -358,4 +352,4 @@ async def test_client_session_progress():
     # Assert the result
     assert isinstance(result, types.CallToolResult)
     assert len(result.content) == 0
-    assert progress_count == 2
+    assert progress_count == send_notification_count


### PR DESCRIPTION
Add support for an optional callback to be called during tool execution to inform of progress

## Motivation and Context
Tracking progress on the client is useful for long running tasks, the low level primitives are available via the protocol however they're a little complex to setup. This patch adds an optional calllback to to the call_tool request and does the heavy lifting for the caller so they don't have to do this.

The soluiton is implemented on the BaseSession object so the approach can be used for both client->server and server->client requests. Currently the only top level method that supports this is clientsession.call_tool which seems like the most common use case. If there are other are other use cases they can be added easilly.

## How Has This Been Tested?
Unit testing only

## Breaking Changes
None expected

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
If this looks useful I can add documentation to the patch
