### PR TITLE
Tests(cli): Add coverage for helper functions

### DIFF
--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,0 +1,100 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mcp.cli.cli import _build_uv_command, _get_npx_command, _parse_file_path
+
+
+@pytest.mark.parametrize(
+    "spec, expected_obj",
+    [
+        ("server.py", None),
+        ("foo.py:srv_obj", "srv_obj"),
+    ],
+)
+def test_parse_file_path_accepts_valid_specs(tmp_path, spec, expected_obj):
+    """Should accept valid file specs."""
+    file = tmp_path / spec.split(":")[0]
+    file.write_text("x = 1")
+    path, obj = _parse_file_path(f"{file}:{expected_obj}" if ":" in spec else str(file))
+    assert path == file.resolve()
+    assert obj == expected_obj
+
+
+def test_parse_file_path_missing(tmp_path):
+    """Should system exit if a file is missing."""
+    with pytest.raises(SystemExit):
+        _parse_file_path(str(tmp_path / "missing.py"))
+
+
+def test_parse_file_exit_on_dir(tmp_path):
+    """Should system exit if a directory is passed"""
+    dir_path = tmp_path / "dir"
+    dir_path.mkdir()
+    with pytest.raises(SystemExit):
+        _parse_file_path(str(dir_path))
+
+
+def test_build_uv_command_minimal():
+    """Should emit core command when no extras specified."""
+    cmd = _build_uv_command("foo.py")
+    assert cmd == ["uv", "run", "--with", "mcp", "mcp", "run", "foo.py"]
+
+
+def test_build_uv_command_adds_editable_and_packages():
+    """Should include --with-editable and every --with pkg in correct order."""
+    test_path = Path("/pkg")
+    cmd = _build_uv_command(
+        "foo.py",
+        with_editable=test_path,
+        with_packages=["package1", "package2"],
+    )
+    assert cmd == [
+        "uv",
+        "run",
+        "--with",
+        "mcp",
+        "--with-editable",
+        str(test_path),  # Use str() to match what the function does
+        "--with",
+        "package1",
+        "--with",
+        "package2",
+        "mcp",
+        "run",
+        "foo.py",
+    ]
+
+
+def test_get_npx_unix_like(monkeypatch):
+    """Should return "npx" on unix-like systems."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert _get_npx_command() == "npx"
+
+
+def test_get_npx_windows(monkeypatch):
+    """Should return one of the npx candidates on Windows."""
+    candidates = ["npx.cmd", "npx.exe", "npx"]
+
+    def fake_run(cmd, **kw):
+        if cmd[0] in candidates:
+            return subprocess.CompletedProcess(cmd, 0)
+        else:
+            raise subprocess.CalledProcessError(1, cmd[0])
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert _get_npx_command() in candidates
+
+
+def test_get_npx_returns_none_when_npx_missing(monkeypatch):
+    """Should give None if every candidate fails."""
+    monkeypatch.setattr(sys, "platform", "win32", raising=False)
+
+    def always_fail(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0])
+
+    monkeypatch.setattr(subprocess, "run", always_fail)
+    assert _get_npx_command() is None


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
### Summary
This PR is tests‑only; it adds coverage but introduces no functional changes.

Add unit tests for three un-covered helpers in `src/mcp/cli/cli.py`  
* **_parse_file_path** (valid / invalid specs)  
* **_build_uv_command** (minimal and “editable + packages” cases)  
* **_get_npx_command** (POSIX and Windows code paths)

Resulting coverage:
* CLI module: **17 % → ~34 %**
* Overall project: **88 % → 89 %** (measured locally with `pytest --cov`)

No production code touched.

## Motivation and Context
The CLI is the primary entry-point for MCP users but previously had few tests, so regressions could slip in unnoticed.  
These focused unit tests provide a safety net while keeping the codebase lean.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
* Ran locally on macOS and ran ruff linting/formatting.  
  ```bash
  uv run pytest
  uv run pyright
  uv run ruff check .
  uv run ruff format .
  ```

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Target branch: `main` per CONTRIBUTING guidelines (house-keeping / tests, not a released-version bug-fix).
Happy to address any feedback or add more coverage if requested.