### PR TITLE
Fix the issue of get Authorization header fails during bearer auth

### DIFF
--- a/src/mcp/server/auth/middleware/bearer_auth.py
+++ b/src/mcp/server/auth/middleware/bearer_auth.py
@@ -34,7 +34,9 @@ class BearerAuthBackend(AuthenticationBackend):
         self.provider = provider
 
     async def authenticate(self, conn: HTTPConnection):
-        auth_header = conn.headers.get("Authorization") or conn.headers.get("authorization")
+        auth_header = conn.headers.get("Authorization") or conn.headers.get(
+            "authorization"
+        )
         if not auth_header or not auth_header.startswith("Bearer "):
             return None
 

--- a/src/mcp/server/auth/middleware/bearer_auth.py
+++ b/src/mcp/server/auth/middleware/bearer_auth.py
@@ -34,10 +34,15 @@ class BearerAuthBackend(AuthenticationBackend):
         self.provider = provider
 
     async def authenticate(self, conn: HTTPConnection):
-        auth_header = conn.headers.get("Authorization") or conn.headers.get(
-            "authorization"
+        auth_header = next(
+            (
+                conn.headers.get(key)
+                for key in conn.headers
+                if key.lower() == "authorization"
+            ),
+            None,
         )
-        if not auth_header or not auth_header.startswith("Bearer "):
+        if not auth_header or not auth_header.lower().startswith("bearer "):
             return None
 
         token = auth_header[7:]  # Remove "Bearer " prefix

--- a/src/mcp/server/auth/middleware/bearer_auth.py
+++ b/src/mcp/server/auth/middleware/bearer_auth.py
@@ -34,7 +34,7 @@ class BearerAuthBackend(AuthenticationBackend):
         self.provider = provider
 
     async def authenticate(self, conn: HTTPConnection):
-        auth_header = conn.headers.get("Authorization")
+        auth_header = conn.headers.get("Authorization") or conn.headers.get("authorization")
         if not auth_header or not auth_header.startswith("Bearer "):
             return None
 


### PR DESCRIPTION
The bearer auth retrieves the Authorization from the headers, but the HTTPConnection.headers uses lowercase authorization, resulting in authentication failure.

