### PR TITLE
docs: fix broken link to OAuthServerProvider in Authentication section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ mcp = FastMCP("My App",
 )
 ```
 
-See [OAuthServerProvider](mcp/server/auth/provider.py) for more details.
+See [OAuthServerProvider](src/mcp/server/auth/provider.py) for more details.
 
 ## Running Your Server
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

- Updated the broken link in [Authentication](https://github.com/modelcontextprotocol/python-sdk?tab=readme-ov-file#authentication) section of README.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

- I wanted to understand how OAuth works with MCP and while browsing through the docs I found that the link to the OAuthServerProvider was broken

https://github.com/user-attachments/assets/9119803c-50a7-401d-9b21-0b758b7f1ae5

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

- Tested local branch on GH.
- Verified the file and the link is working now.

https://github.com/user-attachments/assets/7e6f24ea-b7ef-4307-aaeb-6982c2376c16



## Breaking Changes
<!-- Will users need to update their code or configurations? -->
- No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
