### PR TITLE
Properly infer prefix for SSE messages

### DIFF
--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -100,9 +100,24 @@ class SseServerTransport:
         write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
 
         session_id = uuid4()
-        session_uri = f"{quote(self._endpoint)}?session_id={session_id.hex}"
         self._read_stream_writers[session_id] = read_stream_writer
         logger.debug(f"Created new session with ID: {session_id}")
+
+        # Determine the full path for the message endpoint to be sent to the client.
+        # scope['root_path'] is the prefix where the current Starlette app instance is mounted.
+        # e.g., "" if top-level, or "/api_prefix" if mounted under "/api_prefix".
+        root_path = scope.get("root_path", "")
+
+        # self._endpoint is the path *within* this app, e.g., "/messages".
+        # Concatenating them gives the full absolute path from the server root.
+        # e.g., "" + "/messages" -> "/messages"
+        # e.g., "/api_prefix" + "/messages" -> "/api_prefix/messages"
+        full_message_path_for_client = root_path.rstrip("/") + self._endpoint
+
+        # This is the URI (path + query) the client will use to POST messages.
+        client_post_uri_data = (
+            f"{quote(full_message_path_for_client)}?session_id={session_id.hex}"
+        )
 
         sse_stream_writer, sse_stream_reader = anyio.create_memory_object_stream[
             dict[str, Any]
@@ -111,8 +126,10 @@ class SseServerTransport:
         async def sse_writer():
             logger.debug("Starting SSE writer")
             async with sse_stream_writer, write_stream_reader:
-                await sse_stream_writer.send({"event": "endpoint", "data": session_uri})
-                logger.debug(f"Sent endpoint event: {session_uri}")
+                await sse_stream_writer.send(
+                    {"event": "endpoint", "data": client_post_uri_data}
+                )
+                logger.debug(f"Sent endpoint event: {client_post_uri_data}")
 
                 async for session_message in write_stream_reader:
                     logger.debug(f"Sending message via SSE: {session_message}")

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -104,7 +104,8 @@ class SseServerTransport:
         logger.debug(f"Created new session with ID: {session_id}")
 
         # Determine the full path for the message endpoint to be sent to the client.
-        # scope['root_path'] is the prefix where the current Starlette app instance is mounted.
+        # scope['root_path'] is the prefix where the current Starlette app
+        # instance is mounted.
         # e.g., "" if top-level, or "/api_prefix" if mounted under "/api_prefix".
         root_path = scope.get("root_path", "")
 


### PR DESCRIPTION
I've been following the issue in #386 and see the solution merged in #540. However, it feels very wrong. An app should never have to know its mount path in advance in order to work properly. Furthermore, this results in a cumbersome DX where *either* users specify the mount paths when creating the FastMCP server, effectively preventing it from being used in any other context *or* users double-specify mount paths when mounting the SSE app into another Starlette application, which is confusing and awkward.

With that in mind, consider this example from the docs of #540. The GitHub and browser apps will simply break if they are mounted under any other path. This is not a good user-facing outcome.

```python
# Create Starlette app with multiple mounted servers
app = Starlette(
    routes=[
        # Using settings-based configuration
        Mount("/github", app=github_mcp.sse_app()),
        Mount("/browser", app=browser_mcp.sse_app()),
        # Using direct mount path parameter
        Mount("/curl", app=curl_mcp.sse_app("/curl")),
        Mount("/search", app=search_mcp.sse_app("/search")),
    ]
)
```

Happily I don't think we need to settle, or pollute the FastMCP server with new user-facing configuration. The ASGI spec provides for pretty much this exact circumstance with a `root_path` attribute on the `Scope` object. By examining the root path when constructing the messages POST endpoint, we can ensure that it is always generated at the correct absolute path, without having to perform any complex parsing or even asking users to provide additional configuration. 

With this PR, the following works out of the box:

```python
import uvicorn
from starlette.applications import Starlette
from starlette.routing import Mount

from mcp.server.fastmcp import FastMCP

mcp = FastMCP()


@mcp.tool()
async def hello() -> str:
    return "Hello, world!"


sse_app = mcp.sse_app()
main_app = Starlette(routes=[Mount("/nested/mount/", app=sse_app)])

if __name__ == "__main__":
    uvicorn.run(main_app, host="127.0.0.1", port=8000)
```
