### PR TITLE
Fix timeout parameter not being passed in HTTP posts

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -120,6 +120,7 @@ async def sse_client(
                                             mode="json",
                                             exclude_none=True,
                                         ),
+                                        timeout=httpx.Timeout(timeout),
                                     )
                                     response.raise_for_status()
                                     logger.debug(


### PR DESCRIPTION
Use the sse_client timeout in POSTs it sends.

## Motivation and Context
A server I am writing has need for timeouts longer than the httpx default for tool calls (they are about intentionally delaying an agent's execution loop until a condition is met in order to save cycles, so it wouldn't be appropriate to switch to a job pattern)

The timeout parameters are already passed into the event source that wraps the client via kwargs, but POSTs are made using the httpx client directly. Before this change when I pass long timeouts into the sse_client, it still timeouts when the MCP server takes longer than the httpx default to respond to POSTs.

## How Has This Been Tested?
I tried using https://github.com/Coral-Protocol/coral-server 's `wait_for_mentions` tool with a client powered by the MCP python sdk.  When using with timeouts too close to exceeding the default httpx timeout, it fails with
```
Error in post writer:
```
(Side note: the underlying exception has no description.  I recommend we use `repr(e)` to show the exception type)

With this change made in site-packages, it works with timeouts greater than the httpx default.

 
## Breaking Changes
Any users who are passing in longer timeouts than they desire, relying on the POST timeout to be ignored, will end up with undesired behaviour. I estimate this to be extremely rare.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- N/A I have added appropriate error handling
- N/A I have added or updated documentation as needed

## Additional context

Since this is a HTTP post via httpx, only the write timeout needs to be set. Though I am conscious of underlying implementations and/or future versions also being liable to `ReadTimeout`s  (e.g. developers wish for separate timeouts on preflight requests), I would have included a read timeout, though this function's `sse_read_timeout`  is explicitly described about being time without new events, a new parameter for this feels excessive. It is probably premature to consider anyway.
