### PR TITLE
Include server examples folder in pyright check

### DIFF
--- a/examples/servers/simple-auth/mcp_simple_auth/__main__.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/__main__.py
@@ -4,4 +4,4 @@ import sys
 
 from mcp_simple_auth.server import main
 
-sys.exit(main())
+sys.exit(main())  # type: ignore[call-arg]

--- a/examples/servers/simple-prompt/mcp_simple_prompt/__main__.py
+++ b/examples/servers/simple-prompt/mcp_simple_prompt/__main__.py
@@ -2,4 +2,4 @@ import sys
 
 from .server import main
 
-sys.exit(main())
+sys.exit(main())  # type: ignore[call-arg]

--- a/examples/servers/simple-resource/mcp_simple_resource/__main__.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/__main__.py
@@ -2,4 +2,4 @@ import sys
 
 from .server import main
 
-sys.exit(main())
+sys.exit(main())  # type: ignore[call-arg]

--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -2,7 +2,7 @@ import anyio
 import click
 import mcp.types as types
 from mcp.server.lowlevel import Server
-from pydantic import FileUrl
+from pydantic import AnyUrl
 
 SAMPLE_RESOURCES = {
     "greeting": "Hello! This is a sample text resource.",
@@ -26,7 +26,7 @@ def main(port: int, transport: str) -> int:
     async def list_resources() -> list[types.Resource]:
         return [
             types.Resource(
-                uri=FileUrl(f"file:///{name}.txt"),
+                uri=AnyUrl(f"file:///{name}.txt"),
                 name=name,
                 description=f"A sample text resource named {name}",
                 mimeType="text/plain",
@@ -35,7 +35,9 @@ def main(port: int, transport: str) -> int:
         ]
 
     @app.read_resource()
-    async def read_resource(uri: FileUrl) -> str | bytes:
+    async def read_resource(uri: AnyUrl) -> str | bytes:
+        if uri.path is None:
+            raise ValueError(f"Invalid resource path: {uri}")
         name = uri.path.replace(".txt", "").lstrip("/")
 
         if name not in SAMPLE_RESOURCES:

--- a/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/__main__.py
+++ b/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/__main__.py
@@ -1,4 +1,7 @@
 from .server import main
 
 if __name__ == "__main__":
-    main()
+    # Click will handle CLI arguments
+    import sys
+    
+    sys.exit(main())  # type: ignore[call-arg]

--- a/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
+++ b/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
@@ -5,7 +5,7 @@ import anyio
 import click
 import mcp.types as types
 from mcp.server.lowlevel import Server
-from mcp.server.streamableHttp import (
+from mcp.server.streamable_http import (
     StreamableHTTPServerTransport,
 )
 from starlette.applications import Starlette
@@ -143,7 +143,7 @@ def main(
                     app.create_initialization_options(),
                     # Runs in standalone mode for stateless deployments
                     # where clients perform initialization with any node
-                    standalone_mode=True,
+                    stateless=True,
                 )
 
             # Start server task

--- a/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/__main__.py
+++ b/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/__main__.py
@@ -1,4 +1,4 @@
 from .server import main
 
 if __name__ == "__main__":
-    main()
+    main()  # type: ignore[call-arg]

--- a/examples/servers/simple-tool/mcp_simple_tool/__main__.py
+++ b/examples/servers/simple-tool/mcp_simple_tool/__main__.py
@@ -2,4 +2,4 @@ import sys
 
 from .server import main
 
-sys.exit(main())
+sys.exit(main())  # type: ignore[call-arg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ Issues = "https://github.com/modelcontextprotocol/python-sdk/issues"
 packages = ["src/mcp"]
 
 [tool.pyright]
-include = ["src/mcp", "tests"]
+include = ["src/mcp", "tests", "examples/servers"]
 venvPath = "."
 venv = ".venv"
 strict = ["src/mcp/**/*.py"]


### PR DESCRIPTION
Did some refactoring in streamable http and completely broke one of the examples, CI didn't stop me 😞 

Adding pyright check for server/examples + fixing some errors  