### PR TITLE
Fix streamable http sampling

### DIFF
--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -31,6 +31,7 @@ def get_claude_config_path() -> Path | None:
         return path
     return None
 
+
 def get_uv_path() -> str:
     """Get the full path to the uv executable."""
     uv_path = shutil.which("uv")
@@ -41,6 +42,7 @@ def get_uv_path() -> str:
         )
         return "uv"  # Fall back to just "uv" if not found
     return uv_path
+
 
 def update_claude_config(
     file_spec: str,

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -310,6 +310,8 @@ class StreamableHTTPTransport:
                         else None
                     ),
                 )
+                # If the SSE event indicates completion, like returning respose/error
+                # break the loop
                 if is_complete:
                     break
         except Exception as e:

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import anyio
 import httpx
+from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from httpx_sse import EventSource, ServerSentEvent, aconnect_sse
 
@@ -239,7 +240,7 @@ class StreamableHTTPTransport:
                     break
 
     async def _handle_post_request(self, ctx: RequestContext) -> None:
-        """Handle a  POST request with response processing."""
+        """Handle a POST request with response processing."""
         headers = self._update_headers_with_session(ctx.headers)
         message = ctx.session_message.message
         is_initialization = self._is_initialization_request(message)
@@ -300,7 +301,7 @@ class StreamableHTTPTransport:
         try:
             event_source = EventSource(response)
             async for sse in event_source.aiter_sse():
-                await self._handle_sse_event(
+                is_complete = await self._handle_sse_event(
                     sse,
                     ctx.read_stream_writer,
                     resumption_callback=(
@@ -309,6 +310,8 @@ class StreamableHTTPTransport:
                         else None
                     ),
                 )
+                if is_complete:
+                    break
         except Exception as e:
             logger.exception("Error reading SSE stream:")
             await ctx.read_stream_writer.send(e)
@@ -344,6 +347,7 @@ class StreamableHTTPTransport:
         read_stream_writer: StreamWriter,
         write_stream: MemoryObjectSendStream[SessionMessage],
         start_get_stream: Callable[[], None],
+        tg: TaskGroup,
     ) -> None:
         """Handle writing requests to the server."""
         try:
@@ -375,10 +379,17 @@ class StreamableHTTPTransport:
                         sse_read_timeout=self.sse_read_timeout,
                     )
 
-                    if is_resumption:
-                        await self._handle_resumption_request(ctx)
+                    async def handle_request_async():
+                        if is_resumption:
+                            await self._handle_resumption_request(ctx)
+                        else:
+                            await self._handle_post_request(ctx)
+
+                    # If this is a request, start a new task to handle it
+                    if isinstance(message.root, JSONRPCRequest):
+                        tg.start_soon(handle_request_async)
                     else:
-                        await self._handle_post_request(ctx)
+                        await handle_request_async()
 
         except Exception as exc:
             logger.error(f"Error in post_writer: {exc}")
@@ -466,6 +477,7 @@ async def streamablehttp_client(
                     read_stream_writer,
                     write_stream,
                     start_get_stream,
+                    tg,
                 )
 
                 try:

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -47,7 +47,7 @@ from pydantic import AnyUrl
 
 import mcp.types as types
 from mcp.server.models import InitializationOptions
-from mcp.shared.message import SessionMessage, ServerMessageMetadata
+from mcp.shared.message import ServerMessageMetadata, SessionMessage
 from mcp.shared.session import (
     BaseSession,
     RequestResponder,

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -47,7 +47,7 @@ from pydantic import AnyUrl
 
 import mcp.types as types
 from mcp.server.models import InitializationOptions
-from mcp.shared.message import SessionMessage
+from mcp.shared.message import SessionMessage, ServerMessageMetadata
 from mcp.shared.session import (
     BaseSession,
     RequestResponder,
@@ -230,10 +230,11 @@ class ServerSession(
         stop_sequences: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
         model_preferences: types.ModelPreferences | None = None,
+        related_request_id: types.RequestId | None = None,
     ) -> types.CreateMessageResult:
         """Send a sampling/create_message request."""
         return await self.send_request(
-            types.ServerRequest(
+            request=types.ServerRequest(
                 types.CreateMessageRequest(
                     method="sampling/createMessage",
                     params=types.CreateMessageRequestParams(
@@ -248,7 +249,10 @@ class ServerSession(
                     ),
                 )
             ),
-            types.CreateMessageResult,
+            result_type=types.CreateMessageResult,
+            metadata=ServerMessageMetadata(
+                related_request_id=related_request_id,
+            ),
         )
 
     async def list_roots(self) -> types.ListRootsResult:

--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -33,7 +33,6 @@ from mcp.types import (
     ErrorData,
     JSONRPCError,
     JSONRPCMessage,
-    JSONRPCNotification,
     JSONRPCRequest,
     JSONRPCResponse,
     RequestId,

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -223,7 +223,6 @@ class BaseSession(
         Do not use this method to emit notifications! Use send_notification()
         instead.
         """
-
         request_id = self._request_id
         self._request_id = request_id + 1
 

--- a/tests/client/test_config.py
+++ b/tests/client/test_config.py
@@ -54,7 +54,7 @@ def test_absolute_uv_path(mock_config_path: Path):
     """Test that the absolute path to uv is used when available."""
     # Mock the shutil.which function to return a fake path
     mock_uv_path = "/usr/local/bin/uv"
-    
+
     with patch("mcp.cli.claude.get_uv_path", return_value=mock_uv_path):
         # Setup
         server_name = "test_server"
@@ -71,5 +71,5 @@ def test_absolute_uv_path(mock_config_path: Path):
         # Verify the command is the absolute path
         server_config = config["mcpServers"][server_name]
         command = server_config["command"]
-        
+
         assert command == mock_uv_path


### PR DESCRIPTION
Thank you @jlowin for raising https://github.com/modelcontextprotocol/python-sdk/issues/680 🙏

The StreamableHTTP client was experiencing a deadlock when the server initiated sampling callbacks during request
   processing. The issue occurred due to synchronous request handling in the client's post_writer function.

  The Deadlock Scenario:

  1. Client sends a tool call request to the server
  2. Server processes the tool and needs to perform sampling, initiating a callback to the client
  3. Server sends the sampling request to the client as a new JSONRPC request
  4. Client's post_writer receives the sampling request but handles it synchronously
  5. Client blocks waiting for the server's response to the sampling request
  6. Server is blocked waiting for the sampling response before it can complete the original tool call
  7. Deadlock: Both client and server are waiting for each other

  The circular dependency prevented the sampling response from ever reaching the server, causing the system to hang
   indefinitely.

  **The Solution**

Concurrent request handling in the StreamableHTTP client:

  1. Added TaskGroup parameter to post_writer to enable concurrent task execution
  2. Modified request handling logic to process incoming JSONRPC requests (like sampling callbacks) in separate
  tasks using tg.start_soon(), while responses continue to be handled synchronously (notification need to be handled concurrently as we will have other issues like initialisation notifications )
  3. Fixed SSE event handling to properly detect completion and break from the event loop

  The fix ensures that request handling doesn't block the message processing pipeline, allowing the client to:
  - Process server-initiated callbacks in separate tasks
  - Continue listening for new messages in the main task
  - Send callback responses without blocking
  - Receive the server's completion of the original request

**Follow ups:**
- as we are working on integration tests - all tests for all the features and transports combinations 

