### PR TITLE
fix: 204 is an acceptable response to DELETEing the session

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -410,7 +410,7 @@ class StreamableHTTPTransport:
 
             if response.status_code == 405:
                 logger.debug("Server does not allow session termination")
-            elif response.status_code != 200:
+            elif response.status_code not in (200, 204):
                 logger.warning(f"Session termination failed: {response.status_code}")
         except Exception as exc:
             logger.warning(f"Session termination failed: {exc}")


### PR DESCRIPTION
Closes https://github.com/modelcontextprotocol/python-sdk/issues/696

## Motivation and Context
204 is the correct response code to return for a body-less response, [per RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.5).

## How Has This Been Tested?
- [x] New tests

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
