### PR TITLE
Fix example for multiple stateless servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,9 +443,10 @@ from mcp.math import math
 # Create a combined lifespan to manage both session managers
 @contextlib.asynccontextmanager
 async def lifespan(app: FastAPI):
-    async with echo.mcp.session_manager.run():
-        async with math.mcp.session_manager.run():
-            yield
+    async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(echo.mcp.session_manager.run())
+        await stack.enter_async_context(math.mcp.session_manager.run())
+        yield
 
 
 app = FastAPI(lifespan=lifespan)

--- a/README.md
+++ b/README.md
@@ -434,15 +434,21 @@ def add_two(n: int) -> int:
 
 ```python
 # main.py
+import contextlib
 from fastapi import FastAPI
 from mcp.echo import echo
 from mcp.math import math
 
 
-app = FastAPI()
+# Create a combined lifespan to manage both session managers
+@contextlib.asynccontextmanager
+async def lifespan(app: FastAPI):
+    async with echo.mcp.session_manager.run():
+        async with math.mcp.session_manager.run():
+            yield
 
-# Use the session manager's lifespan
-app = FastAPI(lifespan=lambda app: echo.mcp.session_manager.run())
+
+app = FastAPI(lifespan=lifespan)
 app.mount("/echo", echo.mcp.streamable_http_app())
 app.mount("/math", math.mcp.streamable_http_app())
 ```


### PR DESCRIPTION
Fixing example for multiple servers:

https://github.com/modelcontextprotocol/python-sdk/issues/713