### PR TITLE
feat: support embedded resources in sampling

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -651,14 +651,6 @@ class ImageContent(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class SamplingMessage(BaseModel):
-    """Describes a message issued to or received from an LLM API."""
-
-    role: Role
-    content: TextContent | ImageContent
-    model_config = ConfigDict(extra="allow")
-
-
 class EmbeddedResource(BaseModel):
     """
     The contents of a resource, embedded into a prompt or tool call result.
@@ -670,6 +662,14 @@ class EmbeddedResource(BaseModel):
     type: Literal["resource"]
     resource: TextResourceContents | BlobResourceContents
     annotations: Annotations | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class SamplingMessage(BaseModel):
+    """Describes a message issued to or received from an LLM API."""
+
+    role: Role
+    content: TextContent | ImageContent | EmbeddedResource
     model_config = ConfigDict(extra="allow")
 
 
@@ -960,7 +960,7 @@ class CreateMessageResult(Result):
     """The client's response to a sampling/create_message request from the server."""
 
     role: Role
-    content: TextContent | ImageContent
+    content: TextContent | ImageContent | EmbeddedResource
     model: str
     """The name of the model that generated the message."""
     stopReason: StopReason | None = None


### PR DESCRIPTION
Updates sampling to support embedded resources in requests and responses.

## Motivation and Context
Brings sampling to parity with tool calls in terms of supported message types. This PR is intended to support https://github.com/modelcontextprotocol/modelcontextprotocol/pull/522.

## How Has This Been Tested?
Updated integration tests to include an embedded resource test.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This PR will be updated accordingly if #725 is merged before this.