### PR TITLE
Feature/add enable disable methods tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,16 +247,17 @@ async def fetch_weather(city: str) -> str:
         return response.text
 
 
-# Get a reference to the tool
 tool = mcp._tool_manager.get_tool("fetch_weather")
 
 
-# Disable the tool temporarily
-await tool.disable(mcp.get_context())
+async def disable_tool():
+    # Disable the tool temporarily
+    await tool.disable(mcp.get_context())
 
 
-# Later, re-enable the tool
-await tool.enable(mcp.get_context())
+async def enable_tool():
+    # Re-enable the tool when needed
+    await tool.enable(mcp.get_context())
 ```
 
 ### Prompts

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@
     - [Prompts](#prompts)
     - [Images](#images)
     - [Context](#context)
+    - [Authentication](#authentication)
   - [Running Your Server](#running-your-server)
     - [Development Mode](#development-mode)
     - [Claude Desktop Integration](#claude-desktop-integration)
     - [Direct Execution](#direct-execution)
+    - [Streamable HTTP Transport](#streamable-http-transport)
     - [Mounting to an Existing ASGI Server](#mounting-to-an-existing-asgi-server)
   - [Examples](#examples)
     - [Echo Server](#echo-server)
@@ -243,6 +245,15 @@ async def fetch_weather(city: str) -> str:
     async with httpx.AsyncClient() as client:
         response = await client.get(f"https://api.weather.com/{city}")
         return response.text
+
+# Get a reference to the tool
+tool = mcp._tool_manager.get_tool("fetch_weather")
+
+# Disable the tool temporarily
+await tool.disable(mcp.get_context())
+
+# Later, re-enable the tool
+await tool.enable(mcp.get_context())
 ```
 
 ### Prompts

--- a/README.md
+++ b/README.md
@@ -246,11 +246,14 @@ async def fetch_weather(city: str) -> str:
         response = await client.get(f"https://api.weather.com/{city}")
         return response.text
 
+
 # Get a reference to the tool
 tool = mcp._tool_manager.get_tool("fetch_weather")
 
+
 # Disable the tool temporarily
 await tool.disable(mcp.get_context())
+
 
 # Later, re-enable the tool
 await tool.enable(mcp.get_context())

--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -154,7 +154,6 @@ class ClientSessionGroup:
             for exit_stack in self._session_exit_stacks.values():
                 tg.start_soon(exit_stack.aclose)
 
-
     @property
     def sessions(self) -> list[mcp.ClientSession]:
         """Returns the list of sessions being managed."""

--- a/src/mcp/server/fastmcp/tools/base.py
+++ b/src/mcp/server/fastmcp/tools/base.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.server.fastmcp.utilities.func_metadata import FuncMetadata, func_metadata
-from mcp.types import ToolAnnotations
+from mcp.types import ServerNotification, ToolAnnotations, ToolListChangedNotification
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp.server import Context
@@ -35,6 +35,7 @@ class Tool(BaseModel):
     annotations: ToolAnnotations | None = Field(
         None, description="Optional annotations for the tool"
     )
+    enabled: bool = Field(default=True, description="Whether the tool is enabled")
 
     @classmethod
     def from_function(
@@ -99,6 +100,32 @@ class Tool(BaseModel):
             )
         except Exception as e:
             raise ToolError(f"Error executing tool {self.name}: {e}") from e
+
+    async def enable(
+        self, context: Context[ServerSessionT, LifespanContextT] | None = None
+    ) -> None:
+        """Enable the tool and notify clients."""
+        if not self.enabled:
+            self.enabled = True
+            if context and context.session:
+                notification = ToolListChangedNotification(
+                    method="notifications/tools/list_changed"
+                )
+                server_notification = ServerNotification.model_validate(notification)
+                await context.session.send_notification(server_notification)
+
+    async def disable(
+        self, context: Context[ServerSessionT, LifespanContextT] | None = None
+    ) -> None:
+        """Disable the tool and notify clients."""
+        if self.enabled:
+            self.enabled = False
+            if context and context.session:
+                notification = ToolListChangedNotification(
+                    method="notifications/tools/list_changed"
+                )
+                server_notification = ServerNotification.model_validate(notification)
+                await context.session.send_notification(server_notification)
 
 
 def _is_async_callable(obj: Any) -> bool:

--- a/src/mcp/server/fastmcp/tools/tool_manager.py
+++ b/src/mcp/server/fastmcp/tools/tool_manager.py
@@ -39,8 +39,8 @@ class ToolManager:
         return self._tools.get(name)
 
     def list_tools(self) -> list[Tool]:
-        """List all registered tools."""
-        return list(self._tools.values())
+        """List all enabled registered tools."""
+        return [tool for tool in self._tools.values() if tool.enabled]
 
     def add_tool(
         self,
@@ -71,5 +71,8 @@ class ToolManager:
         tool = self.get_tool(name)
         if not tool:
             raise ToolError(f"Unknown tool: {name}")
+
+        if not tool.enabled:
+            raise ToolError(f"Tool is disabled: {name}")
 
         return await tool.run(arguments, context=context)

--- a/tests/server/fastmcp/test_tool_manager.py
+++ b/tests/server/fastmcp/test_tool_manager.py
@@ -453,3 +453,52 @@ class TestToolAnnotations:
         assert tools[0].annotations is not None
         assert tools[0].annotations.title == "Echo Tool"
         assert tools[0].annotations.readOnlyHint is True
+
+
+class TestToolEnableDisable:
+    """Test enabling and disabling tools."""
+
+    @pytest.mark.anyio
+    async def test_enable_disable_tool(self):
+        """Test enabling and disabling a tool."""
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        manager = ToolManager()
+        tool = manager.add_tool(add)
+
+        # Tool should be enabled by default
+        assert tool.enabled is True
+
+        # Disable the tool
+        await tool.disable()
+        assert tool.enabled is False
+
+        # Enable the tool
+        await tool.enable()
+        assert tool.enabled is True
+
+    @pytest.mark.anyio
+    async def test_enable_disable_no_change(self):
+        """Test enabling and disabling a tool when there's no state change."""
+
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        manager = ToolManager()
+        tool = manager.add_tool(add)
+
+        # Enable an already enabled tool (should not change state)
+        await tool.enable()
+        assert tool.enabled is True
+
+        # Disable the tool
+        await tool.disable()
+        assert tool.enabled is False
+
+        # Disable an already disabled tool (should not change state)
+        await tool.disable()
+        assert tool.enabled is False


### PR DESCRIPTION
Added the ability to dynamically enable and disable tools at runtime with client notifications.

## Motivation and Context
This change allows developers to temporarily restrict access to specific tools without removing them from the tool manager. This is useful for implementing feature flags, managing resource availability, or controlling access to functionality based on runtime conditions.

## How Has This Been Tested?
- Added unit tests for enabling/disabling tools
- Verified that disabled tools don't appear in tool listings and cannot be called
- Tested re-enabling previously disabled tools

## Breaking Changes
The tool list now includes the enabled state of each tool. However, all tools are initialized with enabled=True by default, maintaining backward compatibility with existing code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed