### PR TITLE
Allow kwargs down in AsyncClient when instantiating sse or streamable…

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -34,7 +34,8 @@ async def sse_client(
     `sse_read_timeout` determines how long (in seconds) the client will wait for a new
     event before disconnecting. All other HTTP operations are controlled by `timeout`.
 
-    `**client_kwargs` : dict, optional - Additional http client configurations used to configure the AsyncClient.
+    `**client_kwargs` : dict, optional - Additional http client configurations used
+    to configure the AsyncClient.
 
     """
     read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -26,12 +26,16 @@ async def sse_client(
     headers: dict[str, Any] | None = None,
     timeout: float = 5,
     sse_read_timeout: float = 60 * 5,
+    **client_kwargs: Any,
 ):
     """
     Client transport for SSE.
 
     `sse_read_timeout` determines how long (in seconds) the client will wait for a new
     event before disconnecting. All other HTTP operations are controlled by `timeout`.
+
+    `**client_kwargs` : dict, optional - Additional http client configurations used to configure the AsyncClient.
+
     """
     read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]
     read_stream_writer: MemoryObjectSendStream[SessionMessage | Exception]
@@ -45,7 +49,9 @@ async def sse_client(
     async with anyio.create_task_group() as tg:
         try:
             logger.info(f"Connecting to SSE endpoint: {remove_request_params(url)}")
-            async with create_mcp_http_client(headers=headers) as client:
+            async with create_mcp_http_client(
+                headers=headers, client_kwargs=client_kwargs
+            ) as client:
                 async with aconnect_sse(
                     client,
                     "GET",

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -427,6 +427,7 @@ async def streamablehttp_client(
     timeout: timedelta = timedelta(seconds=30),
     sse_read_timeout: timedelta = timedelta(seconds=60 * 5),
     terminate_on_close: bool = True,
+    **client_kwargs: Any,
 ) -> AsyncGenerator[
     tuple[
         MemoryObjectReceiveStream[SessionMessage | Exception],
@@ -440,6 +441,8 @@ async def streamablehttp_client(
 
     `sse_read_timeout` determines how long (in seconds) the client will wait for a new
     event before disconnecting. All other HTTP operations are controlled by `timeout`.
+
+    `**client_kwargs` : dict, optional - Additional http client configurations used to configure the AsyncClient.
 
     Yields:
         Tuple containing:
@@ -465,6 +468,7 @@ async def streamablehttp_client(
                 timeout=httpx.Timeout(
                     transport.timeout.seconds, read=transport.sse_read_timeout.seconds
                 ),
+                client_kwargs=client_kwargs,
             ) as client:
                 # Define callbacks that need access to tg
                 def start_get_stream() -> None:

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -442,7 +442,8 @@ async def streamablehttp_client(
     `sse_read_timeout` determines how long (in seconds) the client will wait for a new
     event before disconnecting. All other HTTP operations are controlled by `timeout`.
 
-    `**client_kwargs` : dict, optional - Additional http client configurations used to configure the AsyncClient.
+    `**client_kwargs` : dict, optional - Additional http client configurations used
+    to configure the AsyncClient.
 
     Yields:
         Tuple containing:

--- a/src/mcp/shared/_httpx_utils.py
+++ b/src/mcp/shared/_httpx_utils.py
@@ -22,7 +22,7 @@ def create_mcp_http_client(
         headers: Optional headers to include with all requests.
         timeout: Request timeout as httpx.Timeout object.
             Defaults to 30 seconds if not specified.
-        client_kwargs : dict[str, Any], optional. Used to configure the AsyncClient.
+        client_kwargs : dict[str, Any]. Optional. To configure the AsyncClient.
 
     Returns:
         Configured httpx.AsyncClient instance with MCP defaults.

--- a/src/mcp/shared/_httpx_utils.py
+++ b/src/mcp/shared/_httpx_utils.py
@@ -10,6 +10,7 @@ __all__ = ["create_mcp_http_client"]
 def create_mcp_http_client(
     headers: dict[str, str] | None = None,
     timeout: httpx.Timeout | None = None,
+    client_kwargs: dict[str, Any] | None = None,
 ) -> httpx.AsyncClient:
     """Create a standardized httpx AsyncClient with MCP defaults.
 
@@ -21,6 +22,7 @@ def create_mcp_http_client(
         headers: Optional headers to include with all requests.
         timeout: Request timeout as httpx.Timeout object.
             Defaults to 30 seconds if not specified.
+        client_kwargs : dict[str, Any], optional. Used to configure the AsyncClient.
 
     Returns:
         Configured httpx.AsyncClient instance with MCP defaults.
@@ -45,18 +47,18 @@ def create_mcp_http_client(
             response = await client.get("/long-request")
     """
     # Set MCP defaults
-    kwargs: dict[str, Any] = {
-        "follow_redirects": True,
-    }
+    if not client_kwargs:
+        client_kwargs = {}
+    client_kwargs["follow_redirects"] = True
 
     # Handle timeout
     if timeout is None:
-        kwargs["timeout"] = httpx.Timeout(30.0)
+        client_kwargs["timeout"] = httpx.Timeout(30.0)
     else:
-        kwargs["timeout"] = timeout
+        client_kwargs["timeout"] = timeout
 
     # Handle headers
     if headers is not None:
-        kwargs["headers"] = headers
+        client_kwargs["headers"] = headers
 
-    return httpx.AsyncClient(**kwargs)
+    return httpx.AsyncClient(**client_kwargs)

--- a/tests/shared/test_httpx_utils.py
+++ b/tests/shared/test_httpx_utils.py
@@ -22,3 +22,11 @@ def test_custom_parameters():
 
     assert client.headers["Authorization"] == "Bearer token"
     assert client.timeout.connect == 60.0
+
+
+def test_client_kwargs_parameters():
+    """Test if additional kwargs are set correctly."""
+    client_kwargs = {"max_redirects": 999}
+
+    client = create_mcp_http_client(client_kwargs=client_kwargs)
+    assert client.max_redirects == 999


### PR DESCRIPTION
Adding support of AsynClient kwargs at the level of sse and streamable http client creation. That allows client implementations to set certain options, which are otherwise unreachable from outside the mcp code base (like max_redirects, verify, and others).

## Motivation and Context
Please have a look into the thread at https://github.com/run-llama/llama_index/issues/18752#issuecomment-2885961439

Initially, I tried to achieve a simple MCP server integration into my llama-index based agentic network and used to create a self-signed ssl certificate for local network testig. However, there is currently no option to get around the self-signed certification verification checks, so I had to monkeypatch the mcp code base in orer to set the 'verify' argument of the underlying AsyncClient. This PR extends the configuration options of the mcp clients and allows the developers to be more flexible.

## How Has This Been Tested?
Yes. I have tested ths with a patch inside the llama-index code and your code base. No productional application, just local dev.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [] [Not needed] - I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
-
