### PR TITLE
Change default binding from 0.0.0.0 to 127.0.0.1 to align with security recommendations

### DIFF
--- a/examples/servers/simple-prompt/mcp_simple_prompt/server.py
+++ b/examples/servers/simple-prompt/mcp_simple_prompt/server.py
@@ -114,7 +114,7 @@ def main(port: int, transport: str) -> int:
 
         import uvicorn
 
-        uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+        uvicorn.run(starlette_app, host="127.0.0.1", port=port)
     else:
         from mcp.server.stdio import stdio_server
 

--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -72,7 +72,7 @@ def main(port: int, transport: str) -> int:
 
         import uvicorn
 
-        uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+        uvicorn.run(starlette_app, host="127.0.0.1", port=port)
     else:
         from mcp.server.stdio import stdio_server
 

--- a/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
+++ b/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
@@ -136,6 +136,6 @@ def main(
 
     import uvicorn
 
-    uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+    uvicorn.run(starlette_app, host="127.0.0.1", port=port)
 
     return 0

--- a/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
+++ b/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
@@ -164,6 +164,6 @@ def main(
 
     import uvicorn
 
-    uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+    uvicorn.run(starlette_app, host="127.0.0.1", port=port)
 
     return 0

--- a/examples/servers/simple-tool/mcp_simple_tool/server.py
+++ b/examples/servers/simple-tool/mcp_simple_tool/server.py
@@ -84,7 +84,7 @@ def main(port: int, transport: str) -> int:
 
         import uvicorn
 
-        uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+        uvicorn.run(starlette_app, host="127.0.0.1", port=port)
     else:
         from mcp.server.stdio import stdio_server
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -87,7 +87,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 
     # HTTP settings
-    host: str = "0.0.0.0"
+    host: str = "127.0.0.1"
     port: int = 8000
     mount_path: str = "/"  # Mount path (e.g. "/github", defaults to root path)
     sse_path: str = "/sse"

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -27,7 +27,7 @@ Example usage:
 
     # Create and run Starlette app
     starlette_app = Starlette(routes=routes)
-    uvicorn.run(starlette_app, host="0.0.0.0", port=port)
+    uvicorn.run(starlette_app, host="127.0.0.1", port=port)
 ```
 
 Note: The handle_sse function must return a Response to avoid a "TypeError: 'NoneType'


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Change default server settings and all example code to bind to `127.0.0.1` rather than `0.0.0.0`

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The [official docs](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#security-warning) note that 
> When running locally, servers SHOULD bind only to localhost (127.0.0.1) rather than all network interfaces (0.0.0.0)

This change attempts to make that behavior the default and reduce the chances of successful DNS rebinding attacks.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Not tested.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
This could be breaking in the scenario where users are relying on this default behavior to make the server accessible outside of localhost. An alternative would be to remove the change to [src/mcp/server/fastmcp/server.py](https://github.com/modelcontextprotocol/python-sdk/compare/main...ciccolo-anthropic:python-sdk:main?expand=1#diff-14a2991a8f2be5b9e60dab5fae92d2230dc23e57937ad5e5641b832d9c662738) but keep the changes in example files and comments. That version would not be breaking.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
