### PR TITLE
add support for parallel run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,17 +108,13 @@ members = ["examples/servers/*"]
 [tool.uv.sources]
 mcp = { workspace = true }
 
-[tool.pytest_env]
-LOGGING_DISABLED = true
-
 [tool.pytest.ini_options]
+log_cli = true
 xfail_strict = true
 addopts = """
-    -vv
     --color=yes
     --capture=fd
-    --numprocesses 4
-    --disable-warnings
+    --numprocesses auto
 """
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,18 @@ members = ["examples/servers/*"]
 [tool.uv.sources]
 mcp = { workspace = true }
 
+[tool.pytest_env]
+LOGGING_DISABLED = true
+
 [tool.pytest.ini_options]
 xfail_strict = true
+addopts = """
+    -vv
+    --color=yes
+    --capture=fd
+    --numprocesses 4
+    --disable-warnings
+"""
 filterwarnings = [
     "error",
     # This should be fixed on Uvicorn's side.


### PR DESCRIPTION
@jerome3o-anthropic @jspahrsummers  not able to add you guys as reviewer, please help me out here.


Ticket: https://github.com/modelcontextprotocol/python-sdk/issues/736

Added pytest configuration to enable parallel test execution and disable logging during tests for faster and cleaner test runs.

## Motivation and Context
Running tests sequentially was causing longer test suite execution times, slowing down development and CI feedback. Enabling parallel test runs with multiple workers improves overall testing speed and efficiency.

## How Has This Been Tested?
Tests were run locally with the new configuration enabled. Verified that:
- [x] Tests execute in parallel across 4 processes.
- [x] Logging output is disabled during test runs.

## Breaking Changes
No breaking changes. This update only affects how tests are executed, not the application code or configurations.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally

## Additional context
Uses pytest-xdist plugin for parallel test execution with --numprocesses 4
Disables logging during tests to reduce noise and improve test output clarity.
