### PR TITLE
Support custom httpx client creation

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -1,6 +1,6 @@
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import anyio

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -19,7 +19,7 @@ from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from httpx_sse import EventSource, ServerSentEvent, aconnect_sse
 
-from mcp.shared._httpx_utils import create_mcp_http_client
+from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
 from mcp.shared.message import ClientMessageMetadata, SessionMessage
 from mcp.types import (
     ErrorData,
@@ -427,6 +427,7 @@ async def streamablehttp_client(
     timeout: timedelta = timedelta(seconds=30),
     sse_read_timeout: timedelta = timedelta(seconds=60 * 5),
     terminate_on_close: bool = True,
+    httpx_client_factory: McpHttpClientFactory = create_mcp_http_client,
 ) -> AsyncGenerator[
     tuple[
         MemoryObjectReceiveStream[SessionMessage | Exception],
@@ -460,7 +461,7 @@ async def streamablehttp_client(
         try:
             logger.info(f"Connecting to StreamableHTTP endpoint: {url}")
 
-            async with create_mcp_http_client(
+            async with httpx_client_factory(
                 headers=transport.request_headers,
                 timeout=httpx.Timeout(
                     transport.timeout.seconds, read=transport.sse_read_timeout.seconds

--- a/src/mcp/shared/_httpx_utils.py
+++ b/src/mcp/shared/_httpx_utils.py
@@ -1,10 +1,19 @@
 """Utilities for creating standardized httpx AsyncClient instances."""
 
-from typing import Any
+from typing import Any, Protocol
 
 import httpx
 
 __all__ = ["create_mcp_http_client"]
+
+
+class McpHttpClientFactory(Protocol):
+    def __call__(
+        self,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+    ) -> httpx.AsyncClient:
+        ...
 
 
 def create_mcp_http_client(

--- a/src/mcp/shared/_httpx_utils.py
+++ b/src/mcp/shared/_httpx_utils.py
@@ -12,8 +12,7 @@ class McpHttpClientFactory(Protocol):
         self,
         headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | None = None,
-    ) -> httpx.AsyncClient:
-        ...
+    ) -> httpx.AsyncClient: ...
 
 
 def create_mcp_http_client(


### PR DESCRIPTION
## Motivation and Context
Currently the SDK defaults imply certain properties for httpx clients, two notable ones are redirect policies as well as proxies. To support various security configurations instead make the client wholly injectable. This avoids clients needing to fork the entire transport method.

## How Has This Been Tested?
Tested locally with a fake client.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A