### PR TITLE
fix: documentation and arg type for RequireAuthMiddleware class

### DIFF
--- a/src/mcp/server/auth/middleware/bearer_auth.py
+++ b/src/mcp/server/auth/middleware/bearer_auth.py
@@ -8,7 +8,7 @@ from starlette.authentication import (
 )
 from starlette.exceptions import HTTPException
 from starlette.requests import HTTPConnection
-from starlette.types import Receive, Scope, Send
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from mcp.server.auth.provider import AccessToken, OAuthAuthorizationServerProvider
 
@@ -67,13 +67,12 @@ class RequireAuthMiddleware:
     auth info in the request state.
     """
 
-    def __init__(self, app: Any, required_scopes: list[str]):
+    def __init__(self, app: ASGIApp, required_scopes: list[str]):
         """
         Initialize the middleware.
 
         Args:
             app: ASGI application
-            provider: Authentication provider to validate tokens
             required_scopes: Optional list of scopes that the token must have
         """
         self.app = app


### PR DESCRIPTION
Changes in RequireAuthMiddleware class's __init__ method
1. changed type of "app" from Any to ASGIApp
2. Removed extra arg "provider" mentioned in doc string

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? --> Helps in understanding the code flow better.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? --> All Existing test cases has passed

## Type checking --> Done
## Lint checking --> Done

## Breaking Changes
<!-- Will users need to update their code or configurations? --> No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
