### PR TITLE
Remove `lstrip` in each OAuth endpoint

### DIFF
--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -167,10 +167,10 @@ def build_metadata(
     revocation_options: RevocationOptions,
 ) -> OAuthMetadata:
     authorization_url = modify_url_path(
-        issuer_url, lambda path: path.rstrip("/") + AUTHORIZATION_PATH.lstrip("/")
+        issuer_url, lambda path: path.rstrip("/") + AUTHORIZATION_PATH
     )
     token_url = modify_url_path(
-        issuer_url, lambda path: path.rstrip("/") + TOKEN_PATH.lstrip("/")
+        issuer_url, lambda path: path.rstrip("/") + TOKEN_PATH
     )
     # Create metadata
     metadata = OAuthMetadata(
@@ -194,13 +194,13 @@ def build_metadata(
     # Add registration endpoint if supported
     if client_registration_options.enabled:
         metadata.registration_endpoint = modify_url_path(
-            issuer_url, lambda path: path.rstrip("/") + REGISTRATION_PATH.lstrip("/")
+            issuer_url, lambda path: path.rstrip("/") + REGISTRATION_PATH
         )
 
     # Add revocation endpoint if supported
     if revocation_options.enabled:
         metadata.revocation_endpoint = modify_url_path(
-            issuer_url, lambda path: path.rstrip("/") + REVOCATION_PATH.lstrip("/")
+            issuer_url, lambda path: path.rstrip("/") + REVOCATION_PATH
         )
         metadata.revocation_endpoint_auth_methods_supported = ["client_secret_post"]
 


### PR DESCRIPTION
`lstrip` strips left `/` which results in `ISSUER_URLauthorize`

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

`/.well-known/oauth-authorization-server` output is weirld.

- expected: `"authorization_endpoint": "https://$MY_ISSUER/authorize",`
- actual: `"authorization_endpoint": "https://$MY_ISSUERauthorize",`

It seems `lstrip` is unnecessary for each OAuth endpoint

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Check following result:

```
curl $MY_MCP_SERVER/.well-known/oauth-authorization-server

{
  "issuer": "$MY_ISSUER",
  "authorization_endpoint": "$MY_ISSUERauthorize",   # / is missing between $MY_ISSUER and authorize
  "token_endpoint": "$MY_ISSUERtoken",
  "registration_endpoint": "$MY_ISSUERregister",
  "scopes_supported": [
    "openid"
  ],
  "response_types_supported": [
    "code"
  ],
  "grant_types_supported": [
    "authorization_code",
    "refresh_token"
  ],
  "token_endpoint_auth_methods_supported": [
    "client_secret_post"
  ],
  "revocation_endpoint": "$MY_ISSUERrevoke",
  "revocation_endpoint_auth_methods_supported": [
    "client_secret_post"
  ],
  "code_challenge_methods_supported": [
    "S256"
  ]
}
```


## Breaking Changes

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
