### PR TITLE
[OpenAI Codex PR] Fix cleanup order issue with task groups

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -12,6 +12,7 @@ from httpx_sse import aconnect_sse
 import mcp.types as types
 from mcp.shared._httpx_utils import create_mcp_http_client
 from mcp.shared.message import SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ async def sse_client(
     read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
     write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
 
-    async with anyio.create_task_group() as tg:
+    async with CompatTaskGroup() as tg:
         try:
             logger.info(f"Connecting to SSE endpoint: {remove_request_params(url)}")
             async with create_mcp_http_client(headers=headers, auth=auth) as client:

--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field
 
 import mcp.types as types
 from mcp.shared.message import SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 
 from .win32 import (
     create_windows_process,
@@ -168,7 +169,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
             await anyio.lowlevel.checkpoint()
 
     async with (
-        anyio.create_task_group() as tg,
+        CompatTaskGroup() as tg,
         process,
     ):
         tg.start_soon(stdout_reader)

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -15,12 +15,12 @@ from typing import Any
 
 import anyio
 import httpx
-from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from httpx_sse import EventSource, ServerSentEvent, aconnect_sse
 
 from mcp.shared._httpx_utils import create_mcp_http_client
 from mcp.shared.message import ClientMessageMetadata, SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 from mcp.types import (
     ErrorData,
     JSONRPCError,
@@ -352,7 +352,7 @@ class StreamableHTTPTransport:
         read_stream_writer: StreamWriter,
         write_stream: MemoryObjectSendStream[SessionMessage],
         start_get_stream: Callable[[], None],
-        tg: TaskGroup,
+        tg: CompatTaskGroup,
     ) -> None:
         """Handle writing requests to the server."""
         try:
@@ -460,7 +460,7 @@ async def streamablehttp_client(
         SessionMessage
     ](0)
 
-    async with anyio.create_task_group() as tg:
+    async with CompatTaskGroup() as tg:
         try:
             logger.info(f"Connecting to StreamableHTTP endpoint: {url}")
 

--- a/src/mcp/client/websocket.py
+++ b/src/mcp/client/websocket.py
@@ -11,6 +11,7 @@ from websockets.typing import Subprotocol
 
 import mcp.types as types
 from mcp.shared.message import SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +80,7 @@ async def websocket_client(
                     )
                     await ws.send(json.dumps(msg_dict))
 
-        async with anyio.create_task_group() as tg:
+        async with CompatTaskGroup() as tg:
             # Start reader and writer tasks
             tg.start_soon(ws_reader)
             tg.start_soon(ws_writer)

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -74,7 +74,6 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from contextlib import AbstractAsyncContextManager, AsyncExitStack, asynccontextmanager
 from typing import Any, Generic, TypeVar
 
-import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from pydantic import AnyUrl
 
@@ -87,6 +86,7 @@ from mcp.shared.context import RequestContext
 from mcp.shared.exceptions import McpError
 from mcp.shared.message import SessionMessage
 from mcp.shared.session import RequestResponder
+from mcp.shared.taskgroup import CompatTaskGroup
 
 logger = logging.getLogger(__name__)
 
@@ -503,7 +503,7 @@ class Server(Generic[LifespanResultT]):
                 )
             )
 
-            async with anyio.create_task_group() as tg:
+            async with CompatTaskGroup() as tg:
                 async for message in session.incoming_messages:
                     logger.debug(f"Received message: {message}")
 

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -53,6 +53,7 @@ from starlette.types import Receive, Scope, Send
 
 import mcp.types as types
 from mcp.shared.message import SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 
 logger = logging.getLogger(__name__)
 
@@ -143,7 +144,7 @@ class SseServerTransport:
                         }
                     )
 
-        async with anyio.create_task_group() as tg:
+        async with CompatTaskGroup() as tg:
 
             async def response_wrapper(scope: Scope, receive: Receive, send: Send):
                 """

--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -28,6 +28,7 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 
 import mcp.types as types
 from mcp.shared.message import SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 
 
 @asynccontextmanager
@@ -84,7 +85,7 @@ async def stdio_server(
         except anyio.ClosedResourceError:
             await anyio.lowlevel.checkpoint()
 
-    async with anyio.create_task_group() as tg:
+    async with CompatTaskGroup() as tg:
         tg.start_soon(stdin_reader)
         tg.start_soon(stdout_writer)
         yield read_stream, write_stream

--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -25,6 +25,7 @@ from starlette.responses import Response
 from starlette.types import Receive, Scope, Send
 
 from mcp.shared.message import ServerMessageMetadata, SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 from mcp.types import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
@@ -508,7 +509,7 @@ class StreamableHTTPServerTransport:
                 # Start the SSE response (this will send headers immediately)
                 try:
                     # First send the response to establish the SSE connection
-                    async with anyio.create_task_group() as tg:
+                    async with CompatTaskGroup() as tg:
                         tg.start_soon(response, scope, receive, send)
                         # Then send the message to be processed by the server
                         session_message = SessionMessage(message)
@@ -840,7 +841,7 @@ class StreamableHTTPServerTransport:
         self._write_stream = write_stream
 
         # Start a task group for message routing
-        async with anyio.create_task_group() as tg:
+        async with CompatTaskGroup() as tg:
             # Create a message router that distributes messages to request streams
             async def message_router():
                 try:

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -22,6 +22,7 @@ from mcp.server.streamable_http import (
     EventStore,
     StreamableHTTPServerTransport,
 )
+from mcp.shared.taskgroup import CompatTaskGroup
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +104,7 @@ class StreamableHTTPSessionManager:
                 )
             self._has_started = True
 
-        async with anyio.create_task_group() as tg:
+        async with CompatTaskGroup() as tg:
             # Store the task group for later use
             self._task_group = tg
             logger.info("StreamableHTTP session manager started")

--- a/src/mcp/server/websocket.py
+++ b/src/mcp/server/websocket.py
@@ -9,6 +9,7 @@ from starlette.websockets import WebSocket
 
 import mcp.types as types
 from mcp.shared.message import SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ async def websocket_server(scope: Scope, receive: Receive, send: Send):
         except anyio.ClosedResourceError:
             await websocket.close()
 
-    async with anyio.create_task_group() as tg:
+    async with CompatTaskGroup() as tg:
         tg.start_soon(ws_reader)
         tg.start_soon(ws_writer)
         yield (read_stream, write_stream)

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 
 from mcp.shared.exceptions import McpError
 from mcp.shared.message import MessageMetadata, ServerMessageMetadata, SessionMessage
+from mcp.shared.taskgroup import CompatTaskGroup
 from mcp.types import (
     CancelledNotification,
     ClientNotification,
@@ -201,7 +202,7 @@ class BaseSession(
         self._exit_stack = AsyncExitStack()
 
     async def __aenter__(self) -> Self:
-        self._task_group = anyio.create_task_group()
+        self._task_group = CompatTaskGroup()
         await self._task_group.__aenter__()
         self._task_group.start_soon(self._receive_loop)
         return self

--- a/src/mcp/shared/taskgroup.py
+++ b/src/mcp/shared/taskgroup.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
+from typing import Any, TypeVar
+
+import anyio
+
+_T = TypeVar("_T")
+
+class _AsyncioCancelScope:
+    def __init__(self, tasks: set[asyncio.Task[Any]]):
+        self._tasks = tasks
+
+    def cancel(self) -> None:
+        for task in list(self._tasks):
+            task.cancel()
+
+class CompatTaskGroup(AbstractAsyncContextManager):
+    """Minimal compatibility layer mimicking ``anyio.TaskGroup``."""
+
+    def __init__(self) -> None:
+        self._use_asyncio = sys.version_info >= (3, 11)
+        if self._use_asyncio:
+            self._tg = asyncio.TaskGroup()
+            self._tasks: set[asyncio.Task[Any]] = set()
+            self.cancel_scope = _AsyncioCancelScope(self._tasks)
+        else:
+            self._tg = anyio.create_task_group()
+            self.cancel_scope = self._tg.cancel_scope  # type: ignore[attr-defined]
+
+    async def __aenter__(self) -> CompatTaskGroup:
+        await self._tg.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool | None:
+        return await self._tg.__aexit__(exc_type, exc, tb)
+
+    def start_soon(
+        self,
+        func: Callable[..., Awaitable[Any]],
+        *args: Any,
+        name: Any | None = None,
+    ) -> None:
+        if self._use_asyncio:
+            task = self._tg.create_task(func(*args))
+            self._tasks.add(task)
+        else:
+            self._tg.start_soon(func, *args, name=name)
+
+    async def start(
+        self,
+        func: Callable[..., Awaitable[Any]],
+        *args: Any,
+        name: Any | None = None,
+    ) -> Any:
+        if self._use_asyncio:
+            fut: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+
+            async def runner() -> None:
+                try:
+                    result = await func(*args, task_status=fut)
+                    if not fut.done():
+                        fut.set_result(result)
+                except BaseException as exc:
+                    if not fut.done():
+                        fut.set_exception(exc)
+                    raise
+
+            task = self._tg.create_task(runner())
+            self._tasks.add(task)
+            return await fut
+        else:
+            return await self._tg.start(func, *args, name=name)


### PR DESCRIPTION
## Summary
- fix the issue mentioned in #577 
- add CompatTaskGroup helper that uses `asyncio.TaskGroup` when available
- use CompatTaskGroup across client and server transports
- update BaseSession to rely on CompatTaskGroup
- this PR is created by **OpenAI Codex**

## Testing
- `ruff check --fix .`
- `pyright -p .` *(fails: venv not found and missing deps)*
- `pytest -q` *(fails: command not found)*
- test with the following example

```
import os, asyncio, json
from typing import Optional
from contextlib import AsyncExitStack
from mcp import ClientSession, StdioServerParameters
from mcp.types import TextContent
from mcp.client.stdio import stdio_client

class MCPClient:
    def __init__(self, command: str, args: list[str], env: Optional[dict] = None):
        self.session: Optional[ClientSession] = None
        self.command, self.args, self.env = command, args, env
        self._cleanup_lock = asyncio.Lock()
        self.exit_stack: Optional[AsyncExitStack] = None

    async def connect_to_server(self):
        await self.cleanup()
        self.exit_stack = AsyncExitStack()

        server_params = StdioServerParameters(
            command=self.command, args=self.args, env=self.env
        )
        stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
        self.stdio, self.write = stdio_transport
        self.session = await self.exit_stack.enter_async_context(
            ClientSession(self.stdio, self.write)
        )
        await self.session.initialize()

    async def cleanup(self):
        if self.exit_stack:
            async with self._cleanup_lock:
                await self.exit_stack.aclose()
                self.session = None
            self.exit_stack = None

async def main():
    cfg = {
      "command": "npx",
      "args": [
        "-y",
        "@modelcontextprotocol/server-filesystem",
        "/Users/jhaoming/Desktop"
      ]
    }

    c1, c2 = MCPClient(**cfg), MCPClient(**cfg)
    await c1.connect_to_server()
    await c2.connect_to_server()

    # Works (FILO)
    await c2.cleanup()
    await c1.cleanup()

    # Fails (FIFO)
    # await c1.cleanup()      # <-- boom before pr, fixed after pr
    # await c2.cleanup()

if __name__ == "__main__":
    asyncio.run(main())
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
