### PR TITLE
Fix OAuth metadata validation for compliant servers

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -117,7 +117,7 @@ class OAuthMetadata(BaseModel):
         list[Literal["authorization_code", "refresh_token"]] | None
     ) = None
     token_endpoint_auth_methods_supported: (
-        list[Literal["none", "client_secret_post"]] | None
+        list[Literal["none", "client_secret_post", "client_secret_basic"]] | None
     ) = None
     token_endpoint_auth_signing_alg_values_supported: None = None
     service_documentation: AnyHttpUrl | None = None
@@ -134,4 +134,4 @@ class OAuthMetadata(BaseModel):
         list[Literal["client_secret_post"]] | None
     ) = None
     introspection_endpoint_auth_signing_alg_values_supported: None = None
-    code_challenge_methods_supported: list[Literal["S256"]] | None = None
+    code_challenge_methods_supported: list[Literal["S256", "plain"]] | None = None


### PR DESCRIPTION
## Problem

The `OAuthMetadata` validation in `src/mcp/shared/auth.py` was overly restrictive, rejecting valid OAuth 2.0 server configurations that advertise additional authentication methods beyond the minimum required set.

This caused connection failures with compliant MCP servers like Asana (`mcp.asana.com`) that support multiple OAuth authentication methods as allowed by the specifications.

## Root Cause

The server returns:
- `token_endpoint_auth_methods_supported`: `["client_secret_basic","client_secret_post","none"]` 
- `code_challenge_methods_supported`: `["plain","S256"]`

But the client validation only accepted:
- `token_endpoint_auth_methods_supported`: `["none", "client_secret_post"]`
- `code_challenge_methods_supported`: `["S256"]`

## Solution

**Expanded the validation to accept additional methods:**
- Added `client_secret_basic` to `token_endpoint_auth_methods_supported`
- Added `plain` to `code_challenge_methods_supported`

## Compliance Verification

✅ **MCP Specification Compliant**: The [MCP authorization specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization.md) does not restrict which authentication methods servers can support - it only requires PKCE support.

✅ **OAuth 2.0 Compliant**: These are standard OAuth 2.0 authentication methods defined in relevant RFCs.

## Testing

- ✅ Successfully connects to `https://mcp.asana.com/sse`
- ✅ OAuth flow completes without validation errors
- ✅ Maintains backward compatibility with existing servers

## Impact

This fix enables the MCP Python SDK to work with any compliant MCP server regardless of which optional OAuth authentication methods they advertise support for.