### PR TITLE
fix: Clean up sessions from manager when terminated via DELETE request

### DIFF
--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -1,5 +1,7 @@
 """Tests for StreamableHTTPSessionManager."""
 
+import json
+
 import anyio
 import pytest
 
@@ -70,7 +72,7 @@ async def test_handle_request_without_run_raises_error():
         return {"type": "http.request", "body": b""}
 
     async def send(message):
-        pass
+        del message  # Suppress unused parameter warning
 
     # Should raise error because run() hasn't been called
     with pytest.raises(RuntimeError) as excinfo:
@@ -79,3 +81,98 @@ async def test_handle_request_without_run_raises_error():
     assert "Task group is not initialized. Make sure to use run()." in str(
         excinfo.value
     )
+
+
+@pytest.mark.anyio
+async def test_session_cleanup_on_delete_request():
+    """Test sessions are properly cleaned up when DELETE request terminates them."""
+    app = Server("test-server")
+    manager = StreamableHTTPSessionManager(app=app, json_response=True, stateless=False)
+
+    async with manager.run():
+        # Create a new session by making a POST request
+        session_id = None
+
+        # Mock ASGI parameters for POST request (session creation)
+        post_scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/test",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"accept", b"application/json, text/event-stream"),
+            ],
+        }
+
+        # Mock initialization request
+        init_request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        }
+
+        post_body = json.dumps(init_request).encode()
+        post_request_body_sent = False
+
+        async def post_receive():
+            nonlocal post_request_body_sent
+            if not post_request_body_sent:
+                post_request_body_sent = True
+                return {"type": "http.request", "body": post_body}
+            else:
+                return {"type": "http.request", "body": b""}
+
+        response_data = {}
+
+        async def post_send(message):
+            if message["type"] == "http.response.start":
+                response_data["status"] = message["status"]
+                response_data["headers"] = dict(message.get("headers", []))
+            elif message["type"] == "http.response.body":
+                response_data["body"] = message.get("body", b"")
+
+        # Make POST request to create session
+        await manager.handle_request(post_scope, post_receive, post_send)
+
+        # Extract session ID from response headers
+        session_id = response_data["headers"].get(b"mcp-session-id")
+        if session_id:
+            session_id = session_id.decode()
+
+        # Verify session was created
+        assert session_id is not None
+        assert session_id in manager._server_instances
+
+        # Now make DELETE request to terminate session
+        delete_scope = {
+            "type": "http",
+            "method": "DELETE",
+            "path": "/test",
+            "headers": [(b"mcp-session-id", session_id.encode())],
+        }
+
+        async def delete_receive():
+            return {"type": "http.request", "body": b""}
+
+        delete_response_data = {}
+
+        async def delete_send(message):
+            if message["type"] == "http.response.start":
+                delete_response_data["status"] = message["status"]
+
+        # Make DELETE request
+        await manager.handle_request(delete_scope, delete_receive, delete_send)
+
+        # Verify DELETE request succeeded
+        assert delete_response_data["status"] == 200
+
+        # Give a moment for the callback to execute
+        await anyio.sleep(0.01)
+
+        # Verify session was removed from manager
+        assert session_id not in manager._server_instances


### PR DESCRIPTION
## Summary

This PR fixes a memory leak issue in `StreamableHTTPSessionManager` where sessions were not being cleaned up from the manager's internal dictionary when terminated via DELETE requests.

## Problem

Previously, when clients sent DELETE requests to terminate sessions:
- The `StreamableHTTPServerTransport` would mark itself as terminated
- However, the `StreamableHTTPSessionManager` would continue to hold references to these terminated sessions in its `_server_instances` dictionary
- This caused memory accumulation over time in long-running servers

## Solution

Added a callback mechanism to properly clean up terminated sessions:

- **Added callback parameter** to `StreamableHTTPServerTransport` constructor (`on_session_terminated`)
- **Implemented cleanup method** in `StreamableHTTPSessionManager` (`_on_session_terminated`)
- **Enhanced termination flow** to notify manager when sessions are terminated via DELETE
- **Fixed HTTP status codes** to return 404 NOT_FOUND for unknown session IDs (was 400 BAD_REQUEST)

## Technical Details

1. When a DELETE request terminates a session, `StreamableHTTPServerTransport._terminate_session()` now calls the callback
2. The callback removes the session from `StreamableHTTPSessionManager._server_instances`
3. Subsequent requests with that session ID properly return 404 NOT_FOUND
4. Memory is freed for garbage collection

## Test Plan

- [x] Added comprehensive test `test_session_cleanup_on_delete_request` 
- [x] Verified existing session termination tests still pass
- [x] Confirmed no regressions in broader test suite
- [x] Validated proper HTTP status codes (404 for unknown sessions)

## Backward Compatibility

✅ This change is fully backward compatible - no breaking changes to existing APIs.

Generated with [Claude Code](https://claude.ai/code)