### PR TITLE
Clarify docstring for Context implicit injection in Resource functions

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -897,7 +897,7 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT]):
     """Context object providing access to MCP capabilities.
 
     This provides a cleaner interface to MCP's RequestContext functionality.
-    It gets injected into tool and resource functions that request it via type hints.
+    It gets injected into tool functions that request it via type hints.
 
     To use context in a tool function, add a parameter with the Context type annotation:
 


### PR DESCRIPTION
Resource functions do not (currently) support context injection, but support is implied by the current `Context` docstring. This change updates the docstring to accurately reflect the current implementation.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Lack of clarity in documentation. Developers may try to implicitly inject `context` into `@resource`-decorated functions following the current documentation and encounter surprising errors.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Documentation only

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Context injection support for `resource` functions (as is the case for `tool`s) would be very nice to have, but there seems to be some complexity in how that interacts with the concept of concrete/direct resources vs resource templates. In particular, a resource function might accept _only_ a `Context` param, for example if it lists all objects that a (contextual) user can access. Reading through the code, it appears that concrete resources are already lazy - so we could consider `Context`-only resources as concrete/direct and thread through the `context` in the [read](https://github.com/modelcontextprotocol/python-sdk/blob/10cf0f78a8ee8b5bc7152591cb5eb115ab2b6656/src/mcp/server/fastmcp/resources/base.py#L45-L48) method. I'm happy to add a follow-up issue and work towards implementing that if there's interest.