### PR TITLE
Add root_path support to properly route subpaths for SSE and streamable-http endpoints when behind Nginx or other HTTP reverse proxies

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -89,6 +89,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     # HTTP settings
     host: str = "0.0.0.0"
     port: int = 8000
+    root_path: str = "/" # root path, same with root_path in uvicorn config, for sse or streamable http
     mount_path: str = "/"  # Mount path (e.g. "/github", defaults to root path)
     sse_path: str = "/sse"
     message_path: str = "/messages/"

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -605,6 +605,7 @@ class FastMCP:
             starlette_app,
             host=self.settings.host,
             port=self.settings.port,
+            root_path=self.settings.root_path,
             log_level=self.settings.log_level.lower(),
         )
         server = uvicorn.Server(config)
@@ -620,6 +621,7 @@ class FastMCP:
             starlette_app,
             host=self.settings.host,
             port=self.settings.port,
+            root_path=self.settings.root_path,
             log_level=self.settings.log_level.lower(),
         )
         server = uvicorn.Server(config)

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     # HTTP settings
     host: str = "0.0.0.0"
     port: int = 8000
-    root_path: str = "/" # root path, same with root_path in uvicorn config, for sse or streamable http
+    root_path: str = "" # root path, same with root_path in uvicorn config, for sse or streamable http
     mount_path: str = "/"  # Mount path (e.g. "/github", defaults to root path)
     sse_path: str = "/sse"
     message_path: str = "/messages/"


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR adds support for `root_path` in subpath routing of SSE andstreamable-http endpoints when using Nginx or other HTTP middleware as a reverse proxy.


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When deploying applications behind a reverse proxy (e.g., Nginx), it's common to route requests via subpaths like `/server1/` or  `/server2/` . Without proper handling of these subpaths, SSE and streamable-http endpoints may fail to receive correctly routed requests.

This issue was originally reported in https://github.com/modelcontextprotocol/python-sdk/issues/242

Similar functionality exists in other web applications:
- [base_url in jupyter](https://jupyter-server-proxy.readthedocs.io/en/latest/server-process.html#command)
- [base_url in filebrowser](https://filebrowser.org/cli/filebrowser-config-set#options) 
- [root_url in grafana](https://grafana.com/tutorials/run-grafana-behind-a-proxy/#alternative-for-serving-grafana-under-a-sub-path)



## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, this has been tested and running stably in production environments for several days. Both sse and streamable-http endpoints have been verified to work correctly under subpaths behind Nginx.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes are introduced. Users do not need to update their code or configuration files. This is an optional enhancement that activates only when `root_path` is provided.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This change ensures that the application respects the `root_path` setting for streaming endpoints by utilizing Uvicorn’s built-in support for it. It does not introduce any custom routing logic but instead makes sure that streaming responses behave consistently with regular HTTP responses under subpath deployments.