### PR TITLE
Session validation error

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -154,7 +154,6 @@ class ClientSessionGroup:
             for exit_stack in self._session_exit_stacks.values():
                 tg.start_soon(exit_stack.aclose)
 
-
     @property
     def sessions(self) -> list[mcp.ClientSession]:
         """Returns the list of sessions being managed."""

--- a/tests/shared/test_session_handles_error.py
+++ b/tests/shared/test_session_handles_error.py
@@ -1,0 +1,42 @@
+from collections.abc import AsyncGenerator
+
+import pytest
+from anyio.streams.memory import MemoryObjectSendStream
+
+from mcp.shared.memory import create_client_server_memory_streams
+from mcp.shared.message import SessionMessage
+from mcp.shared.session import BaseSession
+from mcp.types import ClientNotification, ClientRequest, JSONRPCMessage, JSONRPCRequest
+
+
+@pytest.fixture
+async def client_write() -> (
+    AsyncGenerator[MemoryObjectSendStream[SessionMessage], None]
+):
+    """A stream that allows to write to a running session."""
+    async with create_client_server_memory_streams() as (
+        (_, client_write),
+        (server_read, server_write),
+    ):
+        async with BaseSession(
+            read_stream=server_read,
+            write_stream=server_write,
+            receive_request_type=ClientRequest,
+            receive_notification_type=ClientNotification,
+        ) as _:
+            yield client_write
+
+
+@pytest.mark.anyio
+async def test_session_does_not_raise_error_with_bad_input(
+    client_write: MemoryObjectSendStream[SessionMessage],
+):
+    # Given a running session
+
+    # When the client sends a bad request to the session
+    request = JSONRPCRequest(jsonrpc="2.0", id=1, method="bad_method", params=None)
+    message = SessionMessage(message=JSONRPCMessage(root=request))
+    await client_write.send(message)
+
+    # Then the session can still be talked to
+    await client_write.send(message)


### PR DESCRIPTION
This PR adds exception handling to validation of incoming grpc requests in the session.

## Motivation and Context

While the public interface of the session (e.g. `session.send_request`) makes assumptions about the data types send to the session, the `StreamableHttpServerTransport` does not use this, and rather sends data directly to the [channel](https://github.com/moldhouse/python-sdk/blob/ab9c9ed0afb3f18935b61acf8e33b5c9c3cdbc82/src/mcp/server/streamable_http.py#L515). Therefore, [the validation](https://github.com/moldhouse/python-sdk/blob/ab9c9ed0afb3f18935b61acf8e33b5c9c3cdbc82/src/mcp/shared/session.py#L355) of the incoming data in the receive loop of the session may fail. This can be integration tested by sending an invalid method to the server, which crashes the task of the particular session.

## How Has This Been Tested?

I added a unit test on the session level that verifies that the session is unresponsive after a bad input. Construction of the session in the test feels a bit awkward, and there might be better ways to test this particular piece of code. One refactor idea might be to move the logic in the session loop to a separate method to better unit test it.

## Breaking Changes

This change does not break any public apis. It does however change behaviour, in that the server does not crash on invalid messages, but swallows them, similar how it is already happening for notifications which can not be validated.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed