### PR TITLE
Fix in README.md to use right request_context syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ server = Server("example-server", lifespan=server_lifespan)
 # Access lifespan context in handlers
 @server.call_tool()
 async def query_db(name: str, arguments: dict) -> list:
-    ctx = server.get_context()
+    ctx = server.request_context
     db = ctx.lifespan_context["db"]
     return await db.query(arguments["query"])
 ```


### PR DESCRIPTION
Fix in README.md to use right request_context syntax as discussed in discussion in the [issue](https://github.com/modelcontextprotocol/python-sdk/issues/793). 
TESTED = all current tests pass

## Motivation and Context
Addressing the issue in documentations as discussed [here](https://github.com/modelcontextprotocol/python-sdk/issues/793).

## How Has This Been Tested?
TESTED = all current tests pass

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

