### PR TITLE
[DOC] Fix example usage of get_context (plus a little more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ from dataclasses import dataclass
 
 from fake_database import Database  # Replace with your actual DB type
 
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp import FastMCP
 
 # Create a named server
 mcp = FastMCP("My App")


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Fixes: #793 

**NOTE**: Sorry, I'm not sure what the target branch for this PR is supposed to be, I thought I initially branched off of v1.9.1, but that doesn't appear to be a branch, i can rebase it to v1.7.x, where it looks like the `get_context()` issue was already fixed... but the README doesn't reflect this...

The example code in the readme contains a line that invokes `server.get_context()` on the lowlevel server. There is no such method, the proper way to access the context is via the property-decorated function `server.request_context`.

This apparently was just raised in #799 as well. However, I think the issue is a bit more problematic. Forgive me if I'm getting it wrong.

The example code for the lowlevel server was corrected here and in #799 to avoid `get_context()`. But this _is_ in fact a method on FastMCP() - but this is not actually illustrated in the code examples(!). In the README, the part on FastMCP uses `request_context`:

```python
# Access type-safe lifespan context in tools
@mcp.tool()
def query_db(ctx: Context) -> str:
    """Tool that uses initialized resources"""
    db = ctx.request_context.lifespan_context.db
    return db.query()
```

So:
* The lowlevel server example incorrectly uses `get_context()`
* The FastMCP example uses `request_context` and there is no actual example of correct usage of `get_context()`

So this is very odd.

It seems to me that if anything, the convenience method that FastMCP offers that the lowlevel server lacks is `get_context()`, so this ought to be the thing that's documented in the README. What's worse is I don't really see what advantage there is in using `get_context()` vs. passing in the `ctx: Context` parameter. Because if you use `get_context()`, **you still have to access `.request_context`** e.g. if you want the lifespan, you need to do `app.get_context().request_context.lifespan_context`, which is equivalent to `ctx.request_context.lifespan_context`. So, again my apologies if I am the one confused, but I think there is either some redundancy in the way these things are accessed, _or_, `get_context()` should really be directly returning `ctx.request_context`. Then you could do something like `lifespan = app.get_context().lifespan_context`.

In my PR, besides fixing the incorrect invocation of `get_context` I add an example that illustrates correct usage of `get_context` for FastMCP.

All the being said, given the existence of the `get_context` method, I'm struggling a bit to see what reason or convenience there is in using the `ctx: Context` parameter to access the context instead of just `my_app.get_context()`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
All tests/list/etc. are passing.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
It seems to me that the API for FastMCP should be simplified, I don't see a good reason to have two different "convenience" ways to get the same result, and it strikes me as confusing. I don't personally have a preference for one or the other. Alternatively, `get_context` could be refactored to return the `ctx.request_context` itself, which would be some kind of differentiator at least.