### PR TITLE
Fix auth tests and ruff format

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -154,7 +154,6 @@ class ClientSessionGroup:
             for exit_stack in self._session_exit_stacks.values():
                 tg.start_soon(exit_stack.aclose)
 
-
     @property
     def sessions(self) -> list[mcp.ClientSession]:
         """Returns the list of sessions being managed."""

--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -153,12 +153,8 @@ def build_metadata(
     client_registration_options: ClientRegistrationOptions,
     revocation_options: RevocationOptions,
 ) -> OAuthMetadata:
-    authorization_url = AnyHttpUrl(
-        str(issuer_url).rstrip("/") + AUTHORIZATION_PATH
-    )
-    token_url = AnyHttpUrl(
-        str(issuer_url).rstrip("/") + TOKEN_PATH
-    )
+    authorization_url = AnyHttpUrl(str(issuer_url).rstrip("/") + AUTHORIZATION_PATH)
+    token_url = AnyHttpUrl(str(issuer_url).rstrip("/") + TOKEN_PATH)
 
     # Create metadata
     metadata = OAuthMetadata(

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -359,7 +359,8 @@ class TestOAuthClientProvider:
 
         assert oauth_provider._has_valid_token()
 
-    def test_has_valid_token_expired(self, oauth_provider, oauth_token):
+    @pytest.mark.anyio
+    async def test_has_valid_token_expired(self, oauth_provider, oauth_token):
         """Test token validation with expired token."""
         oauth_provider._current_tokens = oauth_token
         oauth_provider._token_expiry_time = time.time() - 3600  # Past expiry
@@ -810,7 +811,8 @@ class TestOAuthClientProvider:
         # No scope should be set since client metadata doesn't have explicit scope
         assert "scope" not in auth_params
 
-    def test_scope_priority_no_scope(self, oauth_provider, oauth_client_info):
+    @pytest.mark.anyio
+    async def test_scope_priority_no_scope(self, oauth_provider, oauth_client_info):
         """Test that no scope parameter is set when no scopes specified."""
         oauth_provider.client_metadata.scope = None
         oauth_provider._client_info = oauth_client_info


### PR DESCRIPTION
We started running tests in parallel and this uncovered, strangely see this only in local run.

`oauth_provider` fixture in the test file is defined as an async fixture (async def oauth_provider), but two tests were trying to use it as a synchronous fixture:

  1. t`est_has_valid_token_expired` - was a synchronous test (def test_...) but used the async oauth_provider fixture
  2. `test_scope_priority_no_scope` - was also a synchronous test but used the async oauth_provider fixture

This caused an AttributeError because pytest was passing a coroutine object instead of the actual OAuthClientProvider instance to these tests. When the tests tried to access attributes like oauth_provider._current_tokens, they failed because coroutine objects don't have these attributes.

  The fix was to make both tests async by:
  - Adding @pytest.mark.anyio decorator
  - Changing def test_... to async def test_...

Also noticed that out CI does not catch `ruff format` so adding it here