### PR TITLE
RFC: Lower log levels used for connections

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -53,7 +53,7 @@ async def sse_client(
 
     async with anyio.create_task_group() as tg:
         try:
-            logger.info(f"Connecting to SSE endpoint: {remove_request_params(url)}")
+            logger.debug(f"Connecting to SSE endpoint: {remove_request_params(url)}")
             async with httpx_client_factory(headers=headers, auth=auth) as client:
                 async with aconnect_sse(
                     client,
@@ -73,7 +73,7 @@ async def sse_client(
                                 match sse.event:
                                     case "endpoint":
                                         endpoint_url = urljoin(url, sse.data)
-                                        logger.info(
+                                        logger.debug(
                                             f"Received endpoint URL: {endpoint_url}"
                                         )
 
@@ -146,7 +146,7 @@ async def sse_client(
                             await write_stream.aclose()
 
                     endpoint_url = await tg.start(sse_reader)
-                    logger.info(
+                    logger.debug(
                         f"Starting post writer with endpoint URL: {endpoint_url}"
                     )
                     tg.start_soon(post_writer, endpoint_url)

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -463,7 +463,7 @@ async def streamablehttp_client(
 
     async with anyio.create_task_group() as tg:
         try:
-            logger.info(f"Connecting to StreamableHTTP endpoint: {url}")
+            logger.debug(f"Connecting to StreamableHTTP endpoint: {url}")
 
             async with httpx_client_factory(
                 headers=transport.request_headers,


### PR DESCRIPTION
It's not ideal, but currently some servers encode authorization in their URI. To reduce risk of such servers in other situations lower the log level of messages including the URI so we don't log potentially auth-containing data by default.

## Motivation and Context
As above really, it could be done by altering log levels but it's unclear this granularity is needed so instead proposing changing it.

## How Has This Been Tested?
Ran locally

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A