### PR TITLE
Fix and update `OAuthAuthorizationServerProvider` snippet in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,11 @@ providing an implementation of the `OAuthAuthorizationServerProvider` protocol.
 ```python
 from mcp import FastMCP
 from mcp.server.auth.provider import OAuthAuthorizationServerProvider
-from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions, RevocationOptions
+from mcp.server.auth.settings import (
+    AuthSettings,
+    ClientRegistrationOptions,
+    RevocationOptions,
+)
 
 
 class MyOAuthServerProvider(OAuthAuthorizationServerProvider):
@@ -328,7 +332,8 @@ class MyOAuthServerProvider(OAuthAuthorizationServerProvider):
     ...
 
 
-mcp = FastMCP("My App",
+mcp = FastMCP(
+    "My App",
     auth_server_provider=MyOAuthServerProvider(),
     auth=AuthSettings(
         issuer_url="https://myapp.com",


### PR DESCRIPTION
This PR adds `python` as the language for a snippet that had no language i.e., no syntax highlighting in `README.md`, and also fixes the indentation as it was using 8-spaces instead of 4-spaces as in the rest of the snippets. This PR also updates the references from `OAuthServerProvider` (wrong import symbol) to `OAuthAuthorizationServerProvider` (correct import symbol), as well as adding the missing imports in the snippet and a reference on how to implement your own `OAuthAuthorizationServerProvider` based on an existing example under `examples/`.

## Motivation and Context

To improve the readability and allow for easier copy-paste without having to format it afterwards.

## How Has This Been Tested?

N/A

## Breaking Changes

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist

- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context

N/A