### PR TITLE
normalize string ID to int in server messages for compatibility

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -98,6 +98,21 @@ async def sse_client(
                                             message = types.JSONRPCMessage.model_validate_json(  # noqa: E501
                                                 sse.data
                                             )
+                                            
+                                            # Normalize ID to int if it's a numeric string.
+                                            # Some non-standard SSE servers return numeric IDs as strings,
+                                            # even if the original request used an integer ID.
+                                            if isinstance(message.root, types.JSONRPCResponse):
+                                                msg_id = message.root.id
+                                                if isinstance(msg_id, str) and msg_id.isdigit():
+                                                    message.root.id = int(msg_id)
+                                                elif not isinstance(msg_id, int):
+                                                    logger.warning(
+                                                        "Ignored message with "
+                                                        f"invalid ID: {msg_id!r}"
+                                                    )
+                                                    continue
+
                                             logger.debug(
                                                 f"Received server message: {message}"
                                             )


### PR DESCRIPTION
Some non-standard SSE servers may return numeric IDs as strings, even when the original request used an integer. This change ensures that message.root.id is always an integer to maintain consistency and avoid type issues in downstream processing.

<!-- Provide a brief summary of your changes -->
Normalize `message.root.id` to integer if it is a numeric string returned by non-standard SSE servers.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Some SSE servers return numeric IDs as strings, causing mismatches between request and response IDs. This leads to callbacks not being triggered and the client waiting indefinitely. The change improves compatibility and stability by normalizing the ID type.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested with mock SSE server responses containing string IDs; verified that messages with string numeric IDs are correctly converted to int and processed without errors.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This is a backward-compatible bug fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This fix addresses compatibility issues with SSE servers that do not strictly follow numeric ID typing conventions. It ensures the client logic for callback matching remains reliable.
