### PR TITLE
fix: Expose completions capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,13 +1204,13 @@ The MCP protocol defines three core primitives that servers can implement:
 
 MCP servers declare capabilities during initialization:
 
-| Capability  | Feature Flag                 | Description                        |
-|-------------|------------------------------|------------------------------------|
-| `prompts`   | `listChanged`                | Prompt template management         |
-| `resources` | `subscribe`<br/>`listChanged`| Resource exposure and updates      |
-| `tools`     | `listChanged`                | Tool discovery and execution       |
-| `logging`   | -                            | Server logging configuration       |
-| `completion`| -                            | Argument completion suggestions    |
+| Capability   | Feature Flag                 | Description                        |
+|--------------|------------------------------|------------------------------------|
+| `prompts`    | `listChanged`                | Prompt template management         |
+| `resources`  | `subscribe`<br/>`listChanged`| Resource exposure and updates      |
+| `tools`      | `listChanged`                | Tool discovery and execution       |
+| `logging`    | -                            | Server logging configuration       |
+| `completions`| -                            | Argument completion suggestions    |
 
 ## Documentation
 

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -190,6 +190,7 @@ class Server(Generic[LifespanResultT, RequestT]):
         resources_capability = None
         tools_capability = None
         logging_capability = None
+        completions_capability = None
 
         # Set prompt capabilities if handler exists
         if types.ListPromptsRequest in self.request_handlers:
@@ -209,12 +210,17 @@ class Server(Generic[LifespanResultT, RequestT]):
         if types.SetLevelRequest in self.request_handlers:
             logging_capability = types.LoggingCapability()
 
+        # Set completions capabilities if handler exists
+        if types.CompleteRequest in self.request_handlers:
+            completions_capability = types.CompletionsCapability()
+
         return types.ServerCapabilities(
             prompts=prompts_capability,
             resources=resources_capability,
             tools=tools_capability,
             logging=logging_capability,
             experimental=experimental_capabilities,
+            completions=completions_capability,
         )
 
     @property

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -286,6 +286,12 @@ class LoggingCapability(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class CompletionsCapability(BaseModel):
+    """Capability for completions operations."""
+
+    model_config = ConfigDict(extra="allow")
+
+
 class ServerCapabilities(BaseModel):
     """Capabilities that a server may support."""
 
@@ -299,6 +305,10 @@ class ServerCapabilities(BaseModel):
     """Present if the server offers any resources to read."""
     tools: ToolsCapability | None = None
     """Present if the server offers any tools to call."""
+    completions: CompletionsCapability | None = None
+    """
+    Present if the server offers autocompletion suggestions for prompts and resources.
+    """
     model_config = ConfigDict(extra="allow")
 
 

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -306,9 +306,7 @@ class ServerCapabilities(BaseModel):
     tools: ToolsCapability | None = None
     """Present if the server offers any tools to call."""
     completions: CompletionsCapability | None = None
-    """
-    Present if the server offers autocompletion suggestions for prompts and resources.
-    """
+    """Present if the server offers autocompletion suggestions for prompts and resources."""
     model_config = ConfigDict(extra="allow")
 
 

--- a/tests/server/test_session.py
+++ b/tests/server/test_session.py
@@ -109,9 +109,7 @@ async def test_server_capabilities():
 
     # Add a complete handler
     @server.completion()
-    async def complete(
-        ref: PromptReference | ResourceReference, argument: CompletionArgument
-    ):
+    async def complete(ref: PromptReference | ResourceReference, argument: CompletionArgument):
         return Completion(
             values=["completion1", "completion2"],
         )

--- a/tests/server/test_session.py
+++ b/tests/server/test_session.py
@@ -11,8 +11,13 @@ from mcp.shared.message import SessionMessage
 from mcp.shared.session import RequestResponder
 from mcp.types import (
     ClientNotification,
+    Completion,
+    CompletionArgument,
+    CompletionsCapability,
     InitializedNotification,
+    PromptReference,
     PromptsCapability,
+    ResourceReference,
     ResourcesCapability,
     ServerCapabilities,
 )
@@ -80,6 +85,7 @@ async def test_server_capabilities():
     caps = server.get_capabilities(notification_options, experimental_capabilities)
     assert caps.prompts is None
     assert caps.resources is None
+    assert caps.completions is None
 
     # Add a prompts handler
     @server.list_prompts()
@@ -89,6 +95,7 @@ async def test_server_capabilities():
     caps = server.get_capabilities(notification_options, experimental_capabilities)
     assert caps.prompts == PromptsCapability(listChanged=False)
     assert caps.resources is None
+    assert caps.completions is None
 
     # Add a resources handler
     @server.list_resources()
@@ -98,6 +105,21 @@ async def test_server_capabilities():
     caps = server.get_capabilities(notification_options, experimental_capabilities)
     assert caps.prompts == PromptsCapability(listChanged=False)
     assert caps.resources == ResourcesCapability(subscribe=False, listChanged=False)
+    assert caps.completions is None
+
+    # Add a complete handler
+    @server.completion()
+    async def complete(
+        ref: PromptReference | ResourceReference, argument: CompletionArgument
+    ):
+        return Completion(
+            values=["completion1", "completion2"],
+        )
+
+    caps = server.get_capabilities(notification_options, experimental_capabilities)
+    assert caps.prompts == PromptsCapability(listChanged=False)
+    assert caps.resources == ResourcesCapability(subscribe=False, listChanged=False)
+    assert caps.completions == CompletionsCapability()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Advertising support for completions in servers where a completion handler has been defined.
Similar to https://github.com/modelcontextprotocol/typescript-sdk/pull/546

## Motivation and Context
While implementing https://github.com/modelcontextprotocol/inspector/pull/441, I found out that the only way to advertise completions support was defining it manually in constructor argument.

## How Has This Been Tested?
Added corresponding unit tests.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
