### PR TITLE
Add `streamable_http_client` and deprecate old usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@
     - [Prompts](#prompts)
     - [Images](#images)
     - [Context](#context)
+    - [Authentication](#authentication)
   - [Running Your Server](#running-your-server)
     - [Development Mode](#development-mode)
     - [Claude Desktop Integration](#claude-desktop-integration)
     - [Direct Execution](#direct-execution)
+    - [Streamable HTTP Transport](#streamable-http-transport)
     - [Mounting to an Existing ASGI Server](#mounting-to-an-existing-asgi-server)
   - [Examples](#examples)
     - [Echo Server](#echo-server)
@@ -41,6 +43,7 @@
   - [Advanced Usage](#advanced-usage)
     - [Low-Level Server](#low-level-server)
     - [Writing MCP Clients](#writing-mcp-clients)
+    - [OAuth Authentication for Clients](#oauth-authentication-for-clients)
     - [MCP Primitives](#mcp-primitives)
     - [Server Capabilities](#server-capabilities)
   - [Documentation](#documentation)
@@ -73,7 +76,7 @@ The Model Context Protocol allows applications to provide context for LLMs in a 
 
 ### Adding MCP to your python project
 
-We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects. 
+We recommend using [uv](https://docs.astral.sh/uv/) to manage your Python projects.
 
 If you haven't created a uv-managed project yet, create one:
 
@@ -790,13 +793,13 @@ if __name__ == "__main__":
 Clients can also connect using [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http):
 
 ```python
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp import ClientSession
 
 
 async def main():
     # Connect to a streamable HTTP server
-    async with streamablehttp_client("example/mcp") as (
+    async with streamable_http_client("example/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -816,7 +819,7 @@ The SDK includes [authorization support](https://modelcontextprotocol.io/specifi
 ```python
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 
 
@@ -852,7 +855,7 @@ async def main():
     )
 
     # Use with streamable HTTP client
-    async with streamablehttp_client(
+    async with streamable_http_client(
         "https://api.example.com/mcp", auth=oauth_auth
     ) as (read, write, _):
         async with ClientSession(read, write) as session:

--- a/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
+++ b/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
@@ -19,7 +19,7 @@ from urllib.parse import parse_qs, urlparse
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
 
 
@@ -208,7 +208,7 @@ class SimpleAuthClient:
                     await self._run_session(read_stream, write_stream, None)
             else:
                 print("📡 Opening StreamableHTTP transport connection with auth...")
-                async with streamablehttp_client(
+                async with streamable_http_client(
                     url=self.server_url,
                     auth=oauth_auth,
                     timeout=timedelta(seconds=60),

--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -23,7 +23,7 @@ import mcp
 from mcp import types
 from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.exceptions import McpError
 
 
@@ -44,7 +44,7 @@ class SseServerParameters(BaseModel):
 
 
 class StreamableHttpParameters(BaseModel):
-    """Parameters for intializing a streamablehttp_client."""
+    """Parameters for intializing a streamable_http_client."""
 
     # The endpoint URL.
     url: str
@@ -252,11 +252,11 @@ class ClientSessionGroup:
                 )
                 read, write = await session_stack.enter_async_context(client)
             else:
-                client = streamablehttp_client(
+                client = streamable_http_client(
                     url=server_params.url,
                     headers=server_params.headers,
-                    timeout=server_params.timeout,
-                    sse_read_timeout=server_params.sse_read_timeout,
+                    timeout=server_params.timeout.total_seconds(),
+                    sse_read_timeout=server_params.sse_read_timeout.total_seconds(),
                     terminate_on_close=server_params.terminate_on_close,
                 )
                 read, write, _ = await session_stack.enter_async_context(client)

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -296,7 +296,7 @@ class TestClientSessionGroup:
                     url="http://test.com/stream", terminate_on_close=False
                 ),
                 "streamablehttp",
-                "mcp.client.session_group.streamablehttp_client",
+                "mcp.client.session_group.streamable_http_client",
             ),  # url, headers, timeout, sse_read_timeout, terminate_on_close
         ],
     )
@@ -316,7 +316,7 @@ class TestClientSessionGroup:
                 mock_read_stream = mock.AsyncMock(name=f"{client_type_name}Read")
                 mock_write_stream = mock.AsyncMock(name=f"{client_type_name}Write")
 
-                # streamablehttp_client's __aenter__ returns three values
+                # streamable_http_client's __aenter__ returns three values
                 if client_type_name == "streamablehttp":
                     mock_extra_stream_val = mock.AsyncMock(name="StreamableExtra")
                     mock_client_cm_instance.__aenter__.return_value = (

--- a/tests/server/fastmcp/test_integration.py
+++ b/tests/server/fastmcp/test_integration.py
@@ -21,7 +21,7 @@ from starlette.requests import Request
 import mcp.types as types
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.resources import FunctionResource
 from mcp.shared.context import RequestContext
@@ -464,7 +464,7 @@ async def test_fastmcp_streamable_http(
 ) -> None:
     """Test that FastMCP works with StreamableHTTP transport."""
     # Connect to the server using StreamableHTTP
-    async with streamablehttp_client(http_server_url + "/mcp") as (
+    async with streamable_http_client(http_server_url + "/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -489,7 +489,7 @@ async def test_fastmcp_stateless_streamable_http(
 ) -> None:
     """Test that FastMCP works with stateless StreamableHTTP transport."""
     # Connect to the server using StreamableHTTP
-    async with streamablehttp_client(stateless_http_server_url + "/mcp") as (
+    async with streamable_http_client(stateless_http_server_url + "/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -909,7 +909,7 @@ async def test_fastmcp_all_features_streamable_http(
     collector = NotificationCollector()
 
     # Connect to the server using StreamableHTTP
-    async with streamablehttp_client(everything_http_server_url + "/mcp") as (
+    async with streamable_http_client(everything_http_server_url + "/mcp") as (
         read_stream,
         write_stream,
         _,

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -23,7 +23,7 @@ from starlette.routing import Mount
 
 import mcp.types as types
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.server import Server
 from mcp.server.streamable_http import (
     MCP_SESSION_ID_HEADER,
@@ -744,7 +744,7 @@ async def http_client(basic_server, basic_server_url):
 @pytest.fixture
 async def initialized_client_session(basic_server, basic_server_url):
     """Create initialized StreamableHTTP client session."""
-    async with streamablehttp_client(f"{basic_server_url}/mcp") as (
+    async with streamable_http_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -758,9 +758,9 @@ async def initialized_client_session(basic_server, basic_server_url):
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_basic_connection(basic_server, basic_server_url):
+async def test_streamable_http_client_basic_connection(basic_server, basic_server_url):
     """Test basic client connection with initialization."""
-    async with streamablehttp_client(f"{basic_server_url}/mcp") as (
+    async with streamable_http_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -776,7 +776,7 @@ async def test_streamablehttp_client_basic_connection(basic_server, basic_server
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_resource_read(initialized_client_session):
+async def test_streamable_http_client_resource_read(initialized_client_session):
     """Test client resource read functionality."""
     response = await initialized_client_session.read_resource(
         uri=AnyUrl("foobar://test-resource")
@@ -787,7 +787,7 @@ async def test_streamablehttp_client_resource_read(initialized_client_session):
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_tool_invocation(initialized_client_session):
+async def test_streamable_http_client_tool_invocation(initialized_client_session):
     """Test client tool invocation."""
     # First list tools
     tools = await initialized_client_session.list_tools()
@@ -802,7 +802,7 @@ async def test_streamablehttp_client_tool_invocation(initialized_client_session)
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_error_handling(initialized_client_session):
+async def test_streamable_http_client_error_handling(initialized_client_session):
     """Test error handling in client."""
     with pytest.raises(McpError) as exc_info:
         await initialized_client_session.read_resource(
@@ -813,11 +813,11 @@ async def test_streamablehttp_client_error_handling(initialized_client_session):
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_session_persistence(
+async def test_streamable_http_client_session_persistence(
     basic_server, basic_server_url
 ):
     """Test that session ID persists across requests."""
-    async with streamablehttp_client(f"{basic_server_url}/mcp") as (
+    async with streamable_http_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -843,11 +843,11 @@ async def test_streamablehttp_client_session_persistence(
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_json_response(
+async def test_streamable_http_client_json_response(
     json_response_server, json_server_url
 ):
     """Test client with JSON response mode."""
-    async with streamablehttp_client(f"{json_server_url}/mcp") as (
+    async with streamable_http_client(f"{json_server_url}/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -873,7 +873,7 @@ async def test_streamablehttp_client_json_response(
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_get_stream(basic_server, basic_server_url):
+async def test_streamable_http_client_get_stream(basic_server, basic_server_url):
     """Test GET stream functionality for server-initiated messages."""
     import mcp.types as types
     from mcp.shared.session import RequestResponder
@@ -889,7 +889,7 @@ async def test_streamablehttp_client_get_stream(basic_server, basic_server_url):
         if isinstance(message, types.ServerNotification):
             notifications_received.append(message)
 
-    async with streamablehttp_client(f"{basic_server_url}/mcp") as (
+    async with streamable_http_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -920,15 +920,15 @@ async def test_streamablehttp_client_get_stream(basic_server, basic_server_url):
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_session_termination(
+async def test_streamable_http_client_session_termination(
     basic_server, basic_server_url
 ):
     """Test client session termination functionality."""
 
     captured_session_id = None
 
-    # Create the streamablehttp_client with a custom httpx client to capture headers
-    async with streamablehttp_client(f"{basic_server_url}/mcp") as (
+    # Create the streamable_http_client with a custom httpx client to capture headers
+    async with streamable_http_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
         get_session_id,
@@ -948,7 +948,7 @@ async def test_streamablehttp_client_session_termination(
     if captured_session_id:
         headers[MCP_SESSION_ID_HEADER] = captured_session_id
 
-    async with streamablehttp_client(f"{basic_server_url}/mcp", headers=headers) as (
+    async with streamable_http_client(f"{basic_server_url}/mcp", headers=headers) as (
         read_stream,
         write_stream,
         _,
@@ -963,7 +963,7 @@ async def test_streamablehttp_client_session_termination(
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_session_termination_204(
+async def test_streamable_http_client_session_termination_204(
     basic_server, basic_server_url, monkeypatch
 ):
     """Test client session termination functionality with a 204 response.
@@ -993,8 +993,8 @@ async def test_streamablehttp_client_session_termination_204(
 
     captured_session_id = None
 
-    # Create the streamablehttp_client with a custom httpx client to capture headers
-    async with streamablehttp_client(f"{basic_server_url}/mcp") as (
+    # Create the streamable_http_client with a custom httpx client to capture headers
+    async with streamable_http_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
         get_session_id,
@@ -1014,7 +1014,7 @@ async def test_streamablehttp_client_session_termination_204(
     if captured_session_id:
         headers[MCP_SESSION_ID_HEADER] = captured_session_id
 
-    async with streamablehttp_client(f"{basic_server_url}/mcp", headers=headers) as (
+    async with streamable_http_client(f"{basic_server_url}/mcp", headers=headers) as (
         read_stream,
         write_stream,
         _,
@@ -1029,7 +1029,7 @@ async def test_streamablehttp_client_session_termination_204(
 
 
 @pytest.mark.anyio
-async def test_streamablehttp_client_resumption(event_server):
+async def test_streamable_http_client_resumption(event_server):
     """Test client session to resume a long running tool."""
     _, server_url = event_server
 
@@ -1057,7 +1057,9 @@ async def test_streamablehttp_client_resumption(event_server):
         captured_resumption_token = token
 
     # First, start the client session and begin the long-running tool
-    async with streamablehttp_client(f"{server_url}/mcp", terminate_on_close=False) as (
+    async with streamable_http_client(
+        f"{server_url}/mcp", terminate_on_close=False
+    ) as (
         read_stream,
         write_stream,
         get_session_id,
@@ -1109,7 +1111,7 @@ async def test_streamablehttp_client_resumption(event_server):
     if captured_session_id:
         headers[MCP_SESSION_ID_HEADER] = captured_session_id
 
-    async with streamablehttp_client(f"{server_url}/mcp", headers=headers) as (
+    async with streamable_http_client(f"{server_url}/mcp", headers=headers) as (
         read_stream,
         write_stream,
         _,
@@ -1192,7 +1194,7 @@ async def test_streamablehttp_server_sampling(basic_server, basic_server_url):
         )
 
     # Create client with sampling callback
-    async with streamablehttp_client(f"{basic_server_url}/mcp") as (
+    async with streamable_http_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
         _,
@@ -1365,7 +1367,7 @@ async def test_streamablehttp_request_context_propagation(
         "X-Trace-Id": "trace-123",
     }
 
-    async with streamablehttp_client(
+    async with streamable_http_client(
         f"{basic_server_url}/mcp", headers=custom_headers
     ) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
@@ -1402,7 +1404,7 @@ async def test_streamablehttp_request_context_isolation(
             "Authorization": f"Bearer token-{i}",
         }
 
-        async with streamablehttp_client(
+        async with streamable_http_client(
             f"{basic_server_url}/mcp", headers=headers
         ) as (read_stream, write_stream, _):
             async with ClientSession(read_stream, write_stream) as session:


### PR DESCRIPTION
The module is named `streamable_http_client`, it doesn't make sense for the function to be called `streamablehttp_client`.