### PR TITLE
Pass responsibility to user

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -101,6 +101,7 @@ class ClientSession(
         logging_callback: LoggingFnT | None = None,
         message_handler: MessageHandlerFnT | None = None,
         client_info: types.Implementation | None = None,
+        support_roots_list_changed: bool = False,
     ) -> None:
         super().__init__(
             read_stream,
@@ -114,6 +115,7 @@ class ClientSession(
         self._list_roots_callback = list_roots_callback or _default_list_roots_callback
         self._logging_callback = logging_callback or _default_logging_callback
         self._message_handler = message_handler or _default_message_handler
+        self._support_roots_list_changed = support_roots_list_changed
 
     async def initialize(self) -> types.InitializeResult:
         sampling = (
@@ -122,10 +124,7 @@ class ClientSession(
             else None
         )
         roots = (
-            # TODO: Should this be based on whether we
-            # _will_ send notifications, or only whether
-            # they're supported?
-            types.RootsCapability(listChanged=True)
+            types.RootsCapability(listChanged=self._support_roots_list_changed)
             if self._list_roots_callback is not _default_list_roots_callback
             else None
         )


### PR DESCRIPTION
SDK user will set whether it supports RootsListChanged.
To fall into the safe side, the capability defaults to `False`.

## Motivation and Context
I was thinking of a more robust solution for this, but since it's the user providing the callback, I don't think there's much we can do here.

## How Has This Been Tested?
Locally.

## Breaking Changes
No. I added a new arg, but it's in the end of the args list and has a default value.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
