### PR TITLE
Cleans read stream writers list

### DIFF
--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -156,6 +156,7 @@ class SseServerTransport:
                 )(scope, receive, send)
                 await read_stream_writer.aclose()
                 await write_stream_reader.aclose()
+                self._read_stream_writers.pop(session_id, None)
                 logging.debug(f"Client session disconnected {session_id}")
 
             logger.debug("Starting SSE response task")


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently, there is no explicit cleanup of the `session_id` from the `_read_stream_writers`. When the connection closes (client disconnects) the code closes the streams, but does not remove the `session_id` key from `_read_stream_writers` dictionary when the connection is closed.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x ] My code follows the repository's style guidelines
- [ x ] New and existing tests pass locally
- [ x ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
