### PR TITLE
Use `total_seconds` instead of `seconds` on timeout

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -195,7 +195,8 @@ class StreamableHTTPTransport:
                 self.url,
                 headers=headers,
                 timeout=httpx.Timeout(
-                    self.timeout.seconds, read=self.sse_read_timeout.seconds
+                    self.timeout.total_seconds(),
+                    read=self.sse_read_timeout.total_seconds(),
                 ),
             ) as event_source:
                 event_source.response.raise_for_status()
@@ -226,7 +227,7 @@ class StreamableHTTPTransport:
             self.url,
             headers=headers,
             timeout=httpx.Timeout(
-                self.timeout.seconds, read=ctx.sse_read_timeout.seconds
+                self.timeout.total_seconds(), read=ctx.sse_read_timeout.total_seconds()
             ),
         ) as event_source:
             event_source.response.raise_for_status()
@@ -468,7 +469,8 @@ async def streamablehttp_client(
             async with httpx_client_factory(
                 headers=transport.request_headers,
                 timeout=httpx.Timeout(
-                    transport.timeout.seconds, read=transport.sse_read_timeout.seconds
+                    transport.timeout.total_seconds(),
+                    read=transport.sse_read_timeout.total_seconds(),
                 ),
                 auth=transport.auth,
             ) as client:


### PR DESCRIPTION
Since we accept `timedelta`, we are ignoring the other _non-seconds_ fields, which shouldn't be the case.