### PR TITLE
readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ def get_greeting(name: str) -> str:
 
 You can install this server in [Claude Desktop](https://claude.ai/download) and interact with it right away by running:
 ```bash
-mcp install server.py
+uv run mcp install server.py
 ```
 
 Alternatively, you can test it with the MCP Inspector:


### PR DESCRIPTION


## Motivation and Context

The original command mcp install server.py assumes a globally available mcp CLI, which may not be present in uv-managed setups. Using uv run mcp install server.py ensures the command executes within the correct virtual environment, aligning with recommended practices.


## How Has This Been Tested?
Tested locally in a uv-managed project. The server installed successfully and was recognized by Claude Desktop.


## Breaking Changes
None. Users not utilizing uv can continue using mcp install server.py as before.

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This change ensures that users following the uv workflow can install and run their MCP servers without encountering issues related to command execution outside the virtual environment.
