### PR TITLE
Fix: Convert sync tests using async fixtures to async tests

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -756,7 +756,8 @@ class TestOAuthClientProvider:
             # No Authorization header should be added if no token
             assert "Authorization" not in updated_request.headers
 
-    def test_scope_priority_client_metadata_first(
+    @pytest.mark.anyio
+    async def test_scope_priority_client_metadata_first(
         self, oauth_provider, oauth_client_info
     ):
         """Test that client metadata scope takes priority."""
@@ -785,7 +786,8 @@ class TestOAuthClientProvider:
 
         assert auth_params["scope"] == "read write"
 
-    def test_scope_priority_no_client_metadata_scope(
+    @pytest.mark.anyio
+    async def test_scope_priority_no_client_metadata_scope(
         self, oauth_provider, oauth_client_info
     ):
         """Test that no scope parameter is set when client metadata has no scope."""


### PR DESCRIPTION
## Description

This PR fixes test failures in `test_auth.py` where two synchronous test methods were incorrectly using an async fixture.

Fixes #902

## Problem

Two test methods were using the async `oauth_provider` fixture but were not marked as async tests:
- `test_scope_priority_client_metadata_first`
- `test_scope_priority_no_client_metadata_scope`

This caused:
```
AttributeError: 'coroutine' object has no attribute 'client_metadata'
```

## Solution

Added `@pytest.mark.anyio` decorator and converted both methods to `async def`, following the pattern established in commit 9dad266.

## Testing

- ✅ Both fixed tests now pass
- ✅ All tests pass locally (except one unrelated flaky test)
- ✅ Linting passes (`uv run ruff check`)
- ✅ Formatting checked (`uv run ruff format`)
- ✅ Type checking passes (`uv run pyright`)

## Note

The CI currently has `continue-on-error: true` for tests, which is why these failures weren't caught. This might be worth addressing in a separate issue.