### PR TITLE
Add .envrc to gitignore with example file

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,3 @@
+source .venv/bin/activate
+export UV_INDEX=https://pypi.org/simple
+unset PYTEST_DISABLE_PLUGIN_AUTOLOAD

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.envrc
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
## Summary
- Added `.envrc` to `.gitignore`
- Created `.envrc.example` as a template

## Motivation
Providing an example file to help setup .venv automatically on `cd` with e.g. direnv.

## Changes
1. Updated `.gitignore` to exclude `.envrc` files
2. Added `.envrc.example` with placeholder environment variables

## Test plan
N/A