### PR TITLE
refactor: align protocol version header capitalization to lowercase

### DIFF
--- a/src/mcp/client/auth.py
+++ b/src/mcp/client/auth.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode, urljoin
 import anyio
 import httpx
 
+from mcp.client.streamable_http import MCP_PROTOCOL_VERSION
 from mcp.shared.auth import (
     OAuthClientInformationFull,
     OAuthClientMetadata,
@@ -129,7 +130,7 @@ class OAuthClientProvider(httpx.Auth):
         # Extract base URL per MCP spec
         auth_base_url = self._get_authorization_base_url(server_url)
         url = urljoin(auth_base_url, "/.well-known/oauth-authorization-server")
-        headers = {"MCP-Protocol-Version": LATEST_PROTOCOL_VERSION}
+        headers = {MCP_PROTOCOL_VERSION: LATEST_PROTOCOL_VERSION}
 
         async with httpx.AsyncClient() as client:
             try:

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -40,7 +40,7 @@ StreamReader = MemoryObjectReceiveStream[SessionMessage]
 GetSessionIdCallback = Callable[[], str | None]
 
 MCP_SESSION_ID = "mcp-session-id"
-MCP_PROTOCOL_VERSION = "MCP-Protocol-Version"
+MCP_PROTOCOL_VERSION = "mcp-protocol-version"
 LAST_EVENT_ID = "last-event-id"
 CONTENT_TYPE = "content-type"
 ACCEPT = "Accept"

--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -16,6 +16,7 @@ from mcp.server.auth.handlers.token import TokenHandler
 from mcp.server.auth.middleware.client_auth import ClientAuthenticator
 from mcp.server.auth.provider import OAuthAuthorizationServerProvider
 from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
+from mcp.server.streamable_http import MCP_PROTOCOL_VERSION_HEADER
 from mcp.shared.auth import OAuthMetadata
 
 
@@ -59,7 +60,7 @@ def cors_middleware(
         app=request_response(handler),
         allow_origins="*",
         allow_methods=allow_methods,
-        allow_headers=["mcp-protocol-version"],
+        allow_headers=[MCP_PROTOCOL_VERSION_HEADER],
     )
     return cors_app
 

--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -46,7 +46,7 @@ MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024  # 4MB
 
 # Header names
 MCP_SESSION_ID_HEADER = "mcp-session-id"
-MCP_PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version"
+MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
 LAST_EVENT_ID_HEADER = "last-event-id"
 
 # Content types

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -1482,7 +1482,7 @@ async def test_streamablehttp_request_context_isolation(
 async def test_client_includes_protocol_version_header_after_init(
     context_aware_server, basic_server_url
 ):
-    """Test that client includes MCP-Protocol-Version header after initialization."""
+    """Test that client includes mcp-protocol-version header after initialization."""
     async with streamablehttp_client(f"{basic_server_url}/mcp") as (
         read_stream,
         write_stream,
@@ -1502,7 +1502,7 @@ async def test_client_includes_protocol_version_header_after_init(
 
             # Verify protocol version header is present
             assert "mcp-protocol-version" in headers_data
-            assert headers_data["mcp-protocol-version"] == negotiated_version
+            assert headers_data[MCP_PROTOCOL_VERSION_HEADER] == negotiated_version
 
 
 def test_server_validates_protocol_version_header(basic_server, basic_server_url):
@@ -1585,7 +1585,7 @@ def test_server_backwards_compatibility_no_protocol_version(
     assert init_response.status_code == 200
     session_id = init_response.headers.get(MCP_SESSION_ID_HEADER)
 
-    # Test request without MCP-Protocol-Version header (backwards compatibility)
+    # Test request without mcp-protocol-version header (backwards compatibility)
     response = requests.post(
         f"{basic_server_url}/mcp",
         headers={


### PR DESCRIPTION
## Summary

This PR standardizes the MCP protocol version header name to lowercase `mcp-protocol-version` across the entire Python SDK codebase for consistency.

## Changes

Changed `MCP-Protocol-Version` to `mcp-protocol-version` throughout and aligned usage of constants

## Rationale

The lowercase format aligns with common HTTP header conventions (similar to headers like `content-type`, `accept-encoding`, etc.) and ensures consistent header handling throughout the SDK.

## Test plan

- [x] All existing tests pass
- [x] Header validation continues to work correctly
- [x] Backwards compatibility is maintained