### PR TITLE
Add stateless mode support for STDIO transport

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -87,6 +87,9 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     debug: bool = False
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 
+    # STDIO settings
+    stateless_stdio: bool = False
+
     # HTTP settings
     host: str = "127.0.0.1"
     port: int = 8000
@@ -597,6 +600,7 @@ class FastMCP:
                 read_stream,
                 write_stream,
                 self._mcp_server.create_initialization_options(),
+                stateless=self.settings.stateless_stdio
             )
 
     async def run_sse_async(self, mount_path: str | None = None) -> None:


### PR DESCRIPTION
## Motivation and Context

This change adds support for the `stateless` flag to STDIO transport, addressing issue #912. Currently, STDIO transport requires a full initialization handshake, making simple command line interactions like `echo '{"jsonrpc":"2.0",...}' | python script.py` impossible.

The stateless flag already exists for HTTP transport but was missing for STDIO. This feature is particularly helpful for:
- Simple CLI debugging and testing
- Support for older MCP clients that don't do the handshake
- Educational scenarios where users are learning about MCP without needing to understand the initialization protocol
- Quick command-line tool interactions

## How Has This Been Tested?

Aside from the added tests, I created a basic server and ran some commands. 

```
from mcp.server.fastmcp import FastMCP

# Create FastMCP server
mcp = FastMCP("StatelessTest")

# Register a simple echo tool
@mcp.tool()
def echo(message: str) -> str:
    """Echo a message back to the client."""
    return f"Echo: {message}"

if __name__ == "__main__":
    # Run in STDIO mode
    mcp.run()
```

```
% echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"Hello world"}}}' | FASTMCP_STATELESS_STDIO=true uv run test_stateless.py
[06/10/25 14:52:17] INFO     Processing request of type CallToolRequest                                                                                                                                                                                                                                                                          server.py:561
{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"Echo: Hello world"}],"isError":false}}

% echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"message":"Hello world"}}}' | FASTMCP_STATELESS_STDIO=false uv run test_stateless.py
<runtime exception>
```

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

I forked from gitish 1a9ead07f5319abf941b54668b911e3f3773a1cb and the tests occasionally hang on that commit.

Fixes #912
