### PR TITLE
Fix simple-auth server example AuthorizationCode.redirect_uri type

### DIFF
--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -6,7 +6,7 @@ import time
 from typing import Any, Literal
 
 import click
-from pydantic import AnyHttpUrl
+from pydantic import AnyHttpUrl, AnyUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
@@ -144,7 +144,7 @@ class SimpleGitHubOAuthProvider(OAuthAuthorizationServerProvider):
             auth_code = AuthorizationCode(
                 code=new_code,
                 client_id=client_id,
-                redirect_uri=AnyHttpUrl(redirect_uri),
+                redirect_uri=AnyUrl(redirect_uri),
                 redirect_uri_provided_explicitly=redirect_uri_provided_explicitly,
                 expires_at=time.time() + 300,
                 scopes=[self.settings.mcp_scope],


### PR DESCRIPTION
The AuthorizationCode.redirect_uri field type is AnyUrl, but the example used AnyHttpUrl type.

This mismatch causes the redirect URI check in TokenHandler to fail, since it compares against AuthorizationCodeRequest.redirect_uri, which also expects AnyUrl.

## Motivation and Context
It makes the simple-auth server example to work with simple-auth client example. Without the change when client requests to get the token it fails with a "Bad Request" error.

## How Has This Been Tested?
Manually by running server and client examples locally.

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [] I have added appropriate error handling
- [] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
