### PR TITLE
fix: HTTP timeout correctly passed to httpx

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -61,6 +61,7 @@ async def sse_client(
                     client,
                     "GET",
                     url,
+                    timeout=httpx.Timeout(timeout, read=sse_read_timeout),
                 ) as event_source:
                     event_source.response.raise_for_status()
                     logger.debug("SSE connection established")
@@ -106,7 +107,7 @@ async def sse_client(
                                     case _:
                                         logger.warning(f"Unknown SSE event: {sse.event}")
                         except Exception as exc:
-                            logger.error(f"Error in sse_reader: {exc}")
+                            logger.error(f"Error in sse_reader: {exc.__class__.__name__}", exc_info=True)
                             await read_stream_writer.send(exc)
                         finally:
                             await read_stream_writer.aclose()
@@ -127,7 +128,8 @@ async def sse_client(
                                     response.raise_for_status()
                                     logger.debug("Client message sent successfully: " f"{response.status_code}")
                         except Exception as exc:
-                            logger.error(f"Error in post_writer: {exc}")
+                            logger.error(f"Error in post_writer: {exc.__class__.__name__}", exc_info=True)
+                            await read_stream_writer.send(exc)
                         finally:
                             await write_stream.aclose()
 


### PR DESCRIPTION
It may take some time for a starting MCP server to response to GET request. Hence, users of MCP Python SDK must have ability to configure HTTP read timeout.

## Motivation and Context
HTTP timeout passed to MCP client does not apply properly.

## How Has This Been Tested?
Our MCP server may respond very slowly during initial warm up and cache filling. 
Hence, if client successfully connects to it, it may timeout and leave the client in a inconsistent state leading to overall application failing to progress.

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

