### PR TITLE
feat: add _meta to more objects

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -69,8 +69,7 @@ class NotificationParams(BaseModel):
 
     meta: Meta | None = Field(alias="_meta", default=None)
     """
-    This parameter name is reserved by MCP to allow clients and servers to attach
-    additional metadata to their notifications.
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
     """
 
 
@@ -105,13 +104,11 @@ class Notification(BaseModel, Generic[NotificationParamsT, MethodT]):
 class Result(BaseModel):
     """Base class for JSON-RPC results."""
 
-    model_config = ConfigDict(extra="allow")
-
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    This result property is reserved by the protocol to allow clients and servers to
-    attach additional metadata to their responses.
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
     """
+    model_config = ConfigDict(extra="allow")
 
 
 class PaginatedResult(Result):
@@ -394,6 +391,10 @@ class Resource(BaseModel):
     This can be used by Hosts to display file sizes and estimate context window usage.
     """
     annotations: Annotations | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -415,6 +416,10 @@ class ResourceTemplate(BaseModel):
     included if all resources matching this template have the same type.
     """
     annotations: Annotations | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -461,6 +466,10 @@ class ResourceContents(BaseModel):
     """The URI of this resource."""
     mimeType: str | None = None
     """The MIME type of this resource, if known."""
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -588,6 +597,10 @@ class Prompt(BaseModel):
     """An optional description of what this prompt provides."""
     arguments: list[PromptArgument] | None = None
     """A list of arguments to use for templating the prompt."""
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -621,6 +634,10 @@ class TextContent(BaseModel):
     text: str
     """The text content of the message."""
     annotations: Annotations | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -636,6 +653,10 @@ class ImageContent(BaseModel):
     image types.
     """
     annotations: Annotations | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -651,6 +672,10 @@ class AudioContent(BaseModel):
     audio types.
     """
     annotations: Annotations | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -673,6 +698,10 @@ class EmbeddedResource(BaseModel):
     type: Literal["resource"]
     resource: TextResourceContents | BlobResourceContents
     annotations: Annotations | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -772,6 +801,10 @@ class Tool(BaseModel):
     """A JSON Schema object defining the expected parameters for the tool."""
     annotations: ToolAnnotations | None = None
     """Optional additional tool information."""
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    """
     model_config = ConfigDict(extra="allow")
 
 
@@ -1063,6 +1096,10 @@ class Root(BaseModel):
     An optional name for the root. This can be used to provide a human-readable
     identifier for the root, which may be useful for display purposes or for
     referencing the root in other parts of the application.
+    """
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+    """
+    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
     """
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Add _meta fields to additional MCP types. This PR updates the Python SDK to align with the protocol changes from https://github.com/modelcontextprotocol/modelcontextprotocol/pull/710, which added _meta fields to several additional types in the MCP specification.

- Resource
- ResourceTemplate
- Tool
- TextContent
- ImageContent
- AudioContent
- Root

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
`uv run ruff check`
`uv run pytest`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
TypeScript equivalent https://github.com/modelcontextprotocol/typescript-sdk/pull/630