### PR TITLE
Allow longer duration in test_188_concurrency

### DIFF
--- a/tests/issues/test_188_concurrency.py
+++ b/tests/issues/test_188_concurrency.py
@@ -35,7 +35,7 @@ async def test_messages_are_executed_concurrently():
         end_time = anyio.current_time()
 
         duration = end_time - start_time
-        assert duration < 6 * _sleep_time_seconds
+        assert duration < 10 * _sleep_time_seconds
         print(duration)
 
 


### PR DESCRIPTION
because I was seeing tests failing on Windows in GitHub Actions

and GitHub Copilot
[said](https://github.com/modelcontextprotocol/python-sdk/pull/968#issuecomment-2978221567)

## Motivation and Context
Windows GitHub Actions runs failing because they exceed the max duration

## How Has This Been Tested?
Hopefully, tests pass in GitHub Actions

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
