### PR TITLE
ci: add --frozen flag to all uv commands in workflows

### DIFF
--- a/.github/workflows/publish-docs-manually.yml
+++ b/.github/workflows/publish-docs-manually.yml
@@ -30,4 +30,4 @@ jobs:
             mkdocs-material-
 
       - run: uv sync --frozen --group docs
-      - run: uv run --no-sync mkdocs gh-deploy --force
+      - run: uv run --frozen --no-sync mkdocs gh-deploy --force

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,7 +22,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Build
-        run: uv build
+        run: uv build --frozen
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -79,4 +79,4 @@ jobs:
             mkdocs-material-
 
       - run: uv sync --frozen --group docs
-      - run: uv run --no-sync mkdocs gh-deploy --force
+      - run: uv run --frozen --no-sync mkdocs gh-deploy --force

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -44,5 +44,5 @@ jobs:
         run: uv sync --frozen --all-extras --python ${{ matrix.python-version }}
 
       - name: Run pytest
-        run: uv run --no-sync pytest
+        run: uv run --frozen --no-sync pytest
     continue-on-error: true


### PR DESCRIPTION
## Summary
- Add `--frozen` flag to all `uv` commands in GitHub workflows
- Ensures deterministic builds by preventing lock file updates in CI
- Maintains consistency with existing `uv sync --frozen` usage

## Changes
- `uv run` → `uv run --frozen` in test workflows
- `uv build` → `uv build --frozen` in PyPI publishing
- `uv run` → `uv run --frozen` for mkdocs deployment

This ensures all CI builds use exact locked dependencies without attempting to update the lock file.

🤖 Generated with [Claude Code](https://claude.ai/code)