### PR TITLE
Update _meta usage guidance in types

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -69,7 +69,8 @@ class NotificationParams(BaseModel):
 
     meta: Meta | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
 
 
@@ -106,7 +107,8 @@ class Result(BaseModel):
 
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -393,7 +395,8 @@ class Resource(BaseModel):
     annotations: Annotations | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -418,7 +421,8 @@ class ResourceTemplate(BaseModel):
     annotations: Annotations | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -468,7 +472,8 @@ class ResourceContents(BaseModel):
     """The MIME type of this resource, if known."""
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -599,7 +604,8 @@ class Prompt(BaseModel):
     """A list of arguments to use for templating the prompt."""
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -636,7 +642,8 @@ class TextContent(BaseModel):
     annotations: Annotations | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -655,7 +662,8 @@ class ImageContent(BaseModel):
     annotations: Annotations | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -674,7 +682,8 @@ class AudioContent(BaseModel):
     annotations: Annotations | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -700,7 +709,8 @@ class EmbeddedResource(BaseModel):
     annotations: Annotations | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -803,7 +813,8 @@ class Tool(BaseModel):
     """Optional additional tool information."""
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 
@@ -1109,7 +1120,8 @@ class Root(BaseModel):
     """
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
     """
-    Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+    See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+    for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
 


### PR DESCRIPTION
Similar to https://github.com/modelcontextprotocol/typescript-sdk/pull/639 updating the comment to reflect guidance in the spec 