### PR TITLE
fix: catch and rethrow SSEError during SSE connection establishment

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -8,6 +8,7 @@ import httpx
 from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from httpx_sse import aconnect_sse
+from httpx_sse._exceptions import SSEError
 
 import mcp.types as types
 from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
@@ -105,6 +106,9 @@ async def sse_client(
                                         await read_stream_writer.send(session_message)
                                     case _:
                                         logger.warning(f"Unknown SSE event: {sse.event}")
+                        except SSEError as sse_exc:
+                            logger.error(f"SSE error: {sse_exc}")
+                            raise sse_exc
                         except Exception as exc:
                             logger.error(f"Error in sse_reader: {exc}")
                             await read_stream_writer.send(exc)

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -107,7 +107,7 @@ async def sse_client(
                                     case _:
                                         logger.warning(f"Unknown SSE event: {sse.event}")
                         except SSEError as sse_exc:
-                            logger.error(f"SSE error: {sse_exc}")
+                            logger.exception("Encountered SSE exception")
                             raise sse_exc
                         except Exception as exc:
                             logger.error(f"Error in sse_reader: {exc}")


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Some errors during SSE connection (e.g., SSEError) are fatal and render read/write streams unusable. Instead of sending the exception via read_stream_writer, which may hang, the error is now raised directly so that the caller can handle it appropriately.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
mcp-config
```
{
    "mcpServers": {
        "zhipu-web-search-sse": {
            "url": "https://open.bigmodel.cn/api/mcp/web_search/sse?Authorization=xxxxx"
        }
    }
}
```
Before fix
`Error in sse_reader: Expected response header Content-Type to contain 'text/event-stream', got 'application/json'`

After fix
```
    | Traceback (most recent call last):
    |   File "/app/app/core/sse_client.py", line 152, in sse_client
    |     endpoint_url = await tg.start(sse_reader)
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 898, in start
    |     return await future
    |            ^^^^^^^^^^^^
    |   File "/app/app/core/sse_client.py", line 119, in sse_reader
    |     raise sse_exc
    |   File "/app/app/core/sse_client.py", line 71, in sse_reader
    |     async for sse in event_source.aiter_sse():
    |   File "/usr/local/lib/python3.12/site-packages/httpx_sse/_api.py", line 37, in aiter_sse
    |     self._check_content_type()
    |   File "/usr/local/lib/python3.12/site-packages/httpx_sse/_api.py", line 18, in _check_content_type
    |     raise SSEError(
    | httpx_sse._exceptions.SSEError: Expected response header Content-Type to contain 'text/event-stream', got 'application/json'
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
