### PR TITLE
Handle '&scope=' in authorize request to return empty list

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -71,6 +71,8 @@ class OAuthClientMetadata(BaseModel):
     def validate_scope(self, requested_scope: str | None) -> list[str] | None:
         if requested_scope is None:
             return None
+        if requested_scope == "":
+            return []
         requested_scopes = requested_scope.split(" ")
         allowed_scopes = [] if self.scope is None else self.scope.split(" ")
         for scope in requested_scopes:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -761,6 +761,17 @@ class TestOAuthClientProvider:
         assert "scope" not in auth_params
 
     @pytest.mark.anyio
+    async def test_client_metadata_validate_scopes_none(self, client_metadata):
+        """Test that validate_scopes method handles None and empty string correctly."""
+        # Should return None
+        requested_scopes = client_metadata.validate_scope(None)
+        assert requested_scopes is None
+
+        # No scopes should be requested; this can happen when a client authorizes with "&scope=".
+        requested_scopes = client_metadata.validate_scope("")
+        assert requested_scopes == []
+
+    @pytest.mark.anyio
     async def test_state_parameter_validation_uses_constant_time(
         self, oauth_provider, oauth_metadata, oauth_client_info
     ):


### PR DESCRIPTION
Resolves #977

## Motivation and Context

I am attempting to authorize to the ChatGPT web client using Okta OAuth. I got it working, but with significant rewrites and patching to the internals of the MCP Python SDK.

I'm not comfortable proposing support for everything I needed to do as many of those are client side issues with OpenAI's implementation, including lack of PKCE support. However, one of the things that tripped me up seems to be a minor issue on the MCP Python SDK's side, which is that the server was requesting `&scope=`. I'm not 100% sure what's going on as I give the client a default scope when it registers that it in turn is not requesting.

In any case, if `None` is a valid value for the scopes, then it seems that `[]` should also be, and furthermore that `&scope=` in the query params should correspond to either `None` or `[]`. However, right now the MCP SDK only sets the scopes to `None` if the query parameter is not defined at all, whereas the ChatGPT web client sends `&scope=`, which parses as `""`, which in turn fails validation unless `""` is defined as a valid scope in the `ClientRegistrationOptions`.

## How Has This Been Tested?
I have a patched version of this running and connecting to ChatGPT's web client.

## Breaking Changes
Should be no breaking changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines **(pre-commit run -a)**
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed **(n/a)**

## Additional context
