### PR TITLE
[feat] Add `user` to `Context`

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -27,6 +27,7 @@ from starlette.types import Receive, Scope, Send
 
 from mcp.server.auth.middleware.auth_context import AuthContextMiddleware
 from mcp.server.auth.middleware.bearer_auth import (
+    AuthenticatedUser,
     BearerAuthBackend,
     RequireAuthMiddleware,
 )
@@ -1046,6 +1047,11 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
             logger=logger_name,
             related_request_id=self.request_id,
         )
+
+    @property
+    def user(self) -> AuthenticatedUser | None:
+        """Get the authenticated user if available."""
+        return self.request_context.request.user if isinstance(self.request_context.request, Request) else None
 
     @property
     def client_id(self) -> str | None:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

Accessing the `ctx.request_context.request.user` is a simple way to retrieve the scopes available to a user (as well as access token and client ID, albeit client ID is already available as an attr to the Context class), which is useful for some request handling. E.g. in some MCP clients (OpenAI's DeepResearch MCP implementations), scopes cannot necessarily be handled at the middleware level because everything needs to hit a specific `fetch` tool, so scopes need to be handled within the request callback. This means scopes need to be available within that callback. Adding a `user` property to the ctx makes it easier for a developer to discern where they might get access to the user's scopes.

## How Has This Been Tested?
I have been able to access the `user` attribute via `ctx.request_context.request.user` in my own code.

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
