### PR TITLE
Compare redirect URIs as strings

### DIFF
--- a/src/mcp/server/auth/handlers/token.py
+++ b/src/mcp/server/auth/handlers/token.py
@@ -151,7 +151,7 @@ class TokenHandler:
                     authorize_request_redirect_uri = auth_code.redirect_uri
                 else:
                     authorize_request_redirect_uri = None
-                if token_request.redirect_uri != authorize_request_redirect_uri:
+                if str(token_request.redirect_uri) != str(authorize_request_redirect_uri):
                     return self.response(
                         TokenErrorResponse(
                             error="invalid_request",


### PR DESCRIPTION
## Motivation and Context

When testing [the simple auth example server](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples/servers/simple-auth), I encountered 400 status codes from `POST /token` because `TokenHandler.handle` was evaluating `token_request.redirect_uri != authorize_request_redirect_uri` as `True`.

This occurred because `token_request.redirect_uri` was of type `AnyUrl`, while `authorize_request_redirect_uri` was `AnyHttpUrl`, and comparing these two different Pydantic types always returns `False` - even if the underlying URLs are the same.

(Example: `AnyUrl("http://google.com") == AnyHttpUrl("http://google.com")` is `False`.)

I believe the example auth server worked before https://github.com/modelcontextprotocol/python-sdk/pull/895 changed some `AnyHttpUrl`s to `AnyUrl`s in the validation code, but the example server was not updated.

## How Has This Been Tested?

Tested using Claude Code as the MCP client to connect to the example server:

`claude mcp add --transport sse github http://localhost:8000/sse`

The auth flow succeeded only after applying this patch.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Documentation update  

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)  
- [x] My code follows the repository's style guidelines  
- [x] New and existing tests pass locally  
- [ ] I have added appropriate error handling  
- [ ] I have added or updated documentation as needed  

## Additional context

We could also update the example server to declare the redirect uri as `AnyHttpUrl`, but I think comparing the URIs as strings would make the validation less brittle.
