### PR TITLE
Enhance FastMCP server with port override functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,17 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("My App")
 
 if __name__ == "__main__":
+    # Run with default settings
     mcp.run()
+    
+    # Override port
+    mcp.run(port=3000)
+    
+    # Specify transport and port
+    mcp.run(transport="streamable-http", port=8080)
+    
+    # SSE with custom mount path and port
+    mcp.run(transport="sse", mount_path="/api", port=9000)
 ```
 
 Run it with:
@@ -512,8 +522,12 @@ python server.py
 mcp run server.py
 ```
 
-Note that `mcp run` or `mcp dev` only supports server using FastMCP and not the low-level server variant.
+The `run()` method accepts these parameters:
+- `transport`: Transport protocol ("stdio", "sse", or "streamable-http")
+- `mount_path`: Optional mount path for SSE transport
+- `port`: Optional port override (defaults to settings.port or 8000)
 
+Note that `mcp run` or `mcp dev` only supports server using FastMCP and not the low-level server variant.
 ### Streamable HTTP Transport
 
 > **Note**: Streamable HTTP transport is superseding SSE transport for production deployments.

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -206,14 +206,18 @@ class FastMCP:
         self,
         transport: Literal["stdio", "sse", "streamable-http"] = "stdio",
         mount_path: str | None = None,
+        port: int | None = None,
     ) -> None:
         """Run the FastMCP server. Note this is a synchronous function.
 
         Args:
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
             mount_path: Optional mount path for SSE transport
+            port: Optional port to run the server on
         """
         TRANSPORTS = Literal["stdio", "sse", "streamable-http"]
+        if port is not None:
+            self.settings.port = port  # override port if provided
         if transport not in TRANSPORTS.__args__:  # type: ignore
             raise ValueError(f"Unknown transport: {transport}")
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -217,7 +217,7 @@ class FastMCP:
         """
         TRANSPORTS = Literal["stdio", "sse", "streamable-http"]
         if port is not None:
-            self.settings.port = port  # override port if provided
+            self.settings.port = port
         if transport not in TRANSPORTS.__args__:  # type: ignore
             raise ValueError(f"Unknown transport: {transport}")
 


### PR DESCRIPTION
## Motivation and Context
Previously, the port could only be set during the initialization of the server. By allowing the port to be passed directly to run(), developers can now override the listening port at runtime. This change aligns with the ergonomics of popular Python web frameworks, enhancing the developer experience.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [] I have added appropriate error handling
- [x] I have added or updated documentation as needed
