### PR TITLE
Fix unhandled TaskGroup exceptions that occur in transport layer

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -471,8 +471,8 @@ async def streamablehttp_client(
     read_stream_writer, read_stream = anyio.create_memory_object_stream[SessionMessage | Exception](0)
     write_stream, write_stream_reader = anyio.create_memory_object_stream[SessionMessage](0)
 
-    async with anyio.create_task_group() as tg:
-        try:
+    try:
+        async with anyio.create_task_group() as tg:
             logger.debug(f"Connecting to StreamableHTTP endpoint: {url}")
 
             async with httpx_client_factory(
@@ -504,6 +504,13 @@ async def streamablehttp_client(
                     if transport.session_id and terminate_on_close:
                         await transport.terminate_session(client)
                     tg.cancel_scope.cancel()
-        finally:
-            await read_stream_writer.aclose()
-            await write_stream.aclose()
+    except Exception as e:
+        logger.error(f"TaskGroup exception in StreamableHTTP transport: {e}")
+        try:
+            await read_stream_writer.send(e)
+        except Exception:
+            logger.error(f"Failed to send TaskGroup exception to read stream: {e}")
+        raise
+    finally:
+        await read_stream_writer.aclose()
+        await write_stream.aclose()


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fixing unhandled TaskGroup exceptions that occur in transport layer

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When MCP server is down or HTTP errors occur (5xx), TaskGroup exceptions are not being properly converted to error responses for pending requests. The response stream never receives the error, causing clients that are waiting for stream responses to hang indefinitely.

This affects any client implementation that waits synchronously for responses from the transport layer, as they never receive the error notifications needed to handle failures gracefully.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Verified that TaskGroup exceptions are properly forwarded to read streams
- Confirmed error responses are delivered immediately with correct JSON-RPC format
- All existing transport tests continue to pass
## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
[Strands SDK](https://github.com/strands-agents/sdk-python) is an example of an implementation that is hanging when MCP Server is down.