### PR TITLE
Fix Windows subprocess NotImplementedError for STDIO clients

### DIFF
--- a/src/mcp/client/stdio/win32.py
+++ b/src/mcp/client/stdio/win32.py
@@ -79,6 +79,18 @@ class DummyProcess:
         self.popen.terminate()
         await to_thread.run_sync(self.popen.wait)
 
+        # Close the file handles to prevent ResourceWarning
+        if self.stdin:
+            await self.stdin.aclose()
+        if self.stdout:
+            await self.stdout.aclose()
+        if self.stdin_raw:
+            self.stdin_raw.close()
+        if self.stdout_raw:
+            self.stdout_raw.close()
+        if self.stderr:
+            self.stderr.close()
+
     async def wait(self):
         """Async wait for process completion."""
         return await to_thread.run_sync(self.popen.wait)


### PR DESCRIPTION
> [!WARNING]
> THIS IS FOR REVIEW ONLY - PR #596 should be the one that gets merged.

This is a rebase of PR #596 (https://github.com/modelcontextprotocol/python-sdk/pull/596) by @theailanguage with merge conflicts resolved and (presumed) unrelated changes removed.

Original fix by @theailanguage implements a fallback mechanism for Windows where asyncio.create_subprocess_exec raises NotImplementedError. Uses subprocess.Popen directly with async stream wrappers to maintain compatibility.

The DummyProcess class wraps the synchronous Popen object and provides the same interface as anyio.Process for seamless integration.

Resolves subprocess creation issues on Windows, particularly in environments with different event loop configurations like Streamlit.