### PR TITLE
feat: Make maximum message size configurable

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -93,6 +93,7 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     # StreamableHTTP settings
     json_response: bool = False
     stateless_http: bool = False  # If True, uses true stateless mode (new transport per request)
+    maximum_message_size: int | None = None  # Specified in bytes
 
     # resource settings
     warn_on_duplicate_resources: bool = True
@@ -838,6 +839,7 @@ class FastMCP:
                 json_response=self.settings.json_response,
                 stateless=self.settings.stateless_http,  # Use the stateless setting
                 security_settings=self.settings.transport_security,
+                maximum_message_size=self.settings.maximum_message_size,
             )
 
         # Create the ASGI handler

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -52,7 +52,8 @@ class StreamableHTTPSessionManager:
         json_response: Whether to use JSON responses instead of SSE streams
         stateless: If True, creates a completely fresh transport for each request
                    with no session tracking or state persistence between requests.
-
+        maximum_message_size: Optional configurable maximum message size specified
+                              in bytes
     """
 
     def __init__(
@@ -62,12 +63,14 @@ class StreamableHTTPSessionManager:
         json_response: bool = False,
         stateless: bool = False,
         security_settings: TransportSecuritySettings | None = None,
+        maximum_message_size: int | None = None,
     ):
         self.app = app
         self.event_store = event_store
         self.json_response = json_response
         self.stateless = stateless
         self.security_settings = security_settings
+        self.maximum_message_size = maximum_message_size
 
         # Session tracking (only used if not stateless)
         self._session_creation_lock = anyio.Lock()
@@ -166,6 +169,7 @@ class StreamableHTTPSessionManager:
             is_json_response_enabled=self.json_response,
             event_store=None,  # No event store in stateless mode
             security_settings=self.security_settings,
+            maximum_message_size=self.maximum_message_size,
         )
 
         # Start server in a new task
@@ -222,6 +226,7 @@ class StreamableHTTPSessionManager:
                     is_json_response_enabled=self.json_response,
                     event_store=self.event_store,  # May be None (no resumability)
                     security_settings=self.security_settings,
+                    maximum_message_size=self.maximum_message_size,
                 )
 
                 assert http_transport.mcp_session_id is not None

--- a/tests/server/fastmcp/test_configure_input_size.py
+++ b/tests/server/fastmcp/test_configure_input_size.py
@@ -1,0 +1,23 @@
+"""Test that the maximum http input size is configurable via FastMCP settings"""
+
+import pytest
+
+from mcp.server.fastmcp import FastMCP
+
+
+@pytest.mark.anyio
+async def test_configure_input_size():
+    """Create a FastMCP server with StreamableHTTP transport."""
+    configured_input_size = 1024
+    mcp = FastMCP("Test Server", maximum_message_size=configured_input_size)
+
+    # Add a simple tool
+    @mcp.tool(description="A simple echo tool")
+    def echo(message: str) -> str:
+        return f"Echo: {message}"
+
+    # Create the StreamableHTTP app
+    _ = mcp.streamable_http_app()
+
+    # Check that the maximum input size is set correctly
+    assert mcp.session_manager.maximum_message_size == configured_input_size


### PR DESCRIPTION
## Motivation and Context
Currently the maximum message/payload size for HTTP requests has been hard coded to 4MB in MCP protocol. This setting should be configurable by the server owners based on the requirements of their specific server as noted by the community in #959 and #1012. This change would help MCP protocol facilitate transmission of base64 encoded images/videos between client and server for multi-modal workloads, that can easily go above 4MB in size.

The change in this PR will allow configuration of maximum message size in FastMCP servers as a server setting.
Resolves #959
Resolves #1012 

## How Has This Been Tested?
- Added relevant unit tests
- Created a FastMCP server with maximum_message_size set to 1 after compiling changes. Confirmed that POST requests are rejected with `413 Content Too Large`

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

