### PR TITLE
add authorizer plugin to enable fine granded authorization checks on …

### DIFF
--- a/src/mcp/server/fastmcp/authorizer.py
+++ b/src/mcp/server/fastmcp/authorizer.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import abc
+from typing import TYPE_CHECKING, Any
+from pydantic import AnyUrl
+
+from mcp.shared.context import LifespanContextT, RequestT
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp.server import Context
+    from mcp.server.session import ServerSessionT
+
+
+class Authorizer:
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def permit_get_tool(self, name: str) -> bool:
+        """Check if the specified tool can be retrieved from the associated mcp server"""
+        return False
+    
+    @abc.abstractmethod
+    def permit_list_tool(self, name: str) -> bool:
+        """Check if the specified tool can be listed from the associated mcp server"""
+        return False
+
+    @abc.abstractmethod
+    def permit_call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Context[ServerSessionT, LifespanContextT, RequestT] | None = None,
+    ) -> bool:
+        """Check if the specified tool can be called from the associated mcp server"""
+        return False
+
+    @abc.abstractmethod
+    def permit_get_resource(self, resource: AnyUrl | str) -> bool:
+        """Check if the specified resource can be retrieved from the associated mcp server"""
+        return False
+
+    @abc.abstractmethod
+    def permit_create_resource(self, uri: str, params: dict[str, Any]) -> bool:
+        """Check if the specified resource can be created on the associated mcp server"""
+        return False
+
+    @abc.abstractmethod
+    def permit_list_resource(self, resource: AnyUrl | str) -> bool:
+        """Check if the specified resource can be listed from the associated mcp server"""
+        return False
+
+    @abc.abstractmethod
+    def permit_list_template(self, resource: AnyUrl | str) -> bool:
+        """Check if the specified template can be listed from the associated mcp server"""
+        return False
+    
+    @abc.abstractmethod
+    def permit_get_prompt(self, name: str) -> bool:
+        """Check if the specified prompt can be retrieved from the associated mcp server"""
+        return False
+        
+    @abc.abstractmethod
+    def permit_list_prompt(self, name: str) -> bool:
+        """Check if the specified prompt can be listed from the associated mcp server"""
+        return False
+    
+    @abc.abstractmethod
+    def permit_render_prompt(self, name: str,  arguments: dict[str, Any] | None = None) -> bool:
+        """Check if the specified prompt can be rendered from the associated mcp server"""
+        return False
+    
+class AllAllAuthorizer(Authorizer):
+    def permit_get_tool(self, name: str) -> bool:
+        return True
+    
+    def permit_list_tool(self, name: str) -> bool:
+        return True
+
+    def permit_call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        context: Context[ServerSessionT, LifespanContextT, RequestT] | None = None,
+    ) -> bool:
+        return True
+
+    def permit_get_resource(self, resource: AnyUrl | str) -> bool:
+        return True
+
+    def permit_create_resource(self, uri: str, params: dict[str, Any]) -> bool:
+        return True
+    
+    def permit_list_resource(self, resource: AnyUrl | str) -> bool:
+        return True
+
+    def permit_list_template(self, resource: AnyUrl | str) -> bool:
+        return True
+    
+    def permit_get_prompt(self, name: str) -> bool:
+        return True
+    
+    def permit_list_prompt(self, name: str) -> bool:
+        return True
+
+    def permit_render_prompt(self, name: str,  arguments: dict[str, Any] | None = None) -> bool:
+        return True
+

--- a/src/mcp/server/fastmcp/authorizer.py
+++ b/src/mcp/server/fastmcp/authorizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 from typing import TYPE_CHECKING, Any
+
 from pydantic import AnyUrl
 
 from mcp.shared.context import LifespanContextT, RequestT

--- a/src/mcp/server/fastmcp/authorizer.py
+++ b/src/mcp/server/fastmcp/authorizer.py
@@ -19,7 +19,7 @@ class Authorizer:
     def permit_get_tool(self, name: str) -> bool:
         """Check if the specified tool can be retrieved from the associated mcp server"""
         return False
-    
+
     @abc.abstractmethod
     def permit_list_tool(self, name: str) -> bool:
         """Check if the specified tool can be listed from the associated mcp server"""
@@ -54,26 +54,27 @@ class Authorizer:
     def permit_list_template(self, resource: AnyUrl | str) -> bool:
         """Check if the specified template can be listed from the associated mcp server"""
         return False
-    
+
     @abc.abstractmethod
     def permit_get_prompt(self, name: str) -> bool:
         """Check if the specified prompt can be retrieved from the associated mcp server"""
         return False
-        
+
     @abc.abstractmethod
     def permit_list_prompt(self, name: str) -> bool:
         """Check if the specified prompt can be listed from the associated mcp server"""
         return False
-    
+
     @abc.abstractmethod
-    def permit_render_prompt(self, name: str,  arguments: dict[str, Any] | None = None) -> bool:
+    def permit_render_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> bool:
         """Check if the specified prompt can be rendered from the associated mcp server"""
         return False
-    
+
+
 class AllAllAuthorizer(Authorizer):
     def permit_get_tool(self, name: str) -> bool:
         return True
-    
+
     def permit_list_tool(self, name: str) -> bool:
         return True
 
@@ -90,19 +91,18 @@ class AllAllAuthorizer(Authorizer):
 
     def permit_create_resource(self, uri: str, params: dict[str, Any]) -> bool:
         return True
-    
+
     def permit_list_resource(self, resource: AnyUrl | str) -> bool:
         return True
 
     def permit_list_template(self, resource: AnyUrl | str) -> bool:
         return True
-    
+
     def permit_get_prompt(self, name: str) -> bool:
         return True
-    
+
     def permit_list_prompt(self, name: str) -> bool:
         return True
 
-    def permit_render_prompt(self, name: str,  arguments: dict[str, Any] | None = None) -> bool:
+    def permit_render_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> bool:
         return True
-

--- a/src/mcp/server/fastmcp/prompts/manager.py
+++ b/src/mcp/server/fastmcp/prompts/manager.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from mcp.server.fastmcp.authorizer import AllAllAuthorizer, Authorizer
 from mcp.server.fastmcp.prompts.base import Message, Prompt
 from mcp.server.fastmcp.utilities.logging import get_logger
 
@@ -11,17 +12,25 @@ logger = get_logger(__name__)
 class PromptManager:
     """Manages FastMCP prompts."""
 
-    def __init__(self, warn_on_duplicate_prompts: bool = True):
+    def __init__(
+        self,
+        warn_on_duplicate_prompts: bool = True,
+        authorizer: Authorizer = AllAllAuthorizer(),
+    ):
         self._prompts: dict[str, Prompt] = {}
+        self._authorizer = authorizer
         self.warn_on_duplicate_prompts = warn_on_duplicate_prompts
 
     def get_prompt(self, name: str) -> Prompt | None:
         """Get prompt by name."""
-        return self._prompts.get(name)
+        if self._authorizer.permit_get_prompt(name):
+            return self._prompts.get(name)
+        else:
+            return None
 
     def list_prompts(self) -> list[Prompt]:
         """List all registered prompts."""
-        return list(self._prompts.values())
+        return [prompt for name, prompt in self._prompts.items() if self._authorizer.permit_list_prompt(name)]
 
     def add_prompt(
         self,
@@ -44,5 +53,7 @@ class PromptManager:
         prompt = self.get_prompt(name)
         if not prompt:
             raise ValueError(f"Unknown prompt: {name}")
-
-        return await prompt.render(arguments)
+        if self._authorizer.permit_render_prompt(name, arguments):
+            return await prompt.render(arguments)
+        else:
+            raise ValueError(f"Unknown prompt: {name}")


### PR DESCRIPTION
Enable fine grained authorization checks for tools/resources/prompts

## Motivation and Context

https://github.com/modelcontextprotocol/python-sdk/issues/1031

Advanced use cases for authorization require fine grained permissions checks, this patch enables a plugin to be provided to the FastMCP server to check if the caller has permission to get/list/call.

The intention is to combine this with auth_context_var to retrieve mcp.server.auth.middleware.bearer_auth.AuthenticatedUser that is performing the action

## How Has This Been Tested?
Unit tests so far

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Minimal unit tests so far as this is a draft to check if it works as expected when deployed
The behaviour has been implemented such that a permission failure is indistinguisable to the caller from a non existant item in order to prevent leaking information about the existence or not of the tool/prompt/resource
