### PR TITLE
update: add the system prompt class in mcp server

### DIFF
--- a/examples/servers/system_prompt.py
+++ b/examples/servers/system_prompt.py
@@ -13,7 +13,7 @@ def weather_system_prompt() -> mcp_messages.SystemMessage:
     """
 
     return mcp_messages.SystemMessage(
-         "You are a helpful agent. You answer questions clearly and simply. "
+         "You are a helpful weather agent. You answer questions clearly and simply. "
         "If you don’t know something, say you don’t have that information."
     )
 

--- a/examples/servers/system_prompt.py
+++ b/examples/servers/system_prompt.py
@@ -1,28 +1,26 @@
-from mcp.server import FastMCP 
-
-# from dotenv import load_dotenv
-import os
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.prompts import base as mcp_messages
 
-mcp = FastMCP("weather") # No reason to initialize stateless 
-
-
+mcp = FastMCP("weather")
 
 
 @mcp.prompt()
 def weather_system_prompt() -> mcp_messages.SystemMessage:
     """
-    Creates a prompt asking an AI to weather 
+    Creates a prompt asking an AI to weather
     Args:
         None: None
     """
-    
-    return mcp_messages.SystemMessage("""You are a helpful weather agent. Your job is to answer weather-related questions clearly and simply. If the user asks for the weather in a city, you tell the current weather, temperature, and a short description like "sunny," "cloudy," or "rainy." If you don’t know the answer, say "Sorry, I don’t have that information.""")
+
+    return mcp_messages.SystemMessage(
+         "You are a helpful agent. You answer questions clearly and simply. "
+        "If you don’t know something, say you don’t have that information."
+    )
 
 
 mcp_app = mcp.streamable_http_app()
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run("system_prompt:mcp_app", host="0.0.0.0", port=8002, reload=True)

--- a/examples/servers/system_prompt.py
+++ b/examples/servers/system_prompt.py
@@ -1,0 +1,28 @@
+from mcp.server import FastMCP 
+
+# from dotenv import load_dotenv
+import os
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.prompts import base as mcp_messages
+
+mcp = FastMCP("weather") # No reason to initialize stateless 
+
+
+
+
+@mcp.prompt()
+def weather_system_prompt() -> mcp_messages.SystemMessage:
+    """
+    Creates a prompt asking an AI to weather 
+    Args:
+        None: None
+    """
+    
+    return mcp_messages.SystemMessage("""You are a helpful weather agent. Your job is to answer weather-related questions clearly and simply. If the user asks for the weather in a city, you tell the current weather, temperature, and a short description like "sunny," "cloudy," or "rainy." If you don’t know the answer, say "Sorry, I don’t have that information.""")
+
+
+mcp_app = mcp.streamable_http_app()
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("system_prompt:mcp_app", host="0.0.0.0", port=8002, reload=True)

--- a/examples/servers/system_prompt.py
+++ b/examples/servers/system_prompt.py
@@ -13,7 +13,7 @@ def weather_system_prompt() -> mcp_messages.SystemMessage:
     """
 
     return mcp_messages.SystemMessage(
-         "You are a helpful weather agent. You answer questions clearly and simply. "
+        "You are a helpful weather agent. You answer questions clearly and simply. "
         "If you don’t know something, say you don’t have that information."
     )
 

--- a/src/mcp/server/fastmcp/prompts/base.py
+++ b/src/mcp/server/fastmcp/prompts/base.py
@@ -13,7 +13,7 @@ from mcp.types import ContentBlock, TextContent
 class Message(BaseModel):
     """Base class for all prompt messages."""
 
-    role: Literal["user", "assistant"]
+    role: Literal["user", "assistant","system"]
     content: ContentBlock
 
     def __init__(self, content: str | ContentBlock, **kwargs: Any):
@@ -25,7 +25,7 @@ class Message(BaseModel):
 class UserMessage(Message):
     """A message from the user."""
 
-    role: Literal["user", "assistant"] = "user"
+    role: Literal["user", "assistant","system"] = "user"
 
     def __init__(self, content: str | ContentBlock, **kwargs: Any):
         super().__init__(content=content, **kwargs)
@@ -34,13 +34,20 @@ class UserMessage(Message):
 class AssistantMessage(Message):
     """A message from the assistant."""
 
-    role: Literal["user", "assistant"] = "assistant"
+    role: Literal["user", "assistant","system"] = "assistant"
 
     def __init__(self, content: str | ContentBlock, **kwargs: Any):
         super().__init__(content=content, **kwargs)
 
+class SystemMessage(Message):
+    """A message from the assistant."""
 
-message_validator = TypeAdapter[UserMessage | AssistantMessage](UserMessage | AssistantMessage)
+    role: Literal["user", "assistant","system"] = "system"
+
+    def __init__(self, content: str | ContentBlock, **kwargs: Any):
+        super().__init__(content=content, **kwargs)
+
+message_validator = TypeAdapter[UserMessage | AssistantMessage | SystemMessage](UserMessage | AssistantMessage | SystemMessage)
 
 SyncPromptResult = str | Message | dict[str, Any] | Sequence[str | Message | dict[str, Any]]
 PromptResult = SyncPromptResult | Awaitable[SyncPromptResult]

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -35,7 +35,7 @@ DEFAULT_NEGOTIATED_VERSION = "2025-03-26"
 
 ProgressToken = str | int
 Cursor = str
-Role = Literal["user", "assistant"]
+Role = Literal["user", "assistant","system"]
 RequestId = Annotated[int | str, Field(union_mode="left_to_right")]
 AnyFunction: TypeAlias = Callable[..., Any]
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

**Added `SystemMessage` class in MCP prompts so users can now return system prompts in their agents.**

## Motivation and Context

<!-- Why is this change needed? What problem does it solve? -->

Before this, MCP only supported user and assistant prompts. There was no option for system prompts. Now, users can directly import `SystemMessage` and use it to set system-level instructions in their agents.

## How Has This Been Tested?

<!-- Have you tested this in a real application? Which scenarios were tested? -->

Yes, tested in a local MCP agent app by creating a system prompt using `SystemMessage`. Verified that it works without errors and system prompts can be added successfully.

## Breaking Changes

<!-- Will users need to update their code or configurations? -->

No breaking changes. This is a non-breaking new feature. Existing code will work as before.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

* [x] I have read the [[MCP Documentation](https://modelcontextprotocol.io/)](https://modelcontextprotocol.io)
* [x] My code follows the repository's style guidelines
* [x] New and existing tests pass locally
* [x] I have added appropriate error handling
* [ ] I have added or updated documentation as needed

## Additional context

<!-- Add any other context, implementation notes, or design decisions -->

This was a simple but important addition to improve prompt control for agents. Now system instructions can be added directly using the new `SystemMessage` class.
