### PR TITLE
feat: Allow any value type in get_prompt arguments

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -344,7 +344,7 @@ class ClientSession(
             types.ListPromptsResult,
         )
 
-    async def get_prompt(self, name: str, arguments: dict[str, str] | None = None) -> types.GetPromptResult:
+    async def get_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> types.GetPromptResult:
         """Send a prompts/get request."""
         return await self.send_request(
             types.ClientRequest(

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -639,7 +639,7 @@ class GetPromptRequestParams(RequestParams):
 
     name: str
     """The name of the prompt or prompt template."""
-    arguments: dict[str, str] | None = None
+    arguments: dict[str, Any] | None = None
     """Arguments to use for templating the prompt."""
     model_config = ConfigDict(extra="allow")
 

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -495,3 +495,72 @@ async def test_client_capabilities_with_custom_callbacks():
     assert received_capabilities.roots is not None  # Custom list_roots callback provided
     assert isinstance(received_capabilities.roots, types.RootsCapability)
     assert received_capabilities.roots.listChanged is True  # Should be True for custom callback
+
+
+@pytest.mark.anyio
+async def test_get_prompt_with_non_string_argument():
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+
+    async def mock_server():
+        await client_to_server_receive.receive()
+
+        await server_to_client_send.send(
+            SessionMessage(
+                JSONRPCMessage(
+                    JSONRPCResponse(
+                        jsonrpc="2.0",
+                        id=0,
+                        result=InitializeResult(
+                            protocolVersion=LATEST_PROTOCOL_VERSION,
+                            capabilities=ServerCapabilities(),
+                            serverInfo=Implementation(name="mock-server", version="0.1.0"),
+                        ).model_dump(by_alias=True, mode="json", exclude_none=True),
+                    )
+                )
+            )
+        )
+
+        await client_to_server_receive.receive()
+
+        # Receive get_prompt request
+        session_message = await client_to_server_receive.receive()
+        jsonrpc_request = session_message.message
+        assert isinstance(jsonrpc_request.root, JSONRPCRequest)
+        request = ClientRequest.model_validate(
+            jsonrpc_request.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )
+        assert isinstance(request.root, types.GetPromptRequest)
+        assert request.root.params.arguments == {"employee_id": 77}
+
+        # Send get_prompt result
+        await server_to_client_send.send(
+            SessionMessage(
+                JSONRPCMessage(
+                    JSONRPCResponse(
+                        jsonrpc="2.0",
+                        id=jsonrpc_request.root.id,
+                        result=types.GetPromptResult(
+                            messages=[
+                                types.PromptMessage(role="user", content=types.TextContent(type="text", text="..."))
+                            ]
+                        ).model_dump(by_alias=True, mode="json", exclude_none=True),
+                    )
+                )
+            )
+        )
+
+    async with (
+        ClientSession(
+            server_to_client_receive,
+            client_to_server_send,
+        ) as session,
+        anyio.create_task_group() as tg,
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        tg.start_soon(mock_server)
+        await session.initialize()
+        await session.get_prompt("get_employee_profile", {"employee_id": 77})


### PR DESCRIPTION
The type hints for the `arguments` parameter in `ClientSession.get_prompt` and the corresponding `GetPromptRequestParams` were previously restricted to `dict[str, str]`.

This was overly restrictive and prevented passing arguments with non-string values, such as numbers or booleans. This commit changes the type to `dict[str, Any]`, allowing for more flexible prompt argument structures.

A corresponding test case has been added to verify that calling `get_prompt` with an integer argument now works as expected.

Fixes #749 

<!-- Provide a brief summary of your changes -->

## Motivation and Context

Imagine this MCP server code:

```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("My MCP Server", host="127.0.0.1", port=9000)

@mcp.prompt()
def get_employee_profile(employee_id: int) -> str:
    return f"Using SQL, get the employee profile from the id: {employee_id}"

if __name__ == "__main__":
    mcp.run(transport="streamable-http")
```

And this client code:

```python
import os
import json
import asyncio
from mcp import ClientSession, StdioServerParameters, types
from mcp.client.stdio import stdio_client
from mcp.client.streamable_http import streamablehttp_client

MCP_SERVER_URL = "http://127.0.0.1:9000/mcp/"

async def run():
    async with streamablehttp_client(MCP_SERVER_URL) as (read, write, _):
        async with ClientSession(
            read, write
        ) as session:
            await session.initialize()

            # Read prompt
            output = await session.get_prompt("get_employee_profile", {"employee_id": "77"}) # this works
            output = await session.get_prompt("get_employee_profile", {"employee_id": 77}) # this fails but we have declared the argument type to be int in the server code. BUG

            print(output.messages[0].content.text)


if __name__ == "__main__":
    asyncio.run(run())
```

It's very strange that we have to send a string argument although the argument type in the MCP server is int.

This PR also gives us flexibility to send an argument with a different type, like a list of strings, as referenced in the bug report.

The argument in calling the tool is not restricted to string. Why do we need to restrict it in the prompt case?

## How Has This Been Tested?

I have added a unit test.

## Breaking Changes

Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

I was not sure where to put the unit test. The `test_session.py` is not ideal. But I couldn't find a better place.
