### PR TITLE
feat: Add CORS configuration for browser-based MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ starlette_app = CORSMiddleware(
 ```
 
 This configuration is necessary because:
+
 - The MCP streamable HTTP transport uses the `Mcp-Session-Id` header for session management
 - Browsers restrict access to response headers unless explicitly exposed via CORS
 - Without this configuration, browser-based clients won't be able to read the session ID from initialization responses

--- a/README.md
+++ b/README.md
@@ -718,11 +718,15 @@ The streamable HTTP transport supports:
 If you'd like your server to be accessible by browser-based MCP clients, you'll need to configure CORS headers. The `Mcp-Session-Id` header must be exposed for browser clients to access it:
 
 ```python
+from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
 
-# Add CORS middleware to your Starlette app
-app = CORSMiddleware(
-    app,
+# Create your Starlette app first
+starlette_app = Starlette(routes=[...])
+
+# Then wrap it with CORS middleware
+starlette_app = CORSMiddleware(
+    starlette_app,
     allow_origins=["*"],  # Configure appropriately for production
     allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
     expose_headers=["Mcp-Session-Id"],

--- a/README.md
+++ b/README.md
@@ -721,8 +721,8 @@ If you'd like your server to be accessible by browser-based MCP clients, you'll 
 from starlette.middleware.cors import CORSMiddleware
 
 # Add CORS middleware to your Starlette app
-app.add_middleware(
-    CORSMiddleware,
+app = CORSMiddleware(
+    app,
     allow_origins=["*"],  # Configure appropriately for production
     allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
     expose_headers=["Mcp-Session-Id"],

--- a/README.md
+++ b/README.md
@@ -713,6 +713,27 @@ The streamable HTTP transport supports:
 - JSON or SSE response formats
 - Better scalability for multi-node deployments
 
+#### CORS Configuration for Browser-Based Clients
+
+If you'd like your server to be accessible by browser-based MCP clients, you'll need to configure CORS headers. The `Mcp-Session-Id` header must be exposed for browser clients to access it:
+
+```python
+from starlette.middleware.cors import CORSMiddleware
+
+# Add CORS middleware to your Starlette app
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Configure appropriately for production
+    allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
+    expose_headers=["Mcp-Session-Id"],
+)
+```
+
+This configuration is necessary because:
+- The MCP streamable HTTP transport uses the `Mcp-Session-Id` header for session management
+- Browsers restrict access to response headers unless explicitly exposed via CORS
+- Without this configuration, browser-based clients won't be able to read the session ID from initialization responses
+
 ### Mounting to an Existing ASGI Server
 
 > **Note**: SSE transport is being superseded by [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).

--- a/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
+++ b/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
@@ -133,9 +133,10 @@ def main(
         lifespan=lifespan,
     )
     
-    # Add CORS middleware to expose Mcp-Session-Id header for browser-based clients
-    starlette_app.add_middleware(
-        CORSMiddleware,
+    # Wrap ASGI application with CORS middleware to expose Mcp-Session-Id header
+    # for browser-based clients (ensures 500 errors get proper CORS headers)
+    starlette_app = CORSMiddleware(
+        starlette_app,
         allow_origins=["*"],  # Allow all origins - adjust as needed for production
         allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
         expose_headers=["Mcp-Session-Id"],

--- a/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
+++ b/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
@@ -132,7 +132,7 @@ def main(
         ],
         lifespan=lifespan,
     )
-    
+
     # Wrap ASGI application with CORS middleware to expose Mcp-Session-Id header
     # for browser-based clients (ensures 500 errors get proper CORS headers)
     starlette_app = CORSMiddleware(

--- a/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
+++ b/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
@@ -8,6 +8,7 @@ import mcp.types as types
 from mcp.server.lowlevel import Server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.applications import Starlette
+from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Mount
 from starlette.types import Receive, Scope, Send
 
@@ -130,6 +131,14 @@ def main(
             Mount("/mcp", app=handle_streamable_http),
         ],
         lifespan=lifespan,
+    )
+    
+    # Add CORS middleware to expose Mcp-Session-Id header for browser-based clients
+    starlette_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # Allow all origins - adjust as needed for production
+        allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
+        expose_headers=["Mcp-Session-Id"],
     )
 
     import uvicorn

--- a/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
+++ b/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
@@ -160,7 +160,7 @@ def main(
         ],
         lifespan=lifespan,
     )
-    
+
     # Wrap ASGI application with CORS middleware to expose Mcp-Session-Id header
     # for browser-based clients (ensures 500 errors get proper CORS headers)
     starlette_app = CORSMiddleware(

--- a/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
+++ b/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
@@ -161,9 +161,10 @@ def main(
         lifespan=lifespan,
     )
     
-    # Add CORS middleware to expose Mcp-Session-Id header for browser-based clients
-    starlette_app.add_middleware(
-        CORSMiddleware,
+    # Wrap ASGI application with CORS middleware to expose Mcp-Session-Id header
+    # for browser-based clients (ensures 500 errors get proper CORS headers)
+    starlette_app = CORSMiddleware(
+        starlette_app,
         allow_origins=["*"],  # Allow all origins - adjust as needed for production
         allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
         expose_headers=["Mcp-Session-Id"],

--- a/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
+++ b/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
@@ -9,6 +9,7 @@ from mcp.server.lowlevel import Server
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from pydantic import AnyUrl
 from starlette.applications import Starlette
+from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Mount
 from starlette.types import Receive, Scope, Send
 
@@ -158,6 +159,14 @@ def main(
             Mount("/mcp", app=handle_streamable_http),
         ],
         lifespan=lifespan,
+    )
+    
+    # Add CORS middleware to expose Mcp-Session-Id header for browser-based clients
+    starlette_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # Allow all origins - adjust as needed for production
+        allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
+        expose_headers=["Mcp-Session-Id"],
     )
 
     import uvicorn


### PR DESCRIPTION
## Summary
- Add CORS middleware to streamable HTTP example servers
- Configure minimal CORS settings to expose `Mcp-Session-Id` header
- Add documentation for CORS configuration in the README

## Problem
Browser-based MCP clients cannot access the `Mcp-Session-Id` header from initialization responses due to CORS restrictions. Without this header, they cannot establish sessions with MCP servers.

## Solution
This PR adds Starlette's `CORSMiddleware` to the example servers and configures it to expose the `Mcp-Session-Id` header via `expose_headers`. The configuration is minimal, only allowing the HTTP methods required by the MCP protocol (GET, POST, DELETE).

## Changes
- Add `CORSMiddleware` import and configuration to:
  - `examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py`
  - `examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py`
- Add CORS configuration section to README under "Streamable HTTP Transport"

## Test plan
- [ ] Example servers start successfully with CORS configured
- [ ] Browser-based clients can read the `Mcp-Session-Id` header from responses
- [ ] CORS headers are properly set on responses
- [ ] Only GET, POST, and DELETE methods are allowed

Reported-by: Jerome