### PR TITLE
Update text to make clear Elicitation is not directly associated with…

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ async def handle_completion(
 ```
 ### Elicitation
 
-Request additional information from users during tool execution:
+Request additional information from users. This example shows an Elicitation during a Tool Call:
 
 ```python
 from mcp.server.fastmcp import FastMCP, Context


### PR DESCRIPTION
… a Tool Call.

Tiny tweak to disassociate Elicitation from being "during a Tool Call"

## Motivation and Context

Elicitations can happen any time - the text made it sound like they were for "during tool calls".

## How Has This Been Tested?

## Breaking Changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
