### PR TITLE
Add minimal regression test for issue #552

### DIFF
--- a/tests/issues/test_552_windows_hang.py
+++ b/tests/issues/test_552_windows_hang.py
@@ -1,0 +1,48 @@
+"""
+Regression test for issue #552: Windows 11 hanging on MCP client initialization.
+
+The bug: Windows-specific process creation code in win32.py causes the client
+to hang indefinitely during initialization.
+
+The fix: Use the generic anyio.open_process for all platforms instead of
+custom Windows-specific code.
+"""
+
+import sys
+import textwrap
+
+import anyio
+import pytest
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific regression test")
+@pytest.mark.anyio
+async def test_issue_552_windows_no_hang():
+    """
+    Test that stdio_client doesn't hang on Windows during initialization.
+
+    Issue #552: The Windows-specific process creation code caused hanging.
+    This test verifies that using a Python subprocess completes without hanging.
+    """
+    # Minimal Python script that responds to initialize request
+    server_script = textwrap.dedent("""
+        import sys, json
+        request = json.loads(sys.stdin.readline())
+        if request.get("method") == "initialize":
+            response = {"jsonrpc": "2.0", "id": request.get("id"), "result": {"protocolVersion": "0.1.0", "capabilities": {}}}
+            print(json.dumps(response))
+            sys.stdout.flush()
+    """)
+
+    params = StdioServerParameters(command=sys.executable, args=["-c", server_script])
+
+    # Should complete without hanging (issue #552 would hang here)
+    with anyio.fail_after(5):
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                result = await session.initialize()
+                assert result is not None
+                assert result.protocolVersion == "0.1.0"


### PR DESCRIPTION
## Summary

This PR adds a minimal, focused regression test for issue #552 where MCP client initialization would hang indefinitely on Windows 11.

## Context

Issue #552 reports that Windows-specific process creation code in `win32.py` causes the client to hang during initialization. The fix involves using the generic `anyio.open_process` for all platforms instead of custom Windows-specific code.

## What This Test Does

The test verifies that stdio_client initialization completes successfully on Windows without hanging by:
1. Creating a minimal Python subprocess that responds to the `initialize` request
2. Attempting to initialize a client session with this subprocess
3. Verifying it completes within 5 seconds without hanging
4. Asserting the initialization succeeded with correct protocol version

## Test Plan

- [ ] Test passes on Windows when fix is applied
- [ ] Test would hang/timeout on Windows without the fix

🤖 Generated with Claude Code