### PR TITLE
Fix Pydantic field alias consistency in structured output

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -111,7 +111,7 @@ class FuncMetadata(BaseModel):
 
             assert self.output_model is not None, "Output model must be set if output schema is defined"
             validated = self.output_model.model_validate(result)
-            structured_content = validated.model_dump(mode="json")
+            structured_content = validated.model_dump(mode="json", by_alias=True)
 
             return (unstructured_content, structured_content)
 

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -839,3 +839,48 @@ def test_structured_output_unserializable_type_error():
         func_metadata(func_returning_namedtuple, structured_output=True)
     assert "is not serializable for structured output" in str(exc_info.value)
     assert "Point" in str(exc_info.value)
+
+
+def test_structured_output_aliases():
+    """Test that field aliases are consistent between schema and output"""
+
+    class ModelWithAliases(BaseModel):
+        field_first: str | None = Field(default=None, alias="first", description="The first field.")
+        field_second: str | None = Field(default=None, alias="second", description="The second field.")
+
+    def func_with_aliases() -> ModelWithAliases:
+        # When aliases are defined, we must use the aliased names to set values
+        return ModelWithAliases(**{"first": "hello", "second": "world"})
+
+    meta = func_metadata(func_with_aliases)
+
+    # Check that schema uses aliases
+    assert meta.output_schema is not None
+    assert "first" in meta.output_schema["properties"]
+    assert "second" in meta.output_schema["properties"]
+    assert "field_first" not in meta.output_schema["properties"]
+    assert "field_second" not in meta.output_schema["properties"]
+
+    # Check that the actual output uses aliases too
+    result = ModelWithAliases(**{"first": "hello", "second": "world"})
+    unstructured_content, structured_content = meta.convert_result(result)
+
+    # The structured content should use aliases to match the schema
+    assert "first" in structured_content
+    assert "second" in structured_content
+    assert "field_first" not in structured_content
+    assert "field_second" not in structured_content
+    assert structured_content["first"] == "hello"
+    assert structured_content["second"] == "world"
+
+    # Also test the case where we have a model with defaults to ensure aliases work in all cases
+    result_with_defaults = ModelWithAliases()  # Uses default None values
+    unstructured_content_defaults, structured_content_defaults = meta.convert_result(result_with_defaults)
+
+    # Even with defaults, should use aliases in output
+    assert "first" in structured_content_defaults
+    assert "second" in structured_content_defaults
+    assert "field_first" not in structured_content_defaults
+    assert "field_second" not in structured_content_defaults
+    assert structured_content_defaults["first"] is None
+    assert structured_content_defaults["second"] is None


### PR DESCRIPTION
# Fix Pydantic field alias consistency in structured output

## Summary
Fixes issue #1073. Fix inconsistency between schema and structured output when using Pydantic models with field aliases in tool return types. The schema would display aliased field names but the actual output would use original field names.
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

When defining Pydantic models with field aliases for tool return types, there was an inconsistency where:
- The output schema would correctly show aliased field names (e.g., "first", "second") 
- The actual structured tool output would use the original field names (e.g., "field_first", "field_second")

This inconsistency made it difficult for clients to reliably consume structured tool outputs, as the field names in the schema didn't match the actual response data.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

- Added comprehensive test case `test_structured_output_aliases()` that verifies both schema generation and output use consistent alias names
- All existing pytest tests continue to pass

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No breaking changes. This is a bug fix that makes the behavior consistent with what the schema advertises. Users who were working around this inconsistency may need to update their code to use the aliased field names consistently.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

The fix was a simple one-line change adding `by_alias=True` to the `model_dump()` call in `func_metadata.py:114`. This ensures that when Pydantic models are serialized for structured output, they use the same field names that appear in the generated JSON schema.

The test case covers both the schema generation and the actual output conversion to ensure they remain consistent. This addresses the core issue described in the original bug report where the schema and output used different field naming conventions.

## Technical Details

### Before the fix:
```python
class Foo(BaseModel):
    field_first: str | None = Field(default=None, alias="first", description="The first field.")
    field_second: str | None = Field(default=None, alias="second", description="The second field.")
```

- Schema would show: `"first"` and `"second"`
- Output would contain: `"field_first"` and `"field_second"`

### After the fix:
- Both schema and output consistently use: `"first"` and `"second"`

### Code change:
```python
# Before
structured_content = validated.model_dump(mode="json")

# After  
structured_content = validated.model_dump(mode="json", by_alias=True)
```