### PR TITLE
remove max message size

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -46,8 +46,6 @@ from mcp.types import (
 
 logger = logging.getLogger(__name__)
 
-# Maximum size for incoming messages
-MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024  # 4MB
 
 # Header names
 MCP_SESSION_ID_HEADER = "mcp-session-id"
@@ -329,13 +327,6 @@ class StreamableHTTPServerTransport:
 
             # Parse the body - only read it once
             body = await request.body()
-            if len(body) > MAXIMUM_MESSAGE_SIZE:
-                response = self._create_error_response(
-                    "Payload Too Large: Message exceeds maximum size",
-                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
-                )
-                await response(scope, receive, send)
-                return
 
             try:
                 raw_message = json.loads(body)


### PR DESCRIPTION
Removes the redundant MAXIMUM_MESSAGE_SIZE check from the HTTP transport layer. The validation was performed after loading the entire request body into memory, providing no actual memory protection.

 **Changes**

  - Removed post-body-read size validation from _handle_post_request()

 **Rationale**

  - Check executed after await request.body(), making it ineffective for memory exhaustion prevention
  - ASGI servers handle flow control via backpressure mechanisms
  - Simplifies codebase by removing ineffective validation