### PR TITLE
Fix completions

### DIFF
--- a/tests/server/test_session.py
+++ b/tests/server/test_session.py
@@ -13,12 +13,13 @@ from mcp.types import (
     ClientNotification,
     Completion,
     CompletionArgument,
+    CompletionContext,
     CompletionsCapability,
     InitializedNotification,
     PromptReference,
     PromptsCapability,
-    ResourceReference,
     ResourcesCapability,
+    ResourceTemplateReference,
     ServerCapabilities,
 )
 
@@ -109,7 +110,11 @@ async def test_server_capabilities():
 
     # Add a complete handler
     @server.completion()
-    async def complete(ref: PromptReference | ResourceReference, argument: CompletionArgument):
+    async def complete(
+        ref: PromptReference | ResourceTemplateReference,
+        argument: CompletionArgument,
+        context: CompletionContext | None,
+    ) -> Completion | None:
         return Completion(
             values=["completion1", "completion2"],
         )


### PR DESCRIPTION
We merged https://github.com/modelcontextprotocol/python-sdk/pull/865 and the PR had an old interface for the completions (pre spec 2025-08-16)

Something is wrong with CI - checking as a separate PR - this should have been caught, but main seems green

(CI fix is here https://github.com/modelcontextprotocol/python-sdk/pull/1108)