### PR TITLE
Fix on streamable‑http auth drop on Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MCP Python SDK
+# MCP Python SDK 
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MCP Python SDK 
+# MCP Python SDK
 
 <div align="center">
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -828,7 +828,7 @@ class FastMCP:
     def streamable_http_app(self) -> Starlette:
         """Return an instance of the StreamableHTTP server app."""
         from starlette.middleware import Middleware
-        from starlette.routing import Mount
+        from starlette.routing import Route
 
         # Create session manager on first call (lazy initialization)
         if self._session_manager is None:
@@ -845,7 +845,7 @@ class FastMCP:
             await self.session_manager.handle_request(scope, receive, send)
 
         # Create routes
-        routes: list[Route | Mount] = []
+        routes: list[Route] = []
         middleware: list[Middleware] = []
         required_scopes = []
 
@@ -889,17 +889,19 @@ class FastMCP:
                 )
 
             routes.append(
-                Mount(
+                Route(
                     self.settings.streamable_http_path,
-                    app=RequireAuthMiddleware(handle_streamable_http, required_scopes, resource_metadata_url),
+                    endpoint=RequireAuthMiddleware(handle_streamable_http, required_scopes, resource_metadata_url),
+                    methods=["POST", "GET", "DELETE"],
                 )
             )
         else:
             # Auth is disabled, no wrapper needed
             routes.append(
-                Mount(
+                Route(
                     self.settings.streamable_http_path,
-                    app=handle_streamable_http,
+                    endpoint=handle_streamable_http,
+                    methods=["POST", "GET", "DELETE"],
                 )
             )
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Replaced all `Mount(self.settings.streamable_http_path, …)` registrations with `Route(self.settings.streamable_http_path, endpoint=…, methods=["POST","GET","DELETE"])` to eliminate the automatic 307 redirect and ensure the Authorization header is preserved on public deployments.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
During the 307 redirect from` /mcp ` to  `/mcp/`, many HTTP clients drop sensitive headers like Authorization when following external redirects. Locally, Uvicorn + HTTPX transparently reattach headers, so the bug only appeared when I distributed the server on Azure. Switching to `Route `removes the redirect entirely, preserving end‑to‑end authentication and restoring expected behavior of the streamable‑http transport.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Local: verified with MCP Inspector that /mcp and /mcp/ calls succeed without dropping headers.

Azure: deployed to Azure App Service, exercised full OAuth flow and MCP Inspector connect; confirmed no 307 redirect and successful streamable‑http sessions.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. This is a transparent change to route registration. Existing clients can continue calling /mcp or /mcp/ with no code or configuration updates.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
