### PR TITLE
Add streamable HTTP starlette example to Python SDK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,9 +838,34 @@ The streamable HTTP transport supports:
 
 ### Mounting to an Existing ASGI Server
 
-> **Note**: SSE transport is being superseded by [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
-
 By default, SSE servers are mounted at `/sse` and Streamable HTTP servers are mounted at `/mcp`. You can customize these paths using the methods described below.
+
+#### Streamable HTTP servers
+
+The following example shows how to use `streamable_http_app()`, a method that returns a `Starlette` application object.
+You can then append additional routes to that application as needed.
+
+```
+from starlette.routing import Route
+
+mcp = FastMCP("My App")
+
+app = mcp.streamable_http_app()
+# Additional non-MCP routes can be added like so:
+# app.router.routes.append(Route("/", endpoint=other_route_function))
+```
+
+To customize the route from the default of "/mcp", either specify the `streamable_http_path` option for the `FastMCP` constructor,
+or set `FASTMCP_STREAMABLE_HTTP_PATH` environment variable.
+
+Note that in Starlette and FastAPI (which is based on Starlette), the "/mcp" route will redirect to "/mcp/",
+so you may need to use "/mcp/" when pointing MCP clients at your servers.
+
+For more information on mounting applications in Starlette, see the [Starlette documentation](https://www.starlette.io/routing/#submounting-routes).
+
+#### SSE servers
+
+> **Note**: SSE transport is being superseded by [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
 
 You can mount the SSE server to an existing ASGI server using the `sse_app` method. This allows you to integrate the SSE server with other ASGI applications.
 


### PR DESCRIPTION
This PR updates the README with an example using streamable_http_app with Starlette.

## Motivation and Context

When I was trying to port my Starlette SSE app to streamable, I couldn't find a simple example that showed how to do that. As far as I can see, the code that I've put in the README is the minimal example. I think it'd help to have some streamable code since its currently just SSE.

## How Has This Been Tested?

Yes, am using it for a public MCP sample here:
https://github.com/Azure-Samples/azure-ai-travel-agents/pull/101

## Breaking Changes

No, docs only

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
