### PR TITLE
Avoiding to parse string arguments containing valid JSON if the argument annotation is str

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -130,7 +130,7 @@ class FuncMetadata(BaseModel):
         for field_name in self.arg_model.model_fields.keys():
             if field_name not in data.keys():
                 continue
-            if isinstance(data[field_name], str):
+            if isinstance(data[field_name], str) and self.arg_model.model_fields[field_name].annotation is not str:
                 try:
                     pre_parsed = json.loads(data[field_name])
                 except json.JSONDecodeError:


### PR DESCRIPTION
Every time a parameter of a tool is passed as a string containing a valid JSON it is parsed and replaced. From the comment of pre_parse_json() "This is to handle cases like `["a", "b", "c"]` being passed in as JSON inside a string rather than an actual list"

Nevertheless this method doesn't check if the annotation of parameters indicates that it is supposed to be a str rather than a dict or a list

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

