### PR TITLE
Ensure failed oauth registration response is read before accessing response.text

### DIFF
--- a/src/mcp/client/auth.py
+++ b/src/mcp/client/auth.py
@@ -308,6 +308,7 @@ class OAuthClientProvider(httpx.Auth):
     async def _handle_registration_response(self, response: httpx.Response) -> None:
         """Handle registration response."""
         if response.status_code not in (200, 201):
+            await response.aread()
             raise OAuthRegistrationError(f"Registration failed: {response.status_code} {response.text}")
 
         try:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

A minor fix - this condition attempts to access `response.text` before the response has been read, which raises an httpx error. Discovered while investigating https://github.com/jlowin/fastmcp/issues/1111

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
