### PR TITLE
[fix] add type field to client session config BaseModels

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import Callable
 from datetime import timedelta
 from types import TracebackType
-from typing import Any, TypeAlias
+from typing import Any, Literal, TypeAlias
 
 import anyio
 from pydantic import BaseModel
@@ -30,6 +30,9 @@ from mcp.shared.exceptions import McpError
 class SseServerParameters(BaseModel):
     """Parameters for intializing a sse_client."""
 
+    # The type of server connection.
+    type: Literal["sse"] = "sse"
+
     # The endpoint URL.
     url: str
 
@@ -45,6 +48,9 @@ class SseServerParameters(BaseModel):
 
 class StreamableHttpParameters(BaseModel):
     """Parameters for intializing a streamablehttp_client."""
+
+    # The type of server connection.
+    type: Literal["streamable_http"] = "streamable_http"
 
     # The endpoint URL.
     url: str

--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -69,6 +69,9 @@ def get_default_environment() -> dict[str, str]:
 
 
 class StdioServerParameters(BaseModel):
+    type: Literal["stdio"] = "stdio"
+    """The type of server connection."""
+
     command: str
     """The executable to run to start the server."""
 


### PR DESCRIPTION
Adds a pre-set `type` field to `SseServerParameters`, `StreamableHttpParameters`, and `StdioServerParameters` so serialized parameters will easily be loaded into the correct class.

## Motivation and Context
All fields of `SseServerParameters` overlap with `StreamableHttpParameters`, so a third party application that would want to connect to multiple session with a config such as:

```python
class ClientConfig(BaseModel):
    mcp_configs: List[Union[StreamableHttpParameters, SseServerParameters]]
```
would not have a way to be instantiated from a serialized config (like a yaml file) since the following is ambiguous.
```yaml
mcp_configs:
  - url: ""
```

Additionally, if someone were to serialize either the sse or http config classes they would not be able to reload the second class listed in the union.

Adding the preset `type` field should fix this in a backwards compatible way.

## How Has This Been Tested?
Existing tests cover backwards compatibility, confirmed this PR addresses the described use case

## Breaking Changes
No, added fields include the only valid Literal default.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
