### PR TITLE
tests: mark trailing slash test as xfail

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -836,16 +836,20 @@ class TestOAuthClientProvider:
         "revocation_endpoint",
     ),
     (
-        # TODO(Marcelo): Since we are using `AnyUrl`, the trailing slash is always added.
-        # pytest.param(
-        #     "https://auth.example.com",
-        #     "https://auth.example.com/docs",
-        #     "https://auth.example.com/authorize",
-        #     "https://auth.example.com/token",
-        #     "https://auth.example.com/register",
-        #     "https://auth.example.com/revoke",
-        #     id="simple-url",
-        # ),
+        # Pydantic's AnyUrl incorrectly adds trailing slash to base URLs
+        # This is being fixed in https://github.com/pydantic/pydantic-core/pull/1719 (Pydantic 2.12+)
+        pytest.param(
+            "https://auth.example.com",
+            "https://auth.example.com/docs",
+            "https://auth.example.com/authorize",
+            "https://auth.example.com/token",
+            "https://auth.example.com/register",
+            "https://auth.example.com/revoke",
+            id="simple-url",
+            marks=pytest.mark.xfail(
+                reason="Pydantic AnyUrl adds trailing slash to base URLs - fixed in Pydantic 2.12+"
+            ),
+        ),
         pytest.param(
             "https://auth.example.com/",
             "https://auth.example.com/docs",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Address https://github.com/modelcontextprotocol/python-sdk/pull/945/files#r2192151570

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Ran full test suite.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
