### PR TITLE
fix: attempt to query resource-specific protected resource metadata before root PRM

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -201,6 +201,16 @@ class TestOAuthFlow:
         request = await oauth_provider._discover_protected_resource()
 
         assert request.method == "GET"
+        assert str(request.url) == "https://api.example.com/.well-known/oauth-protected-resource/v1/mcp"
+        assert "mcp-protocol-version" in request.headers
+
+    @pytest.mark.anyio
+    async def test_discover_protected_resource_request_fallback(self, oauth_provider):
+        """Test protected resource discovery request building after a failure to discover metadata at the standard endpoint."""
+        request = await oauth_provider._discover_protected_resource(is_fallback=True)
+
+        assert request.method == "GET"
+        # Falls back to the root
         assert str(request.url) == "https://api.example.com/.well-known/oauth-protected-resource"
         assert "mcp-protocol-version" in request.headers
 

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -207,7 +207,8 @@ class TestOAuthFlow:
 
     @pytest.mark.anyio
     async def test_discover_protected_resource_request_fallback(self, oauth_provider):
-        """Test protected resource discovery request building after a failure to discover metadata at the standard endpoint."""
+        """Test protected resource discovery request building after a failure to discover metadata at the
+        standard endpoint."""
         request = await oauth_provider._discover_protected_resource(is_fallback=True)
 
         assert request.method == "GET"


### PR DESCRIPTION
Currently, the resource-specific protected resource metadata endpoint is not queried to discover RFC 9728 metadata, which is incorrect per the [specification](https://datatracker.ietf.org/doc/html/rfc9728#name-protected-resource-metadata-).

Given an MCP server at `https://example.com/mcp`, the PRM must be located at `https://example.com/.well-known/oauth-protected-resource/mcp`. However, no matter what path the MCP server is hosted on, the SDK currently attempts to discover PRM at the root, e.g. `https://example.com/.well-known/oauth-protected-resource`. This breaks compatibility with any MCP server with authorization hosted outside of the root, unless the MCP server is double-hosting metadata to account for this.

This PR attempts to handle both cases (giving consideration to the existing behavior potentially being expected now) by querying the most specific resource path first, and then falling back to the existing behavior in the event that PRM is hosted at the root path instead. This is the same behavior used in the [TS SDK](https://github.com/modelcontextprotocol/typescript-sdk/blob/f3584f2a4162febadf39300d7f37be63a91ce05d/src/client/auth.ts#L549-L579).

Note that this fallback behavior is not actually spec-compliant, I've only implemented it this way to account for the possibility that some MCP servers are non-compliant to match the client SDK.

## Motivation and Context
Fixes compatibility with spec-compliant MCP servers.

## How Has This Been Tested?
Unit tests. **TODO: spot check against example server (putting implementation out now for early feedback)**

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
#1052