### PR TITLE
Increasing Buffer Size in MCP stdio Transport

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -54,8 +54,9 @@ async def stdio_server(
     write_stream: MemoryObjectSendStream[SessionMessage]
     write_stream_reader: MemoryObjectReceiveStream[SessionMessage]
 
-    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
-    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+    # FIXED: Changed from 0 to 10 to create buffered streams
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(10)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(10)
 
     async def stdin_reader():
         try:


### PR DESCRIPTION
Fixes: https://github.com/modelcontextprotocol/python-sdk/issues/1141

When using the low-level Server API (mcp.server.lowlevel.Server) with stdio transport, sending progress notifications during request handling causes the server to hang indefinitely and never send the final response.

This issue was discovered while implementing an MCP server that returns large SQL query results and detailed analysis. The server would hang indefinitely when the output exceeded the OS pipe buffer limit.

## Motivation and Context
Provides a fix for https://github.com/modelcontextprotocol/python-sdk/issues/1141

The current stdio transport implementation uses unbuffered memory object streams (buffer size 0), which can cause deadlocks when:
1. Multiple messages are sent in quick succession
2. Progress notifications are combined with tool responses

## How Has This Been Tested?
Tested with code shared in original #1141 and fix works in it.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed


