### PR TITLE
Fix MCP Client SSE URL Parsing Issue

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -73,7 +73,15 @@ async def sse_client(
                                 logger.debug(f"Received SSE event: {sse.event}")
                                 match sse.event:
                                     case "endpoint":
-                                        endpoint_url = urljoin(url, sse.data)
+                                        # endpoint_url = urljoin(url, sse.data)
+
+                                        parsed_url = urlparse(url)
+                                        if parsed_url.path.endswith('/'):
+                                            base_url = url
+                                        else:
+                                            base_path = '/'.join(parsed_url.path.split('/')[:-1]) + '/'
+                                            base_url = f"{parsed_url.scheme}://{parsed_url.netloc}{base_path}"
+                                        endpoint_url = urljoin(base_url, sse.data.lstrip('/'))
                                         logger.debug(f"Received endpoint URL: {endpoint_url}")
 
                                         url_parsed = urlparse(url)


### PR DESCRIPTION
# Motivation and Context
This change fixes a critical URL parsing bug in the MCP (Model Context Protocol) client's SSE (Server-Sent Events) endpoint handling. The original implementation used urljoin(url, sse.data) directly, which incorrectly handled absolute paths in sse.data, causing the client to access wrong endpoints.
Problem scenario:
SSE URL: https://example.com/agent-5o/mcp-stage/sse
sse.data: /messages/
Original result: https://example.com/messages/ (incorrect - loses path prefix)
Fixed result: https://example.com/agent-5o/mcp-stage/messages/ (correct - preserves path prefix)
This bug prevented MCP clients from establishing proper connections to servers deployed with path prefixes or behind reverse proxies.

Tested SSE URLs with various path prefix scenarios. Verified correct parsing of both relative and absolute paths in sse.data
Confirmed proper endpoint URL construction and successful connections. Validated backward compatibility with existing deployments. Tested edge cases including URLs with and without trailing slashes

# Additional context
## Core Implementation Logic:
Parse Original SSE URL: Use urlparse() to analyze the structure of the SSE connection URL
Construct Base URL:
If the path ends with '/', use the original URL as base
Otherwise, remove the last path segment (typically 'sse') while preserving the directory path
Safe URL Joining: Use urljoin(base_url, sse.data.lstrip('/')) to ensure correct relative path resolution
