### PR TITLE
fix markdown error in README in main

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,12 +951,11 @@ The following example shows how to use `streamable_http_app()`, a method that re
 You can then append additional routes to that application as needed.
 
 ```python
-from starlette.routing import Route
-
 mcp = FastMCP("My App")
 
 app = mcp.streamable_http_app()
 # Additional non-MCP routes can be added like so:
+# from starlette.routing import Route
 # app.router.routes.append(Route("/", endpoint=other_route_function))
 ```
 

--- a/README.md
+++ b/README.md
@@ -950,7 +950,7 @@ By default, SSE servers are mounted at `/sse` and Streamable HTTP servers are mo
 The following example shows how to use `streamable_http_app()`, a method that returns a `Starlette` application object.
 You can then append additional routes to that application as needed.
 
-```
+```python
 from starlette.routing import Route
 
 mcp = FastMCP("My App")


### PR DESCRIPTION
This check was added recently, when merging old PRs we might be introducing the failure in the main. Worth merging main before merge for old PRs touching README