### PR TITLE
fix: Return JSON-RPC protocol errors for unknown tools

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -452,6 +452,14 @@ class Server(Generic[LifespanResultT, RequestT]):
                     arguments = req.params.arguments or {}
                     tool = await self._get_cached_tool_definition(tool_name)
 
+                    # Check if tool exists - return protocol error if not found
+                    if tool is None:
+                        raise McpError(
+                            types.ErrorData(
+                                code=types.METHOD_NOT_FOUND,
+                                message=f"Unknown tool: {tool_name}",
+                            )
+                        )
                     # input validation
                     if validate_input and tool:
                         try:
@@ -499,6 +507,8 @@ class Server(Generic[LifespanResultT, RequestT]):
                             isError=False,
                         )
                     )
+                except McpError:
+                    raise
                 except Exception as e:
                     return self._make_error_result(str(e))
 


### PR DESCRIPTION
Return JSON-RPC protocol errors for unknown tools

## Motivation and Context
The MCP server was returning tool execution errors for unknown tools instead of proper JSON-RPC protocol errors. This caused issues where Unknown tools were treated as tool execution failures rather than protocol-level errors

**Before(Tool execution error):**
```
{
  "jsonrpc": "2.0",
  "id": 3,
  "result": {
    "content": [{"type": "text", "text": "Unknown tool: invalid_tool_name"}],
    "isError": true
  }
}
```

**After(Protocol error):**
```
{
  "jsonrpc": "2.0",
  "id": 3,
  "error": {
    "code": -32601,
    "message": "Unknown tool: invalid_tool_name"
  }
}
```

Modified the tool call handler in src/mcp/server/lowlevel/server.py to:
- Check for unknown tools after retrieving from cache
- Raise McpError with METHOD_NOT_FOUND (-32601) error code for unknown tools

## How Has This Been Tested?
- Added unit test
- Verified with a server and client example

## Breaking Changes
This is a breaking change that corrects the error handling behavior:
- Unknown tools now return JSON-RPC protocol errors
- Valid tools that fail during execution still return tool execution errors
- Input validation errors continue to work as before
- Warning logs are still generated for unknown tools during lookup

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
