### PR TITLE
Fix: Replace threading.Lock with anyio.Lock for Ray deployment compatibility

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import logging
-import threading
 from collections.abc import AsyncIterator
 from http import HTTPStatus
 from typing import Any
@@ -75,7 +74,7 @@ class StreamableHTTPSessionManager:
         # The task group will be set during lifespan
         self._task_group = None
         # Thread-safe tracking of run() calls
-        self._run_lock = threading.Lock()
+        self._run_lock = anyio.Lock()
         self._has_started = False
 
     @contextlib.asynccontextmanager
@@ -97,7 +96,7 @@ class StreamableHTTPSessionManager:
                 yield
         """
         # Thread-safe check to ensure run() is only called once
-        with self._run_lock:
+        async with self._run_lock:
             if self._has_started:
                 raise RuntimeError(
                     "StreamableHTTPSessionManager .run() can only be called "


### PR DESCRIPTION
Replace threading.Lock with anyio.Lock for Ray deployment compatibility
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When deploying StreamableHTTP services with Ray, we encountered serialization issues because threading.Lock objects cannot be pickled/serialized. This causes deployment failures when Ray tries to serialize the session manager objects across worker processes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
