### PR TITLE
chore: don't allow users to create issues outside the templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false


### PR DESCRIPTION
I see people going around the issue templates - but this makes it hard to get some labels in the issues, which helps to track issues that are really bugs.