### PR TITLE
fix flaky test test_88_random_error

### DIFF
--- a/tests/issues/test_88_random_error.py
+++ b/tests/issues/test_88_random_error.py
@@ -28,8 +28,7 @@ async def test_notification_validation_error(tmp_path: Path):
 
     server = Server(name="test")
     request_count = 0
-    slow_request_started = anyio.Event()
-    slow_request_complete = anyio.Event()
+    slow_request = anyio.Event()
 
     @server.list_tools()
     async def list_tools() -> list[types.Tool]:
@@ -52,16 +51,9 @@ async def test_notification_validation_error(tmp_path: Path):
         request_count += 1
 
         if name == "slow":
-            # Signal that slow request has started
-            slow_request_started.set()
-            # Long enough to ensure timeout
-            await anyio.sleep(0.2)
-            # Signal completion
-            slow_request_complete.set()
+            await slow_request.wait()  # it should timeout here
             return [TextContent(type="text", text=f"slow {request_count}")]
         elif name == "fast":
-            # Fast enough to complete before timeout
-            await anyio.sleep(0.01)
             return [TextContent(type="text", text=f"fast {request_count}")]
         return [TextContent(type="text", text=f"unknown {request_count}")]
 
@@ -90,16 +82,15 @@ async def test_notification_validation_error(tmp_path: Path):
             # First call should work (fast operation)
             result = await session.call_tool("fast")
             assert result.content == [TextContent(type="text", text="fast 1")]
-            assert not slow_request_complete.is_set()
+            assert not slow_request.is_set()
 
             # Second call should timeout (slow operation)
             with pytest.raises(McpError) as exc_info:
                 await session.call_tool("slow")
             assert "Timed out while waiting" in str(exc_info.value)
 
-            # Wait for slow request to complete in the background
-            with anyio.fail_after(1):  # Timeout after 1 second
-                await slow_request_complete.wait()
+            # release the slow request not to have hagning process
+            slow_request.set()
 
             # Third call should work (fast operation),
             # proving server is still responsive


### PR DESCRIPTION
The test is [flaky](https://github.com/modelcontextprotocol/python-sdk/actions/runs/16372438953/job/46263912823?pr=1169). 


  - Replaced sleep-based synchronization with event-based coordination: Instead of using anyio.sleep() to simulate a slow
  operation, the test now uses anyio.Event() to have deterministic control over when the slow request completes
  - Removed unnecessary timing dependencies: The "fast" operation now completes instantly without any sleep, eliminating
  timing-related flakiness
  - Added  clean up
  - Simplified the synchronization logic: Removed multiple event objects in favor of a single slow_request event that precisely
   controls the test flow