### PR TITLE
[POC] Update logic for constructing protected resource metadata URL to include the resource's path component, for compatibility with Oauth RFCs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,4 @@ cython_debug/
 .vscode/
 .windsurfrules
 **/CLAUDE.local.md
+.idea

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -208,7 +208,7 @@ class TestOAuthFlow:
             return "test_auth_code", "test_state"
 
         provider = OAuthClientProvider(
-            server_url="https://api.example.com",
+            server_url="https://api.example.com/api/2.0/mcp",
             client_metadata=client_metadata,
             storage=mock_storage,
             redirect_handler=redirect_handler,

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -222,7 +222,7 @@ class TestOAuthFlow:
 
         request = await provider._discover_protected_resource(init_response)
         assert request.method == "GET"
-        assert str(request.url) == "https://api.example.com/.well-known/oauth-protected-resource"
+        assert str(request.url) == "https://api.example.com/.well-known/oauth-protected-resource/api/2.0/mcp"
         assert "mcp-protocol-version" in request.headers
 
         # Test with WWW-Authenticate header


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Update logic for constructing the protected resource metadata URL for an MCP server to include the path component of the resource being accessed, [as per section 3.1 of Oauth RFC 9728](https://datatracker.ietf.org/doc/rfc9728/#:~:text=oauth%2Dprotected%2Dresource.-,3.1.%20%20Protected%20Resource%20Metadata%20Request,-A%20protected%20resource):

>  3.1.  Protected Resource Metadata Request
> 
>    A protected resource metadata document MUST be queried using an HTTP
>    GET request at the previously specified URL.
> 
>    The consumer of the metadata would make the following request when
>    the resource identifier is https://resource.example.com and the well-
>    known URI path suffix is oauth-protected-resource to obtain the
>    metadata, since the resource identifier contains no path component:
> 
>      GET /.well-known/oauth-protected-resource HTTP/1.1
>      Host: resource.example.com
> 
>    If the resource identifier value contains a path or query component,
>    any terminating slash (/) following the host component MUST be
>    removed before inserting /.well-known/ and the well-known URI path
>    suffix between the host component and the path and/or query
>    components.  The consumer of the metadata would make the following
>    request when the resource identifier is https://resource.example.com/
>    resource1 and the well-known URI path suffix is oauth-protected-
>    resource to obtain the metadata, since the resource identifier
>    contains a path component:
> 
>      GET /.well-known/oauth-protected-resource/resource1 HTTP/1.1
>      Host: resource.example.com
> 
>    Using path components enables supporting multiple resources per host.
>    This is required in some multi-tenant hosting configurations.  This
>    use of .well-known is for supporting multiple resources per host;
>    unlike its use in [RFC8615], it does not provide general information
>    about the host.

To avoid breaking changes, we first attempt RFC-compliant behavior, e.g. for `https://api.example.com/mcp`, first try to query a PRM endpoint at `https://api.example.com/.well-known/oauth-protected-resource/mcp`. If that fails, we then fall back to querying `https://api.example.com/.well-known/oauth-protected-resource` (existing behavior, excluding the `/mcp` path component)

## How Has This Been Tested?
Updated unit tests - TODO test this against some real example servers
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
