### PR TITLE
Simplify code on `stdio_client`

### DIFF
--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -167,8 +167,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
         tg.start_soon(stdin_writer)
 
         try:
-            async with read_stream, write_stream:
-                yield read_stream, write_stream
+            yield read_stream, write_stream
         finally:
             # MCP spec: stdio shutdown sequence
             # 1. Close input stream to server
@@ -194,6 +193,8 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                 pass
             await read_stream_writer.aclose()
             await write_stream_reader.aclose()
+            await read_stream.aclose()
+            await write_stream.aclose()
 
 
 def _get_executable_command(command: str) -> str:

--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -191,10 +191,10 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
             except ProcessLookupError:
                 # Process already exited, which is fine
                 pass
-            await read_stream_writer.aclose()
-            await write_stream_reader.aclose()
             await read_stream.aclose()
             await write_stream.aclose()
+            await read_stream_writer.aclose()
+            await write_stream_reader.aclose()
 
 
 def _get_executable_command(command: str) -> str:

--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Literal, TextIO
 
@@ -192,6 +192,8 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
             except ProcessLookupError:
                 # Process already exited, which is fine
                 pass
+            await read_stream_writer.aclose()
+            await write_stream_reader.aclose()
 
 
 def _get_executable_command(command: str) -> str:

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -252,12 +252,7 @@ class BaseSession(
             self._progress_callbacks[request_id] = progress_callback
 
         try:
-            jsonrpc_request = JSONRPCRequest(
-                jsonrpc="2.0",
-                id=request_id,
-                **request_data,
-            )
-
+            jsonrpc_request = JSONRPCRequest(jsonrpc="2.0", id=request_id, **request_data)
             await self._write_stream.send(SessionMessage(message=JSONRPCMessage(jsonrpc_request), metadata=metadata))
 
             # request read timeout takes precedence over session read timeout
@@ -329,10 +324,7 @@ class BaseSession(
             await self._write_stream.send(session_message)
 
     async def _receive_loop(self) -> None:
-        async with (
-            self._read_stream,
-            self._write_stream,
-        ):
+        async with self._read_stream, self._write_stream:
             try:
                 async for message in self._read_stream:
                     if isinstance(message, Exception):
@@ -418,10 +410,10 @@ class BaseSession(
                 # Without this handler, the exception would propagate up and
                 # crash the server's task group.
                 logging.debug("Read stream closed by client")
-            except Exception as e:
+            except Exception:
                 # Other exceptions are not expected and should be logged. We purposefully
                 # catch all exceptions here to avoid crashing the server.
-                logging.exception(f"Unhandled exception in receive loop: {e}")
+                logging.exception("Unhandled exception in receive loop")
             finally:
                 # after the read stream is closed, we need to send errors
                 # to any pending requests

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -118,7 +118,7 @@ async def test_stdio_client_universal_cleanup():
         """
         import time
         import sys
-        
+
         # Simulate a long-running process
         for i in range(100):
             time.sleep(0.1)
@@ -532,7 +532,7 @@ async def test_stdio_client_graceful_stdin_exit():
     script_content = textwrap.dedent(
         """
         import sys
-        
+
         # Read from stdin until it's closed
         try:
             while True:
@@ -541,7 +541,7 @@ async def test_stdio_client_graceful_stdin_exit():
                     break
         except:
             pass
-        
+
         # Exit gracefully
         sys.exit(0)
         """
@@ -590,16 +590,16 @@ async def test_stdio_client_stdin_close_ignored():
         import signal
         import sys
         import time
-        
+
         # Set up SIGTERM handler to exit cleanly
         def sigterm_handler(signum, frame):
             sys.exit(0)
-        
+
         signal.signal(signal.SIGTERM, sigterm_handler)
-        
+
         # Close stdin immediately to simulate ignoring it
         sys.stdin.close()
-        
+
         # Keep running until SIGTERM
         while True:
             time.sleep(0.1)


### PR DESCRIPTION
This PR still doesn't solve the issue we have: if the process fails to start, it needs to raise. It doesn't. User is seeing `Client disconnected` message when running `client.initialize()`.

Maybe we can play with something like this in the task group (I'm not sure...):

```python
async def process_cancellation(cancel_scope: anyio.CancelScope):
    _ = await process.wait()
	cancel_scope.cancel()
```

---

It would be cool for `open_process` to raise an exception on `returncode != None`.