### PR TITLE
Fix httpstreamable errorcode

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -266,8 +266,15 @@ class StreamableHTTPTransport:
                 logger.debug("Received 202 Accepted")
                 return
 
-            # ensures that all HTTP error codes are handled
-            if response.status_code >= 400 and response.status_code <= 499:
+            if response.status_code == 400:
+                if isinstance(message.root, JSONRPCRequest):
+                    await self._send_bad_request_error(
+                        ctx.read_stream_writer,
+                        message.root.id,
+                    )
+                return
+            
+            if response.status_code == 404:
                 if isinstance(message.root, JSONRPCRequest):
                     await self._send_session_terminated_error(
                         ctx.read_stream_writer,
@@ -356,6 +363,20 @@ class StreamableHTTPTransport:
             jsonrpc="2.0",
             id=request_id,
             error=ErrorData(code=32600, message="Session terminated"),
+        )
+        session_message = SessionMessage(JSONRPCMessage(jsonrpc_error))
+        await read_stream_writer.send(session_message)
+
+    async def _send_bad_request_error(
+        self,
+        read_stream_writer: StreamWriter,
+        request_id: RequestId,
+    ) -> None:
+        """Send a bad request error response."""
+        jsonrpc_error = JSONRPCError(
+            jsonrpc="2.0",
+            id=request_id,
+            error=ErrorData(code=32600, message="Bad request"),
         )
         session_message = SessionMessage(JSONRPCMessage(jsonrpc_error))
         await read_stream_writer.send(session_message)

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -273,7 +273,7 @@ class StreamableHTTPTransport:
                         message.root.id,
                     )
                 return
-            
+
             if response.status_code == 404:
                 if isinstance(message.root, JSONRPCRequest):
                     await self._send_session_terminated_error(

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -266,7 +266,8 @@ class StreamableHTTPTransport:
                 logger.debug("Received 202 Accepted")
                 return
 
-            if response.status_code == 404:
+            # ensures that all HTTP error codes are handled
+            if response.status_code >= 400 and response.status_code <= 499:
                 if isinstance(message.root, JSONRPCRequest):
                     await self._send_session_terminated_error(
                         ctx.read_stream_writer,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added additional `if` statements to catch a 400 bad request error messages within the `streamable_http.py` file

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This change is needed to fix an issue with the current way that a client uses streamable HTTP to connect to a MCP server. Currently, an unavoidable exception is raised when creating a `SessionGroup` and adding a steamable HTTP connection to an MCP server that returns an error 4xx code when a primitive (prompts, resources and tools) is requested. As long as at least one of these primitives returns an error 4xx code (except a 404 error), it will cause the exception, which crashes the MCP client.

In cases with independent sessions outside of `SessionGroup`, this error can be handled by the developer building the MCP client. However, when using `SessionGroup`, the developer cannot handle these errors, and so cannot prevent the program from crashing. This is because the `SessionGroup` automatically sends web requests to prompts, resources and tools without checking if they are supported, which I think goes against the [specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#operation).

The change is needed to ensure that an MCP client doesn't crash when an MCP server sends an error code for a bad request (which it can do as defined in the [specifciation](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server)). The change was made to the `streamable_http.py` file, as this avoids a possible breaking change if the `SessionGroup` was changed instead.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This has been tested with the [AWS Knowledge MCP Server](https://github.com/awslabs/mcp/tree/main/src/aws-knowledge-mcp-server), which returns an error code 400 when interacting with a `prompt` or `resource` primitive.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. The only possible scenario of a breaking change is if a developer relies on the httpx status error exception currently raised to detect an error 400 code for an unsupported capability. In this case, the developer should be following the [specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#operation), and check if a capability is supported before it is requested.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
I apologise in advance if I have missunderstood anything about the code regarding this issue or anything about the MCP specification. Please correct me on any errors I have made so that I can learn from them.