### PR TITLE
Add CORS middleware to Starlette app for frontend support

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -847,7 +847,19 @@ class FastMCP(Generic[LifespanResultT]):
         routes.extend(self._custom_starlette_routes)
 
         # Create Starlette app with routes and middleware
-        return Starlette(debug=self.settings.debug, routes=routes, middleware=middleware)
+        app = Starlette(debug=self.settings.debug, routes=routes, middleware=middleware)
+        
+        # Add CORS middleware for web frontend compatibility
+        from starlette.middleware.cors import CORSMiddleware
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["http://localhost:*", "http://127.0.0.1:*", "https://localhost:*", "https://127.0.0.1:*"],
+            allow_credentials=True,
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["Content-Type", "Authorization", "X-Requested-With", "Accept"],
+        )
+        
+        return app
 
     def streamable_http_app(self) -> Starlette:
         """Return an instance of the StreamableHTTP server app."""
@@ -949,12 +961,25 @@ class FastMCP(Generic[LifespanResultT]):
 
         routes.extend(self._custom_starlette_routes)
 
-        return Starlette(
+        # Create Starlette app with routes and middleware
+        app = Starlette(
             debug=self.settings.debug,
             routes=routes,
             middleware=middleware,
             lifespan=lambda app: self.session_manager.run(),
         )
+        
+        # Add CORS middleware for web frontend compatibility
+        from starlette.middleware.cors import CORSMiddleware
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["http://localhost:*", "http://127.0.0.1:*", "https://localhost:*", "https://127.0.0.1:*"],
+            allow_credentials=True,
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["Content-Type", "Authorization", "X-Requested-With", "Accept"],
+        )
+        
+        return app
 
     async def list_prompts(self) -> list[MCPPrompt]:
         """List all available prompts."""


### PR DESCRIPTION
Introduces CORS middleware to the Starlette app instances in FastMCP to allow requests from local web frontends. This enables compatibility with web clients running on localhost and related origins, supporting credentials and common HTTP methods and headers.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Fixes https://github.com/modelcontextprotocol/python-sdk/issues/187#issuecomment-2994114298

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
