### PR TITLE
Fix: avoid uncessary retries in OAuth authenticated requests

### DIFF
--- a/src/mcp/client/auth.py
+++ b/src/mcp/client/auth.py
@@ -131,7 +131,7 @@ class OAuthContext:
             and self.current_tokens.access_token
             and (not self.token_expiry_time or time.time() <= self.token_expiry_time)
         )
-    
+
     def can_refresh_token(self) -> bool:
         """Check if token can be refreshed."""
         return bool(self.current_tokens and self.current_tokens.refresh_token and self.client_info)

--- a/src/mcp/client/auth.py
+++ b/src/mcp/client/auth.py
@@ -131,7 +131,7 @@ class OAuthContext:
             and self.current_tokens.access_token
             and (not self.token_expiry_time or time.time() <= self.token_expiry_time)
         )
-
+    
     def can_refresh_token(self) -> bool:
         """Check if token can be refreshed."""
         return bool(self.current_tokens and self.current_tokens.refresh_token and self.client_info)
@@ -546,6 +546,6 @@ class OAuthClientProvider(httpx.Auth):
                     logger.exception("OAuth flow error")
                     raise
 
-        # Retry with new tokens
-        self._add_auth_header(request)
-        yield request
+                # Retry with new tokens
+                self._add_auth_header(request)
+                yield request

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -721,11 +721,11 @@ class TestAuthFlow:
 
         # Send a successful 200 response
         response = httpx.Response(200, request=request)
-        
+
         # In the buggy version, this would yield the request AGAIN unconditionally
         # In the fixed version, this should end the generator
         try:
-            extra_request = await auth_flow.asend(response)
+            await auth_flow.asend(response)  # extra request
             request_yields += 1
             # If we reach here, the bug is present
             pytest.fail(

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -361,7 +361,19 @@ class TestOAuthFallback:
             ),
             request=token_request,
         )
-        token_request = await auth_flow.asend(token_response)
+        
+        # After OAuth flow completes, the original request is retried with auth header
+        final_request = await auth_flow.asend(token_response)
+        assert final_request.headers["Authorization"] == "Bearer new_access_token"
+        assert final_request.method == "GET"
+        assert str(final_request.url) == "https://api.example.com/v1/mcp"
+        
+        # Send final success response to properly close the generator
+        final_response = httpx.Response(200, request=final_request)
+        try:
+            await auth_flow.asend(final_response)
+        except StopAsyncIteration:
+            pass  # Expected - generator should complete
 
     @pytest.mark.anyio
     async def test_handle_metadata_response_success(self, oauth_provider: OAuthClientProvider):
@@ -693,6 +705,13 @@ class TestAuthFlow:
         assert final_request.headers["Authorization"] == "Bearer new_access_token"
         assert final_request.method == "GET"
         assert str(final_request.url) == "https://api.example.com/mcp"
+
+        # Send final success response to properly close the generator
+        final_response = httpx.Response(200, request=final_request)
+        try:
+            await auth_flow.asend(final_response)
+        except StopAsyncIteration:
+            pass  # Expected - generator should complete
 
         # Verify tokens were stored
         assert oauth_provider.context.current_tokens is not None

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -700,7 +700,9 @@ class TestAuthFlow:
         assert oauth_provider.context.token_expiry_time is not None
 
     @pytest.mark.anyio
-    async def test_auth_flow_no_unnecessary_retry_after_oauth(self, oauth_provider, mock_storage, valid_tokens):
+    async def test_auth_flow_no_unnecessary_retry_after_oauth(
+        self, oauth_provider: OAuthClientProvider, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
+    ):
         """Test that requests are not retried unnecessarily - the core bug that caused 2x performance degradation."""
         # Pre-store valid tokens so no OAuth flow is needed
         await mock_storage.set_tokens(valid_tokens)

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -361,13 +361,13 @@ class TestOAuthFallback:
             ),
             request=token_request,
         )
-        
+
         # After OAuth flow completes, the original request is retried with auth header
         final_request = await auth_flow.asend(token_response)
         assert final_request.headers["Authorization"] == "Bearer new_access_token"
         assert final_request.method == "GET"
         assert str(final_request.url) == "https://api.example.com/v1/mcp"
-        
+
         # Send final success response to properly close the generator
         final_response = httpx.Response(200, request=final_request)
         try:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Tried to connect an MCP client to Notion's MCP client (more info here: https://github.com/modelcontextprotocol/python-sdk/issues/1204)

## How Has This Been Tested?
Using a local script wrapping this code snippet:

```python
async with streamablehttp_client("https://mcp.notion.com/mcp", auth=oauth_auth) as (read, write, _):

    async with ClientSession(read, write) as session:
        await session.initialize()
        tools = await session.list_tools()
        print(f"Available tools: {[tool.name for tool in tools.tools]}")
        resources = await session.list_resources()
        print(f"Available resources: {[r.uri for r in resources.resources]}")

        tool_result = await session.call_tool(name="search", arguments={"query": "John Doe"})
```

Now `list_tools()`, `list_resources()` and `call_tool()` run instantly. 


## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
