### PR TITLE
SEP: Prefix Filtering for Listing Resource / Templates

### DIFF
--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -32,7 +32,9 @@ def main(port: int, transport: str) -> int:
     app = Server("mcp-simple-resource")
 
     @app.list_resources()
-    async def list_resources() -> list[types.Resource]:
+    async def list_resources(
+        request: types.ListResourcesRequest,
+    ) -> list[types.Resource]:
         return [
             types.Resource(
                 uri=FileUrl(f"file:///{name}.txt"),

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -221,25 +221,35 @@ class ClientSession(
             types.EmptyResult,
         )
 
-    async def list_resources(self, cursor: str | None = None) -> types.ListResourcesResult:
+    async def list_resources(self, prefix: str | None = None, cursor: str | None = None) -> types.ListResourcesResult:
         """Send a resources/list request."""
+        params = None
+        if cursor is not None or prefix is not None:
+            params = types.ListResourcesRequestParams(prefix=prefix, cursor=cursor)
         return await self.send_request(
             types.ClientRequest(
                 types.ListResourcesRequest(
                     method="resources/list",
-                    params=types.PaginatedRequestParams(cursor=cursor) if cursor is not None else None,
+                    params=params,
                 )
             ),
             types.ListResourcesResult,
         )
 
-    async def list_resource_templates(self, cursor: str | None = None) -> types.ListResourceTemplatesResult:
+    async def list_resource_templates(
+        self,
+        prefix: str | None = None,
+        cursor: str | None = None,
+    ) -> types.ListResourceTemplatesResult:
         """Send a resources/templates/list request."""
+        params = None
+        if cursor is not None or prefix is not None:
+            params = types.ListResourceTemplatesRequestParams(prefix=prefix, cursor=cursor)
         return await self.send_request(
             types.ClientRequest(
                 types.ListResourceTemplatesRequest(
                     method="resources/templates/list",
-                    params=types.PaginatedRequestParams(cursor=cursor) if cursor is not None else None,
+                    params=params,
                 )
             ),
             types.ListResourceTemplatesResult,

--- a/src/mcp/server/fastmcp/resources/resource_manager.py
+++ b/src/mcp/server/fastmcp/resources/resource_manager.py
@@ -86,12 +86,18 @@ class ResourceManager:
 
         raise ValueError(f"Unknown resource: {uri}")
 
-    def list_resources(self) -> list[Resource]:
-        """List all registered resources."""
-        logger.debug("Listing resources", extra={"count": len(self._resources)})
-        return list(self._resources.values())
+    def list_resources(self, prefix: str | None = None) -> list[Resource]:
+        """List all registered resources, optionally filtered by URI prefix."""
+        resources = list(self._resources.values())
+        if prefix:
+            resources = [r for r in resources if str(r.uri).startswith(prefix)]
+        logger.debug("Listing resources", extra={"count": len(resources), "prefix": prefix})
+        return resources
 
-    def list_templates(self) -> list[ResourceTemplate]:
-        """List all registered templates."""
-        logger.debug("Listing templates", extra={"count": len(self._templates)})
-        return list(self._templates.values())
+    def list_templates(self, prefix: str | None = None) -> list[ResourceTemplate]:
+        """List all registered templates, optionally filtered by URI template prefix."""
+        templates = list(self._templates.values())
+        if prefix:
+            templates = [t for t in templates if t.matches_prefix(prefix)]
+        logger.debug("Listing templates", extra={"count": len(templates), "prefix": prefix})
+        return templates

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -259,11 +259,11 @@ class Server(Generic[LifespanResultT, RequestT]):
         return decorator
 
     def list_resources(self):
-        def decorator(func: Callable[[], Awaitable[list[types.Resource]]]):
+        def decorator(func: Callable[[types.ListResourcesRequest], Awaitable[list[types.Resource]]]):
             logger.debug("Registering handler for ListResourcesRequest")
 
-            async def handler(_: Any):
-                resources = await func()
+            async def handler(request: types.ListResourcesRequest):
+                resources = await func(request)
                 return types.ServerResult(types.ListResourcesResult(resources=resources))
 
             self.request_handlers[types.ListResourcesRequest] = handler
@@ -272,11 +272,11 @@ class Server(Generic[LifespanResultT, RequestT]):
         return decorator
 
     def list_resource_templates(self):
-        def decorator(func: Callable[[], Awaitable[list[types.ResourceTemplate]]]):
+        def decorator(func: Callable[[types.ListResourceTemplatesRequest], Awaitable[list[types.ResourceTemplate]]]):
             logger.debug("Registering handler for ListResourceTemplatesRequest")
 
-            async def handler(_: Any):
-                templates = await func()
+            async def handler(request: types.ListResourceTemplatesRequest):
+                templates = await func(request)
                 return types.ServerResult(types.ListResourceTemplatesResult(resourceTemplates=templates))
 
             self.request_handlers[types.ListResourceTemplatesRequest] = handler

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -63,6 +63,20 @@ class PaginatedRequestParams(RequestParams):
     """
 
 
+class ListResourcesRequestParams(PaginatedRequestParams):
+    """Parameters for listing resources with optional prefix filtering."""
+
+    prefix: str | None = None
+    """Optional prefix to filter resources by URI."""
+
+
+class ListResourceTemplatesRequestParams(PaginatedRequestParams):
+    """Parameters for listing resource templates with optional prefix filtering."""
+
+    prefix: str | None = None
+    """Optional prefix to filter resource templates by URI template."""
+
+
 class NotificationParams(BaseModel):
     class Meta(BaseModel):
         model_config = ConfigDict(extra="allow")
@@ -394,10 +408,11 @@ class ProgressNotification(Notification[ProgressNotificationParams, Literal["not
     params: ProgressNotificationParams
 
 
-class ListResourcesRequest(PaginatedRequest[Literal["resources/list"]]):
+class ListResourcesRequest(Request[ListResourcesRequestParams | None, Literal["resources/list"]]):
     """Sent from the client to request a list of resources the server has."""
 
     method: Literal["resources/list"]
+    params: ListResourcesRequestParams | None = None
 
 
 class Annotations(BaseModel):
@@ -461,10 +476,13 @@ class ListResourcesResult(PaginatedResult):
     resources: list[Resource]
 
 
-class ListResourceTemplatesRequest(PaginatedRequest[Literal["resources/templates/list"]]):
+class ListResourceTemplatesRequest(
+    Request[ListResourceTemplatesRequestParams | None, Literal["resources/templates/list"]]
+):
     """Sent from the client to request a list of resource templates the server has."""
 
     method: Literal["resources/templates/list"]
+    params: ListResourceTemplatesRequestParams | None = None
 
 
 class ListResourceTemplatesResult(PaginatedResult):

--- a/tests/issues/test_152_resource_mime_type.py
+++ b/tests/issues/test_152_resource_mime_type.py
@@ -79,7 +79,7 @@ async def test_lowlevel_resource_mime_type():
     ]
 
     @server.list_resources()
-    async def handle_list_resources():
+    async def handle_list_resources(request: types.ListResourcesRequest):
         return test_resources
 
     @server.read_resource()

--- a/tests/server/fastmcp/resources/test_resource_template.py
+++ b/tests/server/fastmcp/resources/test_resource_template.py
@@ -186,3 +186,117 @@ class TestResourceTemplate:
         assert isinstance(resource, FunctionResource)
         content = await resource.read()
         assert content == '"hello"'
+
+    def test_matches_prefix_exact_template(self):
+        """Test that templates match when prefix matches template exactly."""
+
+        def dummy_func() -> str:
+            return "data"
+
+        template = ResourceTemplate.from_function(
+            dummy_func, uri_template="http://api.example.com/users/{user_id}", name="test"
+        )
+
+        # Exact prefix of template
+        assert template.matches_prefix("http://api.example.com/users/")
+        assert template.matches_prefix("http://api.example.com/users")
+        assert template.matches_prefix("http://api.example.com/")
+        assert template.matches_prefix("http://")
+
+    def test_matches_prefix_partial_materialization(self):
+        """Test matching with partially materialized parameters."""
+
+        def dummy_func(user_id: str, post_id: str) -> str:
+            return f"User {user_id} Post {post_id}"
+
+        template = ResourceTemplate.from_function(
+            dummy_func, uri_template="http://api.example.com/users/{user_id}/posts/{post_id}", name="test"
+        )
+
+        # Partial materialization - user_id replaced with value
+        assert template.matches_prefix("http://api.example.com/users/123/")
+        assert template.matches_prefix("http://api.example.com/users/123/posts/")
+        assert template.matches_prefix("http://api.example.com/users/alice/posts/")
+
+        # Without trailing slash
+        assert template.matches_prefix("http://api.example.com/users/123")
+        assert template.matches_prefix("http://api.example.com/users/123/posts")
+
+    def test_matches_prefix_no_match_different_structure(self):
+        """Test that templates don't match when structure differs."""
+
+        def dummy_func(user_id: str) -> str:
+            return f"User {user_id}"
+
+        template = ResourceTemplate.from_function(
+            dummy_func, uri_template="http://api.example.com/users/{user_id}", name="test"
+        )
+
+        # Different path structure
+        assert not template.matches_prefix("http://api.example.com/products/")
+        assert not template.matches_prefix("http://api.example.com/users/123/invalid/")
+        assert not template.matches_prefix("http://different.com/users/")
+
+    def test_matches_prefix_complex_nested(self):
+        """Test matching with complex nested templates."""
+
+        def dummy_func(org_id: str, team_id: str, user_id: str) -> str:
+            return f"Org {org_id} Team {team_id} User {user_id}"
+
+        template = ResourceTemplate.from_function(
+            dummy_func, uri_template="http://api.example.com/orgs/{org_id}/teams/{team_id}/users/{user_id}", name="test"
+        )
+
+        # Various levels of partial materialization
+        assert template.matches_prefix("http://api.example.com/orgs/")
+        assert template.matches_prefix("http://api.example.com/orgs/acme/")
+        assert template.matches_prefix("http://api.example.com/orgs/acme/teams/")
+        assert template.matches_prefix("http://api.example.com/orgs/acme/teams/dev/")
+        assert template.matches_prefix("http://api.example.com/orgs/acme/teams/dev/users/")
+
+    def test_matches_prefix_file_uri(self):
+        """Test matching with file:// URI templates."""
+
+        def dummy_func(category: str, filename: str) -> str:
+            return f"File {category}/{filename}"
+
+        template = ResourceTemplate.from_function(
+            dummy_func, uri_template="file:///data/{category}/{filename}", name="test"
+        )
+
+        assert template.matches_prefix("file:///data/")
+        assert template.matches_prefix("file:///data/images/")
+        assert template.matches_prefix("file:///data/docs/")
+        assert not template.matches_prefix("file:///other/")
+
+    def test_matches_prefix_trailing_slash_semantics(self):
+        """Test that trailing slashes have semantic meaning."""
+
+        def dummy_func(id: str) -> str:
+            return f"Item {id}"
+
+        template = ResourceTemplate.from_function(
+            dummy_func, uri_template="http://api.example.com/items/{id}", name="test"
+        )
+
+        # Prefix without trailing slash matches (looking for items or under items)
+        assert template.matches_prefix("http://api.example.com/items")
+        assert template.matches_prefix("http://api.example.com/items/123")
+
+        # Prefix with trailing slash only matches if template generates something under it
+        assert template.matches_prefix("http://api.example.com/items/")  # template generates items/X
+        assert not template.matches_prefix("http://api.example.com/items/123/")  # template can't generate items/123/...
+
+    def test_matches_prefix_longer_than_template(self):
+        """Test that prefixes longer than template don't match."""
+
+        def dummy_func(id: str) -> str:
+            return f"Item {id}"
+
+        template = ResourceTemplate.from_function(
+            dummy_func, uri_template="http://api.example.com/items/{id}", name="test"
+        )
+
+        # Prefix has more segments than template
+        assert not template.matches_prefix("http://api.example.com/items/123/extra/")
+        assert not template.matches_prefix("http://api.example.com/items/123/extra/more/")

--- a/tests/server/test_session.py
+++ b/tests/server/test_session.py
@@ -100,7 +100,7 @@ async def test_server_capabilities():
 
     # Add a resources handler
     @server.list_resources()
-    async def list_resources():
+    async def list_resources(request: types.ListResourcesRequest):
         return []
 
     caps = server.get_capabilities(notification_options, experimental_capabilities)

--- a/tests/shared/test_memory.py
+++ b/tests/shared/test_memory.py
@@ -9,6 +9,7 @@ from mcp.shared.memory import (
 )
 from mcp.types import (
     EmptyResult,
+    ListResourcesRequest,
     Resource,
 )
 
@@ -18,7 +19,7 @@ def mcp_server() -> Server:
     server = Server(name="test_server")
 
     @server.list_resources()
-    async def handle_list_resources():
+    async def handle_list_resources(request: ListResourcesRequest):
         return [
             Resource(
                 uri=AnyUrl("memory://test"),


### PR DESCRIPTION
Implement support for prefix based filtering in list resources and resource templates  methods based on [SEP-1269](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1269)

## Motivation and Context
This helps clients navigate through large lists of resources exposed by a server efficiently.

## How Has This Been Tested?
Added unit new tests

## Breaking Changes
Should be backward compatible for new clients

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
[SEP-1269](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1269)