### PR TITLE
Fix : token_endpoint_auth_signing_alg_values_supported is a json array

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -117,7 +117,7 @@ class OAuthMetadata(BaseModel):
     response_modes_supported: list[Literal["query", "fragment", "form_post"]] | None = None
     grant_types_supported: list[str] | None = None
     token_endpoint_auth_methods_supported: list[str] | None = None
-    token_endpoint_auth_signing_alg_values_supported: None = None
+    token_endpoint_auth_signing_alg_values_supported: list[str] | None = None
     service_documentation: AnyHttpUrl | None = None
     ui_locales_supported: list[str] | None = None
     op_policy_uri: AnyHttpUrl | None = None


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Fixes the OAuthMetadata model validated by Pydantic, token_endpoint_auth_signing_alg_values_supported has to be a list of string, or validation would fail
## How Has This Been Tested?
Tested against an Auth0 oauth implementation

## Breaking Changes
No

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed


