### PR TITLE
chore: Remove unused var notification_options

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -149,7 +149,6 @@ class Server(Generic[LifespanResultT, RequestT]):
             types.PingRequest: _ping_handler,
         }
         self.notification_handlers: dict[type, Callable[..., Awaitable[None]]] = {}
-        self.notification_options = NotificationOptions()
         self._tool_cache: dict[str, types.Tool] = {}
         logger.debug("Initializing server %r", name)
 


### PR DESCRIPTION
Removing the unused instance variable notification_options from the server. A new variable is instantiated and initialized in __init__ but never used. Instead fresh notification_options object is accepted as an argument in the create_initialization_options and get_capabilities functions.

## Motivation and Context
This removes confusion about the use of notification_options in the server.

## How Has This Been Tested?
Existing tests work as expected

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
None