### PR TITLE
Remove strict validation on `response_modes_supported` member of `OAuthMetadata`

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -114,7 +114,7 @@ class OAuthMetadata(BaseModel):
     registration_endpoint: AnyHttpUrl | None = None
     scopes_supported: list[str] | None = None
     response_types_supported: list[str] = ["code"]
-    response_modes_supported: list[Literal["query", "fragment", "form_post"]] | None = None
+    response_modes_supported: list[str] | None = None
     grant_types_supported: list[str] | None = None
     token_endpoint_auth_methods_supported: list[str] | None = None
     token_endpoint_auth_signing_alg_values_supported: list[str] | None = None

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -37,3 +37,25 @@ class TestOAuthMetadata:
                 "userinfo_endpoint": "https://example.com/oauth2/userInfo",
             }
         )
+
+    def test_oauth_with_jarm(self):
+        """Should not throw when parsing OAuth metadata that includes JARM response modes."""
+        OAuthMetadata.model_validate(
+            {
+                "issuer": "https://example.com",
+                "authorization_endpoint": "https://example.com/oauth2/authorize",
+                "token_endpoint": "https://example.com/oauth2/token",
+                "scopes_supported": ["read", "write"],
+                "response_types_supported": ["code", "token"],
+                "response_modes_supported": [
+                    "query",
+                    "fragment",
+                    "form_post",
+                    "query.jwt",
+                    "fragment.jwt",
+                    "form_post.jwt",
+                    "jwt",
+                ],
+                "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
+            }
+        )


### PR DESCRIPTION
Allows compatibility with servers that support the JWT Secured Authorization response mode per https://openid.net/specs/oauth-v2-jarm.html#name-authorization-server-metada

Resolves #1242 

<!-- Provide a brief summary of your changes -->

## Motivation and Context
Fixes OAuth flow when using Keycloak (or any auth server that supports JARM)

## How Has This Been Tested?
Tested using remote OAuth2.0 flow with FastMCP and Keycloak

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None
