### PR TITLE
feat: support progress_callback propagation in ClientSession (issue #1248)

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -112,6 +112,7 @@ class ClientSession(
         read_stream: MemoryObjectReceiveStream[SessionMessage | Exception],
         write_stream: MemoryObjectSendStream[SessionMessage],
         read_timeout_seconds: timedelta | None = None,
+        progress_callback: ProgressFnT | None = None,
         sampling_callback: SamplingFnT | None = None,
         elicitation_callback: ElicitationFnT | None = None,
         list_roots_callback: ListRootsFnT | None = None,
@@ -127,6 +128,7 @@ class ClientSession(
             read_timeout_seconds=read_timeout_seconds,
         )
         self._client_info = client_info or DEFAULT_CLIENT_INFO
+        self._progress_callback = progress_callback
         self._sampling_callback = sampling_callback or _default_sampling_callback
         self._elicitation_callback = elicitation_callback or _default_elicitation_callback
         self._list_roots_callback = list_roots_callback or _default_list_roots_callback
@@ -302,7 +304,7 @@ class ClientSession(
             ),
             types.CallToolResult,
             request_read_timeout_seconds=read_timeout_seconds,
-            progress_callback=progress_callback,
+            progress_callback=progress_callback or self._progress_callback,
         )
 
         if not result.isError:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This change introduces support for injecting a default `progress_handler` into `ClientSession`. It solves the issue where downstream libraries (e.g., LangChain's MCP adapter) access the raw `client.session` and make tool calls that bypass the top-level `fastmcp.Client`’s `progress_handler`, leading to missing progress reports. With this enhancement, consistent progress reporting is ensured whether tools are called through the high-level client or the lower-level session.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This feature has been tested within an async environment using:

- Direct calls to `ClientSession.call_tool(...)` to ensure the default handler is triggered.
- Calls with explicitly provided `progress_callback` to ensure override behavior works correctly.
- Integration with `langchain_mcp_adapters` to confirm downstream compatibility and improved reporting.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This enhancement is backward-compatible. Existing users who do not pass a `progress_handler` will see no change in behavior. Users who want consistent progress reporting can optionally provide a handler to `ClientSession`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This feature enables clean integration with ecosystem libraries like LangChain without requiring redundant progress callback plumbing at every call site.