### PR TITLE
Add PATHEXT to default env vars in windows

### DIFF
--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -32,6 +32,7 @@ DEFAULT_INHERITED_ENV_VARS = (
         "HOMEPATH",
         "LOCALAPPDATA",
         "PATH",
+        "PATHEXT",
         "PROCESSOR_ARCHITECTURE",
         "SYSTEMDRIVE",
         "SYSTEMROOT",


### PR DESCRIPTION
Add PATHEXT to default env vars in windows

## Motivation and Context
The PATHEXT env var is required for the subprocess to be able to find many executable and other files

## How Has This Been Tested?
Yes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
