### PR TITLE
Consistent casing for default headers Accept and Content-Type

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -42,7 +42,7 @@ GetSessionIdCallback = Callable[[], str | None]
 MCP_SESSION_ID = "mcp-session-id"
 MCP_PROTOCOL_VERSION = "mcp-protocol-version"
 LAST_EVENT_ID = "last-event-id"
-CONTENT_TYPE = "content-type"
+CONTENT_TYPE = "Content-Type"
 ACCEPT = "Accept"
 
 

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -42,8 +42,8 @@ GetSessionIdCallback = Callable[[], str | None]
 MCP_SESSION_ID = "mcp-session-id"
 MCP_PROTOCOL_VERSION = "mcp-protocol-version"
 LAST_EVENT_ID = "last-event-id"
-CONTENT_TYPE = "Content-Type"
-ACCEPT = "Accept"
+CONTENT_TYPE = "content-type"
+ACCEPT = "accept"
 
 
 JSON = "application/json"


### PR DESCRIPTION
## Motivation and Context

- `Accept` uses pascal casing
- `content-type` uses lowercase

Aligning `Accept to also use lowercase.

## How Has This Been Tested?

```
uv run pytest 
```

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

N/A