### PR TITLE
fix: allow elicitations accepted without content

### DIFF
--- a/src/mcp/server/elicitation.py
+++ b/src/mcp/server/elicitation.py
@@ -98,7 +98,7 @@ async def elicit_with_validation(
         related_request_id=related_request_id,
     )
 
-    if result.action == "accept" and result.content:
+    if result.action == "accept" and result.content is not None:
         # Validate and parse the content using the schema
         validated_data = schema.model_validate(result.content)
         return AcceptedElicitation(data=validated_data)


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This change allows to handle elicitations without any data, just the user action.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The change allows to create very simple "Accept / Reject / Cancel" elicitations without check boxes or input data for the user.

cf: https://github.com/modelcontextprotocol/python-sdk/issues/1284

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Yes we have an MCP server which allows create and update documents in a database, and we have an elicitation requiring the user to accept the action

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No, the behavior is exactly the same for all the elicitations which actually require data.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The behavior is possible with the typescript sdk, but not the python sdk:

```
   const result = await server.server.elicitInput({
       message: `${confirmationMessage}`,
        requestedSchema: {
         type: "object",
         properties: {
         },
         required: []
       }
     });  
     if (result.action === "accept") { 
       log.warn(`User accepted usage of ${toolName}`, {
         user: userEmail,
       });
       return true;
     } else {
...

```