### PR TITLE
chore: uncomment .idea/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # vscode
 .vscode/


### PR DESCRIPTION
## Summary
Uncomment the `.idea/` entry in .gitignore to properly ignore JetBrains IDE configuration files.

## Changes
- Uncommented the `.idea/` line in .gitignore (line 165)

## Rationale
This prevents IDE-specific settings and configuration files from being accidentally committed to the repository, keeping the codebase clean of development environment artifacts.

🤖 Generated with [Claude Code](https://claude.ai/code)