### PR TITLE
Remove "unconditionally" from conditional description

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -360,7 +360,7 @@ class FastMCP(Generic[LifespanResultT]):
             annotations: Optional ToolAnnotations providing additional tool information
             structured_output: Controls whether the tool's output is structured or unstructured
                 - If None, auto-detects based on the function's return type annotation
-                - If True, unconditionally creates a structured tool (return type annotation permitting)
+                - If True, creates a structured tool (return type annotation permitting)
                 - If False, unconditionally creates an unstructured tool
         """
         self._tool_manager.add_tool(
@@ -393,7 +393,7 @@ class FastMCP(Generic[LifespanResultT]):
             annotations: Optional ToolAnnotations providing additional tool information
             structured_output: Controls whether the tool's output is structured or unstructured
                 - If None, auto-detects based on the function's return type annotation
-                - If True, unconditionally creates a structured tool (return type annotation permitting)
+                - If True, creates a structured tool (return type annotation permitting)
                 - If False, unconditionally creates an unstructured tool
 
         Example:

--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -187,7 +187,7 @@ def func_metadata(
             the model.
         structured_output: Controls whether the tool's output is structured or unstructured
             - If None, auto-detects based on the function's return type annotation
-            - If True, unconditionally creates a structured tool (return type annotation permitting)
+            - If True, creates a structured tool (return type annotation permitting)
             - If False, unconditionally creates an unstructured tool
 
         If structured, creates a Pydantic model for the function's result based on its annotation.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

The current docstrings regarding tool creation read, "unconditionally creates a structured tool (return type annotation permitting)". If the return type annotation limits whether or not a structured tool can be created, then creation of a structured tool is *conditional* upon the presence of a proper return type annotation. Therefore, these descriptions should not include the word "unconditionally", as it is inaccurate and contradictory.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Certain docstrings are self-contradictory, which is either a mistake or an indication that the description is not sufficiently clear.

## How Has This Been Tested?
Since this changes only docstrings, it has not been tested.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed