### PR TITLE
SDK Parity: Avoid Parsing Server Response for non-JsonRPCMessage Requests

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -279,11 +279,10 @@ class StreamableHTTPTransport:
             if is_initialization:
                 self._maybe_extract_session_id_from_response(response)
 
-            content_type = response.headers.get(CONTENT_TYPE, "").lower()
-
             # Per https://modelcontextprotocol.io/specification/2025-06-18/basic#notifications:
             # The server MUST NOT send a response to notifications.
             if isinstance(message.root, JSONRPCRequest):
+                content_type = response.headers.get(CONTENT_TYPE, "").lower()
                 if content_type.startswith(JSON):
                     await self._handle_json_response(response, ctx.read_stream_writer, is_initialization)
                 elif content_type.startswith(SSE):

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -281,6 +281,8 @@ class StreamableHTTPTransport:
 
             content_type = response.headers.get(CONTENT_TYPE, "").lower()
 
+            # Per https://modelcontextprotocol.io/specification/2025-06-18/basic#notifications:
+            # The server MUST NOT send a response to notifications.
             if isinstance(message.root, JSONRPCRequest):
                 if content_type.startswith(JSON):
                     await self._handle_json_response(response, ctx.read_stream_writer, is_initialization)

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -281,15 +281,16 @@ class StreamableHTTPTransport:
 
             content_type = response.headers.get(CONTENT_TYPE, "").lower()
 
-            if content_type.startswith(JSON):
-                await self._handle_json_response(response, ctx.read_stream_writer, is_initialization)
-            elif content_type.startswith(SSE):
-                await self._handle_sse_response(response, ctx, is_initialization)
-            else:
-                await self._handle_unexpected_content_type(
-                    content_type,
-                    ctx.read_stream_writer,
-                )
+            if isinstance(message.root, JSONRPCRequest):
+                if content_type.startswith(JSON):
+                    await self._handle_json_response(response, ctx.read_stream_writer, is_initialization)
+                elif content_type.startswith(SSE):
+                    await self._handle_sse_response(response, ctx, is_initialization)
+                else:
+                    await self._handle_unexpected_content_type(
+                        content_type,
+                        ctx.read_stream_writer,
+                    )
 
     async def _handle_json_response(
         self,

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -13,7 +13,6 @@ from collections.abc import Generator
 
 import pytest
 import uvicorn
-from mcp.shared.session import RequestResponder
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -21,7 +20,8 @@ from starlette.routing import Route
 
 from mcp import ClientSession, types
 from mcp.client.streamable_http import streamablehttp_client
-from mcp.types import ClientNotification, Implementation, RootsListChangedNotification
+from mcp.shared.session import RequestResponder
+from mcp.types import ClientNotification, RootsListChangedNotification
 
 
 def create_non_sdk_server_app() -> Starlette:

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -116,11 +116,11 @@ def non_sdk_server(non_sdk_server_port: int) -> Generator[None, None, None]:
 @pytest.mark.anyio
 async def test_non_compliant_notification_response(non_sdk_server: None, non_sdk_server_port: int) -> None:
     """
-   This test verifies that the client ignores unexpected responses to notifications: the spec states they should
-   either be 202 + no response body, or 4xx + optional error body
-   (https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server),
-   but some servers wrongly return other 2xx codes (e.g. 204). For now we simply ignore unexpected responses
-   (aligning behaviour w/ the TS SDK).
+    This test verifies that the client ignores unexpected responses to notifications: the spec states they should
+    either be 202 + no response body, or 4xx + optional error body
+    (https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server),
+    but some servers wrongly return other 2xx codes (e.g. 204). For now we simply ignore unexpected responses
+    (aligning behaviour w/ the TS SDK).
     """
     server_url = f"http://127.0.0.1:{non_sdk_server_port}/mcp"
     returned_exception = None

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -115,12 +115,10 @@ def non_sdk_server(non_sdk_server_port: int) -> Generator[None, None, None]:
 
 @pytest.mark.anyio
 async def test_notification_with_204_response(non_sdk_server: None, non_sdk_server_port: int) -> None:
-    """Test that client handles 204 responses to notifications correctly.
-
-    This test verifies the fix for the issue where non-SDK servers
-    might return 204 No Content for notifications instead of 202 Accepted.
-    The client should handle this gracefully without trying to parse
-    the response body.
+    """
+    This test verifies that the client does not parse responses to non-JsonRPCRequests, which matches the
+    behavior of the TypeScript SDK. The test uses a 204 No Content (commonly seen from servers), but in reality
+    any 2xx response should be handled the same way.
     """
     server_url = f"http://127.0.0.1:{non_sdk_server_port}/mcp"
     returned_exception = None

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -1,0 +1,169 @@
+"""
+Tests for StreamableHTTP client transport with non-SDK servers.
+
+These tests verify client behavior when interacting with servers
+that don't follow SDK conventions.
+"""
+
+import json
+import multiprocessing
+import socket
+import time
+from collections.abc import Generator
+
+import pytest
+import uvicorn
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.types import ClientNotification, Implementation, RootsListChangedNotification
+
+
+def create_non_sdk_server_app() -> Starlette:
+    """Create a minimal server that doesn't follow SDK conventions."""
+    
+    async def handle_mcp_request(request: Request) -> Response:
+        """Handle MCP requests with non-standard responses."""
+        try:
+            body = await request.body()
+            data = json.loads(body)
+            
+            # Handle initialize request normally
+            if data.get("method") == "initialize":
+                response_data = {
+                    "jsonrpc": "2.0",
+                    "id": data["id"],
+                    "result": {
+                        "serverInfo": {
+                            "name": "test-non-sdk-server",
+                            "version": "1.0.0"
+                        },
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {}
+                    }
+                }
+                return JSONResponse(response_data)
+            
+            # For notifications, return 204 No Content (non-SDK behavior)
+            if "id" not in data:
+                return Response(status_code=204)
+            
+            # Default response for other requests
+            return JSONResponse({
+                "jsonrpc": "2.0",
+                "id": data.get("id"),
+                "error": {
+                    "code": -32601,
+                    "message": "Method not found"
+                }
+            })
+            
+        except Exception as e:
+            return JSONResponse(
+                {"error": f"Server error: {str(e)}"},
+                status_code=500
+            )
+    
+    app = Starlette(
+        debug=True,
+        routes=[
+            Route("/mcp", handle_mcp_request, methods=["POST"]),
+        ],
+    )
+    return app
+
+
+def run_non_sdk_server(port: int) -> None:
+    """Run the non-SDK server in a separate process."""
+    app = create_non_sdk_server_app()
+    config = uvicorn.Config(
+        app=app,
+        host="127.0.0.1",
+        port=port,
+        log_level="error",  # Reduce noise in tests
+    )
+    server = uvicorn.Server(config=config)
+    server.run()
+
+
+@pytest.fixture
+def non_sdk_server_port() -> int:
+    """Get an available port for the test server."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def non_sdk_server(non_sdk_server_port: int) -> Generator[None, None, None]:
+    """Start a non-SDK server for testing."""
+    proc = multiprocessing.Process(
+        target=run_non_sdk_server, 
+        kwargs={"port": non_sdk_server_port}, 
+        daemon=True
+    )
+    proc.start()
+    
+    # Wait for server to be ready
+    start_time = time.time()
+    while time.time() - start_time < 10:
+        try:
+            with socket.create_connection(("127.0.0.1", non_sdk_server_port), timeout=0.1):
+                break
+        except (TimeoutError, ConnectionRefusedError):
+            time.sleep(0.1)
+    else:
+        proc.kill()
+        proc.join(timeout=2)
+        pytest.fail("Server failed to start within 10 seconds")
+    
+    yield
+    
+    proc.kill()
+    proc.join(timeout=2)
+
+
+@pytest.mark.anyio
+async def test_notification_with_204_response(
+    non_sdk_server: None, 
+    non_sdk_server_port: int
+) -> None:
+    """Test that client handles 204 responses to notifications correctly.
+    
+    This test verifies the fix for the issue where non-SDK servers
+    might return 204 No Content for notifications instead of 202 Accepted.
+    The client should handle this gracefully without trying to parse
+    the response body.
+    """
+    server_url = f"http://127.0.0.1:{non_sdk_server_port}/mcp"
+    
+    async with streamablehttp_client(server_url) as (read_stream, write_stream, get_session_id):
+        async with ClientSession(
+            read_stream, 
+            write_stream,
+            client_info=Implementation(name="test-client", version="1.0.0")
+        ) as session:
+            # Initialize should work normally
+            await session.initialize()
+            
+            # Send a notification - this should not raise an error
+            # even though the server returns 204 instead of 202
+            notification_sent = False
+            try:
+                await session.send_notification(
+                    ClientNotification(
+                        RootsListChangedNotification(
+                            method="notifications/roots/list_changed",
+                            params={}
+                        )
+                    )
+                )
+                notification_sent = True
+            except Exception as e:
+                pytest.fail(f"Notification failed with 204 response: {e}")
+            
+            assert notification_sent, "Notification should have been sent successfully"

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -26,52 +26,38 @@ from mcp.types import ClientNotification, Implementation, RootsListChangedNotifi
 
 def create_non_sdk_server_app() -> Starlette:
     """Create a minimal server that doesn't follow SDK conventions."""
-    
+
     async def handle_mcp_request(request: Request) -> Response:
         """Handle MCP requests with non-standard responses."""
         try:
             body = await request.body()
             data = json.loads(body)
-            
+
             # Handle initialize request normally
             if data.get("method") == "initialize":
                 response_data = {
                     "jsonrpc": "2.0",
                     "id": data["id"],
                     "result": {
-                        "serverInfo": {
-                            "name": "test-non-sdk-server",
-                            "version": "1.0.0"
-                        },
+                        "serverInfo": {"name": "test-non-sdk-server", "version": "1.0.0"},
                         "protocolVersion": "2024-11-05",
-                        "capabilities": {}
-                    }
+                        "capabilities": {},
+                    },
                 }
                 return JSONResponse(response_data)
-            
+
             # For notifications, return 204 No Content (non-SDK behavior)
             if "id" not in data:
-                return Response(
-                    status_code=204, 
-                    headers={"Content-Type": "application/json"}
-                )
-            
+                return Response(status_code=204, headers={"Content-Type": "application/json"})
+
             # Default response for other requests
-            return JSONResponse({
-                "jsonrpc": "2.0",
-                "id": data.get("id"),
-                "error": {
-                    "code": -32601,
-                    "message": "Method not found"
-                }
-            })
-            
-        except Exception as e:
             return JSONResponse(
-                {"error": f"Server error: {str(e)}"},
-                status_code=500
+                {"jsonrpc": "2.0", "id": data.get("id"), "error": {"code": -32601, "message": "Method not found"}}
             )
-    
+
+        except Exception as e:
+            return JSONResponse({"error": f"Server error: {str(e)}"}, status_code=500)
+
     app = Starlette(
         debug=True,
         routes=[
@@ -105,13 +91,9 @@ def non_sdk_server_port() -> int:
 @pytest.fixture
 def non_sdk_server(non_sdk_server_port: int) -> Generator[None, None, None]:
     """Start a non-SDK server for testing."""
-    proc = multiprocessing.Process(
-        target=run_non_sdk_server, 
-        kwargs={"port": non_sdk_server_port}, 
-        daemon=True
-    )
+    proc = multiprocessing.Process(target=run_non_sdk_server, kwargs={"port": non_sdk_server_port}, daemon=True)
     proc.start()
-    
+
     # Wait for server to be ready
     start_time = time.time()
     while time.time() - start_time < 10:
@@ -124,20 +106,17 @@ def non_sdk_server(non_sdk_server_port: int) -> Generator[None, None, None]:
         proc.kill()
         proc.join(timeout=2)
         pytest.fail("Server failed to start within 10 seconds")
-    
+
     yield
-    
+
     proc.kill()
     proc.join(timeout=2)
 
 
 @pytest.mark.anyio
-async def test_notification_with_204_response(
-    non_sdk_server: None, 
-    non_sdk_server_port: int
-) -> None:
+async def test_notification_with_204_response(non_sdk_server: None, non_sdk_server_port: int) -> None:
     """Test that client handles 204 responses to notifications correctly.
-    
+
     This test verifies the fix for the issue where non-SDK servers
     might return 204 No Content for notifications instead of 202 Accepted.
     The client should handle this gracefully without trying to parse
@@ -145,31 +124,29 @@ async def test_notification_with_204_response(
     """
     server_url = f"http://127.0.0.1:{non_sdk_server_port}/mcp"
     returned_exception = None
-    async def message_handler(message: RequestResponder[types.ServerRequest, types.ClientResult] | types.ServerNotification | Exception):
+
+    async def message_handler(
+        message: RequestResponder[types.ServerRequest, types.ClientResult] | types.ServerNotification | Exception,
+    ):
         nonlocal returned_exception
         if isinstance(message, Exception):
             returned_exception = message
 
     async with streamablehttp_client(server_url) as (read_stream, write_stream, get_session_id):
         async with ClientSession(
-            read_stream, 
+            read_stream,
             write_stream,
             message_handler=message_handler,
         ) as session:
             # Initialize should work normally
             await session.initialize()
-            
+
             # Send a notification - this should not raise an error
             # even though the server returns 204 instead of 202
             # Without the fix, this would fail with a JSON parsing error
             # because the client would try to parse the empty 204 response body
             await session.send_notification(
-                ClientNotification(
-                    RootsListChangedNotification(
-                        method="notifications/roots/list_changed",
-                        params={}
-                    )
-                )
+                ClientNotification(RootsListChangedNotification(method="notifications/roots/list_changed", params={}))
             )
 
     if returned_exception:

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -132,7 +132,7 @@ async def test_notification_with_204_response(non_sdk_server: None, non_sdk_serv
         if isinstance(message, Exception):
             returned_exception = message
 
-    async with streamablehttp_client(server_url) as (read_stream, write_stream, get_session_id):
+    async with streamablehttp_client(server_url) as (read_stream, write_stream, _):
         async with ClientSession(
             read_stream,
             write_stream,
@@ -143,7 +143,7 @@ async def test_notification_with_204_response(non_sdk_server: None, non_sdk_serv
 
             # The test server returns a 204 instead of the expected 202
             await session.send_notification(
-                ClientNotification(RootsListChangedNotification(method="notifications/roots/list_changed", params={}))
+                ClientNotification(RootsListChangedNotification(method="notifications/roots/list_changed"))
             )
 
     if returned_exception:

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -141,10 +141,7 @@ async def test_notification_with_204_response(non_sdk_server: None, non_sdk_serv
             # Initialize should work normally
             await session.initialize()
 
-            # Send a notification - this should not raise an error
-            # even though the server returns 204 instead of 202
-            # Without the fix, this would fail with a JSON parsing error
-            # because the client would try to parse the empty 204 response body
+            # The test server returns a 204 instead of the expected 202
             await session.send_notification(
                 ClientNotification(RootsListChangedNotification(method="notifications/roots/list_changed", params={}))
             )

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -114,11 +114,13 @@ def non_sdk_server(non_sdk_server_port: int) -> Generator[None, None, None]:
 
 
 @pytest.mark.anyio
-async def test_notification_with_204_response(non_sdk_server: None, non_sdk_server_port: int) -> None:
+async def test_non_compliant_notification_response(non_sdk_server: None, non_sdk_server_port: int) -> None:
     """
-    This test verifies that the client does not parse responses to non-JsonRPCRequests, which matches the
-    behavior of the TypeScript SDK. The test uses a 204 No Content (commonly seen from servers), but in reality
-    any 2xx response should be handled the same way.
+   This test verifies that the client ignores unexpected responses to notifications: the spec states they should
+   either be 202 + no response body, or 4xx + optional error body
+   (https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server),
+   but some servers wrongly return other 2xx codes (e.g. 204). For now we simply ignore unexpected responses
+   (aligning behaviour w/ the TS SDK).
     """
     server_url = f"http://127.0.0.1:{non_sdk_server_port}/mcp"
     returned_exception = None


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Achieve parity with the TypeScript SDK by only parsing server responses to JsonRPCRequests.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
In the TypeScript SDK, server responses are only parsed if the request is a JsonRPCRequest (ie. has "method" and "id" fields) - [link](https://github.com/modelcontextprotocol/typescript-sdk/blob/3bc2235d747c320dfa0b6227cc84414c6d0add89/src/client/streamableHttp.ts#L472). Otherwise, the response is ignored. Here in the Python SDK, all responses are parsed. Concretely, we've seen in the wild that servers may try to respond to notifications with a 204 No content rather than a 202 Accepted (which is special cased in both SDKs), resulting in a Pydantic validation error. Subsequently, server developers are confused why their servers work with clients presumably using the TypeScript SDK, but not ones using the Python SDK. 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

This PR includes a test.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No. Per the MCP protocol, the server should not respond to notifications. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
