### PR TITLE
Allow ping requests before initialization

### DIFF
--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -161,6 +161,9 @@ class ServerSession(
                             )
                         )
                     )
+            case types.PingRequest():
+                # Ping requests are allowed at any time
+                pass
             case _:
                 if self._initialization_state != InitializationState.Initialized:
                     raise RuntimeError("Received request before initialization was complete")


### PR DESCRIPTION
Fix #1311

Allow the MCP server to respond the ping requests even if initialization hasn't happened yet, as per the spec.

## Motivation and Context
The MCP specification states that pings should be allowed before initialization, but this SDK doesn't permit them and fail the request.

## How Has This Been Tested?
Unit tests were added.
This was tested with a sample MCP server and client, ensuring that the client is allowed to first send a ping request and subsequently send an initialize request.

## Breaking Changes
No breaking changs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
