### PR TITLE
chore: add ability to remove tools

### DIFF
--- a/src/mcp/server/fastmcp/tools/tool_manager.py
+++ b/src/mcp/server/fastmcp/tools/tool_manager.py
@@ -72,6 +72,7 @@ class ToolManager:
         """Remove a tool by name."""
         if name not in self._tools:
             logger.warning(f"Tried to remove unknown tool: {name}")
+            return
         del self._tools[name]
 
     async def call_tool(

--- a/src/mcp/server/fastmcp/tools/tool_manager.py
+++ b/src/mcp/server/fastmcp/tools/tool_manager.py
@@ -68,6 +68,12 @@ class ToolManager:
         self._tools[tool.name] = tool
         return tool
 
+    def remove_tool(self, name: str) -> None:
+        """Remove a tool by name."""
+        if name not in self._tools:
+            logger.warning(f"Tried to remove unknown tool: {name}")
+        del self._tools[name]
+
     async def call_tool(
         self,
         name: str,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
I am interested in being able to dynamically have a server offer only certain tools based on information received during its initialization. I could conditionally declare the tool, for instance:
```
if cond:
  @mcp.tool
  async def foo():
    ...
```
but I perceive this to be relatively gross. I would prefer to be able to remove a tool within the API.

## How Has This Been Tested?
I can achieve comparable behavior by inserting an `if` before defining a function with the `mcp.tool()` decorator.

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
