### PR TITLE
changes structured temperature to not deadly

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ def get_weather(city: str) -> WeatherData:
     """Get weather for a city - returns structured data."""
     # Simulated weather data
     return WeatherData(
-        temperature=72.5,
+        temperature=22.5,
         humidity=45.0,
         condition="sunny",
         wind_speed=5.2,

--- a/examples/snippets/servers/structured_output.py
+++ b/examples/snippets/servers/structured_output.py
@@ -24,7 +24,7 @@ def get_weather(city: str) -> WeatherData:
     """Get weather for a city - returns structured data."""
     # Simulated weather data
     return WeatherData(
-        temperature=72.5,
+        temperature=22.5,
         humidity=45.0,
         condition="sunny",
         wind_speed=5.2,

--- a/tests/server/fastmcp/test_integration.py
+++ b/tests/server/fastmcp/test_integration.py
@@ -693,7 +693,7 @@ async def test_structured_output(server_transport: str, server_url: str) -> None
 
             # Check that the result contains expected weather data
             result_text = weather_result.content[0].text
-            assert "72.5" in result_text  # temperature
+            assert "22.5" in result_text  # temperature
             assert "sunny" in result_text  # condition
             assert "45" in result_text  # humidity
             assert "5.2" in result_text  # wind_speed


### PR DESCRIPTION
Changed the example in structured output snippet to show 22.5 C instead of 72.5 C for logical example.

closes #1327 

## Motivation and Context

This change only makes the structured output snippet easier for humans to understand seeing how the structure (temperature in Celsius) is consistent with the example value: 22.5 (was 72.5...which is deadly)

## How Has This Been Tested?
documentation only - changes one number in structured output example snippet

## Breaking Changes
documentation only - changes one number in structured output example snippet

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x ] I have added or updated documentation as needed

## Additional context
none. documentation only.
