### PR TITLE
Update simple-resource example to use non-deprecated read_resource return type

### DIFF
--- a/examples/servers/simple-resource/mcp_simple_resource/server.py
+++ b/examples/servers/simple-resource/mcp_simple_resource/server.py
@@ -2,6 +2,7 @@ import anyio
 import click
 import mcp.types as types
 from mcp.server.lowlevel import Server
+from mcp.server.lowlevel.helper_types import ReadResourceContents
 from pydantic import AnyUrl, FileUrl
 from starlette.requests import Request
 
@@ -46,7 +47,7 @@ def main(port: int, transport: str) -> int:
         ]
 
     @app.read_resource()
-    async def read_resource(uri: AnyUrl) -> str | bytes:
+    async def read_resource(uri: AnyUrl):
         if uri.path is None:
             raise ValueError(f"Invalid resource path: {uri}")
         name = uri.path.replace(".txt", "").lstrip("/")
@@ -54,7 +55,7 @@ def main(port: int, transport: str) -> int:
         if name not in SAMPLE_RESOURCES:
             raise ValueError(f"Unknown resource: {uri}")
 
-        return SAMPLE_RESOURCES[name]["content"]
+        return [ReadResourceContents(content=SAMPLE_RESOURCES[name]["content"], mime_type="text/plain")]
 
     if transport == "sse":
         from mcp.server.sse import SseServerTransport


### PR DESCRIPTION
Returning `str | bytes` from `read_resource` functions is [deprecated](https://github.com/modelcontextprotocol/python-sdk/blob/1644b822b31cefb6c257ac28bee6a02ae999225a/src/mcp/server/lowlevel/server.py#L314-L319). Updating this example to use `Iterable[ReadResourceContents]`.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Motivation and Context
Examples should use the preferred APIs to set a good example and help users understand how to use the APIs. See e.g. https://github.com/modelcontextprotocol/python-sdk/issues/1320

## How Has This Been Tested?
```
npx -y @modelcontextprotocol/inspector uv run mcp-simple-resource
```
Fetched all resources via inspector.

## Breaking Changes
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
N/A
