### PR TITLE
Return HTTP 403 for invalid Origin headers

### DIFF
--- a/src/mcp/server/transport_security.py
+++ b/src/mcp/server/transport_security.py
@@ -122,6 +122,6 @@ class TransportSecurityMiddleware:
         # Validate Origin header
         origin = request.headers.get("origin")
         if not self._validate_origin(origin):
-            return Response("Invalid Origin header", status_code=400)
+            return Response("Invalid Origin header", status_code=403)
 
         return None

--- a/tests/server/test_sse_security.py
+++ b/tests/server/test_sse_security.py
@@ -127,7 +127,7 @@ async def test_sse_security_invalid_origin_header(server_port: int):
 
         async with httpx.AsyncClient() as client:
             response = await client.get(f"http://127.0.0.1:{server_port}/sse", headers=headers)
-            assert response.status_code == 400
+            assert response.status_code == 403
             assert response.text == "Invalid Origin header"
 
     finally:

--- a/tests/server/test_streamable_http_security.py
+++ b/tests/server/test_streamable_http_security.py
@@ -155,7 +155,7 @@ async def test_streamable_http_security_invalid_origin_header(server_port: int):
                 json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
                 headers=headers,
             )
-            assert response.status_code == 400
+            assert response.status_code == 403
             assert response.text == "Invalid Origin header"
 
     finally:


### PR DESCRIPTION
If https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1439 is accepted, this PR changes the HTTP status code for invalid Origin headers from 400 (Bad Request) to 403 (Forbidden) to match the updated spec.

## Motivation and Context
https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1398

## How Has This Been Tested?
Unit tests updated and run.

## Breaking Changes
See https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1398 - technically a breaking change, but some servers (e.g. TS SDK) already return 403.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
