### PR TITLE
Adds meta parameter and method for LLM hidden info

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -286,7 +286,7 @@ class ClientSession(
                     params=types.CallToolRequestParams(
                         name=name,
                         arguments=arguments,
-                        **({'_meta': request_meta} if request_meta else {}),
+                        **({"_meta": request_meta} if request_meta else {}),
                     ),
                 )
             ),

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -271,10 +271,14 @@ class ClientSession(
         self,
         name: str,
         arguments: dict[str, Any] | None = None,
+        meta: dict[str, Any] | None = None,
         read_timeout_seconds: timedelta | None = None,
         progress_callback: ProgressFnT | None = None,
     ) -> types.CallToolResult:
         """Send a tools/call request with optional progress callback support."""
+        request_meta = None
+        if meta:
+            request_meta = types.RequestParams.Meta(**meta)
 
         result = await self.send_request(
             types.ClientRequest(
@@ -282,6 +286,7 @@ class ClientSession(
                     params=types.CallToolRequestParams(
                         name=name,
                         arguments=arguments,
+                        **({'_meta': request_meta} if request_meta else {}),
                     ),
                 )
             ),

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -1036,9 +1036,10 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
         # Access resources
         data = ctx.read_resource("resource://data")
 
-        # Get request info
+        # Get request info and metadata
         request_id = ctx.request_id
         client_id = ctx.client_id
+        user_meta = ctx.request_meta
 
         return str(x)
     ```
@@ -1171,6 +1172,15 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
     def request_id(self) -> str:
         """Get the unique ID for this request."""
         return str(self.request_context.request_id)
+
+    @property
+    def request_meta(self) -> dict[str, Any]:
+        """Get the request metadata (hidden data passed from client)."""
+        if not self.request_context.meta:
+            return {}
+
+        meta_dict = self.request_context.meta.model_dump(exclude={'progressToken'})
+        return meta_dict
 
     @property
     def session(self):

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -1179,7 +1179,7 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
         if not self.request_context.meta:
             return {}
 
-        meta_dict = self.request_context.meta.model_dump(exclude={'progressToken'})
+        meta_dict = self.request_context.meta.model_dump(exclude={"progressToken"})
         return meta_dict
 
     @property

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Any
 
 import anyio
@@ -24,8 +25,6 @@ from mcp.types import (
     ServerCapabilities,
     ServerResult,
 )
-import inspect
-from mcp.client.session import ClientSession
 
 
 @pytest.mark.anyio
@@ -500,14 +499,15 @@ async def test_client_capabilities_with_custom_callbacks():
     assert isinstance(received_capabilities.roots, types.RootsCapability)
     assert received_capabilities.roots.listChanged is True  # Should be True for custom callback
 
+
 def test_call_tool_method_signature():
     """Test that call_tool method accepts meta parameter in its signature."""
 
     signature = inspect.signature(ClientSession.call_tool)
 
-    assert 'meta' in signature.parameters, "call_tool method should have 'meta' parameter"
+    assert "meta" in signature.parameters, "call_tool method should have 'meta' parameter"
 
-    meta_param = signature.parameters['meta']
+    meta_param = signature.parameters["meta"]
     assert meta_param.default is None, "meta parameter should default to None"
 
 
@@ -515,10 +515,7 @@ def test_call_tool_request_params_construction():
     """Test that CallToolRequestParams can be constructed with metadata."""
     from mcp.types import CallToolRequestParams, RequestParams
 
-    params_no_meta = CallToolRequestParams(
-        name="test_tool",
-        arguments={"param": "value"}
-    )
+    params_no_meta = CallToolRequestParams(name="test_tool", arguments={"param": "value"})
     assert params_no_meta.name == "test_tool"
     assert params_no_meta.arguments == {"param": "value"}
     assert params_no_meta.meta is None
@@ -527,14 +524,14 @@ def test_call_tool_request_params_construction():
         "progressToken": None,
         "user_id": "test_user",
         "session_id": "test_session",
-        "custom_field": "custom_value"
+        "custom_field": "custom_value",
     }
     test_meta = RequestParams.Meta.model_validate(meta_data)
 
     params_with_meta = CallToolRequestParams(
         name="test_tool",
         arguments={"param": "value"},
-        **{"_meta": test_meta}  # Using alias
+        **{"_meta": test_meta},  # Using alias
     )
 
     assert params_with_meta.name == "test_tool"
@@ -551,21 +548,12 @@ def test_metadata_serialization():
     """Test that metadata is properly serialized with _meta alias."""
     from mcp.types import CallToolRequest, CallToolRequestParams, RequestParams
 
-    meta_data = {
-        "progressToken": None,
-        "user_id": "alice",
-        "api_key": "secret_123",
-        "permissions": ["read", "write"]
-    }
+    meta_data = {"progressToken": None, "user_id": "alice", "api_key": "secret_123", "permissions": ["read", "write"]}
     test_meta = RequestParams.Meta.model_validate(meta_data)
 
     request = CallToolRequest(
         method="tools/call",
-        params=CallToolRequestParams(
-            name="secure_tool",
-            arguments={"query": "sensitive_data"},
-            **{"_meta": test_meta}
-        )
+        params=CallToolRequestParams(name="secure_tool", arguments={"query": "sensitive_data"}, **{"_meta": test_meta}),
     )
 
     serialized = request.model_dump(by_alias=True)


### PR DESCRIPTION
This is a fix for the bug [1224](https://github.com/modelcontextprotocol/python-sdk/issues/1224) and implements the parameter and method for the metadata that is passed for cases when the info is to be hidden from LLMs.

## Motivation and Context
[1224](https://github.com/modelcontextprotocol/python-sdk/issues/1224)

## How Has This Been Tested?
Yes I have tested with 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
