### PR TITLE
Issue 1379 patch - Fix MCP server OAuth not working with Visual Studio Code and others with extra grant_types

### DIFF
--- a/src/mcp/server/auth/handlers/register.py
+++ b/src/mcp/server/auth/handlers/register.py
@@ -72,7 +72,7 @@ class RegistrationHandler:
             return PydanticJSONResponse(
                 content=RegistrationErrorResponse(
                     error="invalid_client_metadata",
-                    error_description="grant_types must contain authorization_code and refresh_token",
+                    error_description="grant_types must be authorization_code and refresh_token",
                 ),
                 status_code=400,
             )

--- a/src/mcp/server/auth/handlers/register.py
+++ b/src/mcp/server/auth/handlers/register.py
@@ -68,11 +68,11 @@ class RegistrationHandler:
                     ),
                     status_code=400,
                 )
-        if set(client_metadata.grant_types) != {"authorization_code", "refresh_token"}:
+        if not {"authorization_code", "refresh_token"}.issubset(set(client_metadata.grant_types)):
             return PydanticJSONResponse(
                 content=RegistrationErrorResponse(
                     error="invalid_client_metadata",
-                    error_description="grant_types must be authorization_code and refresh_token",
+                    error_description="grant_types must contain authorization_code and refresh_token",
                 ),
                 status_code=400,
             )

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, Union
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
 

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
 
@@ -47,7 +47,7 @@ class OAuthClientMetadata(BaseModel):
     # ie: we do not support client_secret_basic
     token_endpoint_auth_method: Literal["none", "client_secret_post"] = "client_secret_post"
     # grant_types: this implementation only supports authorization_code & refresh_token
-    grant_types: list[Union[Literal["authorization_code", "refresh_token"], str]] = [
+    grant_types: list[Literal["authorization_code", "refresh_token"] | str] = [
         "authorization_code",
         "refresh_token",
     ]

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -49,7 +49,7 @@ class OAuthClientMetadata(BaseModel):
     # grant_types: this implementation only supports authorization_code & refresh_token
     grant_types: list[Union[Literal["authorization_code", "refresh_token"], str]] = [
         "authorization_code",
-        "refresh_token"
+        "refresh_token",
     ]
     # The MCP spec requires the "code" response type, but OAuth
     # servers may also return additional types they support

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -47,9 +47,9 @@ class OAuthClientMetadata(BaseModel):
     # ie: we do not support client_secret_basic
     token_endpoint_auth_method: Literal["none", "client_secret_post"] = "client_secret_post"
     # grant_types: this implementation only supports authorization_code & refresh_token
-    grant_types: list[Literal["authorization_code", "refresh_token"]] = [
+    grant_types: list[Union[Literal["authorization_code", "refresh_token"], str]] = [
         "authorization_code",
-        "refresh_token",
+        "refresh_token"
     ]
     # The MCP spec requires the "code" response type, but OAuth
     # servers may also return additional types they support

--- a/tests/server/fastmcp/auth/test_auth_integration.py
+++ b/tests/server/fastmcp/auth/test_auth_integration.py
@@ -938,6 +938,23 @@ class TestAuthEndpoints:
         assert error_data["error_description"] == "grant_types must be authorization_code and refresh_token"
 
     @pytest.mark.anyio
+    async def test_client_registration_with_additional_grant_type(self, test_client: httpx.AsyncClient):
+        client_metadata = {
+            "redirect_uris": ["https://client.example.com/callback"],
+            "client_name": "Test Client",
+            "grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:device_code"],
+        }
+
+        response = await test_client.post("/register", json=client_metadata)
+        assert response.status_code == 201
+        client_info = response.json()
+
+        # Verify client was registered successfully
+        assert "client_id" in client_info
+        assert "client_secret" in client_info
+        assert client_info["client_name"] == "Test Client"
+
+    @pytest.mark.anyio
     async def test_client_registration_with_additional_response_types(
         self, test_client: httpx.AsyncClient, mock_oauth_provider: MockOAuthProvider
     ):


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Visual Studio Code MCP server (and others) inject other grant types in OAuth request that are superfluous and can be ignored. As long as `authorization_code` and `refresh_token` are present this should be sufficient to work without erroring out.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I tested this locally in Visual Studio Code itself, and was able to have OAuth work successfully with these changes.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
