### PR TITLE
Use streamable-http consistently in examples

### DIFF
--- a/examples/clients/simple-auth-client/README.md
+++ b/examples/clients/simple-auth-client/README.md
@@ -71,4 +71,4 @@ mcp> quit
 ## Configuration
 
 - `MCP_SERVER_PORT` - Server URL (default: 8000)
-- `MCP_TRANSPORT_TYPE` - Transport type: `streamable_http` (default) or `sse`
+- `MCP_TRANSPORT_TYPE` - Transport type: `streamable-http` (default) or `sse`

--- a/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
+++ b/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
@@ -150,7 +150,7 @@ class CallbackServer:
 class SimpleAuthClient:
     """Simple MCP client with auth support."""
 
-    def __init__(self, server_url: str, transport_type: str = "streamable_http"):
+    def __init__(self, server_url: str, transport_type: str = "streamable-http"):
         self.server_url = server_url
         self.transport_type = transport_type
         self.session: ClientSession | None = None
@@ -334,10 +334,10 @@ async def main():
     # Default server URL - can be overridden with environment variable
     # Most MCP streamable HTTP servers use /mcp as the endpoint
     server_url = os.getenv("MCP_SERVER_PORT", 8000)
-    transport_type = os.getenv("MCP_TRANSPORT_TYPE", "streamable_http")
+    transport_type = os.getenv("MCP_TRANSPORT_TYPE", "streamable-http")
     server_url = (
         f"http://localhost:{server_url}/mcp"
-        if transport_type == "streamable_http"
+        if transport_type == "streamable-http"
         else f"http://localhost:{server_url}/sse"
     )
 

--- a/examples/servers/simple-auth/README.md
+++ b/examples/servers/simple-auth/README.md
@@ -43,7 +43,7 @@ uv run mcp-simple-auth-rs --port=8001 --auth-server=http://localhost:9000  --tra
 ```bash
 cd examples/clients/simple-auth-client
 # Start client with streamable HTTP
-MCP_SERVER_PORT=8001 MCP_TRANSPORT_TYPE=streamable_http uv run mcp-simple-auth-client
+MCP_SERVER_PORT=8001 MCP_TRANSPORT_TYPE=streamable-http uv run mcp-simple-auth-client
 ```
 
 ## How It Works
@@ -101,7 +101,7 @@ uv run mcp-simple-auth-legacy --port=8002
 ```bash
 # Test with client (will automatically fall back to legacy discovery)
 cd examples/clients/simple-auth-client
-MCP_SERVER_PORT=8002 MCP_TRANSPORT_TYPE=streamable_http uv run mcp-simple-auth-client
+MCP_SERVER_PORT=8002 MCP_TRANSPORT_TYPE=streamable-http uv run mcp-simple-auth-client
 ```
 
 The client will:


### PR DESCRIPTION
Fixes #1386

Updated simple-auth examples to use `streamable-http` (hyphenated) instead of `streamable_http` (underscored) for consistency with the MCP specification and server implementation.