### PR TITLE
fix: update response status code for invalid session ID in HTTPSessionManger

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -274,6 +274,7 @@ class StreamableHTTPSessionManager:
             # Invalid session ID
             response = Response(
                 "Bad Request: No valid session ID provided",
-                status_code=HTTPStatus.BAD_REQUEST,
+                status_code=HTTPStatus.NOT_FOUND,
+                headers={MCP_SESSION_ID_HEADER: request_mcp_session_id} if request_mcp_session_id else {},
             )
             await response(scope, receive, send)


### PR DESCRIPTION

Changed the status code from BAD_REQUEST to NOT_FOUND and added MCP_SESSION_ID_HEADER with `Mcp-Session-Id`

<!-- Provide a brief summary of your changes -->

## Motivation and Context
Current  behavior of HTTP Session Manager is not align with MCP specification.
https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management

4. The server MAY terminate the session at any time, **after which it MUST respond to requests containing that session ID with HTTP 404 Not Found.**

In my opinion the `else` case, in the StreamableHTTP Session Manager for stateful events, handles request with old/invalid `Mcp-Session-Id`after unintentional session terminate (server restart). In that case NOT_FOUND status MUST be returned, not BAD_REQUEST.

## How Has This Been Tested?
Locally with Cursor AI.
Currently Cursor 1.6.x does not start new session after such response, see: https://forum.cursor.com/t/mcp-client-wrong-handling-of-http-not-found-in-session-management-stateful-mcp-server/134781

## Breaking Changes
Probably, depends on MCP client logic implementation.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
