### PR TITLE
Validate metadata keys

### DIFF
--- a/tests/types/test_meta.py
+++ b/tests/types/test_meta.py
@@ -1,0 +1,65 @@
+import pytest
+
+from mcp import types
+
+
+@pytest.mark.parametrize(
+    argnames="key",
+    argvalues=[
+        # Simple keys without reserved prefix
+        "clientId",
+        "request-id",
+        "api_version",
+        "product-id",
+        "x-correlation-id",
+        "my-key",
+        "info",
+        "data-1",
+        "label-key",
+        # Keys with reserved prefix
+        "modelcontextprotocol.io/request-id",
+        "mcp.dev/debug-mode",
+        "api.modelcontextprotocol.org/api-version",
+        "tools.mcp.com/validation-status",
+        "my-company.mcp.io/internal-flag",
+        "modelcontextprotocol.io/a",
+        "mcp.dev/b-c",
+        # Keys with non-reserved prefix
+        "my-app.com/user-preferences",
+        "internal.api/tracking-id",
+        "org.example/resource-type",
+        "custom.domain/status",
+    ],
+)
+def test_metadata_valid_keys(key: str):
+    """
+    Asserts that valid metadata keys does not raise ValueErrors
+    """
+    types.RequestParams.Meta(**{key: "value"})
+
+
+@pytest.mark.parametrize(
+    argnames="key",
+    argvalues=[
+        # Invalid key names (without prefix)
+        "-leading-hyphen",
+        "trailing-hyphen-",
+        "with space",
+        "key/with/slash",
+        "no@special-chars",
+        "...",
+        # Invalid prefixes
+        "mcp.123/key",
+        "my.custom./key",
+        "my-app.com//key",
+        # Invalid combination of prefix and name
+        "mcp.dev/-invalid",
+        "org.example/invalid-name-",
+    ],
+)
+def test_metadata_invalid_keys(key: str):
+    """
+    Asserts that invalid metadata keys raise ValueErrors
+    """
+    with pytest.raises(ValueError):
+        types.RequestParams.Meta(**{key: "value"})


### PR DESCRIPTION
This PR validates `types.RequestParams.Meta` to enforce the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta) for the `_meta` field.

## Motivation and Context
This change ensures that users won't rely on invalid `key` names when using the `_meta` field.

## How Has This Been Tested?
It was tested in a local client/server setup.

Unit-tests were also added to ensure the correct behavior.

## Breaking Changes
There are breaking changes in the case some users are already using invalid `_meta` keys.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
It is the result of discussion in https://github.com/modelcontextprotocol/python-sdk/pull/1231

Although **I'm not entirely sure we should enforce this validation through the SDK**, I'm offering this approach as a possible option.
