### PR TITLE
Add support for context-only resources (#1405)

### DIFF
--- a/examples/snippets/servers/context_resource.py
+++ b/examples/snippets/servers/context_resource.py
@@ -1,0 +1,11 @@
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.session import ServerSession
+
+mcp = FastMCP(name="Context Resource Example")
+
+
+@mcp.resource("resource://only_context")
+def resource_only_context(ctx: Context[ServerSession, None]) -> str:
+    """Resource that only receives context."""
+    assert ctx is not None
+    return "Resource with only context injected"

--- a/src/mcp/server/fastmcp/prompts/base.py
+++ b/src/mcp/server/fastmcp/prompts/base.py
@@ -99,12 +99,12 @@ class Prompt(BaseModel):
 
         # Find context parameter if it exists
         if context_kwarg is None:  # pragma: no branch
-            context_kwarg = find_context_parameter(fn)
+            context_kwarg = find_context_parameter(fn) or ""
 
         # Get schema from func_metadata, excluding context parameter
         func_arg_metadata = func_metadata(
             fn,
-            skip_names=[context_kwarg] if context_kwarg is not None else [],
+            skip_names=[context_kwarg] if context_kwarg else [],
         )
         parameters = func_arg_metadata.arg_model.model_json_schema()
 

--- a/src/mcp/server/fastmcp/resources/base.py
+++ b/src/mcp/server/fastmcp/resources/base.py
@@ -1,7 +1,7 @@
 """Base classes and interfaces for FastMCP resources."""
 
 import abc
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import (
     AnyUrl,
@@ -44,6 +44,6 @@ class Resource(BaseModel, abc.ABC):
         raise ValueError("Either name or uri must be provided")
 
     @abc.abstractmethod
-    async def read(self) -> str | bytes:
+    async def read(self, context: Any | None = None) -> str | bytes:
         """Read the resource content."""
         pass  # pragma: no cover

--- a/src/mcp/server/fastmcp/resources/templates.py
+++ b/src/mcp/server/fastmcp/resources/templates.py
@@ -54,12 +54,12 @@ class ResourceTemplate(BaseModel):
 
         # Find context parameter if it exists
         if context_kwarg is None:  # pragma: no branch
-            context_kwarg = find_context_parameter(fn)
+            context_kwarg = find_context_parameter(fn) or ""
 
         # Get schema from func_metadata, excluding context parameter
         func_arg_metadata = func_metadata(
             fn,
-            skip_names=[context_kwarg] if context_kwarg is not None else [],
+            skip_names=[context_kwarg] if context_kwarg else [],
         )
         parameters = func_arg_metadata.arg_model.model_json_schema()
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -376,7 +376,7 @@ class FastMCP(Generic[LifespanResultT]):
             raise ResourceError(f"Unknown resource: {uri}")
 
         try:
-            content = await resource.read()
+            content = await resource.read(context=context)
             return [ReadResourceContents(content=content, mime_type=resource.mime_type)]
         except Exception as e:  # pragma: no cover
             logger.exception(f"Error reading resource {uri}")
@@ -575,27 +575,24 @@ class FastMCP(Generic[LifespanResultT]):
             )
 
         def decorator(fn: AnyFunction) -> AnyFunction:
-            # Check if this should be a template
             sig = inspect.signature(fn)
+            context_param = find_context_parameter(fn)
+
+            # Determine effective parameters, excluding context
+            effective_func_params = {p for p in sig.parameters.keys() if p != context_param}
+
             has_uri_params = "{" in uri and "}" in uri
-            has_func_params = bool(sig.parameters)
+            has_effective_func_params = bool(effective_func_params)
 
-            if has_uri_params or has_func_params:
-                # Check for Context parameter to exclude from validation
-                context_param = find_context_parameter(fn)
-
-                # Validate that URI params match function params (excluding context)
+            if has_uri_params or has_effective_func_params:
+                # Register as template
                 uri_params = set(re.findall(r"{(\w+)}", uri))
-                # We need to remove the context_param from the resource function if
-                # there is any.
-                func_params = {p for p in sig.parameters.keys() if p != context_param}
 
-                if uri_params != func_params:
+                if uri_params != effective_func_params:
                     raise ValueError(
-                        f"Mismatch between URI parameters {uri_params} and function parameters {func_params}"
+                        f"Mismatch between URI parameters {uri_params} and function parameters {effective_func_params}"
                     )
 
-                # Register as template
                 self._resource_manager.add_template(
                     fn=fn,
                     uri_template=uri,

--- a/src/mcp/server/fastmcp/utilities/context_injection.py
+++ b/src/mcp/server/fastmcp/utilities/context_injection.py
@@ -1,47 +1,40 @@
-"""Context injection utilities for FastMCP."""
-
-from __future__ import annotations
-
 import inspect
 import typing
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import Context
 
 
 def find_context_parameter(fn: Callable[..., Any]) -> str | None:
-    """Find the parameter that should receive the Context object.
-
-    Searches through the function's signature to find a parameter
-    with a Context type annotation.
-
-    Args:
-        fn: The function to inspect
-
-    Returns:
-        The name of the context parameter, or None if not found
     """
-    from mcp.server.fastmcp.server import Context
+    Inspect a function signature to find a parameter annotated with Context.
+    Returns the name of the parameter if found, otherwise None.
+    """
+    from mcp.server.fastmcp import Context
 
-    # Get type hints to properly resolve string annotations
     try:
-        hints = typing.get_type_hints(fn)
-    except Exception:
-        # If we can't resolve type hints, we can't find the context parameter
+        sig = inspect.signature(fn)
+    except ValueError:  # pragma: no cover
+        # Can't inspect signature (e.g. some builtins/wrappers)
         return None
 
-    # Check each parameter's type hint
-    for param_name, annotation in hints.items():
-        # Handle direct Context type
+    for param_name, param in sig.parameters.items():
+        annotation = param.annotation
+        if annotation is inspect.Parameter.empty:
+            continue
+
+        # Handle Optional[Context], Annotated[Context, ...], etc.
+        origin = typing.get_origin(annotation)
+
+        # Check if the annotation itself is Context or a subclass
         if inspect.isclass(annotation) and issubclass(annotation, Context):
             return param_name
 
-        # Handle generic types like Optional[Context]
-        origin = typing.get_origin(annotation)
-        if origin is not None:
-            args = typing.get_args(annotation)
-            for arg in args:
-                if inspect.isclass(arg) and issubclass(arg, Context):
-                    return param_name
+        # Check if it's a generic alias of Context (e.g., Context[...])
+        if origin is not None and inspect.isclass(origin) and issubclass(origin, Context):
+            return param_name  # pragma: no cover
 
     return None
 
@@ -49,20 +42,16 @@ def find_context_parameter(fn: Callable[..., Any]) -> str | None:
 def inject_context(
     fn: Callable[..., Any],
     kwargs: dict[str, Any],
-    context: Any | None,
-    context_kwarg: str | None,
+    context: "Context[Any, Any, Any] | None",
+    context_kwarg: str | None = None,
 ) -> dict[str, Any]:
-    """Inject context into function kwargs if needed.
-
-    Args:
-        fn: The function that will be called
-        kwargs: The current keyword arguments
-        context: The context object to inject (if any)
-        context_kwarg: The name of the parameter to inject into
-
-    Returns:
-        Updated kwargs with context injected if applicable
     """
-    if context_kwarg is not None and context is not None:
-        return {**kwargs, context_kwarg: context}
+    Inject the Context object into kwargs if the function expects it.
+    Returns the updated kwargs.
+    """
+    if context_kwarg is None:
+        context_kwarg = find_context_parameter(fn)
+
+    if context_kwarg:
+        kwargs[context_kwarg] = context
     return kwargs

--- a/tests/server/fastmcp/test_integration.py
+++ b/tests/server/fastmcp/test_integration.py
@@ -25,6 +25,7 @@ from examples.snippets.servers import (
     basic_resource,
     basic_tool,
     completion,
+    context_resource,
     elicitation,
     fastmcp_quickstart,
     notifications,
@@ -124,6 +125,8 @@ def run_server_with_transport(module_name: str, port: int, transport: str) -> No
         mcp = fastmcp_quickstart.mcp
     elif module_name == "structured_output":
         mcp = structured_output.mcp
+    elif module_name == "context_resource":
+        mcp = context_resource.mcp
     else:
         raise ImportError(f"Unknown module: {module_name}")
 
@@ -686,3 +689,42 @@ async def test_structured_output(server_transport: str, server_url: str) -> None
             assert "sunny" in result_text  # condition
             assert "45" in result_text  # humidity
             assert "5.2" in result_text  # wind_speed
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "server_transport",
+    [
+        ("context_resource", "sse"),
+        ("context_resource", "streamable-http"),
+    ],
+    indirect=True,
+)
+async def test_context_only_resource(server_transport: str, server_url: str) -> None:
+    """Test that a resource with only a context argument is registered as a regular resource."""
+    transport = server_transport
+    client_cm = create_client_for_transport(transport, server_url)
+
+    async with client_cm as client_streams:
+        read_stream, write_stream = unpack_streams(client_streams)
+        async with ClientSession(read_stream, write_stream) as session:
+            # Test initialization
+            result = await session.initialize()
+            assert isinstance(result, InitializeResult)
+            assert result.serverInfo.name == "Context Resource Example"
+
+            # Check that it is not in templates
+            templates = await session.list_resource_templates()
+            assert len(templates.resourceTemplates) == 0
+
+            # Check that it is in resources
+            resources = await session.list_resources()
+            assert len(resources.resources) == 1
+            resource = resources.resources[0]
+            assert resource.uri == AnyUrl("resource://only_context")
+
+            # Check that we can read it
+            read_result = await session.read_resource(AnyUrl("resource://only_context"))
+            assert len(read_result.contents) == 1
+            assert isinstance(read_result.contents[0], TextResourceContents)
+            assert read_result.contents[0].text == "Resource with only context injected"

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -686,7 +686,7 @@ class TestServerResources:
         def get_text():
             return "Hello, world!"
 
-        resource = FunctionResource(uri=AnyUrl("resource://test"), name="test", fn=get_text)
+        resource = FunctionResource(uri=AnyUrl("resource://test"), name="test", fn=get_text, context_kwarg=None)
         mcp.add_resource(resource)
 
         async with client_session(mcp._mcp_server) as client:
@@ -1085,7 +1085,7 @@ class TestContextInjection:
         templates = mcp._resource_manager.list_templates()
         assert len(templates) == 1
         template = templates[0]
-        assert template.context_kwarg is None
+        assert not template.context_kwarg
 
         # Test via client
         async with client_session(mcp._mcp_server) as client:
@@ -1119,6 +1119,33 @@ class TestContextInjection:
             content = result.contents[0]
             assert isinstance(content, TextResourceContents)
             assert "Resource 123 with context" in content.text
+
+    @pytest.mark.anyio
+    async def test_resource_only_context(self):
+        """Test that resources without template args can receive context."""
+        mcp = FastMCP()
+
+        @mcp.resource("resource://only_context", name="resource_with_context_no_args")
+        def resource_only_context(ctx: Context[ServerSession, None]) -> str:
+            """Resource that only receives context."""
+            assert ctx is not None
+            return "Resource with only context injected"
+
+        # Test via client
+        async with client_session(mcp._mcp_server) as client:
+            # Verify resource is registered via client
+            resources = await client.list_resources()
+            assert len(resources.resources) == 1
+            resource = resources.resources[0]
+            assert resource.uri == AnyUrl("resource://only_context")
+            assert resource.name == "resource_with_context_no_args"
+
+            # Test reading the resource
+            result = await client.read_resource(AnyUrl("resource://only_context"))
+            assert len(result.contents) == 1
+            content = result.contents[0]
+            assert isinstance(content, TextResourceContents)
+            assert content.text == "Resource with only context injected"
 
     @pytest.mark.anyio
     async def test_prompt_with_context(self):


### PR DESCRIPTION
Add support for context-only resources 

## Motivation and Context
#1405

Currently, it is not possible to define a Resource that takes only the Context parameter as an argument. When attempting to create such a resource, the registration logic incorrectly classifies it as a template resource instead of a regular resource.

This limitation prevents developers from creating resources that need access to server session context but don't require dynamic URI components, reducing flexibility in resource design.

## How Has This Been Tested?

- [x] Added comprehensive unit tests for context-only resource functionality
- [x] Added integration tests to verify correct resource registration
- [x] All existing resource tests continue to pass (22/22 tests passed)
- [x] Tested with example context-only resource implementation
- [x] Verified backward compatibility with existing resource definitions

## Breaking Changes

No breaking changes. The `context` parameter in `Resource.read()` method is optional with default `None`. All existing resource implementations continue to work unchanged.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

