### PR TITLE
Improve OAuth protected resource metadata URL construction per RFC 9728

### DIFF
--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -63,7 +63,7 @@ def create_resource_server(settings: ResourceServerSettings) -> FastMCP:
     # Create token verifier for introspection with RFC 8707 resource validation
     token_verifier = IntrospectionTokenVerifier(
         introspection_endpoint=settings.auth_server_introspection_endpoint,
-        server_url=str(settings.server_url),
+        server_url=f"{str(settings.server_url).rstrip('/')}/mcp",
         validate_resource=settings.oauth_strict,  # Only validate when --oauth-strict is set
     )
 

--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -32,7 +32,7 @@ class ResourceServerSettings(BaseSettings):
     # Server settings
     host: str = "localhost"
     port: int = 8001
-    server_url: AnyHttpUrl = AnyHttpUrl("http://localhost:8001")
+    server_url: AnyHttpUrl = AnyHttpUrl("http://localhost:8001/mcp")
 
     # Authorization Server settings
     auth_server_url: AnyHttpUrl = AnyHttpUrl("http://localhost:9000")
@@ -63,7 +63,7 @@ def create_resource_server(settings: ResourceServerSettings) -> FastMCP:
     # Create token verifier for introspection with RFC 8707 resource validation
     token_verifier = IntrospectionTokenVerifier(
         introspection_endpoint=settings.auth_server_introspection_endpoint,
-        server_url=f"{str(settings.server_url).rstrip('/')}/mcp",
+        server_url=str(settings.server_url),
         validate_resource=settings.oauth_strict,  # Only validate when --oauth-strict is set
     )
 
@@ -79,7 +79,7 @@ def create_resource_server(settings: ResourceServerSettings) -> FastMCP:
         auth=AuthSettings(
             issuer_url=settings.auth_server_url,
             required_scopes=[settings.mcp_scope],
-            resource_server_url=AnyHttpUrl(f"{str(settings.server_url).rstrip('/')}/mcp"),
+            resource_server_url=settings.server_url,
         ),
     )
 
@@ -137,7 +137,7 @@ def main(port: int, auth_server: str, transport: Literal["sse", "streamable-http
 
         # Create settings
         host = "localhost"
-        server_url = f"http://{host}:{port}"
+        server_url = f"http://{host}:{port}/mcp"
         settings = ResourceServerSettings(
             host=host,
             port=port,

--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -79,7 +79,7 @@ def create_resource_server(settings: ResourceServerSettings) -> FastMCP:
         auth=AuthSettings(
             issuer_url=settings.auth_server_url,
             required_scopes=[settings.mcp_scope],
-            resource_server_url=settings.server_url,
+            resource_server_url=AnyHttpUrl(f"{str(settings.server_url).rstrip('/')}/mcp"),
         ),
     )
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -938,9 +938,15 @@ class FastMCP(Generic[LifespanResultT]):
             resource_metadata_url = None
             if self.settings.auth and self.settings.auth.resource_server_url:
                 from pydantic import AnyHttpUrl
+                from urllib.parse import urlparse
 
+                # RFC 9728 §3.1: Insert /.well-known/oauth-protected-resource between host and resource path
+                # This URL will be used in WWW-Authenticate header for client discovery
+                parsed = urlparse(str(self.settings.auth.resource_server_url))
+                # Handle trailing slash: if path is just "/", treat as empty
+                resource_path = parsed.path if parsed.path != "/" else ""
                 resource_metadata_url = AnyHttpUrl(
-                    str(self.settings.auth.resource_server_url).rstrip("/") + "/.well-known/oauth-protected-resource"
+                    f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-protected-resource{resource_path}"
                 )
 
             routes.append(
@@ -963,15 +969,23 @@ class FastMCP(Generic[LifespanResultT]):
             from mcp.server.auth.handlers.metadata import ProtectedResourceMetadataHandler
             from mcp.server.auth.routes import cors_middleware
             from mcp.shared.auth import ProtectedResourceMetadata
+            from urllib.parse import urlparse
 
             protected_resource_metadata = ProtectedResourceMetadata(
                 resource=self.settings.auth.resource_server_url,
                 authorization_servers=[self.settings.auth.issuer_url],
                 scopes_supported=self.settings.auth.required_scopes,
             )
+            
+            # RFC 9728 §3.1: Register route at /.well-known/oauth-protected-resource + resource path
+            parsed = urlparse(str(self.settings.auth.resource_server_url))
+            # Handle trailing slash: if path is just "/", treat as empty
+            resource_path = parsed.path if parsed.path != "/" else ""
+            well_known_path = f"/.well-known/oauth-protected-resource{resource_path}"
+            
             routes.append(
                 Route(
-                    "/.well-known/oauth-protected-resource",
+                    well_known_path,
                     endpoint=cors_middleware(
                         ProtectedResourceMetadataHandler(protected_resource_metadata).handle,
                         ["GET", "OPTIONS"],

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -937,8 +937,9 @@ class FastMCP(Generic[LifespanResultT]):
             # Determine resource metadata URL
             resource_metadata_url = None
             if self.settings.auth and self.settings.auth.resource_server_url:
-                from pydantic import AnyHttpUrl
                 from urllib.parse import urlparse
+
+                from pydantic import AnyHttpUrl
 
                 # RFC 9728 §3.1: Insert /.well-known/oauth-protected-resource between host and resource path
                 # This URL will be used in WWW-Authenticate header for client discovery
@@ -966,23 +967,24 @@ class FastMCP(Generic[LifespanResultT]):
 
         # Add protected resource metadata endpoint if configured as RS
         if self.settings.auth and self.settings.auth.resource_server_url:
+            from urllib.parse import urlparse
+
             from mcp.server.auth.handlers.metadata import ProtectedResourceMetadataHandler
             from mcp.server.auth.routes import cors_middleware
             from mcp.shared.auth import ProtectedResourceMetadata
-            from urllib.parse import urlparse
 
             protected_resource_metadata = ProtectedResourceMetadata(
                 resource=self.settings.auth.resource_server_url,
                 authorization_servers=[self.settings.auth.issuer_url],
                 scopes_supported=self.settings.auth.required_scopes,
             )
-            
+
             # RFC 9728 §3.1: Register route at /.well-known/oauth-protected-resource + resource path
             parsed = urlparse(str(self.settings.auth.resource_server_url))
             # Handle trailing slash: if path is just "/", treat as empty
             resource_path = parsed.path if parsed.path != "/" else ""
             well_known_path = f"/.well-known/oauth-protected-resource{resource_path}"
-            
+
             routes.append(
                 Route(
                     well_known_path,

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -8,7 +8,7 @@ from inline_snapshot import snapshot
 from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 
-from mcp.server.auth.routes import create_protected_resource_routes
+from mcp.server.auth.routes import build_resource_metadata_url, create_protected_resource_routes
 
 
 @pytest.fixture
@@ -103,3 +103,96 @@ async def test_metadata_endpoint_without_path(root_resource_client: httpx.AsyncC
             "bearer_methods_supported": ["header"],
         }
     )
+
+
+class TestMetadataUrlConstruction:
+    """Test URL construction utility function."""
+
+    def test_url_without_path(self):
+        """Test URL construction for resource without path component."""
+        resource_url = AnyHttpUrl("https://example.com")
+        result = build_resource_metadata_url(resource_url)
+        assert str(result) == "https://example.com/.well-known/oauth-protected-resource"
+
+    def test_url_with_path_component(self):
+        """Test URL construction for resource with path component."""
+        resource_url = AnyHttpUrl("https://example.com/mcp")
+        result = build_resource_metadata_url(resource_url)
+        assert str(result) == "https://example.com/.well-known/oauth-protected-resource/mcp"
+
+    def test_url_with_trailing_slash_only(self):
+        """Test URL construction for resource with trailing slash only."""
+        resource_url = AnyHttpUrl("https://example.com/")
+        result = build_resource_metadata_url(resource_url)
+        # Trailing slash should be treated as empty path
+        assert str(result) == "https://example.com/.well-known/oauth-protected-resource"
+
+    @pytest.mark.parametrize(
+        "resource_url,expected_url",
+        [
+            ("https://example.com", "https://example.com/.well-known/oauth-protected-resource"),
+            ("https://example.com/", "https://example.com/.well-known/oauth-protected-resource"),
+            ("https://example.com/mcp", "https://example.com/.well-known/oauth-protected-resource/mcp"),
+            ("http://localhost:8001/mcp", "http://localhost:8001/.well-known/oauth-protected-resource/mcp"),
+        ],
+    )
+    def test_various_resource_configurations(self, resource_url: str, expected_url: str):
+        """Test URL construction with various resource configurations."""
+        result = build_resource_metadata_url(AnyHttpUrl(resource_url))
+        assert str(result) == expected_url
+
+
+class TestRouteConsistency:
+    """Test consistency between URL generation and route registration."""
+
+    def test_route_path_matches_metadata_url(self):
+        """Test that route path matches the generated metadata URL."""
+        resource_url = AnyHttpUrl("https://example.com/mcp")
+
+        # Generate metadata URL
+        metadata_url = build_resource_metadata_url(resource_url)
+
+        # Create routes
+        routes = create_protected_resource_routes(
+            resource_url=resource_url,
+            authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+        )
+
+        # Extract path from metadata URL
+        from urllib.parse import urlparse
+
+        metadata_path = urlparse(str(metadata_url)).path
+
+        # Verify consistency
+        assert len(routes) == 1
+        assert routes[0].path == metadata_path
+
+    @pytest.mark.parametrize(
+        "resource_url,expected_path",
+        [
+            ("https://example.com", "/.well-known/oauth-protected-resource"),
+            ("https://example.com/", "/.well-known/oauth-protected-resource"),
+            ("https://example.com/mcp", "/.well-known/oauth-protected-resource/mcp"),
+        ],
+    )
+    def test_consistent_paths_for_various_resources(self, resource_url: str, expected_path: str):
+        """Test that URL generation and route creation are consistent."""
+        resource_url_obj = AnyHttpUrl(resource_url)
+
+        # Test URL generation
+        metadata_url = build_resource_metadata_url(resource_url_obj)
+        from urllib.parse import urlparse
+
+        url_path = urlparse(str(metadata_url)).path
+
+        # Test route creation
+        routes = create_protected_resource_routes(
+            resource_url=resource_url_obj,
+            authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+        )
+        route_path = routes[0].path
+
+        # Both should match expected path
+        assert url_path == expected_path
+        assert route_path == expected_path
+        assert url_path == route_path

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -36,10 +36,11 @@ async def test_client(test_app: Starlette):
 
 
 @pytest.mark.anyio
-async def test_metadata_endpoint(test_client: httpx.AsyncClient):
-    """Test the OAuth 2.0 Protected Resource metadata endpoint."""
+async def test_metadata_endpoint_with_path(test_client: httpx.AsyncClient):
+    """Test the OAuth 2.0 Protected Resource metadata endpoint for path-based resource."""
 
-    response = await test_client.get("/.well-known/oauth-protected-resource")
+    # For resource with path "/resource", metadata should be accessible at the path-aware location
+    response = await test_client.get("/.well-known/oauth-protected-resource/resource")
     assert response.json() == snapshot(
         {
             "resource": "https://example.com/resource",
@@ -47,6 +48,58 @@ async def test_metadata_endpoint(test_client: httpx.AsyncClient):
             "scopes_supported": ["read", "write"],
             "resource_name": "Example Resource",
             "resource_documentation": "https://docs.example.com/resource",
+            "bearer_methods_supported": ["header"],
+        }
+    )
+
+
+@pytest.mark.anyio
+async def test_metadata_endpoint_root_path_returns_404(test_client: httpx.AsyncClient):
+    """Test that root path returns 404 for path-based resource."""
+
+    # Root path should return 404 for path-based resources
+    response = await test_client.get("/.well-known/oauth-protected-resource")
+    assert response.status_code == 404
+
+
+@pytest.fixture
+def root_resource_app():
+    """Fixture to create protected resource routes for root-level resource."""
+
+    # Create routes for a resource without path component
+    protected_resource_routes = create_protected_resource_routes(
+        resource_url=AnyHttpUrl("https://example.com"),
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+        scopes_supported=["read"],
+        resource_name="Root Resource",
+    )
+
+    app = Starlette(routes=protected_resource_routes)
+    return app
+
+
+@pytest.fixture
+async def root_resource_client(root_resource_app: Starlette):
+    """Fixture to create an HTTP client for the root resource app."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=root_resource_app), base_url="https://mcptest.com"
+    ) as client:
+        yield client
+
+
+@pytest.mark.anyio
+async def test_metadata_endpoint_without_path(root_resource_client: httpx.AsyncClient):
+    """Test metadata endpoint for root-level resource."""
+
+    # For root resource, metadata should be at standard location
+    response = await root_resource_client.get("/.well-known/oauth-protected-resource")
+    assert response.status_code == 200
+    assert response.json() == snapshot(
+        {
+            "resource": "https://example.com/",
+            "authorization_servers": ["https://auth.example.com/"],
+            "scopes_supported": ["read"],
+            "resource_name": "Root Resource",
             "bearer_methods_supported": ["header"],
         }
     )


### PR DESCRIPTION
## Summary

Fixes RFC 9728 compliance issues where the `/.well-known/oauth-protected-resource` endpoint was not correctly constructed for resource identifiers containing path components, causing client discovery failures. (#1400)

## Motivation and Context

**Problem:** The current implementation has two critical RFC 9728 compliance issues:

1. **URL Construction Mismatch**: When `resource_server_url` contains a path (e.g., `http://localhost:8001/mcp`), the WWW-Authenticate header points to `http://localhost:8001/mcp/.well-known/oauth-protected-resource` (appending after the path), but the actual route is served at `http://localhost:8001/.well-known/oauth-protected-resource` (root level only).

2. **Non-RFC Compliant Path Insertion**: RFC 9728 §3.1 specifies that the well-known path should be inserted *between* the host and resource path, not appended after the full URL.

3. **Example Configuration Issue**: The `simple-auth` example had an incorrect `resource_server_url` configuration that didn't include the `/mcp` path component, causing resource validation errors in VS Code MCP clients.

**Impact:** 
- Clients following RFC 9728 get 404 errors when trying to discover metadata
- VS Code shows "Protected Resource Metadata resource does not match MCP server resolved resource" error
- Breaks interoperability with standards-compliant OAuth clients
- Prevents multi-tenant hosting scenarios

**Root Cause:** String concatenation approach doesn't properly handle URL path components according to RFC 9728 specification.

## Changes Made

### 1. Created Reusable Utility Function
Added `build_resource_metadata_url()` in `src/mcp/server/auth/routes.py` to centralize RFC 9728 compliant URL construction:

```python
def build_resource_metadata_url(resource_server_url: AnyHttpUrl) -> AnyHttpUrl:
    """Build RFC 9728 compliant protected resource metadata URL."""
    parsed = urlparse(str(resource_server_url))
    # Handle trailing slash: if path is just "/", treat as empty
    resource_path = parsed.path if parsed.path != "/" else ""
    return AnyHttpUrl(
        f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-protected-resource{resource_path}"
    )
```

### 2. Updated WWW-Authenticate Header Construction
**Before (Non-compliant):**
```python
resource_metadata_url = AnyHttpUrl(
    str(resource_server_url).rstrip("/") + "/.well-known/oauth-protected-resource"
)
```

**After (RFC 9728 Compliant):**
```python
resource_metadata_url = build_resource_metadata_url(resource_server_url)
```

### 3. Updated Route Registration
**Before (Non-compliant):**
```python
Route("/.well-known/oauth-protected-resource", ...)  # Always at root
```

**After (RFC 9728 Compliant):**
```python
# Dynamic path based on resource URL structure
metadata_url = build_resource_metadata_url(resource_url)
parsed = urlparse(str(metadata_url))
well_known_path = parsed.path
Route(well_known_path, ...)
```

### 4. Fixed Example Configuration
Updated `examples/servers/simple-auth/mcp_simple_auth/server.py` to include proper trailing slash handling:

```python
# Before
resource_server_url=AnyHttpUrl(f"{settings.server_url}mcp"),

# After  
resource_server_url=AnyHttpUrl(f"{str(settings.server_url).rstrip('/')}/mcp"),
```

This ensures the resource identifier correctly matches the MCP server endpoint and prevents VS Code authentication errors.

### 5. Eliminated Code Duplication
- Refactored 3 instances of identical URL construction logic to use the utility function
- Replaced inline route creation in `streamable_http_app()` with `create_protected_resource_routes()`
- Reduced code duplication by ~40 lines while improving maintainability

### URL Construction Examples:
| Resource Server URL | WWW-Authenticate Header | Route Path | Status |
|---------------------|------------------------|------------|---------|
| `http://localhost:8001` | `http://localhost:8001/.well-known/oauth-protected-resource` | `/.well-known/oauth-protected-resource` | ✅ Match |
| `http://localhost:8001/` | `http://localhost:8001/.well-known/oauth-protected-resource` | `/.well-known/oauth-protected-resource` | ✅ Match |
| `http://localhost:8001/mcp` | `http://localhost:8001/.well-known/oauth-protected-resource/mcp` | `/.well-known/oauth-protected-resource/mcp` | ✅ Match |

## How Has This Been Tested?

- **Comprehensive Test Suite**: Added 11 new tests covering URL construction, route consistency, and edge cases
- **Edge Case Testing**: Confirmed proper handling of trailing slashes, various URL formats, and localhost scenarios
- **Integration Testing**: Verified consistency between WWW-Authenticate header and actual route registration
- **VS Code Testing**: Confirmed the example fix resolves authentication errors with VS Code MCP client
- **Backwards Compatibility**: Confirmed existing OAuth flows continue to work for root-level resources
- **All Tests Pass**: 14/14 tests pass, including both new and existing functionality

## Breaking Changes

**None.** This fix maintains backward compatibility for existing deployments where `resource_server_url` has no path component, while fixing the broken behavior for path-based resources.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Files Modified
- `src/mcp/server/fastmcp/server.py` - Updated both SSE and StreamableHTTP apps to use RFC 9728 compliant URL construction
- `src/mcp/server/auth/routes.py` - Added utility function and updated `create_protected_resource_routes()`
- `examples/servers/simple-auth/mcp_simple_auth/server.py` - Fixed resource_server_url configuration with proper trailing slash handling
- `tests/server/auth/test_protected_resource.py` - Added comprehensive tests for new functionality

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional Context

**RFC 9728 References:**

**Section 3.1 - Protected Resource Metadata Request** ([RFC 9728 §3.1](https://datatracker.ietf.org/doc/html/rfc9728#section-3.1)):
> "If the resource identifier value contains a path or query component, any terminating slash (/) following the host component MUST be removed before inserting /.well-known/ and the well-known URI path suffix between the host component and the path and/or query components."

**Section 3.3 - Protected Resource Metadata Validation** ([RFC 9728 §3.3](https://datatracker.ietf.org/doc/html/rfc9728#section-3.3)):
> "The resource value returned MUST be identical to the protected resource's resource identifier value into which the well-known URI path suffix was inserted to create the URL used to retrieve the metadata. If these values are not identical, the data contained in the response MUST NOT be used."