### PR TITLE
Fix optional parameters in tools handling

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -2,8 +2,8 @@ import inspect
 import json
 from collections.abc import Awaitable, Callable, Sequence
 from itertools import chain
-from types import GenericAlias
-from typing import Annotated, Any, ForwardRef, cast, get_args, get_origin, get_type_hints
+from types import GenericAlias, UnionType
+from typing import Annotated, Any, ForwardRef, Union, cast, get_args, get_origin, get_type_hints
 
 import pydantic_core
 from pydantic import (
@@ -231,6 +231,14 @@ def func_metadata(
                 # 🤷
                 WithJsonSchema({"title": param.name, "type": "string"}),
             ]
+
+        # If it's Optional[SomeType] or SomeType | None and has no explicit default, set default=None
+        # This ensures optional parameters are not marked as required in the JSON schema
+        origin = get_origin(annotation)
+        if (origin is Union or origin is UnionType) and type(None) in get_args(annotation):
+            # Check if param.default is a FieldInfo with no default set
+            if isinstance(param.default, FieldInfo) and param.default.default is PydanticUndefined:
+                param.default.default = None
 
         field_info = FieldInfo.from_annotated_attribute(
             _get_typed_annotation(annotation, globalns),

--- a/tests/server/fastmcp/test_func_metadata_optional.py
+++ b/tests/server/fastmcp/test_func_metadata_optional.py
@@ -1,0 +1,130 @@
+"""Tests for Optional parameter handling in func_metadata.
+
+This module tests the fix for issue #1402 where Optional[T] parameters
+without explicit defaults were incorrectly marked as required in JSON schemas.
+"""
+
+
+from pydantic import Field
+
+from mcp.server.fastmcp.utilities.func_metadata import func_metadata
+
+
+def test_optional_parameters_not_required():
+    """Test that Optional parameters without defaults are not marked as required."""
+
+    def func_with_optional_params(
+        required: str = Field(description="This should be required"),
+        optional: str | None = Field(description="This should be optional"),
+        optional_with_default: str | None = Field(default="hello", description="This should be optional with default"),
+        optional_with_union_type: str | None = Field(description="This should be optional"),
+        optional_with_union_type_and_default: str | None | None = Field(
+            default="hello", description="This should be optional with default"
+        ),
+    ) -> str:
+        return (
+            f"{required}|{optional}|{optional_with_default}|"
+            f"{optional_with_union_type}|{optional_with_union_type_and_default}"
+        )
+
+    meta = func_metadata(func_with_optional_params)
+    schema = meta.arg_model.model_json_schema()
+
+    # Only 'required' parameter should be in the required list
+    assert schema["required"] == ["required"]
+
+    # All optional parameters should have default=None
+    assert schema["properties"]["optional"]["default"] is None
+    assert schema["properties"]["optional_with_default"]["default"] == "hello"
+    assert schema["properties"]["optional_with_union_type"]["default"] is None
+    assert schema["properties"]["optional_with_union_type_and_default"]["default"] == "hello"
+
+
+def test_required_parameters_still_required():
+    """Test that non-optional parameters remain required."""
+
+    def func_with_required_params(
+        required_str: str = Field(description="Required string"),
+        required_int: int = Field(description="Required int"),
+        optional: str | None = Field(description="Optional string"),
+    ) -> str:
+        return f"{required_str}|{required_int}|{optional}"
+
+    meta = func_metadata(func_with_required_params)
+    schema = meta.arg_model.model_json_schema()
+
+    # Both required parameters should be in the required list
+    assert set(schema["required"]) == {"required_str", "required_int"}
+
+    # Optional parameter should have default=None
+    assert schema["properties"]["optional"]["default"] is None
+
+
+def test_optional_with_explicit_none_default():
+    """Test Optional parameters with explicit None default."""
+
+    def func_with_explicit_none(
+        optional_explicit: str | None = Field(default=None, description="Explicit None default"),
+        optional_implicit: str | None = Field(description="Implicit None default"),
+    ) -> str:
+        return f"{optional_explicit}|{optional_implicit}"
+
+    meta = func_metadata(func_with_explicit_none)
+    schema = meta.arg_model.model_json_schema()
+
+    # No parameters should be required
+    assert schema.get("required", []) == []
+
+    # Both should have None defaults
+    assert schema["properties"]["optional_explicit"]["default"] is None
+    assert schema["properties"]["optional_implicit"]["default"] is None
+
+
+def test_mixed_optional_types():
+    """Test various Optional type patterns."""
+
+    def func_with_mixed_optionals(
+        union_pipe: str | None = Field(description="str | None"),
+        union_optional: str | None = Field(description="Optional[str]"),
+        union_multi: str | int | None = Field(description="str | int | None"),
+        required: str = Field(description="Required"),
+    ) -> str:
+        return f"{union_pipe}|{union_optional}|{union_multi}|{required}"
+
+    meta = func_metadata(func_with_mixed_optionals)
+    schema = meta.arg_model.model_json_schema()
+
+    # Only 'required' should be in required list
+    assert schema["required"] == ["required"]
+
+    # All optional types should have None defaults
+    assert schema["properties"]["union_pipe"]["default"] is None
+    assert schema["properties"]["union_optional"]["default"] is None
+    assert schema["properties"]["union_multi"]["default"] is None
+
+
+def test_runtime_behavior_with_optional_params():
+    """Test that the actual function calls work correctly with optional parameters."""
+
+    def func_with_optionals(
+        required: str = Field(description="Required"),
+        optional: str | None = Field(description="Optional"),
+    ) -> str:
+        return f"required={required}, optional={optional}"
+
+    meta = func_metadata(func_with_optionals)
+
+    # Test with both parameters
+    result1 = meta.arg_model(required="test", optional="value")
+    assert result1.required == "test"
+    assert result1.optional == "value"
+
+    # Test with only required parameter
+    result2 = meta.arg_model(required="test")
+    assert result2.required == "test"
+    assert result2.optional is None
+
+    # Test with explicit None for optional
+    result3 = meta.arg_model(required="test", optional=None)
+    assert result3.required == "test"
+    assert result3.optional is None


### PR DESCRIPTION
## Summary
Fixes #1402 - Optional parameters without explicit defaults are now correctly treated as optional in JSON schemas, aligning Python SDK behavior with the TypeScript SDK.

## Problem
Pydantic treats `Optional[T]` and `T | None` as **required** if no default value is set, even though the type annotation indicates the parameter should be optional. This caused:
- Optional parameters incorrectly marked as required in JSON schemas
- Inconsistency with TypeScript SDK behavior
- Confusing developer experience when defining tools

## Solution
This PR uses a **Pydantic-native approach** (inspired by PR #1404) that checks if a parameter's type annotation is a Union containing None, and sets `default=None` on the FieldInfo if no explicit default exists.

### Implementation (6 lines of code)
```python
# If it's Optional[SomeType] or SomeType | None and has no explicit default, set default=None
origin = get_origin(annotation)
if (origin is Union or origin is UnionType) and type(None) in get_args(annotation):
    if isinstance(param.default, FieldInfo) and param.default.default is PydanticUndefined:
        param.default.default = None
```

This approach:
- ✅ Uses Pydantic's native Union/UnionType detection
- ✅ Avoids complex type introspection
- ✅ Minimal code changes (6 lines vs 61 in previous version)
- ✅ Aligns with maintainer feedback

## Before and After

### Before Fix
```python
def my_tool(
    required: str = Field(description="Required param"),
    optional: str | None = Field(description="Optional param"),
) -> str:
    return f"{required}|{optional}"

# Generated schema (WRONG):
{
    "required": ["required", "optional"],  # ❌ optional is marked required!
    "properties": {
        "optional": {"anyOf": [{"type": "string"}, {"type": "null"}]}
    }
}
```

### After Fix
```python
# Generated schema (CORRECT):
{
    "required": ["required"],  # ✅ Only required params
    "properties": {
        "optional": {
            "anyOf": [{"type": "string"}, {"type": "null"}],
            "default": None  # ✅ Proper default
        }
    }
}
```

## Changes
- **Modified**: `src/mcp/server/fastmcp/utilities/func_metadata.py` (+8 lines)
  - Import `Union` and `UnionType` 
  - Add 6-line check for optional types
- **New**: `tests/server/fastmcp/test_func_metadata_optional.py` (+132 lines)
  - 5 comprehensive test cases
  - Coverage for all optional patterns

## Testing
All tests pass:
- ✅ `test_optional_parameters_not_required` - Verifies optional params not in required list
- ✅ `test_required_parameters_still_required` - Ensures required params unchanged
- ✅ `test_optional_with_explicit_none_default` - Tests explicit None defaults
- ✅ `test_mixed_optional_types` - Various Union patterns (str | None, str | int | None)
- ✅ `test_runtime_behavior_with_optional_params` - Runtime validation works correctly
- ✅ All existing func_metadata tests pass (no regressions)

## Backward Compatibility
✅ **Fully backward compatible**:
- Parameters with explicit defaults unchanged
- Required parameters remain required
- No breaking changes to function semantics
- All existing tests pass

## Comparison with PR #1404
This PR uses the **exact same approach** as PR #1404 (by @vincent0426), addressing the maintainer's feedback about avoiding unnecessary type introspection. Both PRs:
- Use Pydantic-native Union detection
- Set `default=None` for FieldInfo with PydanticUndefined
- Minimal code changes
- Same test coverage goals

The key difference is that this PR was updated to align with the simpler approach after reviewer feedback.

## Addresses Reviewer Feedback
> "Doing all this introspection and type based logic feels like something we shouldn't have to do if we're using the Pydantic tools correctly"

**Response**: Agreed! The updated implementation removes all complex introspection and uses only Pydantic's native `get_origin()` and `get_args()` functions, which is the correct way to work with Pydantic types.

> "I also think we don't use Optional[T] anywhere in this code base"

**Response**: While the codebase may not use `Optional[T]` internally, many users do, and the modern `T | None` syntax (used in this codebase) has the same Pydantic behavior. This fix ensures both patterns work correctly.

Closes #1402