### PR TITLE
Update Icon.sizes to use string array format

### DIFF
--- a/examples/fastmcp/icons_demo.py
+++ b/examples/fastmcp/icons_demo.py
@@ -14,7 +14,7 @@ icon_path = Path(__file__).parent / "mcp.png"
 icon_data = base64.standard_b64encode(icon_path.read_bytes()).decode()
 icon_data_uri = f"data:image/png;base64,{icon_data}"
 
-icon_data = Icon(src=icon_data_uri, mimeType="image/png", sizes="64x64")
+icon_data = Icon(src=icon_data_uri, mimeType="image/png", sizes=["64x64"])
 
 # Create server with icons in implementation
 mcp = FastMCP("Icons Demo Server", website_url="https://github.com/modelcontextprotocol/python-sdk", icons=[icon_data])
@@ -40,9 +40,9 @@ def prompt_with_icon(text: str) -> str:
 
 @mcp.tool(
     icons=[
-        Icon(src=icon_data_uri, mimeType="image/png", sizes="16x16"),
-        Icon(src=icon_data_uri, mimeType="image/png", sizes="32x32"),
-        Icon(src=icon_data_uri, mimeType="image/png", sizes="64x64"),
+        Icon(src=icon_data_uri, mimeType="image/png", sizes=["16x16"]),
+        Icon(src=icon_data_uri, mimeType="image/png", sizes=["32x32"]),
+        Icon(src=icon_data_uri, mimeType="image/png", sizes=["64x64"]),
     ]
 )
 def multi_icon_tool(action: str) -> str:

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -222,8 +222,8 @@ class Icon(BaseModel):
     mimeType: str | None = None
     """Optional MIME type for the icon."""
 
-    sizes: str | None = None
-    """Optional string specifying icon dimensions (e.g., "48x48 96x96")."""
+    sizes: list[str] | None = None
+    """Optional list of strings specifying icon dimensions (e.g., ["48x48", "96x96"])."""
 
     model_config = ConfigDict(extra="allow")
 

--- a/tests/issues/test_1338_icons_and_metadata.py
+++ b/tests/issues/test_1338_icons_and_metadata.py
@@ -15,7 +15,7 @@ async def test_icons_and_website_url():
     test_icon = Icon(
         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
         mimeType="image/png",
-        sizes="1x1",
+        sizes=["1x1"],
     )
 
     # Create server with website URL and icon
@@ -80,9 +80,9 @@ async def test_multiple_icons():
     """Test that multiple icons can be added to tools, resources, and prompts."""
 
     # Create multiple test icons
-    icon1 = Icon(src="data:image/png;base64,icon1", mimeType="image/png", sizes="16x16")
-    icon2 = Icon(src="data:image/png;base64,icon2", mimeType="image/png", sizes="32x32")
-    icon3 = Icon(src="data:image/png;base64,icon3", mimeType="image/png", sizes="64x64")
+    icon1 = Icon(src="data:image/png;base64,icon1", mimeType="image/png", sizes=["16x16"])
+    icon2 = Icon(src="data:image/png;base64,icon2", mimeType="image/png", sizes=["32x32"])
+    icon3 = Icon(src="data:image/png;base64,icon3", mimeType="image/png", sizes=["64x64"])
 
     mcp = FastMCP("MultiIconServer")
 
@@ -98,9 +98,9 @@ async def test_multiple_icons():
     tool = tools[0]
     assert tool.icons is not None
     assert len(tool.icons) == 3
-    assert tool.icons[0].sizes == "16x16"
-    assert tool.icons[1].sizes == "32x32"
-    assert tool.icons[2].sizes == "64x64"
+    assert tool.icons[0].sizes == ["16x16"]
+    assert tool.icons[1].sizes == ["32x32"]
+    assert tool.icons[2].sizes == ["64x64"]
 
 
 async def test_no_icons_or_website():


### PR DESCRIPTION
Changes Icon.sizes from a space-separated string to a list of strings, aligning with spec changes in modelcontextprotocol/modelcontextprotocol#1531.

## Motivation and Context
Aligning with updated spec

## How Has This Been Tested?
Tests updated

## Breaking Changes
Draft spec update

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
