### PR TITLE
Stateful Streamable-HTTP: send 404 Not Found on unknown Mcp-Session-Id

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -273,7 +273,7 @@ class StreamableHTTPSessionManager:
         else:
             # Invalid session ID
             response = Response(
-                "Bad Request: No valid session ID provided",
-                status_code=HTTPStatus.BAD_REQUEST,
+                "Not Found: Unknown session ID",
+                status_code=HTTPStatus.NOT_FOUND,
             )
             await response(scope, receive, send)


### PR DESCRIPTION
## Motivation and Context
Fixes #1004

MCP protocol spec states that when Mcp-Session-Id arrives for a session that has been removed, the server **MUST** reply with a "404 Not Found" HTTP status code. It was replying with a "400 Bad Request" instead. The relevant part of the spec is here in point 2.5.3: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management

> The server MAY terminate the session at any time, after which it MUST respond to requests containing that session ID with HTTP 404 Not Found.

## How Has This Been Tested?
I wrote a unit test.

## Breaking Changes
User apps may be relying on the incorrect behavior of sending "400 Bad Request".
https://xkcd.com/927/

## Types of changes
- [x] Bug fix (~non-~potentially-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
https://github.com/modelcontextprotocol/python-sdk/pull/641/files#r2394152091
