### PR TITLE
Update README to link to Python SDK documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![MIT licensed][mit-badge]][mit-url]
 [![Python Version][python-badge]][python-url]
 [![Documentation][docs-badge]][docs-url]
+[![Protocol][protocol-badge]][protocol-url]
 [![Specification][spec-badge]][spec-url]
 [![GitHub Discussions][discussions-badge]][discussions-url]
 
@@ -74,8 +75,10 @@
 [mit-url]: https://github.com/modelcontextprotocol/python-sdk/blob/main/LICENSE
 [python-badge]: https://img.shields.io/pypi/pyversions/mcp.svg
 [python-url]: https://www.python.org/downloads/
-[docs-badge]: https://img.shields.io/badge/docs-modelcontextprotocol.io-blue.svg
-[docs-url]: https://modelcontextprotocol.io
+[docs-badge]: https://img.shields.io/badge/docs-python--sdk-blue.svg
+[docs-url]: https://modelcontextprotocol.github.io/python-sdk/
+[protocol-badge]: https://img.shields.io/badge/protocol-modelcontextprotocol.io-blue.svg
+[protocol-url]: https://modelcontextprotocol.io
 [spec-badge]: https://img.shields.io/badge/spec-spec.modelcontextprotocol.io-blue.svg
 [spec-url]: https://spec.modelcontextprotocol.io
 [discussions-badge]: https://img.shields.io/github/discussions/modelcontextprotocol/python-sdk


### PR DESCRIPTION
## Summary

Update the documentation badge in the README to point to the Python SDK specific documentation instead of the general MCP protocol site.

## Changes

- Updated docs badge URL to `https://modelcontextprotocol.github.io/python-sdk/`
- Updated docs badge text to "python-sdk" for clarity
- Added new Protocol badge linking to `https://modelcontextprotocol.io` to preserve access to general MCP information

This provides clearer separation between the Python SDK-specific documentation and the general MCP protocol information.