### PR TITLE
Low level MCP server now uses FastMCP log level 

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -207,7 +207,6 @@ class FastMCP(Generic[LifespanResultT]):
         # Set up MCP protocol handlers
         self._setup_handlers()
 
-
     @property
     def name(self) -> str:
         return self._mcp_server.name


### PR DESCRIPTION
Low level MCP server now uses log level set by FastMCP(name="My MCP Server", debug=True, log_level='DEBUG')

<!-- Provide a brief summary of your changes -->

## Motivation and Context
When logging level is set in code at the FastMCP server, this change percolates it to the low lever server by configuring the logging before low level server init. 

## How Has This Been Tested?
uv run pytest :
Results (18.58s):
       653 passed
         2 skipped
         1 xfailed

## Breaking Changes
No

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x] My code follows the repository's style guidelines
- [ x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
