### PR TITLE
fix: uv CVE-2025-62518 astral-tokio-tar issue GHSA-j5gw-2vrg-8fgx

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          version: 0.7.2
+          version: 0.9.5
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras --python 3.10
@@ -46,7 +46,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-          version: 0.7.2
+          version: 0.9.5
 
       - name: Install the project
         run: uv sync --frozen --all-extras --python ${{ matrix.python-version }} --resolution ${{ matrix.dep-resolution }}
@@ -62,7 +62,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          version: 0.7.2
+          version: 0.9.5
 
       - name: Install dependencies
         run: uv sync --frozen --all-extras --python 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ mcp = "mcp.cli:app [cli]"
 
 [tool.uv]
 default-groups = ["dev", "docs"]
-required-version = ">=0.7.2"
+required-version = ">=0.9.5"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Fix https://github.com/advisories/GHSA-j5gw-2vrg-8fgx

Via https://github.com/astral-sh/uv/releases v0.9.5

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

[CVE-2025-62518](https://github.com/advisories/GHSA-j5gw-2vrg-8fgx) is a high-severity vulnerability.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

GitHub Actions tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
