### PR TITLE
Support SSE event "error"

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -157,7 +157,7 @@ class StreamableHTTPTransport:
         is_initialization: bool = False,
     ) -> bool:
         """Handle an SSE event, returning True if the response is complete."""
-        if sse.event == "message":
+        if sse.event in {"message", "error"}:
             try:
                 message = JSONRPCMessage.model_validate_json(sse.data)
                 logger.debug(f"SSE message: {message}")


### PR DESCRIPTION
The Streamable HTTP transport for clients currently only attempts to parse SSEs with the "message" event. This PR expands this to also parse SSEs with the "error" event.

## Motivation and Context
Some servers use the "error" event in the case of sending a JSON-RPC error response (`JSONRPCError`). When this occurs, the SSE is dropped since by the Python MCP SDK and the request never completes or (if configured) times out as no other response is sent. This allows for proper error handling for these servers.

## How Has This Been Tested?
Locally.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None
