### PR TITLE
Add name and title fields to Tool class

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -871,6 +871,19 @@ class ToolAnnotations(BaseModel):
 class Tool(BaseMetadata):
     """Definition for a tool the client can call."""
 
+    name: str
+    """
+    Intended for programmatic or logical use, but used as a display name
+    in past specs or fallback (if title isn’t present).
+    """
+    title: str | None = None
+    """
+    Intended for UI and end-user contexts — optimized to be human-readable
+    and easily understood, even by those unfamiliar with domain-specific terminology.
+
+    If not provided, the name should be used for display
+    (except for Tool, where annotations.title should be given precedence over using name, if present).
+    """
     description: str | None = None
     """A human-readable description of the tool."""
     inputSchema: dict[str, Any]


### PR DESCRIPTION
Adds the `name` and `title` fields to the `Tool` class that were missing from the type definition.