### PR TITLE
fix: Replace remaining manual server polling with wait_for_server helper

### DIFF
--- a/tests/client/test_http_unicode.py
+++ b/tests/client/test_http_unicode.py
@@ -7,13 +7,13 @@ Verifies that Unicode text is correctly transmitted and received in both directi
 
 import multiprocessing
 import socket
-import time
 from collections.abc import Generator
 
 import pytest
 
 from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
+from tests.test_helpers import wait_for_server
 
 # Test constants with various Unicode characters
 UNICODE_TEST_STRINGS = {
@@ -158,19 +158,8 @@ def running_unicode_server(unicode_server_port: int) -> Generator[str, None, Non
     proc = multiprocessing.Process(target=run_unicode_server, kwargs={"port": unicode_server_port}, daemon=True)
     proc.start()
 
-    # Wait for server to be running
-    max_attempts = 20
-    attempt = 0
-    while attempt < max_attempts:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.connect(("127.0.0.1", unicode_server_port))
-                break
-        except ConnectionRefusedError:
-            time.sleep(0.1)
-            attempt += 1
-    else:
-        raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
+    # Wait for server to be ready
+    wait_for_server(unicode_server_port)
 
     try:
         yield f"http://127.0.0.1:{unicode_server_port}"

--- a/tests/server/fastmcp/test_integration.py
+++ b/tests/server/fastmcp/test_integration.py
@@ -13,7 +13,6 @@ single-feature servers across different transports (SSE and StreamableHTTP).
 import json
 import multiprocessing
 import socket
-import time
 from collections.abc import Generator
 
 import pytest
@@ -60,6 +59,7 @@ from mcp.types import (
     TextResourceContents,
     ToolListChangedNotification,
 )
+from tests.test_helpers import wait_for_server
 
 
 class NotificationCollector:
@@ -160,19 +160,8 @@ def server_transport(request: pytest.FixtureRequest, server_port: int) -> Genera
     )
     proc.start()
 
-    # Wait for server to be running
-    max_attempts = 20
-    attempt = 0
-    while attempt < max_attempts:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.connect(("127.0.0.1", server_port))
-                break
-        except ConnectionRefusedError:
-            time.sleep(0.1)
-            attempt += 1
-    else:
-        raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
+    # Wait for server to be ready
+    wait_for_server(server_port)
 
     yield transport
 

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -252,19 +252,8 @@ def mounted_server(server_port: int) -> Generator[None, None, None]:
     proc.start()
 
     # Wait for server to be running
-    max_attempts = 20
-    attempt = 0
     print("waiting for server to start")
-    while attempt < max_attempts:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.connect(("127.0.0.1", server_port))
-                break
-        except ConnectionRefusedError:
-            time.sleep(0.1)
-            attempt += 1
-    else:
-        raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
+    wait_for_server(server_port)
 
     yield
 
@@ -367,19 +356,8 @@ def context_server(server_port: int) -> Generator[None, None, None]:
     proc.start()
 
     # Wait for server to be running
-    max_attempts = 20
-    attempt = 0
     print("waiting for context server to start")
-    while attempt < max_attempts:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.connect(("127.0.0.1", server_port))
-                break
-        except ConnectionRefusedError:
-            time.sleep(0.1)
-            attempt += 1
-    else:
-        raise RuntimeError(f"Context server failed to start after {max_attempts} attempts")
+    wait_for_server(server_port)
 
     yield
 


### PR DESCRIPTION
This PR completes the work started in #1527 by fixing the remaining test fixtures that were still using manual socket polling loops to wait for server startup.

## Motivation and Context

PR #1527 introduced the `wait_for_server()` helper and fixed most test files, but missed 4 test fixtures that were still using manual polling loops with arbitrary `time.sleep()` calls. These remaining fixtures could still cause flaky test failures in CI due to race conditions.

## Changes Made

Fixed 4 test fixtures that still used manual polling:

1. **tests/server/fastmcp/test_integration.py** - `server_transport` fixture
2. **tests/client/test_notification_response.py** - `non_sdk_server` fixture  
3. **tests/client/test_http_unicode.py** - `running_unicode_server` fixture
4. **tests/shared/test_sse.py** - `mounted_server` and `context_server` fixtures

### Before (Manual Polling):
```python
max_attempts = 20
attempt = 0
while attempt < max_attempts:
    try:
        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
            s.connect(("127.0.0.1", server_port))
            break
    except ConnectionRefusedError:
        time.sleep(0.1)  # Arbitrary delay
        attempt += 1
else:
    raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
```

### After (Active Polling):
```python
wait_for_server(server_port)  # Returns immediately when ready
```

## How Has This Been Tested?

All modified test files have been verified:
- `pytest tests/server/fastmcp/test_integration.py` - 20 tests pass
- `pytest tests/client/test_notification_response.py` - 1 test passes
- `pytest tests/client/test_http_unicode.py` - 2 tests pass
- `pytest tests/shared/test_sse.py::test_sse_client_basic_connection_mounted_app` - 1 test passes

## Breaking Changes

None - this is purely an internal test infrastructure improvement.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This change:
- Removes 49 lines of duplicate manual polling code
- Makes tests more deterministic and reliable  
- Reduces wasted time from fixed delays (tests return as soon as server is ready)

All server startup waiting uses the centralized `wait_for_server()` helper.