### PR TITLE
fix: Add accept json headers for token request

### DIFF
--- a/src/mcp/client/auth.py
+++ b/src/mcp/client/auth.py
@@ -424,7 +424,10 @@ class OAuthClientProvider(httpx.Auth):
             token_data["client_secret"] = self.context.client_info.client_secret
 
         return httpx.Request(
-            "POST", token_url, data=token_data, headers={"Content-Type": "application/x-www-form-urlencoded"}
+            "POST",
+            token_url,
+            data=token_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
         )
 
     async def _handle_token_response(self, response: httpx.Response) -> None:
@@ -478,7 +481,10 @@ class OAuthClientProvider(httpx.Auth):
             refresh_data["client_secret"] = self.context.client_info.client_secret
 
         return httpx.Request(
-            "POST", token_url, data=refresh_data, headers={"Content-Type": "application/x-www-form-urlencoded"}
+            "POST",
+            token_url,
+            data=refresh_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
         )
 
     async def _handle_refresh_response(self, response: httpx.Response) -> bool:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -527,6 +527,7 @@ class TestOAuthFallback:
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert request.headers["Accept"] == "application/json"
 
         # Check form data
         content = request.content.decode()
@@ -552,6 +553,7 @@ class TestOAuthFallback:
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert request.headers["Accept"] == "application/json"
 
         # Check form data
         content = request.content.decode()


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Include `"Accept": "application/json"` for exchange token and refresh token to avoid exception 
 
https://github.com/modelcontextprotocol/python-sdk/blob/673423da0d6511127608df3d75360e47e99cb1f1/src/mcp/client/auth.py#L437

https://github.com/modelcontextprotocol/python-sdk/blob/673423da0d6511127608df3d75360e47e99cb1f1/src/mcp/client/auth.py#L493

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Closes https://github.com/modelcontextprotocol/python-sdk/issues/1523

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
added unit test for headers

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
