### PR TITLE
feat: Implement SEP-986: Tool Name Guidance

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1,8 +1,7 @@
-import re
 from collections.abc import Callable
 from typing import Annotated, Any, Generic, Literal, TypeAlias, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel, field_validator
+from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel, StringConstraints
 from pydantic.networks import AnyUrl, UrlConstraints
 from typing_extensions import deprecated
 
@@ -39,10 +38,6 @@ Cursor = str
 Role = Literal["user", "assistant"]
 RequestId = Annotated[int, Field(strict=True)] | str
 AnyFunction: TypeAlias = Callable[..., Any]
-
-# Tool name validation pattern (ASCII letters, digits, underscore, dash, dot)
-# Pattern ensures entire string contains only valid characters by using ^ and $ anchors
-TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 class RequestParams(BaseModel):
@@ -204,7 +199,7 @@ class EmptyResult(Result):
 class BaseMetadata(BaseModel):
     """Base class for entities with name and optional title fields."""
 
-    name: str
+    name: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9_.-]+$")]
     """The programmatic name of the entity."""
 
     title: str | None = None
@@ -895,17 +890,6 @@ class Tool(BaseMetadata):
     for notes on _meta usage.
     """
     model_config = ConfigDict(extra="allow")
-
-    @field_validator("name")
-    @classmethod
-    def _validate_tool_name(cls, value: str) -> str:
-        if not (1 <= len(value) <= 128):
-            raise ValueError(f"Invalid tool name length: {len(value)}. Tool name must be between 1 and 128 characters.")
-
-        if not TOOL_NAME_PATTERN.fullmatch(value):
-            raise ValueError("Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.).")
-
-        return value
 
     """
     See [MCP specification](https://modelcontextprotocol.io/specification/draft/server/tools#tool-names)

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1,5 +1,5 @@
-from collections.abc import Callable
 import re
+from collections.abc import Callable
 from typing import Annotated, Any, Generic, Literal, TypeAlias, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, FileUrl, RootModel, field_validator

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -199,7 +199,7 @@ class EmptyResult(Result):
 class BaseMetadata(BaseModel):
     """Base class for entities with name and optional title fields."""
 
-    name: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9_.-]+$")]
+    name: str
     """The programmatic name of the entity."""
 
     title: str | None = None
@@ -868,9 +868,13 @@ class ToolAnnotations(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class Tool(BaseMetadata):
+class Tool(BaseModel):
     """Definition for a tool the client can call."""
 
+    name: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9_.-]+$")]
+    """The programmatic name of the tool. Must match pattern: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."""
+    title: str | None = None
+    """A human-readable title for the tool."""
     description: str | None = None
     """A human-readable description of the tool."""
     inputSchema: dict[str, Any]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -9,6 +9,7 @@ from mcp.types import (
     InitializeRequestParams,
     JSONRPCMessage,
     JSONRPCRequest,
+    Tool,
 )
 
 
@@ -56,3 +57,37 @@ async def test_method_initialization():
     assert initialize_request.method == "initialize", "method should be set to 'initialize'"
     assert initialize_request.params is not None
     assert initialize_request.params.protocolVersion == LATEST_PROTOCOL_VERSION
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "getUser",
+        "DATA_EXPORT_v2",
+        "admin.tools.list",
+        "a",
+        "Z9_.-",
+        "x" * 128,  # max length
+    ],
+)
+def test_tool_allows_valid_names(name: str) -> None:
+    Tool(name=name, inputSchema={"type": "object"})
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("", "Invalid tool name length: 0. Tool name must be between 1 and 128 characters."),
+        ("x" * 129, "Invalid tool name length: 129. Tool name must be between 1 and 128 characters."),
+        ("has space", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
+        ("comma,name", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
+        ("not/allowed", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
+        ("name@", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
+        ("name#", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
+        ("name$", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
+    ],
+)
+def test_tool_rejects_invalid_names(name: str, expected: str) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        Tool(name=name, inputSchema={"type": "object"})
+    assert expected in str(exc_info.value)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -72,22 +72,3 @@ async def test_method_initialization():
 )
 def test_tool_allows_valid_names(name: str) -> None:
     Tool(name=name, inputSchema={"type": "object"})
-
-
-@pytest.mark.parametrize(
-    ("name", "expected"),
-    [
-        ("", "Invalid tool name length: 0. Tool name must be between 1 and 128 characters."),
-        ("x" * 129, "Invalid tool name length: 129. Tool name must be between 1 and 128 characters."),
-        ("has space", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
-        ("comma,name", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
-        ("not/allowed", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
-        ("name@", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
-        ("name#", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
-        ("name$", "Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.)."),
-    ],
-)
-def test_tool_rejects_invalid_names(name: str, expected: str) -> None:
-    with pytest.raises(ValueError) as exc_info:
-        Tool(name=name, inputSchema={"type": "object"})
-    assert expected in str(exc_info.value)


### PR DESCRIPTION
## Implement SEP-986: Tool Name Guidance for Tool Type

### Changes
- Added a length check that raises an error when the tool name is not within the allowed range:
  ```python
  raise ValueError(f"Invalid tool name length: {len(value)}. Tool name must be between 1 and 128 characters.")
  ```
- Added a regex validation using `re.compile(r"^[A-Za-z0-9_.-]+$")` that raises an error for invalid characters:
  ```python
  raise ValueError("Invalid tool name characters. Allowed: A-Z, a-z, 0-9, underscore (_), dash (-), dot (.).")
  ```

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Related issues: SEP-986 https://github.com/modelcontextprotocol/python-sdk/issues/1537

Implements the guidance from https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986
```
- Tool names SHOULD be between 1 and 128 characters in length (inclusive).
- Tool names SHOULD be considered case-sensitive.
- The following SHOULD be the only allowed characters: uppercase and lowercase ASCII letters (A-Z, a-z), digits
  (0-9), underscore (\_), dash (-), and dot (.)
- Tool names SHOULD NOT contain spaces, commas, or other special characters.
- Tool names SHOULD be unique within a server.
- Example valid tool names:
  - getUser
  - DATA_EXPORT_v2
  - admin.tools.list
```


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
## Unit Tests

### Valid Values
- `getUser`
- `DATA_EXPORT_v2`
- `admin.tools.list`
- `a`
- `Z9_.-`
- `"x" * 128`  (max length)

### Invalid Values
- `""`  (empty string)
- `"x" * 129`  (exceeds max length)
- `has space`
- `comma,name`
- `not/allowed`
- `name@`
- `name#`
- `name$`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
