### PR TITLE
Make test dependencies required instead of optional

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -20,7 +20,7 @@ jobs:
           enable-cache: true
           version: 0.9.5
       - name: Install dependencies
-        run: uv sync --frozen --all-extras --python 3.10
+        run: uv sync --frozen --python 3.10
 
       - uses: pre-commit/action@v3.0.1
         with:
@@ -53,7 +53,7 @@ jobs:
           version: 0.9.5
 
       - name: Install the project
-        run: uv sync ${{ matrix.dep-resolution.install-flags }} --all-extras --python ${{ matrix.python-version }}
+        run: uv sync ${{ matrix.dep-resolution.install-flags }} --python ${{ matrix.python-version }}
 
       - name: Run pytest
         run: uv run ${{ matrix.dep-resolution.install-flags }} --no-sync pytest
@@ -71,7 +71,7 @@ jobs:
           version: 0.9.5
 
       - name: Install dependencies
-        run: uv sync --frozen --all-extras --python 3.10
+        run: uv sync --frozen --python 3.10
 
       - name: Check README snippets are up to date
         run: uv run --frozen scripts/update_readme_snippets.py --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ dev = [
     "pytest-pretty>=1.2.0",
     "inline-snapshot>=0.23.0",
     "dirty-equals>=0.9.0",
+    # Optional dependencies needed for testing
+    "rich>=13.9.4",
+    "typer>=0.16.0",
+    "python-dotenv>=1.0.0",
+    "websockets>=15.0.1",
 ]
 docs = [
     "mkdocs>=1.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -691,8 +691,12 @@ dev = [
     { name = "pytest-flakefinder" },
     { name = "pytest-pretty" },
     { name = "pytest-xdist" },
+    { name = "python-dotenv" },
+    { name = "rich" },
     { name = "ruff" },
     { name = "trio" },
+    { name = "typer" },
+    { name = "websockets" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -732,8 +736,12 @@ dev = [
     { name = "pytest-flakefinder", specifier = ">=1.1.0" },
     { name = "pytest-pretty", specifier = ">=1.2.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "rich", specifier = ">=13.9.4" },
     { name = "ruff", specifier = ">=0.8.5" },
     { name = "trio", specifier = ">=0.26.2" },
+    { name = "typer", specifier = ">=0.16.0" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
 docs = [
     { name = "mkdocs", specifier = ">=1.6.1" },


### PR DESCRIPTION
## Summary

This PR adds `rich`, `typer`, `python-dotenv`, and `websockets` to the required dev dependencies.

## Motivation and Context

Previously, these dependencies were only available when specific optional features were enabled (e.g., `[cli]`, `[sse]`). This meant running `uv sync` without `--all-extras` wouldn't install them, which was problematic because:

1. Test suites that import these libraries would fail when developers ran `uv sync` without `--all-extras`
2. The `--all-extras` flag had to be remembered and used consistently across development workflows
3. CI workflows required `--all-extras` to function properly

This change makes development more ergonomic by ensuring all dependencies needed for testing are always present.

## How Has This Been Tested?

- Verified that `uv sync` now includes rich, typer, python-dotenv, and websockets
- Confirmed CI workflow changes (removed `--all-extras`) still work correctly

## Breaking Changes

None - this only affects development workflow, not the published package.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The main benefit is that `uv sync` now "just works" without needing to remember `--all-extras`. The CI workflow has been updated to remove the `--all-extras` flag since it's no longer needed.