### PR TITLE
docs: use article "an" before "MCP" instead of "a"

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -67,7 +67,7 @@ def _build_uv_command(
     with_editable: Path | None = None,
     with_packages: list[str] | None = None,
 ) -> list[str]:
-    """Build the uv run command that runs a MCP server through mcp run."""
+    """Build the uv run command that runs an MCP server through mcp run."""
     cmd = ["uv"]
 
     cmd.extend(["run", "--with", "mcp"])
@@ -117,7 +117,7 @@ def _parse_file_path(file_spec: str) -> tuple[Path, str | None]:
 
 
 def _import_server(file: Path, server_object: str | None = None):
-    """Import a MCP server from a file.
+    """Import an MCP server from a file.
 
     Args:
         file: Path to the file
@@ -244,7 +244,7 @@ def dev(
         ),
     ] = [],
 ) -> None:
-    """Run a MCP server with the MCP Inspector."""
+    """Run an MCP server with the MCP Inspector."""
     file, server_object = _parse_file_path(file_spec)
 
     logger.debug(
@@ -317,7 +317,7 @@ def run(
         ),
     ] = None,
 ) -> None:
-    """Run a MCP server.
+    """Run an MCP server.
 
     The server can be specified in two ways:\n
     1. Module approach: server.py - runs the module directly, expecting a server.run() call.\n
@@ -412,7 +412,7 @@ def install(
         ),
     ] = None,
 ) -> None:
-    """Install a MCP server in the Claude desktop app.
+    """Install an MCP server in the Claude desktop app.
 
     Environment variables are preserved once added and only updated if new values
     are explicitly provided.


### PR DESCRIPTION
## Motivation and Context

Replaced incorrect "a MCP" with "an MCP" across multiple documentation files to match the correct usage based on pronunciation.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
