### PR TITLE
test: update SSE tests to use StreamingASGITransport instead of uvicorn for server testing

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -1,11 +1,11 @@
 import logging
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, AsyncExitStack
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import anyio
 import httpx
-from anyio.abc import TaskStatus
+from anyio.abc import TaskStatus, TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from httpx_sse import aconnect_sse
 from httpx_sse._exceptions import SSEError
@@ -29,6 +29,7 @@ async def sse_client(
     sse_read_timeout: float = 60 * 5,
     httpx_client_factory: McpHttpClientFactory = create_mcp_http_client,
     auth: httpx.Auth | None = None,
+    maybe_task_group: TaskGroup | None = None,
 ):
     """
     Client transport for SSE.
@@ -52,7 +53,15 @@ async def sse_client(
     read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
     write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
 
-    async with anyio.create_task_group() as tg:
+    async with AsyncExitStack() as stack:
+        # Only create a task group if one wasn't provided
+        if maybe_task_group is None:
+            tg = await stack.enter_async_context(anyio.create_task_group())
+        else:
+            tg = maybe_task_group
+        
+        owns_task_group = maybe_task_group is None
+            
         try:
             logger.debug(f"Connecting to SSE endpoint: {remove_request_params(url)}")
             async with httpx_client_factory(
@@ -142,7 +151,8 @@ async def sse_client(
                     try:
                         yield read_stream, write_stream
                     finally:
-                        tg.cancel_scope.cancel()
+                        if owns_task_group:
+                            tg.cancel_scope.cancel()
         finally:
             await read_stream_writer.aclose()
             await write_stream.aclose()

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -1,11 +1,11 @@
 import logging
-from contextlib import asynccontextmanager, AsyncExitStack
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import anyio
 import httpx
-from anyio.abc import TaskStatus, TaskGroup
+from anyio.abc import TaskGroup, TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from httpx_sse import aconnect_sse
 from httpx_sse._exceptions import SSEError
@@ -59,9 +59,9 @@ async def sse_client(
             tg = await stack.enter_async_context(anyio.create_task_group())
         else:
             tg = maybe_task_group
-        
+
         owns_task_group = maybe_task_group is None
-            
+
         try:
             logger.debug(f"Connecting to SSE endpoint: {remove_request_params(url)}")
             async with httpx_client_factory(

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -190,25 +190,14 @@ class SseServerTransport:
                 )
                 await read_stream_writer.aclose()
                 await write_stream_reader.aclose()
+                await sse_stream_reader.aclose()
                 logging.debug(f"Client session disconnected {session_id}")
 
             logger.debug("Starting SSE response task")
             tg.start_soon(response_wrapper, scope, receive, send)
 
             logger.debug("Yielding read and write streams")
-            try:
-                yield (read_stream, write_stream)
-            finally:
-                # Close all remaining stream ends
-                for stream, name in [
-                    (read_stream, "read_stream"),
-                    (write_stream, "write_stream"),
-                    (sse_stream_reader, "sse_stream_reader"),
-                ]:
-                    try:
-                        await stream.aclose()
-                    except Exception as e:
-                        logger.debug(f"Error closing {name}: {e}")
+            yield (read_stream, write_stream)
 
     async def handle_post_message(self, scope: Scope, receive: Receive, send: Send) -> None:
         logger.debug("Handling POST message")

--- a/src/mcp/server/streaming_asgi_transport.py
+++ b/src/mcp/server/streaming_asgi_transport.py
@@ -149,9 +149,7 @@ class StreamingASGITransport(AsyncBaseTransport):
                 async with asgi_receive_channel:
                     async for message in asgi_receive_channel:
                         if message["type"] == "http.response.start":
-                            if response_started:
-                                # Ignore duplicate response.start from ASGI app during SSE disconnect
-                                continue
+                            assert not response_started
                             status_code = message["status"]
                             response_headers = message.get("headers", [])
                             response_started = True

--- a/src/mcp/server/streaming_asgi_transport.py
+++ b/src/mcp/server/streaming_asgi_transport.py
@@ -174,6 +174,7 @@ class StreamingASGITransport(AsyncBaseTransport):
                 # Ensure events are set even if there's an error
                 initial_response_ready.set()
                 response_complete.set()
+                await content_send_channel.aclose()
 
 
         # Create tasks for running the app and processing messages

--- a/src/mcp/server/streaming_asgi_transport.py
+++ b/src/mcp/server/streaming_asgi_transport.py
@@ -9,8 +9,8 @@ This is only intended for writing tests for the SSE transport.
 """
 
 import typing
+from collections.abc import Awaitable, Callable
 from typing import Any, cast
-from typing import Callable, Awaitable
 
 import anyio
 import anyio.abc

--- a/src/mcp/server/streaming_asgi_transport.py
+++ b/src/mcp/server/streaming_asgi_transport.py
@@ -176,7 +176,6 @@ class StreamingASGITransport(AsyncBaseTransport):
                 response_complete.set()
                 await content_send_channel.aclose()
 
-
         # Create tasks for running the app and processing messages
         self.task_group.start_soon(run_app)
         self.task_group.start_soon(process_messages)

--- a/src/mcp/server/streaming_asgi_transport.py
+++ b/src/mcp/server/streaming_asgi_transport.py
@@ -188,7 +188,7 @@ class StreamingASGITransport(AsyncBaseTransport):
         return Response(
             status_code,
             headers=response_headers,
-            stream = StreamingASGIResponseStream(content_receive_channel, send_disconnect),
+            stream=StreamingASGIResponseStream(content_receive_channel, send_disconnect),
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,45 @@
+import anyio
 import pytest
+import sse_starlette
+from packaging import version
 
 
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+SSE_STARLETTE_VERSION = version.parse(sse_starlette.__version__)
+NEEDS_RESET = SSE_STARLETTE_VERSION < version.parse("3.0.0")
+
+
+@pytest.fixture(autouse=True)
+def reset_sse_app_status():
+    """Reset sse-starlette's global AppStatus singleton before each test.
+
+    AppStatus.should_exit_event is a global asyncio.Event that gets bound to
+    an event loop. This ensures each test gets a fresh Event and prevents
+    RuntimeError("bound to a different event loop") during parallel test
+    execution with pytest-xdist.
+
+    NOTE: This fixture is only necessary for sse-starlette < 3.0.0.
+    Version 3.0+ eliminated the global state issue entirely by using
+    context-local events instead of module-level singletons, providing
+    automatic test isolation without manual cleanup.
+
+    See <https://github.com/sysid/sse-starlette/pull/141> for more details.
+    """
+    if not NEEDS_RESET:
+        yield
+        return
+
+    # lazy import to avoid import errors
+    from sse_starlette.sse import AppStatus
+
+    # Setup: Reset before test
+    AppStatus.should_exit_event = anyio.Event()  # type: ignore[attr-defined]
+
+    yield
+
+    # Teardown: Reset after test to prevent contamination
+    AppStatus.should_exit_event = anyio.Event()  # type: ignore[attr-defined]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,6 @@ def anyio_backend():
     return "asyncio"
 
 
-SSE_STARLETTE_VERSION = version.parse(sse_starlette.__version__)
-NEEDS_RESET = SSE_STARLETTE_VERSION < version.parse("3.0.0")
-
-
 @pytest.fixture(autouse=True)
 def reset_sse_app_status():
     """Reset sse-starlette's global AppStatus singleton before each test.
@@ -29,6 +25,10 @@ def reset_sse_app_status():
 
     See <https://github.com/sysid/sse-starlette/pull/141> for more details.
     """
+
+    SSE_STARLETTE_VERSION = version.parse(sse_starlette.__version__)
+    NEEDS_RESET = SSE_STARLETTE_VERSION < version.parse("3.0.0")
+
     if not NEEDS_RESET:
         yield
         return

--- a/tests/server/test_sse_security.py
+++ b/tests/server/test_sse_security.py
@@ -56,6 +56,7 @@ def create_server_app_with_settings(security_settings: TransportSecuritySettings
         except ValueError as e:
             # Validation error was already handled inside connect_sse
             logger.debug(f"SSE connection failed validation: {e}")
+        # connect_sse already responded; return a no-op ASGI endpoint
         return NoopASGI()
 
     routes = [

--- a/tests/server/test_sse_security.py
+++ b/tests/server/test_sse_security.py
@@ -1,39 +1,30 @@
 """Tests for SSE server DNS rebinding protection."""
 
 import logging
-import multiprocessing
-import socket
+from collections.abc import AsyncGenerator
 
+import anyio
 import httpx
 import pytest
-import uvicorn
+from anyio.abc import TaskGroup
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import Response
 from starlette.routing import Mount, Route
 
 from mcp.server import Server
 from mcp.server.sse import SseServerTransport
+from mcp.server.streaming_asgi_transport import StreamingASGITransport
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import Tool
-from tests.test_helpers import wait_for_server
+from tests.test_helpers import NoopASGI
 
 logger = logging.getLogger(__name__)
 SERVER_NAME = "test_sse_security_server"
+TEST_SERVER_HOST = "testserver"
+TEST_SERVER_BASE_URL = f"http://{TEST_SERVER_HOST}"
 
 
-@pytest.fixture
-def server_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-@pytest.fixture
-def server_url(server_port: int) -> str:
-    return f"http://127.0.0.1:{server_port}"
-
-
+# Test server implementation
 class SecurityTestServer(Server):
     def __init__(self):
         super().__init__(SERVER_NAME)
@@ -42,12 +33,22 @@ class SecurityTestServer(Server):
         return []
 
 
-def run_server_with_settings(port: int, security_settings: TransportSecuritySettings | None = None):
+@pytest.fixture()
+async def tg() -> AsyncGenerator[TaskGroup, None]:
+    """Create a task group for the server."""
+    async with anyio.create_task_group() as tg:
+        try:
+            yield tg
+        finally:
+            tg.cancel_scope.cancel()
+
+
+def create_server_app_with_settings(security_settings: TransportSecuritySettings | None = None):
     """Run the SSE server with specified security settings."""
     app = SecurityTestServer()
     sse_transport = SseServerTransport("/messages/", security_settings)
 
-    async def handle_sse(request: Request):
+    async def handle_sse(request: Request) -> NoopASGI:
         try:
             async with sse_transport.connect_sse(request.scope, request.receive, request._send) as streams:
                 if streams:
@@ -55,7 +56,7 @@ def run_server_with_settings(port: int, security_settings: TransportSecuritySett
         except ValueError as e:
             # Validation error was already handled inside connect_sse
             logger.debug(f"SSE connection failed validation: {e}")
-        return Response()
+        return NoopASGI()
 
     routes = [
         Route("/sse", endpoint=handle_sse),
@@ -63,231 +64,209 @@ def run_server_with_settings(port: int, security_settings: TransportSecuritySett
     ]
 
     starlette_app = Starlette(routes=routes)
-    uvicorn.run(starlette_app, host="127.0.0.1", port=port, log_level="error")
+    return starlette_app
 
 
-def start_server_process(port: int, security_settings: TransportSecuritySettings | None = None):
-    """Start server in a separate process."""
-    process = multiprocessing.Process(target=run_server_with_settings, args=(port, security_settings))
-    process.start()
-    # Wait for server to be ready to accept connections
-    wait_for_server(port)
-    return process
+def make_client(transport: httpx.AsyncBaseTransport) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=transport, base_url=TEST_SERVER_BASE_URL, timeout=5.0)
+
+
+async def close_client_streaming_response(response: httpx.Response):
+    """Close the client streaming response."""
+    # consume the first non-empty line / event, then stop
+    async for line in response.aiter_lines():
+        if line and line.strip():  # skip empty keepalive lines
+            break
+    # close the streaming response cleanly
+    await response.aclose()
 
 
 @pytest.mark.anyio
-async def test_sse_security_default_settings(server_port: int):
+async def test_sse_security_default_settings(tg: TaskGroup):
     """Test SSE with default security settings (protection disabled)."""
-    process = start_server_process(server_port)
+    server_app = create_server_app_with_settings()
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
 
-    try:
-        headers = {"Host": "evil.com", "Origin": "http://evil.com"}
+    headers = {"Host": "evil.com", "Origin": "http://evil.com"}
 
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            async with client.stream("GET", f"http://127.0.0.1:{server_port}/sse", headers=headers) as response:
-                assert response.status_code == 200
-    finally:
-        process.terminate()
-        process.join()
+    async with make_client(transport) as client:
+        async with client.stream("GET", "/sse", headers=headers) as response:
+            assert response.status_code == 200
+            await close_client_streaming_response(response)
 
 
 @pytest.mark.anyio
-async def test_sse_security_invalid_host_header(server_port: int):
+async def test_sse_security_invalid_host_header():
     """Test SSE with invalid Host header."""
     # Enable security by providing settings with an empty allowed_hosts list
     security_settings = TransportSecuritySettings(enable_dns_rebinding_protection=True, allowed_hosts=["example.com"])
-    process = start_server_process(server_port, security_settings)
+    server_app = create_server_app_with_settings(security_settings)
+    transport = httpx.ASGITransport(app=server_app, raise_app_exceptions=True)
 
-    try:
-        # Test with invalid host header
-        headers = {"Host": "evil.com"}
+    # Test with invalid host header
+    headers = {"Host": "evil.com"}
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{server_port}/sse", headers=headers)
-            assert response.status_code == 421
-            assert response.text == "Invalid Host header"
-
-    finally:
-        process.terminate()
-        process.join()
+    response = await make_client(transport).get("/sse", headers=headers)
+    assert response.status_code == 421
+    assert response.text == "Invalid Host header"
 
 
 @pytest.mark.anyio
-async def test_sse_security_invalid_origin_header(server_port: int):
+async def test_sse_security_invalid_origin_header(tg: TaskGroup):
     """Test SSE with invalid Origin header."""
     # Configure security to allow the host but restrict origins
     security_settings = TransportSecuritySettings(
-        enable_dns_rebinding_protection=True, allowed_hosts=["127.0.0.1:*"], allowed_origins=["http://localhost:*"]
+        enable_dns_rebinding_protection=True, allowed_hosts=[TEST_SERVER_HOST], allowed_origins=["http://localhost:*"]
     )
-    process = start_server_process(server_port, security_settings)
+    server_app = create_server_app_with_settings(security_settings)
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
 
-    try:
-        # Test with invalid origin header
-        headers = {"Origin": "http://evil.com"}
+    # Test with invalid origin header
+    headers = {"Origin": "http://evil.com"}
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{server_port}/sse", headers=headers)
-            assert response.status_code == 403
-            assert response.text == "Invalid Origin header"
-
-    finally:
-        process.terminate()
-        process.join()
+    async with make_client(transport) as client:
+        response = await client.get("/sse", headers=headers)
+        assert response.status_code == 403
+        assert response.text == "Invalid Origin header"
 
 
 @pytest.mark.anyio
-async def test_sse_security_post_invalid_content_type(server_port: int):
+async def test_sse_security_post_invalid_content_type(tg: TaskGroup):
     """Test POST endpoint with invalid Content-Type header."""
     # Configure security to allow the host
     security_settings = TransportSecuritySettings(
-        enable_dns_rebinding_protection=True, allowed_hosts=["127.0.0.1:*"], allowed_origins=["http://127.0.0.1:*"]
+        enable_dns_rebinding_protection=True, allowed_hosts=[TEST_SERVER_HOST], allowed_origins=["http://127.0.0.1:*"]
     )
-    process = start_server_process(server_port, security_settings)
+    server_app = create_server_app_with_settings(security_settings)
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
 
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            # Test POST with invalid content type
-            fake_session_id = "12345678123456781234567812345678"
-            response = await client.post(
-                f"http://127.0.0.1:{server_port}/messages/?session_id={fake_session_id}",
-                headers={"Content-Type": "text/plain"},
-                content="test",
-            )
-            assert response.status_code == 400
-            assert response.text == "Invalid Content-Type header"
+    async with make_client(transport) as client:
+        # Test POST with invalid content type
+        fake_session_id = "12345678123456781234567812345678"
+        response = await client.post(
+            f"/messages/?session_id={fake_session_id}",
+            headers={"Content-Type": "text/plain"},
+            content="test",
+        )
+        assert response.status_code == 400
+        assert response.text == "Invalid Content-Type header"
 
-            # Test POST with missing content type
-            response = await client.post(
-                f"http://127.0.0.1:{server_port}/messages/?session_id={fake_session_id}", content="test"
-            )
-            assert response.status_code == 400
-            assert response.text == "Invalid Content-Type header"
-
-    finally:
-        process.terminate()
-        process.join()
+        # Test POST with missing content type
+        response = await client.post(f"/messages/?session_id={fake_session_id}", content="test")
+        assert response.status_code == 400
+        assert response.text == "Invalid Content-Type header"
 
 
 @pytest.mark.anyio
-async def test_sse_security_disabled(server_port: int):
+async def test_sse_security_disabled(tg: TaskGroup):
     """Test SSE with security disabled."""
     settings = TransportSecuritySettings(enable_dns_rebinding_protection=False)
-    process = start_server_process(server_port, settings)
+    server_app = create_server_app_with_settings(settings)
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
 
-    try:
-        # Test with invalid host header - should still work
-        headers = {"Host": "evil.com"}
+    # Test with invalid host header - should still work
+    headers = {"Host": "evil.com"}
 
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            # For SSE endpoints, we need to use stream to avoid timeout
-            async with client.stream("GET", f"http://127.0.0.1:{server_port}/sse", headers=headers) as response:
-                # Should connect successfully even with invalid host
-                assert response.status_code == 200
-
-    finally:
-        process.terminate()
-        process.join()
+    async with make_client(transport) as client:
+        # For SSE endpoints, we need to use stream to avoid timeout
+        async with client.stream("GET", "/sse", headers=headers) as response:
+            # Should connect successfully even with invalid host
+            assert response.status_code == 200
+            await close_client_streaming_response(response)
 
 
 @pytest.mark.anyio
-async def test_sse_security_custom_allowed_hosts(server_port: int):
+async def test_sse_security_custom_allowed_hosts(tg: TaskGroup):
     """Test SSE with custom allowed hosts."""
     settings = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=["localhost", "127.0.0.1", "custom.host"],
+        allowed_hosts=[TEST_SERVER_HOST, "custom.host"],
         allowed_origins=["http://localhost", "http://127.0.0.1", "http://custom.host"],
     )
-    process = start_server_process(server_port, settings)
+    server_app = create_server_app_with_settings(settings)
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
 
-    try:
-        # Test with custom allowed host
-        headers = {"Host": "custom.host"}
+    # Test with custom allowed host
+    headers = {"Host": "custom.host"}
 
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            # For SSE endpoints, we need to use stream to avoid timeout
-            async with client.stream("GET", f"http://127.0.0.1:{server_port}/sse", headers=headers) as response:
-                # Should connect successfully with custom host
-                assert response.status_code == 200
+    async with make_client(transport) as client:
+        # For SSE endpoints, we need to use stream to avoid timeout
+        async with client.stream("GET", "/sse", headers=headers) as response:
+            # Should connect successfully with custom host
+            assert response.status_code == 200
+            await close_client_streaming_response(response)
 
-        # Test with non-allowed host
-        headers = {"Host": "evil.com"}
+    # Test with non-allowed host
+    headers = {"Host": "evil.com"}
 
-        async with httpx.AsyncClient() as client:
-            response = await client.get(f"http://127.0.0.1:{server_port}/sse", headers=headers)
-            assert response.status_code == 421
-            assert response.text == "Invalid Host header"
-
-    finally:
-        process.terminate()
-        process.join()
+    async with make_client(transport) as client:
+        response = await client.get("/sse", headers=headers)
+        assert response.status_code == 421
+        assert response.text == "Invalid Host header"
 
 
 @pytest.mark.anyio
-async def test_sse_security_wildcard_ports(server_port: int):
+async def test_sse_security_wildcard_ports(tg: TaskGroup):
     """Test SSE with wildcard port patterns."""
     settings = TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=["localhost:*", "127.0.0.1:*"],
+        allowed_hosts=[TEST_SERVER_HOST, "localhost:*", "127.0.0.1:*"],
         allowed_origins=["http://localhost:*", "http://127.0.0.1:*"],
     )
-    process = start_server_process(server_port, settings)
+    server_app = create_server_app_with_settings(settings)
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
 
-    try:
-        # Test with various port numbers
-        for test_port in [8080, 3000, 9999]:
-            headers = {"Host": f"localhost:{test_port}"}
+    # Test with various port numbers
+    for test_port in [8080, 3000, 9999]:
+        headers = {"Host": f"localhost:{test_port}"}
 
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                # For SSE endpoints, we need to use stream to avoid timeout
-                async with client.stream("GET", f"http://127.0.0.1:{server_port}/sse", headers=headers) as response:
-                    # Should connect successfully with any port
-                    assert response.status_code == 200
+        async with make_client(transport) as client:
+            # For SSE endpoints, we need to use stream to avoid timeout
+            async with client.stream("GET", "/sse", headers=headers) as response:
+                # Should connect successfully with any port
+                assert response.status_code == 200
+                await close_client_streaming_response(response)
 
-            headers = {"Origin": f"http://localhost:{test_port}"}
+        headers = {"Origin": f"http://localhost:{test_port}"}
 
-            async with httpx.AsyncClient(timeout=5.0) as client:
-                # For SSE endpoints, we need to use stream to avoid timeout
-                async with client.stream("GET", f"http://127.0.0.1:{server_port}/sse", headers=headers) as response:
-                    # Should connect successfully with any port
-                    assert response.status_code == 200
-
-    finally:
-        process.terminate()
-        process.join()
+        async with make_client(transport) as client:
+            # For SSE endpoints, we need to use stream to avoid timeout
+            async with client.stream("GET", "/sse", headers=headers) as response:
+                # Should connect successfully with any port
+                assert response.status_code == 200
+                await close_client_streaming_response(response)
 
 
 @pytest.mark.anyio
-async def test_sse_security_post_valid_content_type(server_port: int):
+async def test_sse_security_post_valid_content_type(tg: TaskGroup):
     """Test POST endpoint with valid Content-Type headers."""
     # Configure security to allow the host
     security_settings = TransportSecuritySettings(
-        enable_dns_rebinding_protection=True, allowed_hosts=["127.0.0.1:*"], allowed_origins=["http://127.0.0.1:*"]
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[TEST_SERVER_HOST, "127.0.0.1:*"],
+        allowed_origins=["http://127.0.0.1:*"],
     )
-    process = start_server_process(server_port, security_settings)
+    server_app = create_server_app_with_settings(security_settings)
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
 
-    try:
-        async with httpx.AsyncClient() as client:
-            # Test with various valid content types
-            valid_content_types = [
-                "application/json",
-                "application/json; charset=utf-8",
-                "application/json;charset=utf-8",
-                "APPLICATION/JSON",  # Case insensitive
-            ]
+    async with make_client(transport) as client:
+        # Test with various valid content types
+        valid_content_types = [
+            "application/json",
+            "application/json; charset=utf-8",
+            "application/json;charset=utf-8",
+            "APPLICATION/JSON",  # Case insensitive
+        ]
 
-            for content_type in valid_content_types:
-                # Use a valid UUID format (even though session won't exist)
-                fake_session_id = "12345678123456781234567812345678"
-                response = await client.post(
-                    f"http://127.0.0.1:{server_port}/messages/?session_id={fake_session_id}",
-                    headers={"Content-Type": content_type},
-                    json={"test": "data"},
-                )
-                # Will get 404 because session doesn't exist, but that's OK
-                # We're testing that it passes the content-type check
-                assert response.status_code == 404
-                assert response.text == "Could not find session"
-
-    finally:
-        process.terminate()
-        process.join()
+        for content_type in valid_content_types:
+            # Use a valid UUID format (even though session won't exist)
+            fake_session_id = "12345678123456781234567812345678"
+            response = await client.post(
+                f"/messages/?session_id={fake_session_id}",
+                headers={"Content-Type": content_type},
+                json={"test": "data"},
+            )
+            # Will get 404 because session doesn't exist, but that's OK
+            # We're testing that it passes the content-type check
+            assert response.status_code == 404
+            assert response.text == "Could not find session"

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -1,14 +1,12 @@
 import json
-import multiprocessing
-import socket
-import time
-from collections.abc import AsyncGenerator, Generator
+from collections.abc import AsyncGenerator
+from anyio.abc import TaskGroup
 from typing import Any
 
 import anyio
 import httpx
+from mcp.shared._httpx_utils import McpHttpClientFactory
 import pytest
-import uvicorn
 from inline_snapshot import snapshot
 from pydantic import AnyUrl
 from starlette.applications import Starlette
@@ -33,21 +31,10 @@ from mcp.types import (
     TextResourceContents,
     Tool,
 )
-from tests.test_helpers import wait_for_server
 
 SERVER_NAME = "test_server_for_SSE"
-
-
-@pytest.fixture
-def server_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-@pytest.fixture
-def server_url(server_port: int) -> str:
-    return f"http://127.0.0.1:{server_port}"
+TEST_SERVER_HOST = "testserver"
+TEST_SERVER_BASE_URL = f"http://{TEST_SERVER_HOST}"
 
 
 # Test server implementation
@@ -80,117 +67,116 @@ class ServerTest(Server):
         async def handle_call_tool(name: str, args: dict[str, Any]) -> list[TextContent]:
             return [TextContent(type="text", text=f"Called {name}")]
 
+def create_asgi_client_factory(app: Starlette, tg: TaskGroup) -> McpHttpClientFactory:
+    """Factory function to create httpx clients with StreamingASGITransport"""
+    def asgi_client_factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        transport = StreamingASGITransport(app=app, task_group=tg)
+        return httpx.AsyncClient(
+            transport=transport, 
+            base_url=TEST_SERVER_BASE_URL, 
+            headers=headers, 
+            timeout=timeout, 
+            auth=auth
+        )
+    return asgi_client_factory
 
-# Test fixtures
-def make_server_app() -> Starlette:
-    """Create test Starlette app with SSE transport"""
-    # Configure security with allowed hosts/origins for testing
+def create_sse_app(server: Server) -> Starlette:
+    """Helper to create SSE app with given server"""
     security_settings = TransportSecuritySettings(
-        allowed_hosts=["127.0.0.1:*", "localhost:*"], allowed_origins=["http://127.0.0.1:*", "http://localhost:*"]
+        allowed_hosts=[TEST_SERVER_HOST],
+        allowed_origins=[TEST_SERVER_BASE_URL],
     )
     sse = SseServerTransport("/messages/", security_settings=security_settings)
-    server = ServerTest()
 
     async def handle_sse(request: Request) -> Response:
         async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
             await server.run(streams[0], streams[1], server.create_initialization_options())
         return Response()
 
-    app = Starlette(
+    return Starlette(
         routes=[
             Route("/sse", endpoint=handle_sse),
             Mount("/messages/", app=sse.handle_post_message),
         ]
     )
 
+
+# Test fixtures
+
+@pytest.fixture()
+def server_app() -> Starlette:
+    """Create test Starlette app with SSE transport"""
+    app = create_sse_app(ServerTest())
     return app
 
-
-def run_server(server_port: int) -> None:
-    app = make_server_app()
-    server = uvicorn.Server(config=uvicorn.Config(app=app, host="127.0.0.1", port=server_port, log_level="error"))
-    print(f"starting server on {server_port}")
-    server.run()
-
-    # Give server time to start
-    while not server.started:
-        print("waiting for server to start")
-        time.sleep(0.5)
+@pytest.fixture()
+async def tg() -> AsyncGenerator[TaskGroup, None]:
+    async with anyio.create_task_group() as tg:
+        yield tg
 
 
 @pytest.fixture()
-def server(server_port: int) -> Generator[None, None, None]:
-    proc = multiprocessing.Process(target=run_server, kwargs={"server_port": server_port}, daemon=True)
-    print("starting process")
-    proc.start()
-
-    # Wait for server to be running
-    print("waiting for server to start")
-    wait_for_server(server_port)
-
-    yield
-
-    print("killing server")
-    # Signal the server to stop
-    proc.kill()
-    proc.join(timeout=2)
-    if proc.is_alive():
-        print("server process failed to terminate")
-
-
-@pytest.fixture()
-async def http_client(server: None, server_url: str) -> AsyncGenerator[httpx.AsyncClient, None]:
-    """Create test client"""
-    async with httpx.AsyncClient(base_url=server_url) as client:
+async def http_client(tg: TaskGroup, server_app: Starlette) -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Create test client using StreamingASGITransport"""
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_SERVER_BASE_URL) as client:
         yield client
+
+@pytest.fixture()
+async def sse_client_session(tg: TaskGroup, server_app: Starlette) -> AsyncGenerator[ClientSession, None]:
+    asgi_client_factory = create_asgi_client_factory(server_app, tg)
+    
+    async with sse_client(f"{TEST_SERVER_BASE_URL}/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory) as streams:
+        async with ClientSession(*streams) as session:
+            yield session
 
 
 # Tests
 @pytest.mark.anyio
 async def test_raw_sse_connection(http_client: httpx.AsyncClient) -> None:
     """Test the SSE connection establishment simply with an HTTP client."""
-    async with anyio.create_task_group():
+        
+    async def connection_test() -> None:
+        async with http_client.stream("GET", "/sse") as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
 
-        async def connection_test() -> None:
-            async with http_client.stream("GET", "/sse") as response:
-                assert response.status_code == 200
-                assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+            line_number = 0
+            async for line in response.aiter_lines():
+                if line_number == 0:
+                    assert line == "event: endpoint"
+                elif line_number == 1:
+                    assert line.startswith("data: /messages/?session_id=")
+                else:
+                    return
+                line_number += 1
 
-                line_number = 0
-                async for line in response.aiter_lines():
-                    if line_number == 0:
-                        assert line == "event: endpoint"
-                    elif line_number == 1:
-                        assert line.startswith("data: /messages/?session_id=")
-                    else:
-                        return
-                    line_number += 1
-
-        # Add timeout to prevent test from hanging if it fails
-        with anyio.fail_after(3):
-            await connection_test()
+    # Add timeout to prevent test from hanging if it fails
+    with anyio.fail_after(3):
+        await connection_test()
 
 
 @pytest.mark.anyio
-async def test_sse_client_basic_connection(server: None, server_url: str) -> None:
-    async with sse_client(server_url + "/sse") as streams:
-        async with ClientSession(*streams) as session:
-            # Test initialization
-            result = await session.initialize()
-            assert isinstance(result, InitializeResult)
-            assert result.serverInfo.name == SERVER_NAME
+async def test_sse_client_basic_connection(sse_client_session: ClientSession) -> None:
+    # Test initialization
+    result = await sse_client_session.initialize()
+    assert isinstance(result, InitializeResult)
+    assert result.serverInfo.name == SERVER_NAME
 
-            # Test ping
-            ping_result = await session.send_ping()
-            assert isinstance(ping_result, EmptyResult)
+    # Test ping
+    ping_result = await sse_client_session.send_ping()
+    assert isinstance(ping_result, EmptyResult)
 
 
 @pytest.fixture
-async def initialized_sse_client_session(server: None, server_url: str) -> AsyncGenerator[ClientSession, None]:
-    async with sse_client(server_url + "/sse", sse_read_timeout=0.5) as streams:
-        async with ClientSession(*streams) as session:
-            await session.initialize()
-            yield session
+async def initialized_sse_client_session(sse_client_session: ClientSession) -> AsyncGenerator[ClientSession, None]:
+    session = sse_client_session
+    await session.initialize()
+    yield session
 
 
 @pytest.mark.anyio
@@ -233,51 +219,32 @@ async def test_sse_client_timeout(
     pytest.fail("the client should have timed out and returned an error already")
 
 
-def run_mounted_server(server_port: int) -> None:
-    app = make_server_app()
-    main_app = Starlette(routes=[Mount("/mounted_app", app=app)])
-    server = uvicorn.Server(config=uvicorn.Config(app=main_app, host="127.0.0.1", port=server_port, log_level="error"))
-    print(f"starting server on {server_port}")
-    server.run()
-
-    # Give server time to start
-    while not server.started:
-        print("waiting for server to start")
-        time.sleep(0.5)
+@pytest.fixture()
+async def mounted_server_app(server_app: Starlette) -> Starlette:
+    """Create a mounted server app"""
+    app = Starlette(routes=[Mount("/mounted_app", app=server_app)])
+    return app
 
 
 @pytest.fixture()
-def mounted_server(server_port: int) -> Generator[None, None, None]:
-    proc = multiprocessing.Process(target=run_mounted_server, kwargs={"server_port": server_port}, daemon=True)
-    print("starting process")
-    proc.start()
-
-    # Wait for server to be running
-    print("waiting for server to start")
-    wait_for_server(server_port)
-
-    yield
-
-    print("killing server")
-    # Signal the server to stop
-    proc.kill()
-    proc.join(timeout=2)
-    if proc.is_alive():
-        print("server process failed to terminate")
-
+async def sse_client_mounted_server_app_session(tg: TaskGroup, mounted_server_app: Starlette) -> AsyncGenerator[ClientSession, None]:
+    asgi_client_factory = create_asgi_client_factory(mounted_server_app, tg)
+    
+    async with sse_client(f"{TEST_SERVER_BASE_URL}/mounted_app/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory) as streams:
+        async with ClientSession(*streams) as session:
+            yield session
 
 @pytest.mark.anyio
-async def test_sse_client_basic_connection_mounted_app(mounted_server: None, server_url: str) -> None:
-    async with sse_client(server_url + "/mounted_app/sse") as streams:
-        async with ClientSession(*streams) as session:
-            # Test initialization
-            result = await session.initialize()
-            assert isinstance(result, InitializeResult)
-            assert result.serverInfo.name == SERVER_NAME
+async def test_sse_client_basic_connection_mounted_app(sse_client_mounted_server_app_session: ClientSession) -> None:
+    session = sse_client_mounted_server_app_session
+    # Test initialization
+    result = await session.initialize()
+    assert isinstance(result, InitializeResult)
+    assert result.serverInfo.name == SERVER_NAME
 
-            # Test ping
-            ping_result = await session.send_ping()
-            assert isinstance(ping_result, EmptyResult)
+    # Test ping
+    ping_result = await session.send_ping()
+    assert isinstance(ping_result, EmptyResult)
 
 
 # Test server with request context that returns headers in the response
@@ -323,78 +290,14 @@ class RequestContextServer(Server[object, Request]):
             ]
 
 
-def run_context_server(server_port: int) -> None:
-    """Run a server that captures request context"""
-    # Configure security with allowed hosts/origins for testing
-    security_settings = TransportSecuritySettings(
-        allowed_hosts=["127.0.0.1:*", "localhost:*"], allowed_origins=["http://127.0.0.1:*", "http://localhost:*"]
-    )
-    sse = SseServerTransport("/messages/", security_settings=security_settings)
-    context_server = RequestContextServer()
-
-    async def handle_sse(request: Request) -> Response:
-        async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
-            await context_server.run(streams[0], streams[1], context_server.create_initialization_options())
-        return Response()
-
-    app = Starlette(
-        routes=[
-            Route("/sse", endpoint=handle_sse),
-            Mount("/messages/", app=sse.handle_post_message),
-        ]
-    )
-
-    server = uvicorn.Server(config=uvicorn.Config(app=app, host="127.0.0.1", port=server_port, log_level="error"))
-    print(f"starting context server on {server_port}")
-    server.run()
-
-
 @pytest.fixture()
-def context_server(server_port: int) -> Generator[None, None, None]:
-    """Fixture that provides a server with request context capture"""
-    proc = multiprocessing.Process(target=run_context_server, kwargs={"server_port": server_port}, daemon=True)
-    print("starting context server process")
-    proc.start()
-
-    # Wait for server to be running
-    print("waiting for context server to start")
-    wait_for_server(server_port)
-
-    yield
-
-    print("killing context server")
-    proc.kill()
-    proc.join(timeout=2)
-    if proc.is_alive():
-        print("context server process failed to terminate")
-
-
-@pytest.fixture()
-async def context_app() -> Starlette:
+async def context_server_app() -> Starlette:
     """Fixture that provides the context server app"""
-    security_settings = TransportSecuritySettings(
-        allowed_hosts=["127.0.0.1:*", "localhost:*", "testserver"],
-        allowed_origins=["http://127.0.0.1:*", "http://localhost:*", "http://testserver"],
-    )
-    sse = SseServerTransport("/messages/", security_settings=security_settings)
-    context_server = RequestContextServer()
-
-    async def handle_sse(request: Request) -> Response:
-        async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
-            await context_server.run(streams[0], streams[1], context_server.create_initialization_options())
-        return Response()
-
-    app = Starlette(
-        routes=[
-            Route("/sse", endpoint=handle_sse),
-            Mount("/messages/", app=sse.handle_post_message),
-        ]
-    )
+    app = create_sse_app(RequestContextServer())
     return app
 
-
 @pytest.mark.anyio
-async def test_request_context_propagation(context_app: Starlette) -> None:
+async def test_request_context_propagation(tg: TaskGroup, context_server_app: Starlette) -> None:
     """Test that request context is properly propagated through SSE transport."""
     # Test with custom headers
     custom_headers = {
@@ -403,61 +306,45 @@ async def test_request_context_propagation(context_app: Starlette) -> None:
         "X-Trace-Id": "trace-123",
     }
 
-    async with anyio.create_task_group() as tg:
+    asgi_client_factory = create_asgi_client_factory(context_server_app, tg)
 
-        def create_test_client(
-            headers: dict[str, str] | None = None,
-            timeout: httpx.Timeout | None = None,
-            auth: httpx.Auth | None = None,
-        ) -> httpx.AsyncClient:
-            transport = StreamingASGITransport(app=context_app, task_group=tg)
-            return httpx.AsyncClient(
-                transport=transport,
-                base_url="http://testserver",
-                headers=headers,
-                timeout=timeout,
-                auth=auth,
-                follow_redirects=True,
-            )
+    async with sse_client(
+        f"{TEST_SERVER_BASE_URL}/sse",
+        headers=custom_headers,
+        httpx_client_factory=asgi_client_factory,
+        sse_read_timeout=0.5,
+    ) as streams:
+        async with ClientSession(*streams) as session:
+            # Initialize the session
+            result = await session.initialize()
+            assert isinstance(result, InitializeResult)
 
-        async with sse_client(
-            "http://testserver/sse",
-            headers=custom_headers,
-            httpx_client_factory=create_test_client,
-            sse_read_timeout=0.5,
-        ) as (
-            read_stream,
-            write_stream,
-        ):
-            async with ClientSession(read_stream, write_stream) as session:
-                # Initialize the session
-                result = await session.initialize()
-                assert isinstance(result, InitializeResult)
+            # Call the tool that echoes headers back
+            tool_result = await session.call_tool("echo_headers", {})
 
-                # Call the tool that echoes headers back
-                tool_result = await session.call_tool("echo_headers", {})
+            # Parse the JSON response
+            assert len(tool_result.content) == 1
+            content_item = tool_result.content[0]
+            headers_data = json.loads(content_item.text if content_item.type == "text" else "{}")
 
-                # Parse the JSON response
-                assert len(tool_result.content) == 1
-                content_item = tool_result.content[0]
-                headers_data = json.loads(content_item.text if content_item.type == "text" else "{}")
-
-                # Verify headers were propagated
-                assert headers_data.get("authorization") == "Bearer test-token"
-                assert headers_data.get("x-custom-header") == "test-value"
-                assert headers_data.get("x-trace-id") == "trace-123"
+            # Verify headers were propagated
+            assert headers_data.get("authorization") == "Bearer test-token"
+            assert headers_data.get("x-custom-header") == "test-value"
+            assert headers_data.get("x-trace-id") == "trace-123"
 
 
 @pytest.mark.anyio
-async def test_request_context_isolation(context_server: None, server_url: str) -> None:
+async def test_request_context_isolation(tg: TaskGroup, context_server_app: Starlette) -> None:
     """Test that request contexts are isolated between different SSE clients."""
     contexts: list[dict[str, Any]] = []
+    
+    asgi_client_factory = create_asgi_client_factory(context_server_app, tg)
 
     # Create multiple clients with different headers
     for i in range(3):
         headers = {"X-Request-Id": f"request-{i}", "X-Custom-Value": f"value-{i}"}
 
-        async with sse_client(server_url + "/sse", headers=headers) as (
+        async with sse_client(f"{TEST_SERVER_BASE_URL}/sse", headers=headers, httpx_client_factory=asgi_client_factory) as (
             read_stream,
             write_stream,
         ):

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -95,6 +95,7 @@ def create_sse_app(server: Server) -> Starlette:
     async def handle_sse(request: Request) -> NoopASGI:
         async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
             await server.run(streams[0], streams[1], server.create_initialization_options())
+        # connect_sse already responded; return a no-op ASGI endpoint
         return NoopASGI()
 
     return Starlette(

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -21,8 +21,8 @@ from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.server import Server
 from mcp.server.sse import SseServerTransport
-from mcp.server.transport_security import TransportSecuritySettings
 from mcp.server.streaming_asgi_transport import StreamingASGITransport
+from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import McpError
 from mcp.types import (
     EmptyResult,
@@ -418,7 +418,10 @@ async def test_request_context_propagation(context_app: Starlette) -> None:
                 follow_redirects=True,
             )
 
-        async with sse_client("http://testserver/sse", headers=custom_headers, httpx_client_factory=create_test_client) as (
+        async with sse_client("http://testserver/sse", 
+        headers=custom_headers, 
+        httpx_client_factory=create_test_client,
+        sse_read_timeout=0.5) as (
             read_stream,
             write_stream,
         ):
@@ -432,7 +435,8 @@ async def test_request_context_propagation(context_app: Starlette) -> None:
 
                 # Parse the JSON response
                 assert len(tool_result.content) == 1
-                headers_data = json.loads(tool_result.content[0].text if tool_result.content[0].type == "text" else "{}")
+                content_item = tool_result.content[0]
+                headers_data = json.loads(content_item.text if content_item.type == "text" else "{}")
 
                 # Verify headers were propagated
                 assert headers_data.get("authorization") == "Bearer test-token"

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -5,10 +5,8 @@ from typing import Any
 import anyio
 import httpx
 import pytest
-import sse_starlette
 from anyio.abc import TaskGroup
 from inline_snapshot import snapshot
-from packaging import version
 from pydantic import AnyUrl
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -33,42 +31,6 @@ from mcp.types import (
     TextResourceContents,
     Tool,
 )
-
-SSE_STARLETTE_VERSION = version.parse(sse_starlette.__version__)
-NEEDS_RESET = SSE_STARLETTE_VERSION < version.parse("3.0.0")
-
-
-@pytest.fixture(autouse=True)
-def reset_sse_app_status():
-    """Reset sse-starlette's global AppStatus singleton before each test.
-
-    AppStatus.should_exit_event is a global asyncio.Event that gets bound to
-    an event loop. This ensures each test gets a fresh Event and prevents
-    RuntimeError("bound to a different event loop") during parallel test
-    execution with pytest-xdist.
-
-    NOTE: This fixture is only necessary for sse-starlette < 3.0.0.
-    Version 3.0+ eliminated the global state issue entirely by using
-    context-local events instead of module-level singletons, providing
-    automatic test isolation without manual cleanup.
-
-    See <https://github.com/sysid/sse-starlette/pull/141> for more details.
-    """
-    if not NEEDS_RESET:
-        yield
-        return
-
-    # lazy import to avoid import errors
-    from sse_starlette.sse import AppStatus
-
-    # Setup: Reset before test
-    AppStatus.should_exit_event = anyio.Event()  # type: ignore[attr-defined]
-
-    yield
-
-    # Teardown: Reset after test to prevent contamination
-    AppStatus.should_exit_event = anyio.Event()  # type: ignore[attr-defined]
-
 
 SERVER_NAME = "test_server_for_SSE"
 TEST_SERVER_HOST = "testserver"

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -134,7 +134,9 @@ async def sse_client_session(tg: TaskGroup, server_app: Starlette) -> AsyncGener
     asgi_client_factory = create_asgi_client_factory(server_app, tg)
 
     async with sse_client(
-        f"{TEST_SERVER_BASE_URL}/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory, 
+        f"{TEST_SERVER_BASE_URL}/sse",
+        sse_read_timeout=0.5,
+        httpx_client_factory=asgi_client_factory,
     ) as streams:
         async with ClientSession(*streams) as session:
             yield session
@@ -238,7 +240,9 @@ async def sse_client_mounted_server_app_session(
     asgi_client_factory = create_asgi_client_factory(mounted_server_app, tg)
 
     async with sse_client(
-        f"{TEST_SERVER_BASE_URL}/mounted_app/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory, 
+        f"{TEST_SERVER_BASE_URL}/mounted_app/sse",
+        sse_read_timeout=0.5,
+        httpx_client_factory=asgi_client_factory,
     ) as streams:
         async with ClientSession(*streams) as session:
             yield session
@@ -324,7 +328,6 @@ async def test_request_context_propagation(tg: TaskGroup, context_server_app: St
         headers=custom_headers,
         httpx_client_factory=asgi_client_factory,
         sse_read_timeout=0.5,
-        
     ) as streams:
         async with ClientSession(*streams) as session:
             # Initialize the session
@@ -357,7 +360,9 @@ async def test_request_context_isolation(tg: TaskGroup, context_server_app: Star
         headers = {"X-Request-Id": f"request-{i}", "X-Custom-Value": f"value-{i}"}
 
         async with sse_client(
-            f"{TEST_SERVER_BASE_URL}/sse", headers=headers, httpx_client_factory=asgi_client_factory,
+            f"{TEST_SERVER_BASE_URL}/sse",
+            headers=headers,
+            httpx_client_factory=asgi_client_factory,
         ) as streams:
             async with ClientSession(*streams) as session:
                 await session.initialize()

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -118,7 +118,10 @@ def server_app() -> Starlette:
 @pytest.fixture()
 async def tg() -> AsyncGenerator[TaskGroup, None]:
     async with anyio.create_task_group() as tg:
-        yield tg
+        try:
+            yield tg
+        finally:
+            tg.cancel_scope.cancel()
 
 
 @pytest.fixture()

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -138,7 +138,6 @@ async def sse_client_session(tg: TaskGroup, server_app: Starlette) -> AsyncGener
 
     async with sse_client(
         f"{TEST_SERVER_BASE_URL}/sse",
-        sse_read_timeout=0.5,
         httpx_client_factory=asgi_client_factory,
     ) as streams:
         async with ClientSession(*streams) as session:

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -116,24 +116,28 @@ def server_app() -> Starlette:
 
 
 @pytest.fixture()
-async def http_client(server_app: Starlette) -> AsyncGenerator[httpx.AsyncClient, None]:
-    """Create test client using StreamingASGITransport"""
+async def tg() -> AsyncGenerator[TaskGroup, None]:
     async with anyio.create_task_group() as tg:
-        transport = StreamingASGITransport(app=server_app, task_group=tg)
-        async with httpx.AsyncClient(transport=transport, base_url=TEST_SERVER_BASE_URL) as client:
-            yield client
+        yield tg
 
 
 @pytest.fixture()
-async def sse_client_session(server_app: Starlette) -> AsyncGenerator[ClientSession, None]:
-    async with anyio.create_task_group() as tg:
-        asgi_client_factory = create_asgi_client_factory(server_app, tg)
+async def http_client(tg: TaskGroup, server_app: Starlette) -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Create test client using StreamingASGITransport"""
+    transport = StreamingASGITransport(app=server_app, task_group=tg)
+    async with httpx.AsyncClient(transport=transport, base_url=TEST_SERVER_BASE_URL) as client:
+        yield client
 
-        async with sse_client(
-            f"{TEST_SERVER_BASE_URL}/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory
-        ) as streams:
-            async with ClientSession(*streams) as session:
-                yield session
+
+@pytest.fixture()
+async def sse_client_session(tg: TaskGroup, server_app: Starlette) -> AsyncGenerator[ClientSession, None]:
+    asgi_client_factory = create_asgi_client_factory(server_app, tg)
+
+    async with sse_client(
+        f"{TEST_SERVER_BASE_URL}/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory, 
+    ) as streams:
+        async with ClientSession(*streams) as session:
+            yield session
 
 
 # Tests
@@ -228,15 +232,16 @@ async def mounted_server_app(server_app: Starlette) -> Starlette:
 
 
 @pytest.fixture()
-async def sse_client_mounted_server_app_session(mounted_server_app: Starlette) -> AsyncGenerator[ClientSession, None]:
-    async with anyio.create_task_group() as tg:
-        asgi_client_factory = create_asgi_client_factory(mounted_server_app, tg)
+async def sse_client_mounted_server_app_session(
+    tg: TaskGroup, mounted_server_app: Starlette
+) -> AsyncGenerator[ClientSession, None]:
+    asgi_client_factory = create_asgi_client_factory(mounted_server_app, tg)
 
-        async with sse_client(
-            f"{TEST_SERVER_BASE_URL}/mounted_app/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory
-        ) as streams:
-            async with ClientSession(*streams) as session:
-                yield session
+    async with sse_client(
+        f"{TEST_SERVER_BASE_URL}/mounted_app/sse", sse_read_timeout=0.5, httpx_client_factory=asgi_client_factory, 
+    ) as streams:
+        async with ClientSession(*streams) as session:
+            yield session
 
 
 @pytest.mark.anyio
@@ -303,7 +308,7 @@ async def context_server_app() -> Starlette:
 
 
 @pytest.mark.anyio
-async def test_request_context_propagation(context_server_app: Starlette) -> None:
+async def test_request_context_propagation(tg: TaskGroup, context_server_app: Starlette) -> None:
     """Test that request context is properly propagated through SSE transport."""
     # Test with custom headers
     custom_headers = {
@@ -312,63 +317,59 @@ async def test_request_context_propagation(context_server_app: Starlette) -> Non
         "X-Trace-Id": "trace-123",
     }
 
-    async with anyio.create_task_group() as tg:
-        asgi_client_factory = create_asgi_client_factory(context_server_app, tg)
+    asgi_client_factory = create_asgi_client_factory(context_server_app, tg)
 
-        async with sse_client(
-            f"{TEST_SERVER_BASE_URL}/sse",
-            headers=custom_headers,
-            httpx_client_factory=asgi_client_factory,
-            sse_read_timeout=0.5,
-        ) as streams:
-            async with ClientSession(*streams) as session:
-                # Initialize the session
-                result = await session.initialize()
-                assert isinstance(result, InitializeResult)
+    async with sse_client(
+        f"{TEST_SERVER_BASE_URL}/sse",
+        headers=custom_headers,
+        httpx_client_factory=asgi_client_factory,
+        sse_read_timeout=0.5,
+        
+    ) as streams:
+        async with ClientSession(*streams) as session:
+            # Initialize the session
+            result = await session.initialize()
+            assert isinstance(result, InitializeResult)
 
-                # Call the tool that echoes headers back
-                tool_result = await session.call_tool("echo_headers", {})
+            # Call the tool that echoes headers back
+            tool_result = await session.call_tool("echo_headers", {})
 
-                # Parse the JSON response
-                assert len(tool_result.content) == 1
-                content_item = tool_result.content[0]
-                headers_data = json.loads(content_item.text if content_item.type == "text" else "{}")
+            # Parse the JSON response
+            assert len(tool_result.content) == 1
+            content_item = tool_result.content[0]
+            headers_data = json.loads(content_item.text if content_item.type == "text" else "{}")
 
-                # Verify headers were propagated
-                assert headers_data.get("authorization") == "Bearer test-token"
-                assert headers_data.get("x-custom-header") == "test-value"
-                assert headers_data.get("x-trace-id") == "trace-123"
+            # Verify headers were propagated
+            assert headers_data.get("authorization") == "Bearer test-token"
+            assert headers_data.get("x-custom-header") == "test-value"
+            assert headers_data.get("x-trace-id") == "trace-123"
 
 
 @pytest.mark.anyio
-async def test_request_context_isolation(context_server_app: Starlette) -> None:
+async def test_request_context_isolation(tg: TaskGroup, context_server_app: Starlette) -> None:
     """Test that request contexts are isolated between different SSE clients."""
     contexts: list[dict[str, Any]] = []
 
-    async with anyio.create_task_group() as tg:
-        asgi_client_factory = create_asgi_client_factory(context_server_app, tg)
+    asgi_client_factory = create_asgi_client_factory(context_server_app, tg)
 
-        # Create multiple clients with different headers
-        for i in range(3):
-            headers = {"X-Request-Id": f"request-{i}", "X-Custom-Value": f"value-{i}"}
+    # Create multiple clients with different headers
+    for i in range(3):
+        headers = {"X-Request-Id": f"request-{i}", "X-Custom-Value": f"value-{i}"}
 
-            async with sse_client(
-                f"{TEST_SERVER_BASE_URL}/sse", headers=headers, httpx_client_factory=asgi_client_factory
-            ) as (
-                read_stream,
-                write_stream,
-            ):
-                async with ClientSession(read_stream, write_stream) as session:
-                    await session.initialize()
+        async with sse_client(
+            f"{TEST_SERVER_BASE_URL}/sse", headers=headers, httpx_client_factory=asgi_client_factory,
+        ) as streams:
+            async with ClientSession(*streams) as session:
+                await session.initialize()
 
-                    # Call the tool that echoes context
-                    tool_result = await session.call_tool("echo_context", {"request_id": f"request-{i}"})
+                # Call the tool that echoes context
+                tool_result = await session.call_tool("echo_context", {"request_id": f"request-{i}"})
 
-                    assert len(tool_result.content) == 1
-                    context_data = json.loads(
-                        tool_result.content[0].text if tool_result.content[0].type == "text" else "{}"
-                    )
-                    contexts.append(context_data)
+                assert len(tool_result.content) == 1
+                context_data = json.loads(
+                    tool_result.content[0].text if tool_result.content[0].type == "text" else "{}"
+                )
+                contexts.append(context_data)
 
     # Verify each request had its own context
     assert len(contexts) == 3

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -368,12 +368,13 @@ def context_server(server_port: int) -> Generator[None, None, None]:
     if proc.is_alive():
         print("context server process failed to terminate")
 
+
 @pytest.fixture()
 async def context_app() -> Starlette:
     """Fixture that provides the context server app"""
     security_settings = TransportSecuritySettings(
-        allowed_hosts=["127.0.0.1:*", "localhost:*", "testserver"], 
-        allowed_origins=["http://127.0.0.1:*", "http://localhost:*", "http://testserver"]
+        allowed_hosts=["127.0.0.1:*", "localhost:*", "testserver"],
+        allowed_origins=["http://127.0.0.1:*", "http://localhost:*", "http://testserver"],
     )
     sse = SseServerTransport("/messages/", security_settings=security_settings)
     context_server = RequestContextServer()
@@ -403,6 +404,7 @@ async def test_request_context_propagation(context_app: Starlette) -> None:
     }
 
     async with anyio.create_task_group() as tg:
+
         def create_test_client(
             headers: dict[str, str] | None = None,
             timeout: httpx.Timeout | None = None,
@@ -418,10 +420,12 @@ async def test_request_context_propagation(context_app: Starlette) -> None:
                 follow_redirects=True,
             )
 
-        async with sse_client("http://testserver/sse", 
-        headers=custom_headers, 
-        httpx_client_factory=create_test_client,
-        sse_read_timeout=0.5) as (
+        async with sse_client(
+            "http://testserver/sse",
+            headers=custom_headers,
+            httpx_client_factory=create_test_client,
+            sse_read_timeout=0.5,
+        ) as (
             read_stream,
             write_stream,
         ):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,8 @@
 import socket
 import time
 
+from starlette.types import Receive, Scope, Send
+
 
 def wait_for_server(port: int, timeout: float = 5.0) -> None:
     """Wait for server to be ready to accept connections.
@@ -29,3 +31,16 @@ def wait_for_server(port: int, timeout: float = 5.0) -> None:
             # Server not ready yet, retry quickly
             time.sleep(0.01)
     raise TimeoutError(f"Server on port {port} did not start within {timeout} seconds")
+
+
+class NoopASGI:
+    """
+    This helper exists only for test SSE handlers. Production MCP servers
+    would normally expose an ASGI endpoint directly. We return this no-op
+    ASGI app instead of Response() so Starlette does not send a second
+    http.response.start, which breaks httpx.ASGITransport and
+    StreamingASGITransport.
+    """
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        return


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This implements fixes to the `StreamingASGITransport` to properly handle SSE streaming and disconnect signaling. The key changes were:

- Added disconnect signaling via `receive()` to fix SSE hanging
- Fixed memory stream cleanup in `SseServerTransport` to eliminate ResourceWarnings
- Handle duplicate `http.response.start` with NoopASGI
- Fixed global sse-starlette quirk
- Update all tests in `tests/server/test_sse_security.py` and `tests/shared/test_sse.py` to use transports instead of real servers with uvicorn

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Partially resolves #857 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Since I updated the testing methodology I made sure to run the test in batches of 30 (to check for race conditions). Using the command:

`passed=0; failed=0; for i in {1..30}; do echo "=== Run $i/30 ===" && uv run --resolution="$RESOLUTION" pytest "$FILE_PATH" -q && passed=$((passed+1)) || failed=$((failed+1)); done; echo "==== SUMMARY: $passed passed, $failed failed out of 30 runs ===="`

for the following resolutions and files:

- `tests/server/test_sse_security.py` for `lowest-direct` and `highest`
- `tests/shared/test_sse.py` for `lowest-direct` and `highest`

All tests passed:

<img width="466" height="97" alt="Screenshot 2025-11-08 at 6 41 36 PM" src="https://github.com/user-attachments/assets/1a084948-60c3-4a37-aa1a-3c1f45e6cf54" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. `StreamingASGITransport` is only meant for testing. The only change I made to `SseServerTransport` was to properly clean up `sse_stream_reader` which is best practice and doesn't break functionality. The modified tests all function as expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
