### PR TITLE
Fix typo in `ClientSessionGroup` doc string

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -77,7 +77,7 @@ class ClientSessionGroup:
     Example Usage:
         name_fn = lambda name, server_info: f"{(server_info.name)}_{name}"
         async with ClientSessionGroup(component_name_hook=name_fn) as group:
-            for server_params in server_params:
+            for server_param in server_params:
                 await group.connect_to_server(server_param)
             ...
 


### PR DESCRIPTION
Fixed a typo in the doc string of `ClientSessionGroup`.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
