### PR TITLE
feat: Pass through and expose additional parameters in `ClientSessionGroup.call_tool` and `.connect_to_server`

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -14,11 +14,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 from types import TracebackType
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, overload
 
 import anyio
 from pydantic import BaseModel
-from typing_extensions import Self
+from typing_extensions import Self, deprecated
 
 import mcp
 from mcp import types
@@ -190,21 +190,45 @@ class ClientSessionGroup:
         """Returns the tools as a dictionary of names to tools."""
         return self._tools
 
+    @overload
     async def call_tool(
         self,
         name: str,
-        args: dict[str, Any],
+        arguments: dict[str, Any],
         read_timeout_seconds: timedelta | None = None,
         progress_callback: ProgressFnT | None = None,
         *,
         meta: dict[str, Any] | None = None,
+    ) -> types.CallToolResult: ...
+
+    @overload
+    @deprecated("The 'args' parameter is deprecated. Use 'arguments' instead.")
+    async def call_tool(
+        self,
+        name: str,
+        *,
+        args: dict[str, Any],
+        read_timeout_seconds: timedelta | None = None,
+        progress_callback: ProgressFnT | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> types.CallToolResult: ...
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        read_timeout_seconds: timedelta | None = None,
+        progress_callback: ProgressFnT | None = None,
+        *,
+        meta: dict[str, Any] | None = None,
+        args: dict[str, Any] | None = None,
     ) -> types.CallToolResult:
         """Executes a tool given its name and arguments."""
         session = self._tool_to_session[name]
         session_tool_name = self.tools[name].name
         return await session.call_tool(
             session_tool_name,
-            args,
+            arguments if args is None else args,
             read_timeout_seconds=read_timeout_seconds,
             progress_callback=progress_callback,
             meta=meta,

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -67,7 +67,7 @@ class TestClientSessionGroup:
         # --- Test Execution ---
         result = await mcp_session_group.call_tool(
             name="server1-my_tool",
-            args={
+            arguments={
                 "name": "value1",
                 "args": {},
             },


### PR DESCRIPTION
Exposed additional optional parameters in the `call_tool` and `connect_to_server` methods so that they can fully pass through supported arguments to the underlying session-level methods.  

Replace the parameter `args` in `call_tool`  with `arguments` so that it's aligned with the original `ClientSession.call_tool` method.
Use `@overload` and `@deprecated` to mark `args` as deprecated while still supporting its usage.

## Motivation and Context
Previously, `call_tool` and `connect_to_server` ignored several optional parameters supported by the lower-level `ClientSession` and session methods.  
As a result, certain advanced use cases (e.g., custom timeouts, callbacks, or client metadata) could only be supported by directly accessing lower-level APIs, which was cumbersome and inconsistent.  

This change:  
- Adds new parameters to `call_tool` for timeouts, progress tracking, and metadata.  
- Adds `session_params` to `connect_to_server` to configure `ClientSession` creation directly.  
- Introduces `ClientSessionParameters` dataclass for clear typing.

## How Has This Been Tested?
Pyright static type check and pytest.

## Breaking Changes
- Not strictly breaking, as old usage patterns are still supported.  
- Minor deprecation warning: The `args` parameter in `call_tool` is deprecated in favor of `arguments`.  

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
`ClientSessionParameters` uses `dataclasses.dataclass` instead of `pydantic.BaseModel` because `BaseModel` does not support `Protocol`-typed fields. Attempts with `SkipValidation` and `arbitrary_types_allowed=True` did not resolve the issue.
