### PR TITLE
Add --frozen flag to uv run commands in Claude config

### DIFF
--- a/src/mcp/cli/claude.py
+++ b/src/mcp/cli/claude.py
@@ -99,7 +99,7 @@ def update_claude_config(
                 env_vars = existing_env
 
         # Build uv run command
-        args = ["run"]
+        args = ["run", "--frozen"]
 
         # Collect all packages in a set to deduplicate
         packages = {MCP_PACKAGE}


### PR DESCRIPTION
This PR adds the `--frozen` flag to all `uv run` commands generated in Claude Desktop configuration files.

## Motivation and Context
When Claude Desktop launches MCP servers using the generated configuration, the `uv run` commands were executing without the `--frozen` flag. This could cause uv to update lock files unexpectedly, leading to:

- Spurious changes to `uv.lock` during development
- Test failures when `test_command_execution` ran the command
- Potential issues in CI/CD pipelines
- Inconsistent dependency resolution across environments

The `--frozen` flag ensures that uv uses the existing lock file without modifications, which is the expected behavior for running applications.

## How Has This Been Tested?
- Verified that `test_command_execution` in `tests/client/test_config.py` no longer updates `uv.lock`
- Confirmed that pre-commit hooks pass
- The generated configuration now includes `["run", "--frozen", "--with", "mcp[cli]", ...]` instead of `["run", "--with", "mcp[cli]", ...]`

## Breaking Changes
No breaking changes. This only affects the generated Claude Desktop configuration commands. Users who have already configured MCP servers in Claude Desktop may want to regenerate their configuration to get the `--frozen` flag, but existing configurations will continue to work.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This aligns with uv's best practices for production deployments where lock file stability is important. The `--frozen` flag is already used throughout the repository's own development workflows (in CI, scripts, etc.) and should also be used in generated configurations.