### PR TITLE
Add get_server_capabilities() to ClientSession

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -134,6 +134,7 @@ class ClientSession(
         self._logging_callback = logging_callback or _default_logging_callback
         self._message_handler = message_handler or _default_message_handler
         self._tool_output_schemas: dict[str, dict[str, Any] | None] = {}
+        self._server_capabilities: types.ServerCapabilities | None = None
 
     async def initialize(self) -> types.InitializeResult:
         sampling = types.SamplingCapability() if self._sampling_callback is not _default_sampling_callback else None
@@ -170,9 +171,18 @@ class ClientSession(
         if result.protocolVersion not in SUPPORTED_PROTOCOL_VERSIONS:
             raise RuntimeError(f"Unsupported protocol version from the server: {result.protocolVersion}")
 
+        self._server_capabilities = result.capabilities
+
         await self.send_notification(types.ClientNotification(types.InitializedNotification()))
 
         return result
+
+    def get_server_capabilities(self) -> types.ServerCapabilities | None:
+        """Return the server capabilities received during initialization.
+
+        Returns None if the session has not been initialized yet.
+        """
+        return self._server_capabilities
 
     async def send_ping(self) -> types.EmptyResult:
         """Send a ping request."""


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

Adds `get_server_capabilities()` method to `ClientSession` to provide access to server capabilities after initialization, matching the TypeScript SDK implementation.

Currently, the Python SDK returns `InitializeResult` from the `initialize()` method, but there's no way to access server capabilities later without storing that result manually. The TypeScript SDK provides `getServerCapabilities()` for this purpose, and this change brings the Python SDK to parity.

## Changes

Implemented `get_server_capabilities()` method that:
- Returns `None` before the session has been initialized
- Returns the `ServerCapabilities` received during the MCP initialization handshake after `initialize()` completes
- Allows clients to query available server features (logging, prompts, resources, tools, etc.) at any point during the session lifecycle

This enables clients to make runtime decisions based on server capabilities without needing to store the initialization result separately.

## How Has This Been Tested?
Local tests

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
