### PR TITLE
chore: Lazy import `jsonschema` library

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -376,7 +376,7 @@ class ClientSession(
 
         if output_schema is not None:
             from jsonschema import SchemaError, ValidationError, validate
-            
+
             if result.structuredContent is None:
                 raise RuntimeError(
                     f"Tool {name} has an output schema but did not return structured content"


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->
Changing the import of `jsonschema` to lazy import within the function that uses it, therefore decreasing the cold start import time of mcp.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When running `import mcp.types` at cold start in a Colab Notebook, the command takes around 2.5s, with the jsonschema library taking up 70% of the latency. As MCP is integrated into more production services, especially those that rely on cold start containerized environment like GCP Cloud Run, the cold start time means life-and-death to the application. Therefore, decreasing this import latency is critical to users.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This is trivial change.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Here's some profiling I do for running `import mcp.types` in Colab: 
<img width="1416" height="947" alt="mcp_profiling" src="https://github.com/user-attachments/assets/84a6c8c3-4e0f-4d6f-bac5-799ae1dba92a" />
