### PR TITLE
fix: validate PRM resource field per RFC 9728 Section 3.3

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -144,7 +144,6 @@ class OAuthContext:
         """
         resource = resource_url_from_server_url(self.server_url)
 
-        # If PRM provides a resource that's a valid parent, use it
         if self.protected_resource_metadata and self.protected_resource_metadata.resource:
             resource = str(self.protected_resource_metadata.resource)
 

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -670,8 +670,6 @@ class TestProtectedResourceMetadata:
         )
         result = await oauth_provider._handle_protected_resource_response(response_wrong_port)
         assert result is False
-
-        # Ensure no metadata was set
         assert oauth_provider.context.protected_resource_metadata is None
 
     @pytest.mark.anyio


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Resolves #1581

Adds RFC 9728 Section 3.3 validation to prevent metadata impersonation attacks during PRM discovery. Uses pre-existing `check_resource_allowed()` to validate origin and path hierarchy before storing metadata. Invalid metadata triggers SEP-985 fallback (already implemented).

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Created the following tests:
- `test_reject_metadata_with_mismatched_origin` - validates rejection of wrong scheme/host/port
- `test_reject_metadata_with_invalid_path_hierarchy` - validates path parent/child relationships

Updated:
- `Existing test test_auth_flow_with_no_tokens` updated to use valid resource field

Ran all tests in `tests/client/test_auth.py` to ensure they all pass.
Tested manually as well using `examples/clients/simple-auth-client/mcp_simple_auth_client` and `examples/servers/simple-auth/mcp_simple_auth`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
