### PR TITLE
fixed everything-server vscode support using stdio transport

### DIFF
--- a/examples/servers/everything-server/mcp_everything_server/server.py
+++ b/examples/servers/everything-server/mcp_everything_server/server.py
@@ -306,7 +306,7 @@ def main(port: int, log_level: str, transport: str) -> int:
     logger.info(f"Endpoint will be: http://localhost:{port}/mcp")
 
     mcp.settings.port = port
-    mcp.run(transport=transport)
+    mcp.run(transport="stdio" if transport == "stdio" else "streamable-http")
 
     return 0
 


### PR DESCRIPTION
Adds "transport" parameter to everything-server example.

## Motivation and Context
I encountered an error where the process would not finish when adding the mcp server to the `.vscode/mcp.json` file with the given value:
```
{
  "servers": {
    "mcp-server-demo": {
      "command": "python",
      "args": ["${workspaceFolder}/server.py"],
    }
  }
}
```

Log output:
```
2025-11-09 15:38:21.677 [info] Starting server mcp-server-demo
2025-11-09 15:38:21.678 [info] Connection state: Starting
2025-11-09 15:38:21.685 [info] Starting server from LocalProcess extension host
2025-11-09 15:38:21.686 [info] Connection state: Starting
2025-11-09 15:38:21.687 [info] Connection state: Running
2025-11-09 15:38:22.641 [warning] [server stderr] [11/09/25 15:38:22] INFO     Starting MCP Everything Server on     server.py:307
2025-11-09 15:38:22.641 [warning] [server stderr]                              port 3003
2025-11-09 15:38:22.642 [warning] [server stderr]                     INFO     Endpoint will be:                     server.py:308
2025-11-09 15:38:22.642 [warning] [server stderr]                              http://localhost:3003/mcp
2025-11-09 15:38:22.670 [warning] [server stderr] INFO:     Started server process [19538]
2025-11-09 15:38:22.670 [warning] [server stderr] INFO:     Waiting for application startup.
2025-11-09 15:38:22.673 [warning] [server stderr]                     INFO     StreamableHTTP       streamable_http_manager.py:110
2025-11-09 15:38:22.673 [warning] [server stderr]                              session manager
2025-11-09 15:38:22.673 [warning] [server stderr]                              started
2025-11-09 15:38:22.673 [warning] [server stderr] INFO:     Application startup complete.
2025-11-09 15:38:22.673 [warning] [server stderr] INFO:     Uvicorn running on http://127.0.0.1:3003 (Press CTRL+C to quit)
2025-11-09 15:38:26.689 [info] Waiting for server to respond to `initialize` request...
```

The process would never pass "waiting for server to respod".

## How Has This Been Tested?
Tested using Visual Studio Code:
Version: 1.105.1 (Universal)
Commit: 7d842fb85a0275a4a8e4d7e040d2625abbf7f084
Date: 2025-10-14T22:33:36.618Z
Electron: 37.6.0
ElectronBuildId: 12502201
Chromium: 138.0.7204.251
Node.js: 22.19.0
V8: 13.8.258.32-electron.0
OS: Darwin x64 21.6.0

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ X ] My code follows the repository's style guidelines
- [ X ] New and existing tests pass locally
- [ X ] I have added appropriate error handling
- [ X ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
