### PR TITLE
Add client_id_metadata_document_supported to OAuthMetadata

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -130,6 +130,7 @@ class OAuthMetadata(BaseModel):
     introspection_endpoint_auth_methods_supported: list[str] | None = None
     introspection_endpoint_auth_signing_alg_values_supported: list[str] | None = None
     code_challenge_methods_supported: list[str] | None = None
+    client_id_metadata_document_supported: bool | None = None
 
 
 class ProtectedResourceMetadata(BaseModel):


### PR DESCRIPTION
Add support for the `client_id_metadata_document_supported` field to the `OAuthMetadata` class as specified in [draft-parecki-oauth-client-id-metadata-document-00](https://www.ietf.org/archive/id/draft-parecki-oauth-client-id-metadata-document-00.html#section-5).

## Motivation and Context

This field is part of the OAuth Client ID Metadata Document specification. It allows authorization servers to indicate whether they support retrieving client metadata from a `client_id` URL. This enables clients to determine server capabilities before redirecting users, preventing errors about invalid clients.

## How Has This Been Tested?

The change has been verified with:
- Ruff formatting and linting checks pass
- Pyright type checking passes
- Existing tests continue to pass (the field is optional)

## Breaking Changes

None. This is an additive change that adds an optional field to the `OAuthMetadata` model.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This implements the authorization server metadata field specified in Section 5 of the draft specification. The field is registered in the IANA "OAuth Authorization Server Metadata" registry established by RFC 8414.