### PR TITLE
Add coverage baseline commit to git-blame-ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Applied 120 line-length rule to all files: https://github.com/modelcontextprotocol/python-sdk/pull/856
 543961968c0634e93d919d509cce23a1d6a56c21
+
+# Added 100% code coverage baseline with pragma comments: https://github.com/modelcontextprotocol/python-sdk/pull/1553
+89e9c43acf7e23cf766357d776ec1ce63ac2c58e


### PR DESCRIPTION
Adds commit 89e9c43 from PR #1553 to `.git-blame-ignore-revs` to exclude the large-scale addition of `# pragma: no cover` comments from git blame output.

## Motivation and Context

PR #1553 established a 100% code coverage baseline by adding pragma comments throughout the codebase. While these annotations are valuable for coverage tracking, they add noise to git blame output by attributing lines to a formatting commit rather than showing the original authors of the substantive code.

Adding this commit to `.git-blame-ignore-revs` ensures that `git blame` (when configured to use the file) will skip over these pragma additions and show the actual authors of the underlying code logic.

## How Has This Been Tested?

This is a documentation/tooling change that affects git blame output only. The change can be verified by:
- Running `git blame --ignore-revs-file .git-blame-ignore-revs <file>` on files modified in 89e9c43
- Configuring git globally: `git config blame.ignoreRevsFile .git-blame-ignore-revs`

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This follows the same pattern as the existing entry for commit 5439619 (120 line-length formatting). Developers can configure git to automatically use this file with:

```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```