### PR TITLE
Replace environment variables with CLI arguments in simple-auth-client

### DIFF
--- a/examples/clients/simple-auth-client/README.md
+++ b/examples/clients/simple-auth-client/README.md
@@ -28,13 +28,17 @@ uv run mcp-simple-auth --transport streamable-http --port 3001
 ### 2. Run the client
 
 ```bash
+# Connect to default server (http://localhost:8000/mcp)
 uv run mcp-simple-auth-client
 
-# Or with custom server URL
-MCP_SERVER_PORT=3001 uv run mcp-simple-auth-client
+# Connect to a custom server URL
+uv run mcp-simple-auth-client --url http://localhost:3001/mcp
 
 # Use SSE transport
-MCP_TRANSPORT_TYPE=sse uv run mcp-simple-auth-client
+uv run mcp-simple-auth-client --url http://localhost:3001/sse --transport sse
+
+# View all options
+uv run mcp-simple-auth-client --help
 ```
 
 ### 3. Complete OAuth flow
@@ -42,19 +46,20 @@ MCP_TRANSPORT_TYPE=sse uv run mcp-simple-auth-client
 The client will open your browser for authentication. After completing OAuth, you can use commands:
 
 - `list` - List available tools
-- `call <tool_name> [args]` - Call a tool with optional JSON arguments  
+- `call <tool_name> [args]` - Call a tool with optional JSON arguments
 - `quit` - Exit
 
 ## Example
 
 ```markdown
-🔐 Simple MCP Auth Client
-Connecting to: http://localhost:3001
+🚀 Simple MCP Auth Client
+Connecting to: http://localhost:8001/mcp
+Transport type: streamable-http
 
-Please visit the following URL to authorize the application:
-http://localhost:3001/authorize?response_type=code&client_id=...
+🔗 Attempting to connect to http://localhost:8001/mcp...
+Opening browser for authorization: http://localhost:9000/authorize?...
 
-✅ Connected to MCP server at http://localhost:3001
+✅ Connected to MCP server at http://localhost:8001/mcp
 
 mcp> list
 📋 Available tools:
@@ -68,7 +73,7 @@ mcp> quit
 👋 Goodbye!
 ```
 
-## Configuration
+## Command Line Options
 
-- `MCP_SERVER_PORT` - Server URL (default: 8000)
-- `MCP_TRANSPORT_TYPE` - Transport type: `streamable-http` (default) or `sse`
+- `--url` - Full URL of the MCP server (default: `http://localhost:8000/mcp`)
+- `--transport` - Transport type: `streamable-http` (default) or `sse`

--- a/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
+++ b/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
@@ -6,8 +6,8 @@ This client connects to an MCP server using streamable HTTP transport with OAuth
 
 """
 
+import argparse
 import asyncio
-import os
 import threading
 import time
 import webbrowser
@@ -331,22 +331,32 @@ class SimpleAuthClient:
 
 async def main():
     """Main entry point."""
-    # Default server URL - can be overridden with environment variable
-    # Most MCP streamable HTTP servers use /mcp as the endpoint
-    server_url = os.getenv("MCP_SERVER_PORT", 8000)
-    transport_type = os.getenv("MCP_TRANSPORT_TYPE", "streamable-http")
-    server_url = (
-        f"http://localhost:{server_url}/mcp"
-        if transport_type == "streamable-http"
-        else f"http://localhost:{server_url}/sse"
+    parser = argparse.ArgumentParser(
+        description="Simple MCP client with OAuth authentication support",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="http://localhost:8000/mcp",
+        help="Full URL of the MCP server",
+    )
+    parser.add_argument(
+        "--transport",
+        type=str,
+        choices=["streamable-http", "sse"],
+        default="streamable-http",
+        help="Transport type to use",
     )
 
+    args = parser.parse_args()
+
     print("🚀 Simple MCP Auth Client")
-    print(f"Connecting to: {server_url}")
-    print(f"Transport type: {transport_type}")
+    print(f"Connecting to: {args.url}")
+    print(f"Transport type: {args.transport}")
 
     # Start connection flow - OAuth will be handled automatically
-    client = SimpleAuthClient(server_url, transport_type)
+    client = SimpleAuthClient(args.url, args.transport)
     await client.connect()
 
 

--- a/examples/servers/simple-auth/README.md
+++ b/examples/servers/simple-auth/README.md
@@ -43,7 +43,7 @@ uv run mcp-simple-auth-rs --port=8001 --auth-server=http://localhost:9000  --tra
 ```bash
 cd examples/clients/simple-auth-client
 # Start client with streamable HTTP
-MCP_SERVER_PORT=8001 MCP_TRANSPORT_TYPE=streamable-http uv run mcp-simple-auth-client
+uv run mcp-simple-auth-client --url http://localhost:8001/mcp --transport streamable-http
 ```
 
 ## How It Works
@@ -101,7 +101,7 @@ uv run mcp-simple-auth-legacy --port=8002
 ```bash
 # Test with client (will automatically fall back to legacy discovery)
 cd examples/clients/simple-auth-client
-MCP_SERVER_PORT=8002 MCP_TRANSPORT_TYPE=streamable-http uv run mcp-simple-auth-client
+uv run mcp-simple-auth-client --url http://localhost:8002/mcp --transport streamable-http
 ```
 
 The client will:


### PR DESCRIPTION
## Summary

Replaces environment variables with command-line arguments in the simple-auth-client example, providing a more flexible and intuitive interface for specifying server URLs and transport types.

## Motivation and Context

The simple-auth-client previously used environment variables (`MCP_SERVER_PORT` and `MCP_TRANSPORT_TYPE`) to configure connection settings. This approach had limitations:
- Could only specify localhost ports, not arbitrary URLs
- Less discoverable for users (no `--help` option)
- Didn't follow standard CLI conventions

This change replaces environment variables with proper command-line arguments using argparse, allowing users to specify full server URLs and making the interface more intuitive.

## How Has This Been Tested?

- Verified the `--help` output displays correctly
- Code passes ruff formatting and linting checks
- Code passes pyright type checking
- Pre-commit hooks pass successfully

## Breaking Changes

Yes - users will need to update how they invoke the client:

**Before:**
```bash
MCP_SERVER_PORT=8001 MCP_TRANSPORT_TYPE=streamable-http uv run mcp-simple-auth-client
```

**After:**
```bash
uv run mcp-simple-auth-client --url http://localhost:8001/mcp --transport streamable-http
```

However, this is an example client, not a production tool, so the impact should be minimal.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Changes include:
- Updated `main.py` to use argparse with `--url` and `--transport` arguments
- Updated simple-auth-client README.md with new usage examples
- Updated simple-auth server README.md to reference the new CLI interface
- Removed unused `os` import from main.py