### PR TITLE
Fix OAuth scope selection using wrong parameter

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -506,7 +506,7 @@ class OAuthClientProvider(httpx.Auth):
 
                     # Step 3: Apply scope selection strategy
                     self.context.client_metadata.scope = get_client_metadata_scopes(
-                        www_auth_resource_metadata_url,
+                        extract_scope_from_www_auth(response),
                         self.context.protected_resource_metadata,
                         self.context.oauth_metadata,
                     )


### PR DESCRIPTION
Fixes a bug introduced in #1586 where the OAuth scope selection strategy was incorrectly passing the resource metadata URL instead of the scope from the WWW-Authenticate header.

AFAICT this breaks all Python MCP clients that connect to servers with WWW headers because it treats the URL as a scope with highest priority.


The `get_client_metadata_scopes()` function expects the first parameter to be the scope string extracted from the WWW-Authenticate header. However, in this case it was incorrectly passing `www_auth_resource_metadata_url` (a URL) instead of calling `extract_scope_from_www_auth(response)` to get the actual scope value.


Closes #1630
