### PR TITLE
Propagate version from fastmcp to _mcp_server, add test for clientInfo

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -146,6 +146,7 @@ class FastMCP(Generic[LifespanResultT]):
         instructions: str | None = None,
         website_url: str | None = None,
         icons: list[Icon] | None = None,
+        version: str | None = None,
         auth_server_provider: (OAuthAuthorizationServerProvider[Any, Any, Any] | None) = None,
         token_verifier: TokenVerifier | None = None,
         event_store: EventStore | None = None,
@@ -194,6 +195,7 @@ class FastMCP(Generic[LifespanResultT]):
             instructions=instructions,
             website_url=website_url,
             icons=icons,
+            version=version,
             # TODO(Marcelo): It seems there's a type mismatch between the lifespan type from an FastMCP and Server.
             # We need to create a Lifespan type that is a generic on the server type, like Starlette does.
             lifespan=(lifespan_wrapper(self, self.settings.lifespan) if self.settings.lifespan else default_lifespan),  # type: ignore
@@ -242,6 +244,10 @@ class FastMCP(Generic[LifespanResultT]):
     @property
     def icons(self) -> list[Icon] | None:
         return self._mcp_server.icons
+
+    @property
+    def version(self) -> str | None:
+        return self._mcp_server.version
 
     @property
     def session_manager(self) -> StreamableHTTPSessionManager:

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -21,6 +21,7 @@ from mcp.types import (
     BlobResourceContents,
     ContentBlock,
     EmbeddedResource,
+    Icon,
     ImageContent,
     TextContent,
     TextResourceContents,
@@ -33,9 +34,19 @@ if TYPE_CHECKING:
 class TestServer:
     @pytest.mark.anyio
     async def test_create_server(self):
-        mcp = FastMCP(instructions="Server instructions")
+        mcp = FastMCP(
+            instructions="Server instructions",
+            website_url="https://example.com/mcp_server",
+            version="1.0",
+            icons=[Icon(src="https://example.com/icon.png", mimeType="image/png", sizes=["48x48", "96x96"])],
+        )
         assert mcp.name == "FastMCP"
         assert mcp.instructions == "Server instructions"
+        assert mcp.website_url == "https://example.com/mcp_server"
+        assert mcp.version == "1.0"
+        assert isinstance(mcp.icons, list)
+        assert len(mcp.icons) == 1
+        assert mcp.icons[0].src == "https://example.com/icon.png"
 
     @pytest.mark.anyio
     async def test_normalize_path(self):


### PR DESCRIPTION
Propage version from FastMCP layer to the _mcp_server. Currently the version can not be set and will fallback for mcp package version.

## Motivation and Context
I believe it make sense to have the version correctly.

## How Has This Been Tested?
Tested end to end, tests added in test suite

## Breaking Changes
N/A
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
