### PR TITLE
Improve exception handling for ClientDisconnect errors

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -20,7 +20,7 @@ import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from pydantic import ValidationError
 from sse_starlette import EventSourceResponse
-from starlette.requests import Request
+from starlette.requests import ClientDisconnect, Request
 from starlette.responses import Response
 from starlette.types import Receive, Scope, Send
 
@@ -510,6 +510,15 @@ class StreamableHTTPServerTransport:
                     await sse_stream_writer.aclose()
                     await sse_stream_reader.aclose()
                     await self._clean_up_memory_streams(request_id)
+
+        except ClientDisconnect:
+            logger.info("Client disconnected during request")
+            response = self._create_error_response(
+                "Client closed connection",
+                499,
+            )
+            await response(scope, receive, send)
+            return
 
         except Exception as err:  # pragma: no cover
             logger.exception("Error handling POST request")


### PR DESCRIPTION
# Fix: Handle ClientDisconnect gracefully (return 499, not 500)

## Problem

`ClientDisconnect` exceptions are currently handled incorrectly in `StreamableHTTPServerTransport._handle_post_request`:
- Returns HTTP 500 (Internal Server Error)
- Logs as ERROR with full traceback
- Triggers production 5XX alerts

ClientDisconnect occurs during normal operations when clients disconnect mid-request due to:
- Network timeouts
- User cancellations
- Load balancer timeouts
- Mobile network interruptions

These are **client-side events**, not server failures, and should not be treated as server errors.

## Root Cause

The broad `except Exception` handler in `_handle_post_request` catches `ClientDisconnect` before it can be handled appropriately, resulting in incorrect error logging and HTTP status codes.

**File:** `src/mcp/server/streamable_http.py` (lines ~490-500)

## Solution

This PR adds a specific `ClientDisconnect` exception handler **before** the broad `Exception` handler:

1. Catches `ClientDisconnect` explicitly
2. Returns HTTP 499 (Client Closed Request) instead of 500
3. Logs as INFO instead of ERROR
4. Follows the same pattern as other 4xx responses in the file