### PR TITLE
fix: Fix logic that determines standard resource vs. resource template to account for context param (#1635)

### DIFF
--- a/src/mcp/server/mcpserver/resources/base.py
+++ b/src/mcp/server/mcpserver/resources/base.py
@@ -1,7 +1,9 @@
 """Base classes and interfaces for MCPServer resources."""
 
+from __future__ import annotations
+
 import abc
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import (
     BaseModel,
@@ -12,6 +14,10 @@ from pydantic import (
 )
 
 from mcp.types import Annotations, Icon
+
+if TYPE_CHECKING:
+    from mcp.server.context import LifespanContextT, RequestT
+    from mcp.server.mcpserver.server import Context
 
 
 class Resource(BaseModel, abc.ABC):
@@ -43,6 +49,9 @@ class Resource(BaseModel, abc.ABC):
         raise ValueError("Either name or uri must be provided")
 
     @abc.abstractmethod
-    async def read(self) -> str | bytes:
+    async def read(
+        self,
+        context: Context[LifespanContextT, RequestT] | None = None,
+    ) -> str | bytes:
         """Read the resource content."""
         pass  # pragma: no cover

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -2,17 +2,16 @@
 
 from __future__ import annotations
 
-import inspect
 import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
-from pydantic import BaseModel, Field, validate_call
+from pydantic import BaseModel, Field
 
 from mcp.server.mcpserver.resources.types import FunctionResource, Resource
-from mcp.server.mcpserver.utilities.context_injection import find_context_parameter, inject_context
-from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
+from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata, is_async_callable
 from mcp.types import Annotations, Icon
 
 if TYPE_CHECKING:
@@ -34,6 +33,10 @@ class ResourceTemplate(BaseModel):
     fn: Callable[..., Any] = Field(exclude=True)
     parameters: dict[str, Any] = Field(description="JSON schema for function parameters")
     context_kwarg: str | None = Field(None, description="Name of the kwarg that should receive context")
+    fn_metadata: FuncMetadata = Field(
+        description="Metadata about the function including a pydantic model for arguments"
+    )
+    is_async: bool = Field(description="Whether the function is async")
 
     @classmethod
     def from_function(
@@ -58,15 +61,14 @@ class ResourceTemplate(BaseModel):
         if context_kwarg is None:  # pragma: no branch
             context_kwarg = find_context_parameter(fn)
 
+        is_async = is_async_callable(fn)
+
         # Get schema from func_metadata, excluding context parameter
         func_arg_metadata = func_metadata(
             fn,
             skip_names=[context_kwarg] if context_kwarg is not None else [],
         )
         parameters = func_arg_metadata.arg_model.model_json_schema()
-
-        # ensure the arguments are properly cast
-        fn = validate_call(fn)
 
         return cls(
             uri_template=uri_template,
@@ -80,6 +82,8 @@ class ResourceTemplate(BaseModel):
             fn=fn,
             parameters=parameters,
             context_kwarg=context_kwarg,
+            fn_metadata=func_arg_metadata,
+            is_async=is_async,
         )
 
     def matches(self, uri: str) -> dict[str, Any] | None:
@@ -103,13 +107,12 @@ class ResourceTemplate(BaseModel):
     ) -> Resource:
         """Create a resource from the template with the given parameters."""
         try:
-            # Add context to params if needed
-            params = inject_context(self.fn, params, context, self.context_kwarg)
-
-            # Call function and check if result is a coroutine
-            result = self.fn(**params)
-            if inspect.iscoroutine(result):
-                result = await result
+            result = await self.fn_metadata.call_fn_with_arg_validation(
+                self.fn,
+                self.is_async,
+                params,
+                {self.context_kwarg: context} if self.context_kwarg is not None else None,
+            )
 
             return FunctionResource(
                 uri=uri,  # type: ignore

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -523,3 +523,13 @@ def _convert_to_content(result: Any) -> Sequence[ContentBlock]:
         result = pydantic_core.to_json(result, fallback=str, indent=2).decode()
 
     return [TextContent(type="text", text=result)]
+
+
+def is_async_callable(obj: Any) -> bool:
+    """Check if an object is an async callable."""
+    while isinstance(obj, functools.partial):
+        obj = obj.func
+
+    return inspect.iscoroutinefunction(obj) or (
+        callable(obj) and inspect.iscoroutinefunction(getattr(obj, "__call__", None))
+    )

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -3,6 +3,7 @@
 # pyright: reportMissingParameterType=false
 # pyright: reportUnknownArgumentType=false
 # pyright: reportUnknownLambdaType=false
+import functools
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Annotated, Any, Final, NamedTuple, TypedDict
@@ -13,7 +14,7 @@ from dirty_equals import IsPartialDict
 from pydantic import BaseModel, Field
 
 from mcp.server.mcpserver.exceptions import InvalidSignature
-from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+from mcp.server.mcpserver.utilities.func_metadata import func_metadata, is_async_callable
 from mcp.types import CallToolResult
 
 
@@ -1189,3 +1190,13 @@ def test_preserves_pydantic_metadata():
 
     assert meta.output_schema is not None
     assert meta.output_schema["properties"]["result"] == {"exclusiveMinimum": 1, "title": "Result", "type": "integer"}
+
+
+def test_is_async_callable_nested_partial():
+    """Test that is_async_callable unwraps nested functools.partial objects."""
+
+    async def async_fn() -> None:
+        pass  # pragma: no cover
+
+    nested = functools.partial(functools.partial(async_fn))
+    assert is_async_callable(nested) is True

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -986,7 +986,7 @@ class TestServerResourceMetadata:
                         TextResourceContents(
                             uri="resource://data",
                             mime_type="text/plain",
-                            meta={"version": "1.0", "category": "config"},  # type: ignore[reportUnknownMemberType]
+                            meta={"version": "1.0", "category": "config"},  # type: ignore[reportCallIssue]
                             text="test data",
                         )
                     ]


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

- Fix template detection logic to exclude context  when determining if a resource is a template or not
- Add support for FunctionResources to be read with a context param, allowing resources registered with a context param to read from ccontext objects
- Use ` func_metadata.call_fn_with_arg_validation()` to validate arguments in resources while ignoring injected context param, to avoid Pydantic model validation issues 
- Extracted `is_async_callable()` as a public utility 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This solves the issue of context not being properly injected into regular resources. Per #1635, when registering a resource with `@mcp.resource()`, the logic that determines whether to create a standard resource or a resource template was incorrectly counting the Context parameter as a function parameter. This caused functions with only a Context parameter (no URI parameters) to be incorrectly treated as templates.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I added unit tests plus used the following test application to ensure the fix worked as expected and didn't affect existing functionality around resources and resource templates. I tested reading resources and resource templates with and without context params

```
from contextlib import asynccontextmanager
from datetime import datetime

from mcp import ServerSession
from mcp.server import FastMCP
from mcp.server.fastmcp import Context


class AppContext:
    """Application context with some shared state."""

    def __init__(self):
        self.server_start_time = datetime.now()
        self.request_count = 0

    def increment_requests(self):
        self.request_count += 1


@asynccontextmanager
async def lifespan(server: FastMCP):
    """Initialize application context."""
    print("Server starting up...")
    ctx = AppContext()
    yield ctx
    print(f"Server shutting down. Total requests: {ctx.request_count}")


mcp = FastMCP("Context Test Demo", lifespan=lifespan)


@mcp.resource("time://current")
async def current_time(ctx: Context[ServerSession, AppContext]) -> str:
    return f"Current time: {datetime.now().isoformat()}, request {ctx.request_id}"


@mcp.resource("time://format")
async def time_format() -> str:
    return "Supported formats: ISO8601, RFC3339, Unix timestamp"


@mcp.resource("greeting://{name}")
async def personalized_greeting(name: str, ctx: Context[ServerSession, AppContext]) -> str:
    uptime = (datetime.now() - ctx.request_context.lifespan_context.server_start_time).total_seconds()
    return f"Hello {name}! Server uptime: {uptime:.1f}s"


@mcp.resource("math://{operation}/{a}/{b}")
async def math_operation(operation: str, a: int, b: int) -> str:
    operations = {
        "add": a + b,
        "subtract": a - b,
        "multiply": a * b,
        "divide": a / b if b != 0 else "Error: Division by zero"
    }
    result = operations.get(operation, "Error: Unknown operation")
    return f"{operation}({a}, {b}) = {result}"


if __name__ == "__main__":
    import asyncio

    mcp.run()
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

Technically yes, because the signature of the `read()` function on the `Resource` type now includes an additional optional `context` param, but this shouldn't break at runtime since the arg is optional 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
