### PR TITLE
## Fix race condition in Streamable HTTP transport

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -14,7 +14,7 @@ from datetime import timedelta
 
 import anyio
 import httpx
-from anyio.abc import TaskGroup
+from anyio.abc import TaskGroup, TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from httpx_sse import EventSource, ServerSentEvent, aconnect_sse
 
@@ -376,10 +376,14 @@ class StreamableHTTPTransport:
         write_stream: MemoryObjectSendStream[SessionMessage],
         start_get_stream: Callable[[], None],
         tg: TaskGroup,
+        *,
+        task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED,
     ) -> None:
         """Handle writing requests to the server."""
         try:
             async with write_stream_reader:
+                # Signal that we're ready to receive messages
+                task_status.started(None)
                 async for session_message in write_stream_reader:
                     message = session_message.message
                     metadata = (
@@ -493,7 +497,10 @@ async def streamablehttp_client(
                 def start_get_stream() -> None:
                     tg.start_soon(transport.handle_get_stream, client, read_stream_writer)
 
-                tg.start_soon(
+                # Use tg.start() to ensure post_writer is ready before yielding.
+                # This prevents a race condition where the client might try to send
+                # a message before the writer task is ready to receive it.
+                await tg.start(
                     transport.post_writer,
                     client,
                     write_stream_reader,


### PR DESCRIPTION
# Fix race condition in Streamable HTTP transport

## Motivation and Context

When using the Streamable HTTP transport, `session.list_tools()` intermittently returns empty results immediately after `session.initialize()` completes.

**Root Cause**: In `mcp/client/streamable_http.py`, memory streams are created with buffer size 0 (unbuffered), and `post_writer` is started with `tg.start_soon()` which doesn't wait for the task to be ready:

```python
tg.start_soon(transport.post_writer, ...)  # Doesn't wait for task to start
```

This creates a timing issue where subsequent requests can fail before `post_writer` is ready to receive messages.

**Solution**: Use `tg.start()` instead of `tg.start_soon()` to ensure `post_writer` is fully ready before yielding from the context manager. This follows the existing pattern used in the SSE transport.

## How Has This Been Tested?

Added two new tests:
- `test_streamablehttp_no_race_condition_on_consecutive_requests` - 10 iterations of init → list_tools
- `test_streamablehttp_rapid_request_sequence` - 20 rapid consecutive requests

All 36 streamable HTTP tests pass.

## Breaking Changes

None. This is an internal implementation fix that doesn't change any public API.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Three options were considered for fixing this issue:
- **Option A**: Use a small buffer size instead of 0
- **Option B**: Use `tg.start()` instead of `tg.start_soon()` ✅ (implemented)
- **Option C**: Add an internal ready signal/event

Option B was chosen because it's minimal, follows existing patterns (SSE transport), and preserves buffer/backpressure semantics.
