### PR TITLE
Add working example to easily integrate a FastMCP endpoint to a FastAPI app (which is not trivial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ The Context object provides the following capabilities:
 - `ctx.session` - Access to the underlying session for advanced communication (see [Session Properties and Methods](#session-properties-and-methods))
 - `ctx.request_context` - Access to request-specific data and lifespan resources (see [Request Context Properties](#request-context-properties))
 - `await ctx.debug(message)` - Send debug log message
-- `await ctx.info(message)` - Send info log message  
+- `await ctx.info(message)` - Send info log message
 - `await ctx.warning(message)` - Send warning log message
 - `await ctx.error(message)` - Send error log message
 - `await ctx.log(level, message, logger_name=None)` - Send log with custom level
@@ -1106,13 +1106,13 @@ The session object accessible via `ctx.session` provides advanced control over c
 async def notify_data_update(resource_uri: str, ctx: Context) -> str:
     """Update data and notify clients of the change."""
     # Perform data update logic here
-    
+
     # Notify clients that this specific resource changed
     await ctx.session.send_resource_updated(AnyUrl(resource_uri))
-    
+
     # If this affects the overall resource list, notify about that too
     await ctx.session.send_resource_list_changed()
-    
+
     return f"Updated {resource_uri} and notified clients"
 ```
 
@@ -1141,11 +1141,11 @@ def query_with_config(query: str, ctx: Context) -> str:
     """Execute a query using shared database and configuration."""
     # Access typed lifespan context
     app_ctx: AppContext = ctx.request_context.lifespan_context
-    
+
     # Use shared resources
     connection = app_ctx.db
     settings = app_ctx.config
-    
+
     # Execute query with configuration
     result = connection.execute(query, timeout=settings.query_timeout)
     return str(result)
@@ -1547,6 +1547,10 @@ app = Starlette(
 
 _Full example: [examples/snippets/servers/streamable_http_path_config.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/streamable_http_path_config.py)_
 <!-- /snippet-source -->
+
+#### Mounting to a FastAPI server
+
+To mount a MCP Streamable HTTP endpoint on a FastAPI application see [`examples/servers/fastapi/`](examples/servers/fastapi/).
 
 #### SSE servers
 

--- a/examples/servers/fastapi/README.md
+++ b/examples/servers/fastapi/README.md
@@ -1,0 +1,13 @@
+# FastAPI app with MCP endpoint
+
+A FastAPI application with a Streamable HTTP MCP endpoint mounted on `/mcp`.
+
+The key difference when mounting on FastAPI vs Starlette is that you must manually call `mcp.session_manager.run()` in your FastAPI lifespan, as FastAPI doesn't automatically trigger the lifespan of mounted sub-applications.
+
+## Usage
+
+Start the server:
+
+```bash
+uv run uvicorn main:app --reload
+```

--- a/examples/servers/fastapi/main.py
+++ b/examples/servers/fastapi/main.py
@@ -1,0 +1,81 @@
+"""Example showing how to mount FastMCP on a FastAPI application."""
+
+import contextlib
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from mcp.server.fastmcp import FastMCP
+
+
+@contextlib.asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """FastAPI lifespan that initializes the MCP session manager.
+
+    This is necessary because FastAPI doesn't automatically trigger
+    the lifespan of mounted sub-applications. We need to manually
+    manage the session_manager's lifecycle.
+    """
+    async with mcp.session_manager.run():
+        yield
+
+
+# Create FastAPI app with lifespan
+app = FastAPI(
+    title="My API with MCP",
+    description="Example FastAPI application with mounted MCP endpoint",
+    version="1.0.0",
+    lifespan=lifespan,
+)
+
+# Create FastMCP instance
+mcp = FastMCP(
+    "MCP Tools",
+    debug=True,
+    streamable_http_path="/",
+    json_response=True,
+    stateless_http=False,  # Required when deploying in production with multiple workers
+)
+
+
+@mcp.tool()
+async def process_data(data: str) -> str:
+    """Process some data and return the result
+
+    Args:
+        data: The data to process
+
+    Returns:
+        The processed data
+    """
+    return f"Processed: {data}"
+
+
+# Get the MCP ASGI Starlette app
+mcp_app = mcp.streamable_http_app()
+
+# Mount the MCP app on FastAPI at /mcp
+app.mount("/mcp", mcp_app)
+
+
+# Add regular FastAPI endpoints
+@app.get("/")
+async def root() -> dict[str, str]:
+    """Root endpoint with API information"""
+    return {
+        "mcp_endpoint": "/mcp",
+        "docs": "/docs",
+        "openapi": "/openapi.json",
+    }
+
+
+@app.post("/hello")
+async def hello(name: str = "World") -> dict[str, str]:
+    """Example FastAPI endpoint
+
+    Args:
+        name: Name to greet
+
+    Returns:
+        A greeting message
+    """
+    return {"message": f"Hello, {name}!"}

--- a/examples/servers/fastapi/pyproject.toml
+++ b/examples/servers/fastapi/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "fastapi-mcp"
+version = "0.1.0"
+description = "A simple FastAPI application with a MCP endpoint."
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["mcp", "llm", "fastapi"]
+license = { text = "MIT" }
+dependencies = [
+    "mcp",
+    "fastapi>=0.123.0",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = []
+
+[tool.ruff]
+line-length = 120
+target-version = "py310"
+
+[dependency-groups]
+dev = ["pyright>=1.1.378", "pytest>=8.3.3", "ruff>=0.6.9"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ packages = ["src/mcp"]
 [tool.pyright]
 typeCheckingMode = "strict"
 include = ["src/mcp", "tests", "examples/servers", "examples/snippets"]
+exclude = ["examples/servers/fastapi"]
 venvPath = "."
 venv = ".venv"
 # The FastAPI style of using decorators in tests gives a `reportUnusedFunction` error.


### PR DESCRIPTION
This PR adds an example for integrating a FastMCP endpoint in a FastAPI app (which is not straightforward, and could be better documented). 

I have added an `examples/servers/fastapi/` folder with a minimal, focused, working example: `main.py`, `pyproject.toml`, and `README.md` (with basic uvicorn command).

I have also added a line to point to this folder in the README, this way devs searching for "fastapi" with ctrl+F in the readme will find the docs easily.

## Motivation and Context

For now only Starlette is documented, but as far as I know, most developers build APIs directly with FastAPI (which is a wrapper around Starlette) and not Starlette directly:

- FastAPI provides out of the box OpenAPI specs and docs from type annotations
- FastAPI enables devs to build well documented APIs easily, exactly the same way as FastMCP does: by using decorators and type annotations
- FastMCP took a huge inspiration from FastAPI (which is even reflected in its name!), but it is not clear how to make the 2 interoperable, current documentation encourages to use Starlette when many developers want to use the same dev friendly API for the MCP tools and other API endpoints: "Decorators and type annotations for me (MCP), not for thee (every other endpoints on the API)" :)

I already discussed the issue in https://github.com/modelcontextprotocol/python-sdk/issues/1367 without fully solving the problem (and I was already not the only one to face this problem according to the reactions on the issue)

The main problem when building a FastAPI app with a MCP endpoint is the missing `run()` lifespan (it is predefined for Starlette, but needs to be manually defined for FastAPI). It is not much, but it is not documented, and increases friction when wanting to integrate FastMCP in FastAPI.

Trying to simply mount a Starlette `mcp.streamable_http_app()` on a FastAPI `app` will end up throwing this error at runtime:

```
  File ".venv/lib/python3.13/site-packages/mcp/server/streamable_http_manager.py", line 138, in handle_request
    raise RuntimeError("Task group is not initialized. Make sure to use run().")
RuntimeError: Task group is not initialized. Make sure to use run().
```

Meanwhile it works out of the box when mounting on a Starlette app, so all existing Starlette example are a bit misleading when you want to use FastAPI (which is a large amount of the users)

## How Has This Been Tested?

I have ran the command documented in the `README.md` of the folder `examples/servers/fastapi/` locally and it worked


## Breaking Changes

No, it's just an example added to the existing docs

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

I have added `exclude = ["examples/servers/fastapi"]` to the pyright config in the root `pyproject.toml`, otherwise pyright checks fails because monorepo is still not supported by pyright. I also tried to add `[tool.pyright] exclude = ["."]` to the `examples/servers/fastapi/pyproject.toml`, but it does not seems like pyright understand the concept of nested config files.

It would be good for the sake of diversity of provided examples that the examples can use dependencies not defined in the main `pyproject.toml`

Other solutions to fix this pyright fumble could be:
- Adding `fastapi` to the dev dependency group in the root `pyproject.toml`
- Telling pyright in the root `pyproject.toml` to ignore the folder

> I am used to `mypy` and waiting for `ty`, so my knowledge of `pyright` config is limited, let me know if there is a better approach to this 

We could also make this a snippet directly integrated in the root `README.md` through `examples/snippets/` folder if you prefer

