### PR TITLE
feat: add workflow to comment on PRs when released

### DIFF
--- a/.github/workflows/release-comment.yml
+++ b/.github/workflows/release-comment.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           comment-template: |
-            :rocket: This PR is included in version [{release_tag}]({release_link})
+            This PR is included in version [{release_tag}]({release_link})


### PR DESCRIPTION
When a new release is published, this workflow automatically comments on all PRs
that were included in the release, notifying contributors that their changes are
now available.

## Motivation and Context

Contributors currently have no easy way to know when their PR has been included
in a release. This workflow provides automatic notification by commenting on PRs.

## How Has This Been Tested?

This uses the well-established `apexskier/github-release-commenter` action.

## Breaking Changes

None.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed