### PR TITLE
fix client/sse: skip empty message keealive pings

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -105,6 +105,9 @@ async def sse_client(
                                         task_status.started(endpoint_url)
 
                                     case "message":
+                                        if not sse.data:
+                                            logger.debug("Skipping empty data (keep-alive pings)")
+                                            continue
                                         try:
                                             message = types.JSONRPCMessage.model_validate_json(  # noqa: E501
                                                 sse.data


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Skip empty message keepalive pings

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
SSE client in LangFlow doesn't work with my MCP Server. It fails to parse empty message

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
In my local installation of langflow. MCP Server now works via SSE as intended

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] ~~I have added appropriate error handling~~
- [ ] ~~I have added or updated documentation as needed~~

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
I have tried to write unit tests for functionality, but the mock server implementation doesn't support custom data in messages. I could allocate some time for writing a low-level mock that directly writes to the stream, but I would rather get some advice on how to make it simpler.
