### PR TITLE
docs: add guidance on discussing features before opening PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the MCP Python SDK! This document
 
 We welcome contributions! These guidelines exist to save everyone time, yours included. Following them means your work is more likely to be accepted.
 
-**All pull requests require a corresponding issue.** Unless your change is trivial (typo, docs tweak, broken link), create an issue first. PRs without a linked issue will be closed.
+**All pull requests require a corresponding issue.** Unless your change is trivial (typo, docs tweak, broken link), create an issue first. Every merged feature becomes ongoing maintenance, so we need to agree something is worth doing before reviewing code. PRs without a linked issue will be closed.
 
 Having an issue doesn't guarantee acceptance. Wait for maintainer feedback or a `ready for work` label before starting. PRs for issues without buy-in may also be closed.
 
@@ -27,11 +27,17 @@ These always require an issue first:
 
 Bug fixes for clear, reproducible issues are welcome—but still create an issue to track the fix.
 
-### Good Candidates for Contribution
+### Finding Issues to Work On
 
-Issues labeled [`good first issue`](https://github.com/modelcontextprotocol/python-sdk/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) or [`help wanted`](https://github.com/modelcontextprotocol/python-sdk/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) are great starting points. Issues labeled [`ready for work`](https://github.com/modelcontextprotocol/python-sdk/issues?q=is%3Aopen+is%3Aissue+label%3A%22ready+for+work%22) have been triaged and are ready for implementation.
+| Label | For | Description |
+|-------|-----|-------------|
+| [`good first issue`](https://github.com/modelcontextprotocol/python-sdk/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) | Newcomers | Can tackle without deep codebase knowledge |
+| [`help wanted`](https://github.com/modelcontextprotocol/python-sdk/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) | Experienced contributors | Maintainers probably won't get to this |
+| [`ready for work`](https://github.com/modelcontextprotocol/python-sdk/issues?q=is%3Aopen+is%3Aissue+label%3A%22ready+for+work%22) | Maintainers | Triaged and ready for a maintainer to pick up |
 
-Issues labeled `needs confirmation` or `needs maintainer action` are **not** good candidates—wait for maintainer input before starting work.
+Issues labeled `needs confirmation` or `needs maintainer action` are **not** ready for work—wait for maintainer input first.
+
+Before starting, comment on the issue so we can assign it to you. This prevents duplicate effort.
 
 ## Development Setup
 
@@ -102,13 +108,29 @@ pre-commit run --all-files
 - Add type hints to all functions
 - Include docstrings for public APIs
 
-## Pull Request Process
+## Pull Requests
+
+By the time you open a PR, the "what" and "why" should already be settled in an issue. This keeps reviews focused on implementation.
+
+### Scope
+
+Small PRs get reviewed fast. Large PRs sit in the queue.
+
+A few dozen lines can be reviewed in minutes. Hundreds of lines across many files takes real effort and things slip through. If your change is big, break it into smaller PRs or get alignment from a maintainer first.
+
+### What Gets Rejected
+
+- **No prior discussion**: Features or significant changes without an approved issue
+- **Scope creep**: Changes that go beyond what was discussed
+- **Misalignment**: Even well-implemented features may be rejected if they don't fit the SDK's direction
+- **Overengineering**: Unnecessary complexity for simple problems
+
+### Checklist
 
 1. Update documentation as needed
 2. Add tests for new functionality
 3. Ensure CI passes
-4. Maintainers will review your code
-5. Address review feedback
+4. Address review feedback
 
 ## Code of Conduct
 


### PR DESCRIPTION
Adds a "Before You Start" section to CONTRIBUTING.md that sets clear expectations for contributors about when to open an issue before submitting a PR.

## Motivation and Context

Currently, we occasionally receive large unsolicited PRs (e.g., major refactoring, new architectural patterns) without prior discussion. This creates awkward situations where we have to close well-intentioned contributions because they don't align with the SDK's direction. Having clear policy in CONTRIBUTING.md gives us something to reference and sets expectations upfront.

This is inspired by how Ruff and other major open source projects handle this.

## How Has This Been Tested?

N/A - documentation only change. Verified that the issue filter links work correctly.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The new section covers:
- **Bug fixes**: Welcome to PR directly for straightforward bugs
- **New features/enhancements**: Please open an issue first to discuss
- **What counts as "significant"**: New APIs, architectural changes, multi-module changes, spec-level features
- **Good candidates**: Points to `good first issue`, `help wanted`, and `ready for work` labels
- **Not good candidates**: Issues labeled `needs confirmation` or `needs maintainer action`