### PR TITLE
docs: add Read the Docs configuration for versioned documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ The Context object provides the following capabilities:
 - `ctx.session` - Access to the underlying session for advanced communication (see [Session Properties and Methods](#session-properties-and-methods))
 - `ctx.request_context` - Access to request-specific data and lifespan resources (see [Request Context Properties](#request-context-properties))
 - `await ctx.debug(message)` - Send debug log message
-- `await ctx.info(message)` - Send info log message  
+- `await ctx.info(message)` - Send info log message
 - `await ctx.warning(message)` - Send warning log message
 - `await ctx.error(message)` - Send error log message
 - `await ctx.log(level, message, logger_name=None)` - Send log with custom level
@@ -1107,13 +1107,13 @@ The session object accessible via `ctx.session` provides advanced control over c
 async def notify_data_update(resource_uri: str, ctx: Context) -> str:
     """Update data and notify clients of the change."""
     # Perform data update logic here
-    
+
     # Notify clients that this specific resource changed
     await ctx.session.send_resource_updated(AnyUrl(resource_uri))
-    
+
     # If this affects the overall resource list, notify about that too
     await ctx.session.send_resource_list_changed()
-    
+
     return f"Updated {resource_uri} and notified clients"
 ```
 
@@ -1142,11 +1142,11 @@ def query_with_config(query: str, ctx: Context) -> str:
     """Execute a query using shared database and configuration."""
     # Access typed lifespan context
     app_ctx: AppContext = ctx.request_context.lifespan_context
-    
+
     # Use shared resources
     connection = app_ctx.db
     settings = app_ctx.config
-    
+
     # Execute query with configuration
     result = connection.execute(query, timeout=settings.query_timeout)
     return str(result)
@@ -2545,7 +2545,9 @@ MCP servers declare capabilities during initialization:
 
 ## Documentation
 
-- [API Reference](https://modelcontextprotocol.github.io/python-sdk/api/)
+- [Current Release Documentation](https://modelcontextprotocol.github.io/python-sdk/)
+- [Current Release API Reference](https://modelcontextprotocol.github.io/python-sdk/api/)
+- [Versioned Documentation](https://mcp-python-sdk.readthedocs.io/)
 - [Experimental Features (Tasks)](https://modelcontextprotocol.github.io/python-sdk/experimental/tasks/)
 - [Model Context Protocol documentation](https://modelcontextprotocol.io)
 - [Model Context Protocol specification](https://modelcontextprotocol.io/specification/latest)


### PR DESCRIPTION
Currently, the documentation for the current release is published at https://modelcontextprotocol.github.io/python-sdk/. However, documentation for older releases is unavailable.

This commit adds a `.readthedocs.yaml` configuration file to enable publishing versioned documentation to Read the Docs in addition to the existing GitHub Pages deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Before merging this PR**, someone with sufficient repository rights will need to register the project on Read the Docs:

1. Import the project at https://readthedocs.org (sign in with GitHub)
2. Import `modelcontextprotocol/python-sdk`
3. In Admin → Versions, activate release tags to document (e.g., `v1.0.0`)

Then I will update the link in the README to use the proper slug (some suggestions: `mcp-python-sdk`, `modelcontextprotocol`, `mcp-sdk`).
