### PR TITLE
Add agencyHint to ToolAnnotations

### DIFF
--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -1292,10 +1292,10 @@ class ToolAnnotations(BaseModel):
 
     agencyHint: bool | None = None
     """
-    If true, this tool encapsulates an internal “agent loop” (e.g., plan–act–observe cycles, tool-chaining, or autonomous retries).
+    If true, this tool encapsulates an internal "agent loop" (e.g., plan–act–observe cycles, tool-chaining, or autonomous retries).
     Default: false
     """
-  
+
     model_config = ConfigDict(extra="allow")
 
 

--- a/tests/server/fastmcp/test_tool_manager.py
+++ b/tests/server/fastmcp/test_tool_manager.py
@@ -428,6 +428,7 @@ class TestToolAnnotations:
             title="File Reader",
             readOnlyHint=True,
             openWorldHint=False,
+            agencyHint=True,
         )
 
         manager = ToolManager()
@@ -437,6 +438,7 @@ class TestToolAnnotations:
         assert tool.annotations.title == "File Reader"
         assert tool.annotations.readOnlyHint is True
         assert tool.annotations.openWorldHint is False
+        assert tool.annotations.agencyHint is True
 
     @pytest.mark.anyio
     async def test_tool_annotations_in_fastmcp(self):
@@ -444,7 +446,7 @@ class TestToolAnnotations:
 
         app = FastMCP()
 
-        @app.tool(annotations=ToolAnnotations(title="Echo Tool", readOnlyHint=True))
+        @app.tool(annotations=ToolAnnotations(title="Echo Tool", readOnlyHint=True, agencyHint=False))
         def echo(message: str) -> str:  # pragma: no cover
             """Echo a message back."""
             return message
@@ -454,6 +456,7 @@ class TestToolAnnotations:
         assert tools[0].annotations is not None
         assert tools[0].annotations.title == "Echo Tool"
         assert tools[0].annotations.readOnlyHint is True
+        assert tools[0].annotations.agencyHint is False
 
 
 class TestStructuredOutput:

--- a/tests/server/test_lowlevel_tool_annotations.py
+++ b/tests/server/test_lowlevel_tool_annotations.py
@@ -35,6 +35,7 @@ async def test_lowlevel_server_tool_annotations():
                 annotations=ToolAnnotations(
                     title="Echo Tool",
                     readOnlyHint=True,
+                    agencyHint=True,
                 ),
             )
         ]
@@ -98,3 +99,4 @@ async def test_lowlevel_server_tool_annotations():
     assert tools_result.tools[0].annotations is not None
     assert tools_result.tools[0].annotations.title == "Echo Tool"
     assert tools_result.tools[0].annotations.readOnlyHint is True
+    assert tools_result.tools[0].annotations.agencyHint is True


### PR DESCRIPTION
This PR adds support for the new `agencyHint` annotation to the Model Context Protocol Python SDK. The `agencyHint` boolean field in `ToolAnnotations` allows tools to signal that they encapsulate an internal “agent loop” (plan–act–observe cycles, tool chaining, or autonomous retries). This helps clients handle agent-like tools appropriately and differentiates them from simple single-step tools.  

## Motivation and Context  
This change aligns the Python SDK with the latest MCP specification (SEP-1938) by adding the `agencyHint` flag. Tools that encapsulate agent loops may behave differently from simple tools, so exposing this hint allows orchestrators and clients to make better decisions about tool invocation.  

## How Has This Been Tested?  
All existing tests have been run locally to ensure no regressions. The new field is optional and defaults to `false`, so it should not affect existing behavior. No additional tests were required because it is a schema-level change.  

## Breaking Changes  
There are no breaking changes. The new field is optional and defaults to `false`.  

## Types of changes  
- [x] New feature (non-breaking change which adds functionality)  

## Checklist  
- [x] I have read the MCP Documentation  
- [x] My code follows the repository's style guidelines  
- [x] New and existing tests pass locally  
- [ ] I have added appropriate error handling (not applicable – no new logic)  
- [ ] I have added or updated documentation as needed (docstring added for the new field)  

## Additional context  
N/A