### PR TITLE
fix: use correct python command name in test_stdio.py

### DIFF
--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -69,7 +69,7 @@ async def test_stdio_client():
 @pytest.mark.anyio
 async def test_stdio_client_bad_path():
     """Check that the connection doesn't hang if process errors."""
-    server_params = StdioServerParameters(command="python", args=["-c", "non-existent-file.py"])
+    server_params = StdioServerParameters(command=sys.executable, args=["-c", "non-existent-file.py"])
     async with stdio_client(server_params) as (read_stream, write_stream):
         async with ClientSession(read_stream, write_stream) as session:
             # The session should raise an error when the connection closes


### PR DESCRIPTION
## Motivation and Context
Some platforms (e.g. Fedora) don't provide an unversioned `python` binary. In such case `tests/client/test_stdio.py` fails when it tries to call it. Use `sys.executable` instead, which works reliably.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Verified that this makes the test pass on Fedora.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
