### PR TITLE
feat: support setting title and description for server

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -139,6 +139,8 @@ class Server(Generic[LifespanResultT, RequestT]):
         self,
         name: str,
         version: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
         instructions: str | None = None,
         website_url: str | None = None,
         icons: list[types.Icon] | None = None,
@@ -149,6 +151,8 @@ class Server(Generic[LifespanResultT, RequestT]):
     ):
         self.name = name
         self.version = version
+        self.title = title
+        self.description = description
         self.instructions = instructions
         self.website_url = website_url
         self.icons = icons
@@ -186,6 +190,8 @@ class Server(Generic[LifespanResultT, RequestT]):
                 experimental_capabilities or {},
             ),
             instructions=self.instructions,
+            server_title=self.title,
+            server_description=self.description,
             website_url=self.website_url,
             icons=self.icons,
         )

--- a/src/mcp/server/models.py
+++ b/src/mcp/server/models.py
@@ -16,5 +16,7 @@ class InitializationOptions(BaseModel):
     server_version: str
     capabilities: ServerCapabilities
     instructions: str | None = None
+    server_title: str | None = None
+    server_description: str | None = None
     website_url: str | None = None
     icons: list[Icon] | None = None

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -176,7 +176,9 @@ class ServerSession(
                                 capabilities=self._init_options.capabilities,
                                 serverInfo=types.Implementation(
                                     name=self._init_options.server_name,
+                                    title=self._init_options.server_title,
                                     version=self._init_options.server_version,
+                                    description=self._init_options.server_description,
                                     websiteUrl=self._init_options.website_url,
                                     icons=self._init_options.icons,
                                 ),

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -265,6 +265,15 @@ class Implementation(BaseMetadata):
 
     version: str
 
+    description: str | None = None
+    """
+    An optional human-readable description of what this implementation does.
+
+    This can be used by clients or servers to provide context about their purpose
+    and capabilities. For example, a server might describe the types of resources
+    or tools it provides, while a client might describe its intended use case.
+    """
+
     websiteUrl: str | None = None
     """An optional URL of the website for this implementation."""
 


### PR DESCRIPTION
Add support for the `title` and `description` fields in the `Implementation` type, allowing servers to provide human-readable metadata during initialization.

Changes:
- Add `description` field to `types.Implementation`
- Add `server_title` and `server_description` to `InitializationOptions`
- Wire up title/description through `Server` constructor and session
- Add test for title and description passthrough

Github-Issue:#1783

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
