### PR TITLE
ci: add v1.x branch to main-checks workflow

### DIFF
--- a/.github/workflows/main-checks.yml
+++ b/.github/workflows/main-checks.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - "v*.*.*"
+      - "v1.x"
     tags:
       - "v*.*.*"
 


### PR DESCRIPTION
Prepare for v2 development by ensuring CI runs on the v1.x maintenance branch.

## Motivation and Context

As part of the v2 branching strategy, a `v1.x` branch will be created to receive security and critical bug fixes while `main` becomes the v2 development branch. This PR ensures CI checks run on pushes to the `v1.x` branch.

The existing pattern `v*.*.*` only matches branches with 3 segments (like `v1.0.x`), so `v1.x` needs to be added explicitly.

## How Has This Been Tested?

Workflow syntax validated. The change will be tested when the `v1.x` branch is created and pushed to.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This is the first step in implementing the v2 branching strategy. After this is merged, the `v1.x` branch will be created from `main` and branch protection will be configured.