### PR TITLE
add support for resource metadata

### DIFF
--- a/src/mcp/server/fastmcp/resources/base.py
+++ b/src/mcp/server/fastmcp/resources/base.py
@@ -1,7 +1,7 @@
 """Base classes and interfaces for FastMCP resources."""
 
 import abc
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import (
     AnyUrl,
@@ -32,6 +32,7 @@ class Resource(BaseModel, abc.ABC):
     )
     icons: list[Icon] | None = Field(default=None, description="Optional list of icons for this resource")
     annotations: Annotations | None = Field(default=None, description="Optional annotations for the resource")
+    meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for the resource")
 
     @field_validator("name", mode="before")
     @classmethod

--- a/src/mcp/server/fastmcp/resources/resource_manager.py
+++ b/src/mcp/server/fastmcp/resources/resource_manager.py
@@ -64,6 +64,7 @@ class ResourceManager:
         mime_type: str | None = None,
         icons: list[Icon] | None = None,
         annotations: Annotations | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> ResourceTemplate:
         """Add a template from a function."""
         template = ResourceTemplate.from_function(
@@ -75,6 +76,7 @@ class ResourceManager:
             mime_type=mime_type,
             icons=icons,
             annotations=annotations,
+            meta=meta,
         )
         self._templates[template.uri_template] = template
         return template

--- a/src/mcp/server/fastmcp/resources/templates.py
+++ b/src/mcp/server/fastmcp/resources/templates.py
@@ -33,6 +33,7 @@ class ResourceTemplate(BaseModel):
     fn: Callable[..., Any] = Field(exclude=True)
     parameters: dict[str, Any] = Field(description="JSON schema for function parameters")
     context_kwarg: str | None = Field(None, description="Name of the kwarg that should receive context")
+    meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for the resource template")
 
     @classmethod
     def from_function(
@@ -46,6 +47,7 @@ class ResourceTemplate(BaseModel):
         icons: list[Icon] | None = None,
         annotations: Annotations | None = None,
         context_kwarg: str | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> ResourceTemplate:
         """Create a template from a function."""
         func_name = name or fn.__name__
@@ -77,6 +79,7 @@ class ResourceTemplate(BaseModel):
             fn=fn,
             parameters=parameters,
             context_kwarg=context_kwarg,
+            meta=meta,
         )
 
     def matches(self, uri: str) -> dict[str, Any] | None:
@@ -113,6 +116,7 @@ class ResourceTemplate(BaseModel):
                 icons=self.icons,
                 annotations=self.annotations,
                 fn=lambda: result,  # Capture result in closure
+                meta=self.meta,
             )
         except Exception as e:
             raise ValueError(f"Error creating resource from template: {e}")

--- a/src/mcp/server/fastmcp/resources/types.py
+++ b/src/mcp/server/fastmcp/resources/types.py
@@ -83,6 +83,7 @@ class FunctionResource(Resource):
         mime_type: str | None = None,
         icons: list[Icon] | None = None,
         annotations: Annotations | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> "FunctionResource":
         """Create a FunctionResource from a function."""
         func_name = name or fn.__name__
@@ -101,6 +102,7 @@ class FunctionResource(Resource):
             fn=fn,
             icons=icons,
             annotations=annotations,
+            meta=meta,
         )
 
 

--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -358,6 +358,7 @@ class FastMCP(Generic[LifespanResultT]):
                 mimeType=resource.mime_type,
                 icons=resource.icons,
                 annotations=resource.annotations,
+                _meta=resource.meta,
             )
             for resource in resources
         ]
@@ -373,6 +374,7 @@ class FastMCP(Generic[LifespanResultT]):
                 mimeType=template.mime_type,
                 icons=template.icons,
                 annotations=template.annotations,
+                _meta=template.meta,
             )
             for template in templates
         ]
@@ -539,6 +541,7 @@ class FastMCP(Generic[LifespanResultT]):
         mime_type: str | None = None,
         icons: list[Icon] | None = None,
         annotations: Annotations | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> Callable[[AnyFunction], AnyFunction]:
         """Decorator to register a function as a resource.
 
@@ -615,6 +618,7 @@ class FastMCP(Generic[LifespanResultT]):
                     mime_type=mime_type,
                     icons=icons,
                     annotations=annotations,
+                    meta=meta,
                 )
             else:
                 # Register as regular resource
@@ -627,6 +631,7 @@ class FastMCP(Generic[LifespanResultT]):
                     mime_type=mime_type,
                     icons=icons,
                     annotations=annotations,
+                    meta=meta,
                 )
                 self.add_resource(resource)
             return fn

--- a/tests/server/fastmcp/resources/test_function_resources.py
+++ b/tests/server/fastmcp/resources/test_function_resources.py
@@ -155,3 +155,23 @@ class TestFunctionResource:
         assert resource.mime_type == "text/plain"
         assert resource.name == "test"
         assert resource.uri == AnyUrl("function://test")
+
+    @pytest.mark.anyio
+    def test_from_function_with_meta(self):
+        """Test creating a FunctionResource with metadata."""
+
+        async def get_data() -> str:  # pragma: no cover
+            return "Hello, world!"
+
+        meta = {"ui": {"type": "card"}, "version": "1.0"}
+
+        resource = FunctionResource.from_function(
+            fn=get_data,
+            uri="function://test",
+            name="test",
+            meta=meta,
+        )
+
+        assert resource.meta is not None
+        assert resource.meta == meta
+        assert resource.meta["ui"]["type"] == "card"


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adds support for including metadata in the `mcp.resource` decorator.

## Motivation and Context
This is required by OpenAI to support the [Content Security Policy](https://developers.openai.com/apps-sdk/build/mcp-server#content-security-policy-csp).

## How Has This Been Tested?
I added metadata to a resource from my MCP server, then called `resources/list` with the MCP Inspector. The metadata was in the resource schema.

## Breaking Changes
Nope, it's all optional keywords

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
