### PR TITLE
docs: update CONTRIBUTING with v2 branching strategy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,14 @@ uv tool install pre-commit --with pre-commit-uv --force-reinstall
 ## Development Workflow
 
 1. Choose the correct branch for your changes:
-   - For bug fixes to a released version: use the latest release branch (e.g. v1.1.x for 1.1.3)
-   - For new features: use the main branch (which will become the next minor/major version)
-   - If unsure, ask in an issue first
+
+   | Change Type | Target Branch | Example |
+   |-------------|---------------|---------|
+   | New features, breaking changes | `main` | New APIs, refactors |
+   | Security fixes for v1 | `v1.x` | Critical patches |
+   | Bug fixes for v1 | `v1.x` | Non-breaking fixes |
+
+   > **Note:** `main` is the v2 development branch. Breaking changes are welcome on `main`. The `v1.x` branch receives only security and critical bug fixes.
 
 2. Create a new branch from your chosen base branch
 


### PR DESCRIPTION
Clarify the branching strategy now that v2 development has begun.

## Motivation and Context

With the v2 branching strategy in place (`main` for v2 development, `v1.x` for maintenance), the CONTRIBUTING guide needed updating to help contributors target the correct branch.

## How Has This Been Tested?

Documentation change only.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed