### PR TITLE
feat(cmid-server): Implement Server-Side Support for Client ID Metadata Documents (CIMD)

### DIFF
--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -173,6 +173,7 @@ def build_metadata(
         op_tos_uri=None,
         introspection_endpoint=None,
         code_challenge_methods_supported=["S256"],
+        client_id_metadata_document_supported=True,
     )
 
     # Add registration endpoint if supported

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1359,6 +1359,7 @@ def test_build_metadata(
             "revocation_endpoint": Is(revocation_endpoint),
             "revocation_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
             "code_challenge_methods_supported": ["S256"],
+            "client_id_metadata_document_supported": True,
         }
     )
 


### PR DESCRIPTION
Implement Server-Side Support for Client ID Metadata Documents (CIMD)

## Motivation and Context
This PR addresses issue #1801 by implementing server-side support for Client ID Metadata Documents (CIMD), as defined in SEP-991 and the MCP authorization specification.
Previously, the Authorization Server logic in the Python SDK could not resolve or validate clients that identify themselves via a URL (CIMD). This change enables the server to:

- **Advertise Support**: Tells clients the server supports CIMD by adding client_id_metadata_document_supported: True to the server metadata.
- **Dynamic Resolution**: Detects when a client_id is an HTTPS URL during the authorization flow.
- **Fetch & Validate:** Fetches the metadata document from the provided URL and validates that the client_id inside the document matches the request.
- **Fallback Mechanism**: If a client is not found in the static provider registry, it attempts to resolve it as a CIMD before returning an error.

## How Has This Been Tested?
Added Unit Test Cases for the CIMD Server authorization flow - 
- test_cimd_authorization_flow
- test_cimd_authorization_invalid_cimd_url
- test_cimd_authorization_invalid_client_id
- test_cimd_authorization_metadata_fetch_error

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

