### PR TITLE
fix: raise clear error for server-to-client requests in stateless mode

### DIFF
--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -93,6 +93,7 @@ class ServerSession(
         stateless: bool = False,
     ) -> None:
         super().__init__(read_stream, write_stream, types.ClientRequest, types.ClientNotification)
+        self._stateless = stateless
         self._initialization_state = (
             InitializationState.Initialized if stateless else InitializationState.NotInitialized
         )
@@ -155,6 +156,26 @@ class ServerSession(
                 return False
 
         return True
+
+    def _require_stateful_mode(self, feature_name: str) -> None:
+        """Raise an error if trying to use a feature that requires stateful mode.
+
+        Server-to-client requests (sampling, elicitation, list_roots) are not
+        supported in stateless HTTP mode because there is no persistent connection
+        for bidirectional communication.
+
+        Args:
+            feature_name: Name of the feature being used (for error message)
+
+        Raises:
+            RuntimeError: If the session is in stateless mode
+        """
+        if self._stateless:
+            raise RuntimeError(
+                f"Cannot use {feature_name} in stateless HTTP mode. "
+                "Stateless mode does not support server-to-client requests. "
+                "Use stateful mode (stateless_http=False) to enable this feature."
+            )
 
     async def _receive_loop(self) -> None:
         async with self._incoming_message_stream_writer:
@@ -311,7 +332,9 @@ class ServerSession(
         Raises:
             McpError: If tools are provided but client doesn't support them.
             ValueError: If tool_use or tool_result message structure is invalid.
+            RuntimeError: If called in stateless HTTP mode.
         """
+        self._require_stateful_mode("sampling")
         client_caps = self._client_params.capabilities if self._client_params else None
         validate_sampling_tools(client_caps, tools, tool_choice)
         validate_tool_use_result_messages(messages)
@@ -349,6 +372,7 @@ class ServerSession(
 
     async def list_roots(self) -> types.ListRootsResult:
         """Send a roots/list request."""
+        self._require_stateful_mode("list_roots")
         return await self.send_request(
             types.ServerRequest(types.ListRootsRequest()),
             types.ListRootsResult,
@@ -391,7 +415,11 @@ class ServerSession(
 
         Returns:
             The client's response with form data
+
+        Raises:
+            RuntimeError: If called in stateless HTTP mode.
         """
+        self._require_stateful_mode("elicitation")
         return await self.send_request(
             types.ServerRequest(
                 types.ElicitRequest(
@@ -425,7 +453,11 @@ class ServerSession(
 
         Returns:
             The client's response indicating acceptance, decline, or cancellation
+
+        Raises:
+            RuntimeError: If called in stateless HTTP mode.
         """
+        self._require_stateful_mode("elicitation")
         return await self.send_request(
             types.ServerRequest(
                 types.ElicitRequest(

--- a/tests/server/test_stateless_mode.py
+++ b/tests/server/test_stateless_mode.py
@@ -1,0 +1,263 @@
+"""Tests for stateless HTTP mode limitations.
+
+Stateless HTTP mode does not support server-to-client requests because there
+is no persistent connection for bidirectional communication. These tests verify
+that appropriate errors are raised when attempting to use unsupported features.
+
+See: https://github.com/modelcontextprotocol/python-sdk/issues/1097
+"""
+
+import anyio
+import pytest
+
+import mcp.types as types
+from mcp.server.models import InitializationOptions
+from mcp.server.session import ServerSession
+from mcp.shared.message import SessionMessage
+from mcp.types import ServerCapabilities
+
+
+def create_test_streams():
+    """Create memory streams for testing."""
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    return (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    )
+
+
+def create_init_options():
+    """Create default initialization options for testing."""
+    return InitializationOptions(
+        server_name="test",
+        server_version="0.1.0",
+        capabilities=ServerCapabilities(),
+    )
+
+
+@pytest.mark.anyio
+async def test_list_roots_fails_in_stateless_mode():
+    """Test that list_roots raises RuntimeError in stateless mode."""
+    (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    ) = create_test_streams()
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        async with ServerSession(
+            client_to_server_receive,
+            server_to_client_send,
+            create_init_options(),
+            stateless=True,
+        ) as session:
+            with pytest.raises(RuntimeError) as exc_info:
+                await session.list_roots()
+
+            assert "stateless HTTP mode" in str(exc_info.value)
+            assert "list_roots" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_create_message_fails_in_stateless_mode():
+    """Test that create_message raises RuntimeError in stateless mode."""
+    (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    ) = create_test_streams()
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        async with ServerSession(
+            client_to_server_receive,
+            server_to_client_send,
+            create_init_options(),
+            stateless=True,
+        ) as session:
+            with pytest.raises(RuntimeError) as exc_info:
+                await session.create_message(
+                    messages=[
+                        types.SamplingMessage(
+                            role="user",
+                            content=types.TextContent(type="text", text="hello"),
+                        )
+                    ],
+                    max_tokens=100,
+                )
+
+            assert "stateless HTTP mode" in str(exc_info.value)
+            assert "sampling" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_elicit_form_fails_in_stateless_mode():
+    """Test that elicit_form raises RuntimeError in stateless mode."""
+    (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    ) = create_test_streams()
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        async with ServerSession(
+            client_to_server_receive,
+            server_to_client_send,
+            create_init_options(),
+            stateless=True,
+        ) as session:
+            with pytest.raises(RuntimeError) as exc_info:
+                await session.elicit_form(
+                    message="Please provide input",
+                    requestedSchema={"type": "object", "properties": {}},
+                )
+
+            assert "stateless HTTP mode" in str(exc_info.value)
+            assert "elicitation" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_elicit_url_fails_in_stateless_mode():
+    """Test that elicit_url raises RuntimeError in stateless mode."""
+    (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    ) = create_test_streams()
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        async with ServerSession(
+            client_to_server_receive,
+            server_to_client_send,
+            create_init_options(),
+            stateless=True,
+        ) as session:
+            with pytest.raises(RuntimeError) as exc_info:
+                await session.elicit_url(
+                    message="Please authenticate",
+                    url="https://example.com/auth",
+                    elicitation_id="test-123",
+                )
+
+            assert "stateless HTTP mode" in str(exc_info.value)
+            assert "elicitation" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_elicit_deprecated_fails_in_stateless_mode():
+    """Test that the deprecated elicit method also fails in stateless mode."""
+    (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    ) = create_test_streams()
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        async with ServerSession(
+            client_to_server_receive,
+            server_to_client_send,
+            create_init_options(),
+            stateless=True,
+        ) as session:
+            with pytest.raises(RuntimeError) as exc_info:
+                await session.elicit(
+                    message="Please provide input",
+                    requestedSchema={"type": "object", "properties": {}},
+                )
+
+            assert "stateless HTTP mode" in str(exc_info.value)
+            assert "elicitation" in str(exc_info.value)
+
+
+@pytest.mark.anyio
+async def test_require_stateful_mode_does_not_raise_in_stateful_mode():
+    """Test that _require_stateful_mode does not raise in stateful mode."""
+    (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    ) = create_test_streams()
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        async with ServerSession(
+            client_to_server_receive,
+            server_to_client_send,
+            create_init_options(),
+            stateless=False,  # Stateful mode
+        ) as session:
+            # These should not raise - the check passes in stateful mode
+            session._require_stateful_mode("list_roots")
+            session._require_stateful_mode("sampling")
+            session._require_stateful_mode("elicitation")
+
+
+@pytest.mark.anyio
+async def test_stateless_error_message_is_actionable():
+    """Test that the error message provides actionable guidance."""
+    (
+        server_to_client_send,
+        server_to_client_receive,
+        client_to_server_send,
+        client_to_server_receive,
+    ) = create_test_streams()
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        async with ServerSession(
+            client_to_server_receive,
+            server_to_client_send,
+            create_init_options(),
+            stateless=True,
+        ) as session:
+            with pytest.raises(RuntimeError) as exc_info:
+                await session.list_roots()
+
+            error_message = str(exc_info.value)
+            # Should mention it's stateless mode
+            assert "stateless HTTP mode" in error_message
+            # Should explain why it doesn't work
+            assert "server-to-client requests" in error_message
+            # Should tell user how to fix it
+            assert "stateless_http=False" in error_message


### PR DESCRIPTION
## Motivation and Context

Fixes #1097

Server-to-client requests (list_roots, create_message, elicit_form, elicit_url) require bidirectional communication which is not available in stateless HTTP mode. Previously, these requests would hang indefinitely. Now they raise an immediate `RuntimeError` with a clear, actionable message:

```
RuntimeError: Cannot use list_roots in stateless HTTP mode. Stateless mode does not support server-to-client requests. Use stateful mode (stateless_http=False) to enable this feature.
```

## Technical Context: Why This Cannot Work

### The Fundamental Problem

In stateless mode (`stateless_http=True`), each HTTP request creates a completely fresh transport with no session tracking:

```python
# streamable_http_manager.py:168-173
http_transport = StreamableHTTPServerTransport(
    mcp_session_id=None,    # NO session tracking
    event_store=None,       # NO resumability
)
```

When a server tool handler calls `session.elicit()` or `session.create_message()`:

1. **`send_request()` blocks waiting for a response** - It creates a response stream and waits:
   ```python
   response_stream, response_stream_reader = anyio.create_memory_object_stream[...]()
   await self._write_stream.send(SessionMessage(...))
   response_or_error = await response_stream_reader.receive()  # Blocks forever
   ```

2. **In JSON response mode**: The server-initiated request is **discarded** before reaching the client:
   ```python
   # streamable_http.py:548-555
   async for event_message in request_stream_reader:
       if isinstance(event_message.message.root, JSONRPCResponse | JSONRPCError):
           response_message = event_message.message
           break
       else:
           logger.debug(f"received: {event_message.message.root.method}")  # Just logs it\!
   ```

3. **In SSE mode**: The request IS sent to the client via SSE, but:
   - Client receives the elicitation request
   - Client needs to send back a JSONRPCResponse via POST
   - **In stateless mode, this POST creates a NEW transport** with no knowledge of the pending request
   - The original `send_request()` blocks forever waiting on a response stream that will never receive anything

### Why `related_request_id` Doesn't Help

The `related_request_id` metadata helps route server messages to the correct SSE stream (the one handling the original tool call), but it does NOT solve the fundamental problem:
- In JSON mode: Messages are discarded before reaching the client
- In SSE mode: The client's response creates a new transport with no correlation mechanism

### What This Looks Like in Practice

| Mode | Server→Client Request Sent? | Client Can Respond? | Result |
|------|---------------------------|---------------------|--------|
| JSON Response + Stateless | NO (discarded) | N/A | **Hangs** |
| SSE + Stateless | YES | NO (no session) | **Hangs** |
| SSE + Stateful | YES | YES | Works |

### Future Direction (SEP-1442)

The upcoming transport changes will properly address this with:
- Intermediate result responses for "pausing" requests
- Cookie mechanism for correlating resumed requests
- Sessions at the data model layer, not protocol layer

Until then, failing fast with a clear error is the best we can do.

## How Has This Been Tested?

- Reproduced the original issue with the reporter's code - confirmed hang behavior
- Added 7 new unit tests covering all affected methods
- Verified existing tests still pass

## Breaking Changes

Yes, but intentionally so. Code that previously hung indefinitely will now raise a `RuntimeError`. This is a strict improvement - failing fast with a clear error is better than hanging.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed