### PR TITLE
Add type checker to `examples/client`

### DIFF
--- a/examples/clients/simple-chatbot/mcp_simple_chatbot/main.py
+++ b/examples/clients/simple-chatbot/mcp_simple_chatbot/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
@@ -93,7 +95,7 @@ class Server:
             await self.cleanup()
             raise
 
-    async def list_tools(self) -> list[Any]:
+    async def list_tools(self) -> list[Tool]:
         """List available tools from the server.
 
         Returns:
@@ -106,10 +108,10 @@ class Server:
             raise RuntimeError(f"Server {self.name} not initialized")
 
         tools_response = await self.session.list_tools()
-        tools = []
+        tools: list[Tool] = []
 
         for item in tools_response:
-            if isinstance(item, tuple) and item[0] == "tools":
+            if item[0] == "tools":
                 tools.extend(Tool(tool.name, tool.description, tool.inputSchema, tool.title) for tool in item[1])
 
         return tools
@@ -189,7 +191,7 @@ class Tool:
         Returns:
             A formatted string describing the tool.
         """
-        args_desc = []
+        args_desc: list[str] = []
         if "properties" in self.input_schema:
             for param_name, param_info in self.input_schema["properties"].items():
                 arg_desc = f"- {param_name}: {param_info.get('description', 'No description')}"
@@ -311,9 +313,9 @@ class ChatSession:
                             result = await server.execute_tool(tool_call["tool"], tool_call["arguments"])
 
                             if isinstance(result, dict) and "progress" in result:
-                                progress = result["progress"]
-                                total = result["total"]
-                                percentage = (progress / total) * 100
+                                progress = result["progress"]  # type: ignore
+                                total = result["total"]  # type: ignore
+                                percentage = (progress / total) * 100  # type: ignore
                                 logging.info(f"Progress: {progress}/{total} ({percentage:.1f}%)")
 
                             return f"Tool execution result: {result}"
@@ -338,7 +340,7 @@ class ChatSession:
                     await self.cleanup_servers()
                     return
 
-            all_tools = []
+            all_tools: list[Tool] = []
             for server in self.servers:
                 tools = await server.list_tools()
                 all_tools.extend(tools)

--- a/examples/clients/simple-task-client/mcp_simple_task_client/main.py
+++ b/examples/clients/simple-task-client/mcp_simple_task_client/main.py
@@ -4,12 +4,12 @@ import asyncio
 
 import click
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.types import CallToolResult, TextContent
 
 
 async def run(url: str) -> None:
-    async with streamablehttp_client(url) as (read, write, _):
+    async with streamable_http_client(url) as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
 
@@ -28,12 +28,13 @@ async def run(url: str) -> None:
             task_id = result.task.taskId
             print(f"Task created: {task_id}")
 
+            status = None
             # Poll until done (respects server's pollInterval hint)
             async for status in session.experimental.poll_task(task_id):
                 print(f"  Status: {status.status} - {status.statusMessage or ''}")
 
             # Check final status
-            if status.status != "completed":
+            if status and status.status != "completed":
                 print(f"Task ended with status: {status.status}")
                 return
 

--- a/examples/clients/simple-task-interactive-client/mcp_simple_task_interactive_client/main.py
+++ b/examples/clients/simple-task-interactive-client/mcp_simple_task_interactive_client/main.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import click
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.context import RequestContext
 from mcp.types import (
     CallToolResult,
@@ -73,7 +73,7 @@ def get_text(result: CallToolResult) -> str:
 
 
 async def run(url: str) -> None:
-    async with streamablehttp_client(url) as (read, write, _):
+    async with streamable_http_client(url) as (read, write, _):
         async with ClientSession(
             read,
             write,

--- a/examples/clients/sse-polling-client/mcp_sse_polling_client/main.py
+++ b/examples/clients/sse-polling-client/mcp_sse_polling_client/main.py
@@ -20,7 +20,7 @@ import logging
 
 import click
 from mcp import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ async def run_demo(url: str, items: int, checkpoint_every: int) -> None:
     print(f"Processing {items} items with checkpoints every {checkpoint_every}")
     print(f"{'=' * 60}\n")
 
-    async with streamablehttp_client(url) as (read_stream, write_stream, _):
+    async with streamable_http_client(url) as (read_stream, write_stream, _):
         async with ClientSession(read_stream, write_stream) as session:
             # Initialize the connection
             print("Initializing connection...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,13 @@ packages = ["src/mcp"]
 
 [tool.pyright]
 typeCheckingMode = "strict"
-include = ["src/mcp", "tests", "examples/servers", "examples/snippets"]
+include = [
+    "src/mcp",
+    "tests",
+    "examples/servers",
+    "examples/snippets",
+    "examples/clients",
+]
 venvPath = "."
 venv = ".venv"
 # The FastAPI style of using decorators in tests gives a `reportUnusedFunction` error.
@@ -102,7 +108,9 @@ venv = ".venv"
 # those private functions instead of testing the private functions directly. It makes it easier to maintain the code source
 # and refactor code that is not public.
 executionEnvironments = [
-    { root = "tests", extraPaths = ["."], reportUnusedFunction = false, reportPrivateUsage = false },
+    { root = "tests", extraPaths = [
+        ".",
+    ], reportUnusedFunction = false, reportPrivateUsage = false },
     { root = "examples/servers", reportUnusedFunction = false },
 ]
 


### PR DESCRIPTION
This is why my IDE detected it, but the pipeline was passing.

---

As a note, I think most or all the examples are too complex, and we need to refactor them. We need to improve the SDK.