### PR TITLE
feat: add stateless_sse option for SSE transport

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -107,6 +107,10 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     stateless_http: bool
     """Define if the server should create a new transport per request."""
 
+    # SSE settings
+    stateless_sse: bool
+    """Define if the SSE server should bypass MCP initialization handshake."""
+
     # resource settings
     warn_on_duplicate_resources: bool
 
@@ -169,6 +173,7 @@ class FastMCP(Generic[LifespanResultT]):
         streamable_http_path: str = "/mcp",
         json_response: bool = False,
         stateless_http: bool = False,
+        stateless_sse: bool = False,
         warn_on_duplicate_resources: bool = True,
         warn_on_duplicate_tools: bool = True,
         warn_on_duplicate_prompts: bool = True,
@@ -196,6 +201,7 @@ class FastMCP(Generic[LifespanResultT]):
             streamable_http_path=streamable_http_path,
             json_response=json_response,
             stateless_http=stateless_http,
+            stateless_sse=stateless_sse,
             warn_on_duplicate_resources=warn_on_duplicate_resources,
             warn_on_duplicate_tools=warn_on_duplicate_tools,
             warn_on_duplicate_prompts=warn_on_duplicate_prompts,
@@ -858,6 +864,7 @@ class FastMCP(Generic[LifespanResultT]):
                     streams[0],
                     streams[1],
                     self._mcp_server.create_initialization_options(),
+                    stateless=self.settings.stateless_sse,
                 )
             return Response()
 


### PR DESCRIPTION

  Body:
  ## Summary
  Add a `stateless_sse` parameter to FastMCP that bypasses the MCP protocol initialization handshake for SSE transport, fixing issues where fast clients send requests before initialization completes.

  ## Changes
  - Add `stateless_sse` field to `Settings` class in FastMCP
  - Add `stateless_sse` parameter to `FastMCP.__init__()` (default: `False`)
  - Pass `stateless=self.settings.stateless_sse` to `server.run()` in `sse_app()` method
  - Add integration test for stateless SSE mode

  ## Problem
  When Claude Code (or other fast clients) connects via SSE transport, tool call requests can arrive before the initialization handshake completes, causing:
  `RuntimeError: Received request before initialization was complete`

  ## Solution
  Mirror the existing `stateless_http` option by adding `stateless_sse`. When enabled, bypasses the initialization barrier.

  ## Testing
  - All existing SSE tests pass (26 passed)
  - New test added: `test_sse_stateless_mode_allows_requests_without_initialization`

  Fixes #1844
