### PR TITLE
Add missing TasksCallCapability to enable proper MCP task support

### DIFF
--- a/src/mcp/server/lowlevel/experimental.py
+++ b/src/mcp/server/lowlevel/experimental.py
@@ -31,6 +31,7 @@ from mcp.types import (
     ServerResult,
     ServerTasksCapability,
     ServerTasksRequestsCapability,
+    TasksCallCapability,
     TasksCancelCapability,
     TasksListCapability,
     TasksToolsCapability,
@@ -79,7 +80,7 @@ class ExperimentalHandlers:
             capabilities.tasks.cancel = TasksCancelCapability()
 
         capabilities.tasks.requests = ServerTasksRequestsCapability(
-            tools=TasksToolsCapability()
+            tools=TasksToolsCapability(call=TasksCallCapability())
         )  # assuming always supported for now
 
     def enable_tasks(

--- a/tests/experimental/tasks/server/test_run_task_flow.py
+++ b/tests/experimental/tasks/server/test_run_task_flow.py
@@ -227,6 +227,10 @@ async def test_enable_tasks_auto_registers_handlers() -> None:
     assert caps_after.tasks is not None
     assert caps_after.tasks.list is not None
     assert caps_after.tasks.cancel is not None
+    # Verify nested call capability is present
+    assert caps_after.tasks.requests is not None
+    assert caps_after.tasks.requests.tools is not None
+    assert caps_after.tasks.requests.tools.call is not None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
The enable_tasks() method was creating TasksToolsCapability without
the required nested call capability. This caused VS Code Copilot and
other MCP clients to fail their capability detection check
(tasks?.requests?.tools?.call !== undefined), silently falling back
to synchronous tool calls instead of using the proper asynchronous
MCP Tasks protocol.

This fix:
- Imports TasksCallCapability from mcp.types
- Passes call=TasksCallCapability() when creating TasksToolsCapability
- Adds unit test to verify the nested capability is properly set

Without this fix, long-running tools would timeout after 5 minutes
instead of receiving proper asynchronous task handling.

Github-Issue: #1853