### PR TITLE
fix: suppress GeneratorExit during client cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pyjwt[crypto]>=2.10.1",
     "typing-extensions>=4.13.0",
     "typing-inspection>=0.4.1",
+    "exceptiongroup>=1.0.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -1,10 +1,16 @@
 import logging
+import sys
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import Any
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import anyio
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup  # pragma: lax no cover
+else:
+    from exceptiongroup import BaseExceptionGroup  # pragma: lax no cover
 import httpx
 from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
@@ -155,8 +161,19 @@ async def sse_client(
 
                     try:
                         yield read_stream, write_stream
+                    # Suppress GeneratorExit to prevent "generator didn't stop after athrow()"
+                    # when client code exits the context manager during cancellation.
+                    # See https://github.com/python/cpython/issues/95571
+                    except GeneratorExit:
+                        pass
+                    # anyio wraps GeneratorExit in BaseExceptionGroup; extract and re-raise other exceptions
+                    except BaseExceptionGroup as eg:
+                        _, rest = eg.split(GeneratorExit)
+                        if rest:
+                            raise rest from None
                     finally:
                         tg.cancel_scope.cancel()
         finally:
             await read_stream_writer.aclose()
+            await read_stream.aclose()
             await write_stream.aclose()

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -4,11 +4,17 @@ from __future__ import annotations as _annotations
 
 import contextlib
 import logging
+import sys
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
 import anyio
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup  # pragma: lax no cover
+else:
+    from exceptiongroup import BaseExceptionGroup  # pragma: lax no cover
 import httpx
 from anyio.abc import TaskGroup
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
@@ -570,10 +576,21 @@ async def streamable_http_client(
 
                 try:
                     yield read_stream, write_stream
+                # Suppress GeneratorExit to prevent "generator didn't stop after athrow()"
+                # when client code exits the context manager during cancellation.
+                # See https://github.com/python/cpython/issues/95571
+                except GeneratorExit:
+                    pass
+                # anyio wraps GeneratorExit in BaseExceptionGroup; extract and re-raise other exceptions
+                except BaseExceptionGroup as eg:
+                    _, rest = eg.split(GeneratorExit)
+                    if rest:
+                        raise rest from None
                 finally:
                     if transport.session_id and terminate_on_close:
                         await transport.terminate_session(client)
                     tg.cancel_scope.cancel()
         finally:
             await read_stream_writer.aclose()
+            await read_stream.aclose()
             await write_stream.aclose()

--- a/tests/client/test_resource_cleanup.py
+++ b/tests/client/test_resource_cleanup.py
@@ -1,13 +1,30 @@
+import sys
+from collections.abc import Callable
 from typing import Any
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup  # pragma: lax no cover
+else:
+    from exceptiongroup import BaseExceptionGroup  # pragma: lax no cover
+
 from unittest.mock import patch
 
 import anyio
 import pytest
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from pydantic import TypeAdapter
 
+from mcp.client.sse import sse_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.message import SessionMessage
 from mcp.shared.session import BaseSession, RequestId, SendResultT
 from mcp.types import ClientNotification, ClientRequest, ClientResult, EmptyResult, ErrorData, PingRequest
+
+ClientTransport = tuple[
+    str,
+    Callable[..., Any],
+    Callable[[Any], tuple[MemoryObjectReceiveStream[Any], MemoryObjectSendStream[Any]]],
+]
 
 
 @pytest.mark.anyio
@@ -17,7 +34,6 @@ async def test_send_request_stream_cleanup():
     This test mocks out most of the session functionality to focus on stream cleanup.
     """
 
-    # Create a mock session with the minimal required functionality
     class TestSession(BaseSession[ClientRequest, ClientNotification, ClientResult, Any, Any]):
         async def _send_response(
             self, request_id: RequestId, response: SendResultT | ErrorData
@@ -32,35 +48,77 @@ async def test_send_request_stream_cleanup():
         def _receive_notification_adapter(self) -> TypeAdapter[Any]:
             return TypeAdapter(object)  # pragma: no cover
 
-    # Create streams
     write_stream_send, write_stream_receive = anyio.create_memory_object_stream[SessionMessage](1)
     read_stream_send, read_stream_receive = anyio.create_memory_object_stream[SessionMessage](1)
 
-    # Create the session
     session = TestSession(read_stream_receive, write_stream_send)
 
-    # Create a test request
     request = PingRequest()
 
-    # Patch the _write_stream.send method to raise an exception
     async def mock_send(*args: Any, **kwargs: Any):
         raise RuntimeError("Simulated network error")
 
-    # Record the response streams before the test
     initial_stream_count = len(session._response_streams)
 
-    # Run the test with the patched method
     with patch.object(session._write_stream, "send", mock_send):
         with pytest.raises(RuntimeError):
             await session.send_request(request, EmptyResult)
 
-    # Verify that no response streams were leaked
-    assert len(session._response_streams) == initial_stream_count, (
-        f"Expected {initial_stream_count} response streams after request, but found {len(session._response_streams)}"
-    )
+    assert len(session._response_streams) == initial_stream_count
 
-    # Clean up
     await write_stream_send.aclose()
     await write_stream_receive.aclose()
     await read_stream_send.aclose()
     await read_stream_receive.aclose()
+
+
+@pytest.fixture(params=["sse", "streamable"])
+def client_transport(
+    request: pytest.FixtureRequest, sse_server_url: str, streamable_server_url: str
+) -> ClientTransport:
+    if request.param == "sse":
+        return (sse_server_url, sse_client, lambda x: (x[0], x[1]))
+    else:
+        return (streamable_server_url, streamable_http_client, lambda x: (x[0], x[1]))
+
+
+@pytest.mark.anyio
+async def test_generator_exit_on_gc_cleanup(client_transport: ClientTransport) -> None:
+    """Suppress GeneratorExit from aclose() during GC cleanup (python/cpython#95571)."""
+    url, client_func, unpack = client_transport
+    cm = client_func(url)
+    result = await cm.__aenter__()
+    read_stream, write_stream = unpack(result)
+    await cm.gen.aclose()
+    await read_stream.aclose()
+    await write_stream.aclose()
+
+
+@pytest.mark.anyio
+async def test_generator_exit_in_exception_group(client_transport: ClientTransport) -> None:
+    """Extract GeneratorExit from BaseExceptionGroup (python/cpython#135736)."""
+    url, client_func, unpack = client_transport
+    async with client_func(url) as result:
+        unpack(result)
+        raise BaseExceptionGroup("unhandled errors in a TaskGroup", [GeneratorExit()])
+
+
+@pytest.mark.anyio
+async def test_generator_exit_mixed_group(client_transport: ClientTransport) -> None:
+    """Extract GeneratorExit from BaseExceptionGroup, re-raise other exceptions (python/cpython#135736)."""
+    url, client_func, unpack = client_transport
+    with pytest.raises(BaseExceptionGroup) as exc_info:
+        async with client_func(url) as result:
+            unpack(result)
+            raise BaseExceptionGroup("errors", [GeneratorExit(), ValueError("real error")])
+
+    def has_generator_exit(eg: BaseExceptionGroup[Any]) -> bool:
+        for e in eg.exceptions:
+            if isinstance(e, GeneratorExit):
+                return True  # pragma: no cover
+            if isinstance(e, BaseExceptionGroup):
+                if has_generator_exit(eg=e):  # type: ignore[arg-type]
+                    return True  # pragma: no cover
+        return False
+
+    assert not has_generator_exit(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -784,6 +784,7 @@ name = "mcp"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "jsonschema" },
@@ -838,6 +839,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.5" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.1" },
     { name = "httpx-sse", specifier = ">=0.4" },
     { name = "jsonschema", specifier = ">=4.20.0" },


### PR DESCRIPTION
## Motivation and Context

In integrating latest llama-stack with MCP examples via OpenAI Responses API, I ran into a couple glitches which broke requests. I narrowed them down to `GeneratorExit` handling. When rebuilding llama-stack against this branch all scenarios pass.

I noticed this also fixes #1214 which was closed due to missing tests. This adds them.

### The Problem

**Scenario 1: GC cleanup leaks GeneratorExit**

When garbage collector cleans up an orphaned generator while a background task has failed:
```
BaseExceptionGroup: unhandled errors in a TaskGroup (2 sub-exceptions)
├─ HTTPStatusError: Client error '401 Unauthorized'
└─ GeneratorExit  ← leaked from GC calling aclose()
```

Background:
 - streetrace-ai/streetrace#87 - same bug

**Scenario 2: User TaskGroup wraps GeneratorExit**

When user code has a generator yielding inside a TaskGroup:
```
BaseExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
└─ GeneratorExit  ← wrapped by user's TaskGroup during cleanup
```

Background:
  - python/cpython#95571 - why GeneratorExit leaks from async generators                                                                                                      
  - python/cpython#135736 - why TaskGroup wraps GeneratorExit                                                                                                                 
  - python-trio/trio#3324 - why except* breaks generator cleanup

### The Fix

Two exception handlers at the yield point handle both scenarios:

```
┌─────────────────────────────────────────────────────────────────┐
│                        yield streams                             │
└──────────────────────────────┬──────────────────────────────────┘
                               │
           ┌───────────────────┴───────────────────┐
           │                                       │
           ▼                                       ▼
┌─────────────────────────┐          ┌─────────────────────────────┐
│  Branch 1               │          │  Branch 2                    │
│  except GeneratorExit   │          │  except BaseExceptionGroup   │
│  → suppress             │          │  → split(GeneratorExit)      │
│                         │          │  → re-raise rest             │
└─────────────────────────┘          └─────────────────────────────┘
        │                                       │
        ▼                                       ▼
   Scenario 1:                         Scenario 2:
   GC calls aclose()                   User TaskGroup wraps
   on suspended generator              GeneratorExit
```

## Changes
- Added `GeneratorExit` and `BaseExceptionGroup` handling in `sse_client` and `streamable_http_client`
- Added `exceptiongroup>=1.0.0` as conditional dependency for Python 3.10 support
- Fixed stream cleanup: closes `read_stream` in finally block

## How Has This Been Tested?
Parameterized tests in `tests/client/test_resource_cleanup.py` (each runs for both SSE and Streamable HTTP):
- `test_generator_exit_on_gc_cleanup[sse/streamable]` - Scenario 1: GC cleanup
- `test_generator_exit_in_exception_group[sse/streamable]` - Scenario 2: `BaseExceptionGroup([GeneratorExit])`
- `test_generator_exit_mixed_group[sse/streamable]` - Scenario 2: `BaseExceptionGroup([GeneratorExit, ValueError])`

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
