### PR TITLE
fix(tests): skip proxy for localhost in Windows environments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,8 @@
+import os
+
 import pytest
+
+os.environ["NO_PROXY"] = "127.0.0.1"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Set `NO_PROXY` environment variable to `127.0.0.1` in `tests/conftest.py`
- Prevents tests from failing on Windows systems with a proxy enabled

## Test plan
- [x] Verified the fix matches the suggestion in the issue
- [ ] Run `uv run pytest` on Windows with proxy enabled

Closes #1477