### PR TITLE
fix(ci): use bash shell for pytest step to ensure consistent error handling

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -56,6 +56,7 @@ jobs:
         run: uv sync ${{ matrix.dep-resolution.install-flags }} --all-extras --python ${{ matrix.python-version }}
 
       - name: Run pytest with coverage
+        shell: bash
         run: |
           uv run --frozen --no-sync coverage run -m pytest
           uv run --frozen --no-sync coverage combine


### PR DESCRIPTION
## Summary

Fixes inconsistent CI behavior where Windows tests appeared to pass even when pytest failed.

## Problem

The pytest step runs multiple commands:
```bash
uv run --frozen --no-sync coverage run -m pytest
uv run --frozen --no-sync coverage combine
uv run --frozen --no-sync coverage report
```

On **Linux (bash)**: When pytest fails, bash's `set -e` stops execution immediately → step exits with code 1 → marked as failed.

On **Windows (PowerShell)**: PowerShell doesn't stop on first error by default. When pytest fails, it continues to run `coverage combine` and `coverage report`. Since the last command succeeds → step exits with code 0 → marked as passed (incorrectly).

## Solution

Add `shell: bash` to the pytest step. Bash is available on Windows runners in GitHub Actions and provides consistent error handling behavior across platforms.