### PR TITLE
ci: add weekly lockfile update workflow

### DIFF
--- a/.github/workflows/weekly-lockfile-update.yml
+++ b/.github/workflows/weekly-lockfile-update.yml
@@ -29,7 +29,7 @@ jobs:
           echo '```' >> pr_body.md
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           commit-message: "chore: update uv.lock with latest dependencies"
           title: "chore: weekly dependency update"


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Action that updates `uv.lock` with the latest dependency versions weekly.

## Motivation and Context

After removing the `highest` resolution strategy from the test matrix (which was causing CI failures due to missing platform wheels), we still want to periodically test against the latest versions of our dependencies.

This workflow:
1. Runs every Monday at 8:00 UTC (and can be triggered manually)
2. Executes `uv lock --upgrade` to update all dependencies to their latest compatible versions
3. Creates a PR with the changes, so CI runs before merging
4. Only touches `uv.lock` - does not modify `pyproject.toml`

## How It Works

Uses [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) to automatically create a PR with the updated lockfile. The PR body includes the output from `uv lock --upgrade` showing what changed.

## Repository Setup Required

For this workflow to create PRs, you need to enable "Allow GitHub Actions to create and approve pull requests" in:
**Settings → Actions → General → Workflow permissions**

## Breaking Changes

None.

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines