### PR TITLE
refactor: add jsonrpc field to base Notification class

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -320,8 +320,8 @@ class BaseSession(
         """
         # Some transport implementations may need to set the related_request_id
         # to attribute to the notifications to the request that triggered them.
+        # Note: notification already has jsonrpc="2.0" from base Notification class
         jsonrpc_notification = JSONRPCNotification(
-            jsonrpc="2.0",
             **notification.model_dump(by_alias=True, mode="json", exclude_none=True),
         )
         session_message = SessionMessage(  # pragma: no cover

--- a/src/mcp/types.py
+++ b/src/mcp/types.py
@@ -108,6 +108,7 @@ class PaginatedRequest(Request[PaginatedRequestParams | None, MethodT], Generic[
 class Notification(MCPModel, Generic[NotificationParamsT, MethodT]):
     """Base class for JSON-RPC notifications."""
 
+    jsonrpc: Literal["2.0"] = "2.0"
     method: MethodT
     params: NotificationParamsT
 
@@ -142,7 +143,6 @@ class JSONRPCRequest(Request[dict[str, Any] | None, str]):
 class JSONRPCNotification(Notification[dict[str, Any] | None, str]):
     """A notification which does not expect a response."""
 
-    jsonrpc: Literal["2.0"]
     params: dict[str, Any] | None = None
 
 


### PR DESCRIPTION
## Summary

Adds the `jsonrpc: Literal["2.0"] = "2.0"` field to the base `Notification` class, aligning with the TypeScript SDK where notification types extend `JSONRPCNotification`.

## Motivation and Context

Issue #1729 identified that notification types like `ProgressNotification` inherit from `Notification`, not `JSONRPCNotification`, meaning they lack the `jsonrpc: "2.0"` field.

This PR addresses the **Notifications** part of that issue. The **Results** part is intentionally not changed because:
- Results need an `id` field that comes from the request
- Handlers don't know the request ID when returning a result  
- The session layer must wrap results with the request ID
- The TypeScript SDK also keeps Results as payloads (extending `Result`, not `JSONRPCResultResponse`)

Partially fixes #1729

## How Has This Been Tested?

- All 1100 tests pass
- pyright and ruff pass

## Breaking Changes

None. The `jsonrpc` field has a default value, so existing code continues to work.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed