### PR TITLE
refactor: use Client class in tests

### DIFF
--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -4,7 +4,7 @@ import anyio
 import pytest
 
 import mcp.types as types
-from mcp.client._memory import InMemoryTransport
+from mcp import Client
 from mcp.client.session import ClientSession
 from mcp.server.lowlevel.server import Server
 from mcp.shared.exceptions import McpError
@@ -25,68 +25,55 @@ from mcp.types import (
 )
 
 
-@pytest.fixture
-def mcp_server() -> Server:
-    return Server(name="test server")
-
-
 @pytest.mark.anyio
-async def test_in_flight_requests_cleared_after_completion(mcp_server: Server):
+async def test_in_flight_requests_cleared_after_completion():
     """Verify that _in_flight is empty after all requests complete."""
-    transport = InMemoryTransport(mcp_server)
-    async with transport.connect() as (read_stream, write_stream):
-        async with ClientSession(read_stream=read_stream, write_stream=write_stream) as session:
-            await session.initialize()
+    server = Server(name="test server")
+    async with Client(server) as client:
+        # Send a request and wait for response
+        response = await client.send_ping()
+        assert isinstance(response, EmptyResult)
 
-            # Send a request and wait for response
-            response = await session.send_ping()
-            assert isinstance(response, EmptyResult)
-
-            # Verify _in_flight is empty
-            assert len(session._in_flight) == 0
+        # Verify _in_flight is empty
+        assert len(client.session._in_flight) == 0
 
 
 @pytest.mark.anyio
 async def test_request_cancellation():
     """Test that requests can be cancelled while in-flight."""
-    # The tool is already registered in the fixture
-
     ev_tool_called = anyio.Event()
     ev_cancelled = anyio.Event()
     request_id = None
 
-    # Start the request in a separate task so we can cancel it
-    def make_server() -> Server:
-        server = Server(name="TestSessionServer")
+    # Create a server with a slow tool
+    server = Server(name="TestSessionServer")
 
-        # Register the tool handler
-        @server.call_tool()
-        async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextContent]:
-            nonlocal request_id, ev_tool_called
-            if name == "slow_tool":
-                request_id = server.request_context.request_id
-                ev_tool_called.set()
-                await anyio.sleep(10)  # Long enough to ensure we can cancel
-                return []  # pragma: no cover
-            raise ValueError(f"Unknown tool: {name}")  # pragma: no cover
+    # Register the tool handler
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextContent]:
+        nonlocal request_id, ev_tool_called
+        if name == "slow_tool":
+            request_id = server.request_context.request_id
+            ev_tool_called.set()
+            await anyio.sleep(10)  # Long enough to ensure we can cancel
+            return []  # pragma: no cover
+        raise ValueError(f"Unknown tool: {name}")  # pragma: no cover
 
-        # Register the tool so it shows up in list_tools
-        @server.list_tools()
-        async def handle_list_tools() -> list[types.Tool]:
-            return [
-                types.Tool(
-                    name="slow_tool",
-                    description="A slow tool that takes 10 seconds to complete",
-                    input_schema={},
-                )
-            ]
+    # Register the tool so it shows up in list_tools
+    @server.list_tools()
+    async def handle_list_tools() -> list[types.Tool]:
+        return [
+            types.Tool(
+                name="slow_tool",
+                description="A slow tool that takes 10 seconds to complete",
+                input_schema={},
+            )
+        ]
 
-        return server
-
-    async def make_request(session: ClientSession):
+    async def make_request(client: Client):
         nonlocal ev_cancelled
         try:
-            await session.send_request(
+            await client.session.send_request(
                 ClientRequest(
                     types.CallToolRequest(
                         params=types.CallToolRequestParams(name="slow_tool", arguments={}),
@@ -100,31 +87,28 @@ async def test_request_cancellation():
             assert "Request cancelled" in str(e)
             ev_cancelled.set()
 
-    transport = InMemoryTransport(make_server())
-    async with transport.connect() as (read_stream, write_stream):
-        async with ClientSession(read_stream=read_stream, write_stream=write_stream) as session:
-            await session.initialize()
-            async with anyio.create_task_group() as tg:  # pragma: no branch
-                tg.start_soon(make_request, session)
+    async with Client(server) as client:
+        async with anyio.create_task_group() as tg:  # pragma: no branch
+            tg.start_soon(make_request, client)
 
-                # Wait for the request to be in-flight
-                with anyio.fail_after(1):  # Timeout after 1 second
-                    await ev_tool_called.wait()
+            # Wait for the request to be in-flight
+            with anyio.fail_after(1):  # Timeout after 1 second
+                await ev_tool_called.wait()
 
-                # Send cancellation notification
-                assert request_id is not None
-                await session.send_notification(
-                    ClientNotification(
-                        CancelledNotification(
-                            params=CancelledNotificationParams(request_id=request_id),
-                        )
+            # Send cancellation notification
+            assert request_id is not None
+            await client.session.send_notification(
+                ClientNotification(
+                    CancelledNotification(
+                        params=CancelledNotificationParams(request_id=request_id),
                     )
                 )
+            )
 
-                # Give cancellation time to process
-                # TODO(Marcelo): Drop the pragma once https://github.com/coveragepy/coveragepy/issues/1987 is fixed.
-                with anyio.fail_after(1):  # pragma: no cover
-                    await ev_cancelled.wait()
+            # Give cancellation time to process
+            # TODO(Marcelo): Drop the pragma once https://github.com/coveragepy/coveragepy/issues/1987 is fixed.
+            with anyio.fail_after(1):  # pragma: no cover
+                await ev_cancelled.wait()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Refactors unit tests to use the ergonomic `Client` class instead of the verbose `InMemoryTransport` + `ClientSession` pattern.

## Motivation and Context

Follow-up from #1870. The new `Client` class provides a simpler API for testing MCP servers:

```python
# Before
transport = InMemoryTransport(server)
async with transport.connect() as (read_stream, write_stream):
    async with ClientSession(read_stream, write_stream) as session:
        await session.initialize()
        result = await session.list_tools()

# After
async with Client(server) as client:
    result = await client.list_tools()
```

## How Has This Been Tested?

All refactored tests pass. The `stream_spy` fixture continues to work with `Client` since it patches the underlying memory streams used by `InMemoryTransport`.

## Breaking Changes

None - internal test refactoring only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Files changed (5):**
- `tests/client/transports/test_memory.py` - 3 tests
- `tests/shared/test_session.py` - 2 tests
- `tests/server/test_cancel_handling.py` - 1 test
- `tests/shared/test_progress_notifications.py` - 1 test
- `tests/client/test_list_methods_cursor.py` - 6 tests

**Net change:** -64 lines (163 added, 227 removed)