### PR TITLE
ci: add all-green job to pull-request-checks workflow

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -6,3 +6,12 @@ on:
 jobs:
   checks:
     uses: ./.github/workflows/shared.yml
+
+  all-green:
+    if: always()
+    needs: [checks]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Motivation and Context

PRs targeting `v1.x` are permanently blocked because the repository ruleset requires an `all-green` status check, but the `pull-request-checks.yml` workflow on this branch doesn't include that job.

On `main`, the CI workflow has an `all-green` aggregation job. The `v1.x` branch split the workflow into separate files (`pull-request-checks.yml` and `main-checks.yml`) but omitted the `all-green` job from the PR workflow.

## Changes

Adds the `all-green` job to `pull-request-checks.yml`, matching the pattern used on `main`. This unblocks PR #1928 and any future PRs targeting `v1.x`.