### PR TITLE
chore: remove relative_files from coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,6 @@ branch = true
 patch = ["subprocess"]
 concurrency = ["multiprocessing", "thread"]
 source = ["src", "tests"]
-relative_files = true
 omit = [
     "src/mcp/client/__main__.py",
     "src/mcp/server/__main__.py",


### PR DESCRIPTION
Remove `relative_files = true` from the `[tool.coverage.run]` configuration in pyproject.toml as it is no longer needed.