### PR TITLE
fix: strip trailing slashes from OAuth metadata URLs

### DIFF
--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -157,7 +157,7 @@ def build_metadata(
 
     # Create metadata
     metadata = OAuthMetadata(
-        issuer=AnyHttpUrl(str(issuer_url).rstrip("/")),
+        issuer=issuer_url,
         authorization_endpoint=authorization_url,
         token_endpoint=token_url,
         scopes_supported=client_registration_options.valid_scopes,
@@ -222,8 +222,8 @@ def create_protected_resource_routes(
         List of Starlette routes for protected resource metadata
     """
     metadata = ProtectedResourceMetadata(
-        resource=AnyHttpUrl(str(resource_url).rstrip("/")),
-        authorization_servers=[AnyHttpUrl(str(server).rstrip("/")) for server in authorization_servers],
+        resource=resource_url,
+        authorization_servers=authorization_servers,
         scopes_supported=scopes_supported,
         resource_name=resource_name,
         resource_documentation=resource_documentation,

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_serializer, field_validator
 
 
 class OAuthToken(BaseModel):
@@ -129,6 +129,11 @@ class OAuthMetadata(BaseModel):
     code_challenge_methods_supported: list[str] | None = None
     client_id_metadata_document_supported: bool | None = None
 
+    @field_serializer("issuer")
+    def serialize_issuer(self, v: AnyHttpUrl) -> str:
+        """Strip trailing slash from issuer URL for RFC 8414 §3.3 compliance."""
+        return str(v).rstrip("/")
+
 
 class ProtectedResourceMetadata(BaseModel):
     """RFC 9728 OAuth 2.0 Protected Resource Metadata.
@@ -151,3 +156,13 @@ class ProtectedResourceMetadata(BaseModel):
     dpop_signing_alg_values_supported: list[str] | None = None
     # dpop_bound_access_tokens_required default is False, but ommited here for clarity
     dpop_bound_access_tokens_required: bool | None = None
+
+    @field_serializer("resource")
+    def serialize_resource(self, v: AnyHttpUrl) -> str:
+        """Strip trailing slash from resource URL for RFC 9728 §3 compliance."""
+        return str(v).rstrip("/")
+
+    @field_serializer("authorization_servers")
+    def serialize_authorization_servers(self, v: list[AnyHttpUrl]) -> list[str]:
+        """Strip trailing slashes from authorization server URLs for RFC 9728 §3 compliance."""
+        return [str(s).rstrip("/") for s in v]

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -96,8 +96,8 @@ async def test_metadata_endpoint_without_path(root_resource_client: httpx.AsyncC
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "resource": "https://example.com/",
-            "authorization_servers": ["https://auth.example.com/"],
+            "resource": "https://example.com",
+            "authorization_servers": ["https://auth.example.com"],
             "scopes_supported": ["read"],
             "resource_name": "Root Resource",
             "bearer_methods_supported": ["header"],

--- a/tests/server/auth/test_trailing_slash_fix.py
+++ b/tests/server/auth/test_trailing_slash_fix.py
@@ -18,10 +18,10 @@ from tests.server.fastmcp.auth.test_auth_integration import MockOAuthProvider
 
 
 def test_build_metadata_strips_trailing_slash_from_issuer():
-    """Test that build_metadata strips trailing slash from issuer URL.
+    """Test that build_metadata strips trailing slash from issuer URL when serialized.
 
     Pydantic's AnyHttpUrl automatically adds trailing slashes to bare hostnames.
-    This test verifies that we strip them to comply with RFC 8414 §3.3.
+    This test verifies that we strip them during serialization to comply with RFC 8414 §3.3.
     """
     # Use a bare hostname URL which Pydantic will add a trailing slash to
     issuer_url = AnyHttpUrl("http://localhost:8000")
@@ -33,13 +33,14 @@ def test_build_metadata_strips_trailing_slash_from_issuer():
         revocation_options=RevocationOptions(enabled=False),
     )
 
-    # The issuer should NOT have a trailing slash
-    assert str(metadata.issuer) == "http://localhost:8000"
-    assert not str(metadata.issuer).endswith("/")
+    # The serialized issuer should NOT have a trailing slash
+    serialized = metadata.model_dump(mode="json")
+    assert serialized["issuer"] == "http://localhost:8000"
+    assert not serialized["issuer"].endswith("/")
 
 
 def test_build_metadata_strips_trailing_slash_from_issuer_with_path():
-    """Test that build_metadata strips trailing slash from issuer URL with path."""
+    """Test that build_metadata strips trailing slash from issuer URL with path when serialized."""
     # URL with path that has trailing slash
     issuer_url = AnyHttpUrl("http://localhost:8000/auth/")
 
@@ -50,9 +51,10 @@ def test_build_metadata_strips_trailing_slash_from_issuer_with_path():
         revocation_options=RevocationOptions(enabled=False),
     )
 
-    # The issuer should NOT have a trailing slash
-    assert str(metadata.issuer) == "http://localhost:8000/auth"
-    assert not str(metadata.issuer).endswith("/")
+    # The serialized issuer should NOT have a trailing slash
+    serialized = metadata.model_dump(mode="json")
+    assert serialized["issuer"] == "http://localhost:8000/auth"
+    assert not serialized["issuer"].endswith("/")
 
 
 def test_build_metadata_endpoints_have_no_double_slashes():
@@ -81,7 +83,7 @@ def test_build_metadata_endpoints_have_no_double_slashes():
 
 
 def test_protected_resource_metadata_strips_trailing_slash_from_resource():
-    """Test that protected resource metadata strips trailing slash from resource URL.
+    """Test that protected resource metadata strips trailing slash from resource URL when serialized.
 
     RFC 9728 §3 requires that the resource URL in the metadata response must be
     identical to the URL used for discovery.
@@ -104,13 +106,14 @@ def test_protected_resource_metadata_strips_trailing_slash_from_resource():
 
     metadata = handler.__self__.metadata  # type: ignore
 
-    # The resource URL should NOT have a trailing slash
-    assert str(metadata.resource) == "http://localhost:8000"
-    assert not str(metadata.resource).endswith("/")
+    # The serialized resource URL should NOT have a trailing slash
+    serialized = metadata.model_dump(mode="json")
+    assert serialized["resource"] == "http://localhost:8000"
+    assert not serialized["resource"].endswith("/")
 
 
 def test_protected_resource_metadata_strips_trailing_slash_from_authorization_servers():
-    """Test that protected resource metadata strips trailing slashes from authorization server URLs."""
+    """Test that protected resource metadata strips trailing slashes from auth server URLs when serialized."""
     resource_url = AnyHttpUrl("http://localhost:8000/resource")
     # Use bare hostname URLs which Pydantic will add trailing slashes to
     auth_servers = [
@@ -129,11 +132,12 @@ def test_protected_resource_metadata_strips_trailing_slash_from_authorization_se
     handler = cors_app.app.func  # type: ignore
     metadata = handler.__self__.metadata  # type: ignore
 
-    # All authorization server URLs should NOT have trailing slashes
-    assert str(metadata.authorization_servers[0]) == "http://auth1.example.com"
-    assert str(metadata.authorization_servers[1]) == "http://auth2.example.com"
-    assert not str(metadata.authorization_servers[0]).endswith("/")
-    assert not str(metadata.authorization_servers[1]).endswith("/")
+    # All serialized authorization server URLs should NOT have trailing slashes
+    serialized = metadata.model_dump(mode="json")
+    assert serialized["authorization_servers"][0] == "http://auth1.example.com"
+    assert serialized["authorization_servers"][1] == "http://auth2.example.com"
+    assert not serialized["authorization_servers"][0].endswith("/")
+    assert not serialized["authorization_servers"][1].endswith("/")
 
 
 @pytest.fixture

--- a/tests/server/fastmcp/auth/test_auth_integration.py
+++ b/tests/server/fastmcp/auth/test_auth_integration.py
@@ -311,7 +311,7 @@ class TestAuthEndpoints:
         assert response.status_code == 200
 
         metadata = response.json()
-        assert metadata["issuer"] == "https://auth.example.com/"
+        assert metadata["issuer"] == "https://auth.example.com"
         assert metadata["authorization_endpoint"] == "https://auth.example.com/authorize"
         assert metadata["token_endpoint"] == "https://auth.example.com/token"
         assert metadata["registration_endpoint"] == "https://auth.example.com/register"


### PR DESCRIPTION
Fixes #1919

Pydantic's `AnyHttpUrl` automatically appends a trailing slash to bare hostnames (e.g., `http://localhost:8000` becomes `http://localhost:8000/`). This causes OAuth discovery to fail in clients like Google's ADK and IBM's MCP Context Forge because RFC 8414 §3.3 and RFC 9728 §3 require that the issuer/resource URL in the metadata response must be identical to the URL used for discovery.

### Changes

Modified `src/mcp/server/auth/routes.py` to strip trailing slashes from:
- `issuer` in `build_metadata()`
- `resource` and `authorization_servers` in `create_protected_resource_routes()`

The fix follows the same pattern already used for `authorization_endpoint` and `token_endpoint`.

This also fixes #1265.

---

Generated with [Claude Code](https://claude.ai/code)