### PR TITLE
feat: store server_info on ClientSession after initialization

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -133,6 +133,7 @@ class ClientSession(
         self._message_handler = message_handler or _default_message_handler
         self._tool_output_schemas: dict[str, dict[str, Any] | None] = {}
         self._server_capabilities: types.ServerCapabilities | None = None
+        self._server_info: types.Implementation | None = None
         self._experimental_features: ExperimentalClientFeatures | None = None
 
         # Experimental: Task handlers (use defaults if not provided)
@@ -190,6 +191,7 @@ class ClientSession(
             raise RuntimeError(f"Unsupported protocol version from the server: {result.protocol_version}")
 
         self._server_capabilities = result.capabilities
+        self._server_info = result.server_info
 
         await self.send_notification(types.InitializedNotification())
 
@@ -201,6 +203,13 @@ class ClientSession(
         Returns None if the session has not been initialized yet.
         """
         return self._server_capabilities
+
+    def get_server_info(self) -> types.Implementation | None:
+        """Return the server info (name and version) received during initialization.
+
+        Returns None if the session has not been initialized yet.
+        """
+        return self._server_info
 
     @property
     def experimental(self) -> ExperimentalClientFeatures:


### PR DESCRIPTION
**Summary**
Stores `server_info` from the init response on `ClientSession` so you can grab the server's name and version without manually extracting from the result.

**Changes**
- Added `_server_info` field to `ClientSession.__init__`
- Store `result.server_info` during `initialize()`
- Added `get_server_info()` getter (mirrors existing `get_server_capabilities()`)
- Added test for the new method

**Before**
```python
server = await session.initialize()
name = server.serverInfo.name  # had to grab manually
```

**After**
```python
await session.initialize()
info = session.get_server_info()
name = info.name  # available directly
```

**Testing**
- All existing tests pass
- Added `test_get_server_info` covering None-before-init and populated-after

Closes #1018