### PR TITLE
[v1.x] fix: return HTTP 404 for unknown session IDs instead of 400

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -22,6 +22,7 @@ from mcp.server.streamable_http import (
     StreamableHTTPServerTransport,
 )
 from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import INVALID_REQUEST, ErrorData, JSONRPCError
 
 logger = logging.getLogger(__name__)
 
@@ -276,10 +277,21 @@ class StreamableHTTPSessionManager:
 
                 # Handle the HTTP request and return the response
                 await http_transport.handle_request(scope, receive, send)
-        else:  # pragma: no cover
-            # Invalid session ID
+        else:
+            # Unknown or expired session ID - return 404 per MCP spec
+            # TODO: Align error code once spec clarifies
+            # See: https://github.com/modelcontextprotocol/python-sdk/issues/1821
+            error_response = JSONRPCError(
+                jsonrpc="2.0",
+                id="server-error",
+                error=ErrorData(
+                    code=INVALID_REQUEST,
+                    message="Session not found",
+                ),
+            )
             response = Response(
-                "Bad Request: No valid session ID provided",
-                status_code=HTTPStatus.BAD_REQUEST,
+                content=error_response.model_dump_json(by_alias=True, exclude_none=True),
+                status_code=HTTPStatus.NOT_FOUND,
+                media_type="application/json",
             )
             await response(scope, receive, send)


### PR DESCRIPTION
This is a backport of #1808 to the v1.x branch. Original PR description:

> ## Summary
> Fixes incorrect HTTP status code returned by `StreamableHTTPSessionManager` when receiving requests with unknown or expired session IDs.
> 
> Per the MCP Streamable HTTP transport specification, servers MUST respond with HTTP 404 (Not Found) when the session ID is not recognized. The previous implementation returned HTTP 400 (Bad Request), which incorrectly signals a malformed request rather than a missing resource.
> 
> This change aligns the Python SDK behavior with:
> 
> * The MCP specification requirements
> * The TypeScript SDK implementation
> 
> ## Changes
> * Return HTTP 404 instead of 400 for unknown session IDs
> * Use JSON-RPC error format in the response body, matching TypeScript SDK behavior
> 
> Fixes #1727

