### PR TITLE
ci: skip claude code review for fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   claude-review:
+    # Fork PRs don't have access to secrets or OIDC tokens, so the action
+    # cannot authenticate. See https://github.com/anthropics/claude-code-action/issues/339
+    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Motivation and Context

The Claude Code Review workflow (`claude-code-review.yml`) fails on every PR from a fork, producing noisy CI failures. This has been hitting external contributions consistently — for example, PR #1948 from `skyvanguard/python-sdk` and every other recent fork PR. @jlowin ran into the same issue on FastMCP as well (https://github.com/jlowin/fastmcp/pull/1499).

### Root Cause

There are two authentication paths for `claude-code-action`, and **both are broken for fork PRs**:

1. **`pull_request` trigger (current):** GitHub does not expose repository secrets or OIDC tokens to workflows triggered by fork PRs. This means `secrets.ANTHROPIC_API_KEY` is empty and the `ACTIONS_ID_TOKEN_REQUEST_URL` env var is unset, so the action cannot authenticate at all. The action retries OIDC 3 times and then fails with:
   ```
   Failed to setup GitHub token: Error: Could not fetch an OIDC token.
   Did you remember to add `id-token: write` to your workflow permissions?
   ```

2. **`pull_request_target` trigger (the obvious fix):** This trigger runs in the base repo context so secrets and OIDC tokens *are* available from GitHub. However, Anthropic's OIDC token exchange endpoint (`api.anthropic.com/api/github/github-app-token-exchange`) **rejects OIDC tokens from `pull_request_target` events** because the event type is not in their server-side allowlist ([anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713)).

This is a known upstream limitation tracked across multiple issues:
- [anthropics/claude-code-action#339](https://github.com/anthropics/claude-code-action/issues/339) — "Claude review fails on PRs from forks"
- [anthropics/claude-code-action#542](https://github.com/anthropics/claude-code-action/issues/542) — "Could not fetch an OIDC token when attempting to execute on a branch from a fork"
- [anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713) — "OIDC token exchange rejects pull_request_target events"

### Evidence

I checked the last 15 runs of the `claude-code-review` workflow. Every successful run was from a branch in `modelcontextprotocol/python-sdk` (not a fork), and every failure was from a fork — 100% correlation.

### Fix

Add an `if` condition to skip the job when the PR is from a fork. This eliminates the noisy failures until the upstream action adds fork PR support.

## How Has This Been Tested?

Verified that the `if` expression `github.event.pull_request.head.repo.fork == false` is the standard GitHub Actions pattern for detecting fork PRs. Confirmed the workflow YAML is syntactically valid via pre-commit hooks.

## Breaking Changes

None. The claude code review was already non-functional for fork PRs (always errored out), so this just makes the failure silent rather than red.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Once the upstream `claude-code-action` supports fork PRs (likely by adding `pull_request_target` to their OIDC allowlist), this condition can be removed.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>