### PR TITLE
docs: add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Documentation][docs-badge]][docs-url]
 [![Protocol][protocol-badge]][protocol-url]
 [![Specification][spec-badge]][spec-url]
+[![Discord][discord-badge]][discord-url]
 
 </div>
 
@@ -87,6 +88,8 @@
 [protocol-url]: https://modelcontextprotocol.io
 [spec-badge]: https://img.shields.io/badge/spec-spec.modelcontextprotocol.io-blue.svg
 [spec-url]: https://modelcontextprotocol.io/specification/latest
+[discord-badge]: https://img.shields.io/discord/1358869848138059966?logo=discord
+[discord-url]: https://discord.gg/6CSzBmMkjX
 
 ## Overview
 


### PR DESCRIPTION
Add a Discord badge to the README badge row, linking to the MCP Discord server. Uses the shields.io Discord badge with live member count.