### PR TITLE
Store server_info on ClientSession during initialization

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -133,6 +133,7 @@ class ClientSession(
         self._message_handler = message_handler or _default_message_handler
         self._tool_output_schemas: dict[str, dict[str, Any] | None] = {}
         self._server_capabilities: types.ServerCapabilities | None = None
+        self._server_info: types.Implementation | None = None
         self._experimental_features: ExperimentalClientFeatures | None = None
 
         # Experimental: Task handlers (use defaults if not provided)
@@ -190,6 +191,7 @@ class ClientSession(
             raise RuntimeError(f"Unsupported protocol version from the server: {result.protocol_version}")
 
         self._server_capabilities = result.capabilities
+        self._server_info = result.server_info
 
         await self.send_notification(types.InitializedNotification())
 
@@ -201,6 +203,13 @@ class ClientSession(
         Returns None if the session has not been initialized yet.
         """
         return self._server_capabilities
+
+    def get_server_info(self) -> types.Implementation | None:
+        """Return the server info received during initialization.
+
+        Returns None if the session has not been initialized yet.
+        """
+        return self._server_info
 
     @property
     def experimental(self) -> ExperimentalClientFeatures:

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -608,6 +608,63 @@ async def test_get_server_capabilities():
 
 
 @pytest.mark.anyio
+async def test_get_server_info():
+    """Test that get_server_info returns None before init and server info after"""
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+
+    expected_server_info = Implementation(name="test-server", version="1.2.3")
+
+    async def mock_server():
+        session_message = await client_to_server_receive.receive()
+        jsonrpc_request = session_message.message
+        assert isinstance(jsonrpc_request, JSONRPCRequest)
+        request = client_request_adapter.validate_python(
+            jsonrpc_request.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )
+        assert isinstance(request, InitializeRequest)
+
+        result = InitializeResult(
+            protocol_version=LATEST_PROTOCOL_VERSION,
+            capabilities=ServerCapabilities(),
+            server_info=expected_server_info,
+        )
+
+        async with server_to_client_send:
+            await server_to_client_send.send(
+                SessionMessage(
+                    JSONRPCResponse(
+                        jsonrpc="2.0",
+                        id=jsonrpc_request.id,
+                        result=result.model_dump(by_alias=True, mode="json", exclude_none=True),
+                    )
+                )
+            )
+            await client_to_server_receive.receive()
+
+    async with (
+        ClientSession(
+            server_to_client_receive,
+            client_to_server_send,
+        ) as session,
+        anyio.create_task_group() as tg,
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        assert session.get_server_info() is None
+
+        tg.start_soon(mock_server)
+        await session.initialize()
+
+        server_info = session.get_server_info()
+        assert server_info is not None
+        assert server_info.name == "test-server"
+        assert server_info.version == "1.2.3"
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(argnames="meta", argvalues=[None, {"toolMeta": "value"}])
 async def test_client_tool_call_with_meta(meta: RequestParamsMeta | None):
     """Test that client tool call requests can include metadata"""


### PR DESCRIPTION
## Summary

- Adds `_server_info` attribute to `ClientSession` that stores `InitializeResult.server_info` after initialization
- Adds `get_server_info()` method to access the stored server info (matches existing `get_server_capabilities()` pattern)

This lets clients access the connected server's name and version without capturing the `initialize()` return value.

## Test plan

- [x] Added `test_get_server_info` test that verifies:
  - Returns `None` before initialization
  - Returns correct server info after initialization
- [x] All 12 client session tests pass

Fixes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)