### PR TITLE
fix: remove unused `requests` dependency from simple-chatbot example

### DIFF
--- a/examples/clients/simple-chatbot/pyproject.toml
+++ b/examples/clients/simple-chatbot/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
 ]
 dependencies = [
     "python-dotenv>=1.0.0",
-    "requests>=2.31.0",
     "mcp",
     "uvicorn>=0.32.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -934,7 +934,6 @@ source = { editable = "examples/clients/simple-chatbot" }
 dependencies = [
     { name = "mcp" },
     { name = "python-dotenv" },
-    { name = "requests" },
     { name = "uvicorn" },
 ]
 
@@ -949,7 +948,6 @@ dev = [
 requires-dist = [
     { name = "mcp", editable = "." },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "requests", specifier = ">=2.31.0" },
     { name = "uvicorn", specifier = ">=0.32.1" },
 ]
 


### PR DESCRIPTION
## Summary

The `mcp-simple-chatbot` example declared `requests>=2.31.0` as a dependency but never imports or uses it — the code uses `httpx` (via the `mcp` dependency) instead. This stale dependency pulled `urllib3` into the lock file, triggering three high-severity Dependabot alerts:

- **CVE-2025-66418** — unbounded decompression chain length (fixed in urllib3 2.6.0)
- **CVE-2025-66471** — streaming API decompression bomb (fixed in urllib3 2.6.0)
- **CVE-2026-21441** — decompression bomb bypass via redirects (fixed in urllib3 2.6.3)

## Impact

**None of these CVEs affect the SDK.** The SDK uses `httpx`, which has its own HTTP stack (`httpcore` → `h11`) and does not depend on `urllib3` at any point in its transitive dependency tree.

## Changes

- Removed unused `requests>=2.31.0` from `examples/clients/simple-chatbot/pyproject.toml`
- Regenerated `uv.lock` — `urllib3` remains only via `mkdocs-material` (docs-only dev dependency)

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>