### PR TITLE
ci: skip Claude code review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -9,7 +9,7 @@ jobs:
   claude-review:
     # Fork PRs don't have access to secrets or OIDC tokens, so the action
     # cannot authenticate. See https://github.com/anthropics/claude-code-action/issues/339
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Dependabot PRs fail the claude-review check because the action rejects bot actors not in the `allowed_bots` list. Skip the job for Dependabot since dependency bumps don't need code review.