### PR TITLE
Rename MCPServer alias to LowLevelServer in streamable_http_manager

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -24,7 +24,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import INVALID_REQUEST, ErrorData, JSONRPCError
 
 if TYPE_CHECKING:
-    from mcp.server.lowlevel.server import Server as MCPServer
+    from mcp.server.lowlevel.server import Server as LowLevelServer
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class StreamableHTTPSessionManager:
 
     def __init__(
         self,
-        app: MCPServer[Any, Any],
+        app: LowLevelServer[Any, Any],
         event_store: EventStore | None = None,
         json_response: bool = False,
         stateless: bool = False,


### PR DESCRIPTION
The `streamable_http_manager.py` module imported `Server as MCPServer` from the low-level server module. This alias is confusing because there is already an `MCPServer` class elsewhere in the codebase. Renaming to `LowLevelServer` makes it clear which server is being referenced.