### PR TITLE
chore: update author metadata to LF Projects

### DIFF
--- a/examples/clients/simple-auth-client/pyproject.toml
+++ b/examples/clients/simple-auth-client/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple OAuth client for the MCP simple-auth server"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic" }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "oauth", "client", "auth"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/clients/simple-chatbot/pyproject.toml
+++ b/examples/clients/simple-chatbot/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple CLI chatbot using the Model Context Protocol (MCP)"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Edoardo Cilia" }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "chatbot", "cli"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/clients/simple-task-client/pyproject.toml
+++ b/examples/clients/simple-task-client/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple MCP client demonstrating task polling"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "tasks", "client"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/clients/simple-task-interactive-client/pyproject.toml
+++ b/examples/clients/simple-task-interactive-client/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple MCP client demonstrating interactive task responses"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "tasks", "client", "elicitation", "sampling"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/clients/sse-polling-client/pyproject.toml
+++ b/examples/clients/sse-polling-client/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Demo client for SSE polling with auto-reconnect"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "sse", "polling", "client"]
 license = { text = "MIT" }
 dependencies = ["click>=8.2.0", "mcp"]

--- a/examples/servers/everything-server/pyproject.toml
+++ b/examples/servers/everything-server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Comprehensive MCP server implementing all protocol features for conformance testing"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "automation", "conformance", "testing"]
 license = { text = "MIT" }
 dependencies = ["anyio>=4.5", "click>=8.2.0", "httpx>=0.27", "mcp", "starlette", "uvicorn"]

--- a/examples/servers/simple-auth/pyproject.toml
+++ b/examples/servers/simple-auth/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server demonstrating OAuth authentication"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 license = { text = "MIT" }
 dependencies = [
     "anyio>=4.5",

--- a/examples/servers/simple-pagination/pyproject.toml
+++ b/examples/servers/simple-pagination/pyproject.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server demonstrating pagination for tools, resources, and prompts"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
-maintainers = [
-    { name = "David Soria Parra", email = "davidsp@anthropic.com" },
-    { name = "Justin Spahr-Summers", email = "justin@anthropic.com" },
-]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "automation", "pagination", "cursor"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/servers/simple-prompt/pyproject.toml
+++ b/examples/servers/simple-prompt/pyproject.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server exposing a customizable prompt"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
-maintainers = [
-    { name = "David Soria Parra", email = "davidsp@anthropic.com" },
-    { name = "Justin Spahr-Summers", email = "justin@anthropic.com" },
-]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "automation", "web", "fetch"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/servers/simple-resource/pyproject.toml
+++ b/examples/servers/simple-resource/pyproject.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server exposing sample text resources"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
-maintainers = [
-    { name = "David Soria Parra", email = "davidsp@anthropic.com" },
-    { name = "Justin Spahr-Summers", email = "justin@anthropic.com" },
-]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "automation", "web", "fetch"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/servers/simple-streamablehttp-stateless/pyproject.toml
+++ b/examples/servers/simple-streamablehttp-stateless/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server exposing a StreamableHttp transport in stateless mode"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "automation", "web", "fetch", "http", "streamable", "stateless"]
 license = { text = "MIT" }
 dependencies = ["anyio>=4.5", "click>=8.2.0", "httpx>=0.27", "mcp", "starlette", "uvicorn"]

--- a/examples/servers/simple-streamablehttp/pyproject.toml
+++ b/examples/servers/simple-streamablehttp/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server exposing a StreamableHttp transport for testing"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "automation", "web", "fetch", "http", "streamable"]
 license = { text = "MIT" }
 dependencies = ["anyio>=4.5", "click>=8.2.0", "httpx>=0.27", "mcp", "starlette", "uvicorn"]

--- a/examples/servers/simple-task-interactive/pyproject.toml
+++ b/examples/servers/simple-task-interactive/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server demonstrating interactive tasks (elicitation & sampling)"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "tasks", "elicitation", "sampling"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/servers/simple-task/pyproject.toml
+++ b/examples/servers/simple-task/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server demonstrating tasks"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "tasks"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/servers/simple-tool/pyproject.toml
+++ b/examples/servers/simple-tool/pyproject.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 description = "A simple MCP server exposing a website fetching tool"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
-maintainers = [
-    { name = "David Soria Parra", email = "davidsp@anthropic.com" },
-    { name = "Justin Spahr-Summers", email = "justin@anthropic.com" },
-]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "llm", "automation", "web", "fetch"]
 license = { text = "MIT" }
 classifiers = [

--- a/examples/servers/sse-polling-demo/pyproject.toml
+++ b/examples/servers/sse-polling-demo/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Demo server showing SSE polling with close_sse_stream for long-running tasks"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 keywords = ["mcp", "sse", "polling", "streamable", "http"]
 license = { text = "MIT" }
 dependencies = ["anyio>=4.5", "click>=8.2.0", "httpx>=0.27", "mcp", "starlette", "uvicorn"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,9 @@ dynamic = ["version"]
 description = "Model Context Protocol SDK"
 readme = "README.md"
 requires-python = ">=3.10"
-authors = [{ name = "Anthropic, PBC." }]
+authors = [{ name = "Model Context Protocol a Series of LF Projects, LLC." }]
 maintainers = [
     { name = "David Soria Parra", email = "davidsp@anthropic.com" },
-    { name = "Justin Spahr-Summers", email = "justin@anthropic.com" },
     { name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" },
     { name = "Max Isbey", email = "maxisbey@anthropic.com" },
     { name = "Felix Weinberger", email = "fweinberger@anthropic.com" }


### PR DESCRIPTION
Update `authors` across all pyproject.toml files to `Model Context Protocol a Series of LF Projects, LLC.`, matching the [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk/blob/faeb03e/package.json#L7). Also removes stale `maintainers` from example pyproject.toml files.