### PR TITLE
feat: add idle timeout for StreamableHTTP sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,11 @@ This document contains critical information about working with this codebase. Fo
    - Coverage: test edge cases and errors
    - New features require tests
    - Bug fixes require regression tests
-   - NEVER use `anyio.sleep()` with a fixed duration as a synchronization mechanism. Instead:
+   - Avoid `anyio.sleep()` with a fixed duration to wait for async operations. Instead:
      - Use `anyio.Event` — set it in the callback/handler, `await event.wait()` in the test
      - For stream messages, use `await stream.receive()` instead of `sleep()` + `receive_nowait()`
-     - Wrap waits in `anyio.fail_after(5)` as a timeout guard
+     - Exception: `sleep()` is appropriate when testing time-based features (e.g., timeouts)
+   - Wrap indefinite waits (`event.wait()`, `stream.receive()`) in `anyio.fail_after(5)` to prevent hangs
 
 - For commits fixing bugs or adding features based on user reports add:
 

--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -778,7 +778,7 @@ class StreamableHTTPServerTransport:
         Calling this method multiple times is safe (idempotent).
         """
 
-        if self._terminated:
+        if self._terminated:  # pragma: no cover
             return
 
         self._terminated = True

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -46,25 +46,20 @@ class StreamableHTTPSessionManager:
 
     Args:
         app: The MCP server instance
-        event_store: Optional event store for resumability support.
-                     If provided, enables resumable connections where clients
-                     can reconnect and receive missed events.
-                     If None, sessions are still tracked but not resumable.
+        event_store: Optional event store for resumability support. If provided, enables resumable connections
+            where clients can reconnect and receive missed events. If None, sessions are still tracked but not
+            resumable.
         json_response: Whether to use JSON responses instead of SSE streams
-        stateless: If True, creates a completely fresh transport for each request
-                   with no session tracking or state persistence between requests.
+        stateless: If True, creates a completely fresh transport for each request with no session tracking or
+            state persistence between requests.
         security_settings: Optional transport security settings.
-        retry_interval: Retry interval in milliseconds to suggest to clients in SSE
-                       retry field. Used for SSE polling behavior.
-        session_idle_timeout: Optional idle timeout in seconds for stateful
-                              sessions. If set, sessions that receive no HTTP
-                              requests for this duration will be automatically
-                              terminated and removed. When retry_interval is
-                              also configured, ensure the idle timeout
-                              comfortably exceeds the retry interval to avoid
-                              reaping sessions during normal SSE polling gaps.
-                              Default is None (no timeout). A value of 1800
-                              (30 minutes) is recommended for most deployments.
+        retry_interval: Retry interval in milliseconds to suggest to clients in SSE retry field. Used for SSE
+            polling behavior.
+        session_idle_timeout: Optional idle timeout in seconds for stateful sessions. If set, sessions that
+            receive no HTTP requests for this duration will be automatically terminated and removed. When
+            retry_interval is also configured, ensure the idle timeout comfortably exceeds the retry interval to
+            avoid reaping sessions during normal SSE polling gaps. Default is None (no timeout). A value of 1800
+            (30 minutes) is recommended for most deployments.
     """
 
     def __init__(
@@ -80,7 +75,7 @@ class StreamableHTTPSessionManager:
         if session_idle_timeout is not None and session_idle_timeout <= 0:
             raise ValueError("session_idle_timeout must be a positive number of seconds")
         if stateless and session_idle_timeout is not None:
-            raise ValueError("session_idle_timeout is not supported in stateless mode")
+            raise RuntimeError("session_idle_timeout is not supported in stateless mode")
 
         self.app = app
         self.event_store = event_store
@@ -283,16 +278,12 @@ class StreamableHTTPSessionManager:
                                 )
 
                             if idle_scope.cancelled_caught:
-                                session_id = http_transport.mcp_session_id
-                                logger.info(f"Session {session_id} idle timeout")
-                                if session_id is not None:  # pragma: no branch
-                                    self._server_instances.pop(session_id, None)
+                                assert http_transport.mcp_session_id is not None
+                                logger.info(f"Session {http_transport.mcp_session_id} idle timeout")
+                                self._server_instances.pop(http_transport.mcp_session_id, None)
                                 await http_transport.terminate()
-                        except Exception as e:
-                            logger.error(
-                                f"Session {http_transport.mcp_session_id} crashed: {e}",
-                                exc_info=True,
-                            )
+                        except Exception:
+                            logger.exception(f"Session {http_transport.mcp_session_id} crashed")
                         finally:
                             if (  # pragma: no branch
                                 http_transport.mcp_session_id


### PR DESCRIPTION
## Summary

Adds a `session_idle_timeout` parameter to `StreamableHTTPSessionManager` that enables automatic cleanup of idle sessions, fixing the memory leak described in #1283.

## Motivation and Context

Sessions created via `StreamableHTTPSessionManager` persist indefinitely in `_server_instances` even after clients disconnect without sending DELETE. Over time this leaks memory. This was reported in #1283 and originally addressed in #1159 by @hopeful0 — this PR reworks that approach.

Key design decisions:

- Uses a **`CancelScope` with a deadline** inside each session's `run_server` task. When the deadline passes, `app.run()` is cancelled and the session cleans up. No background tasks needed — each session manages its own lifecycle.
- Incoming requests **push the deadline forward**, so active sessions are never terminated.
- `terminate()` on the transport is now **idempotent** (early return if already terminated).
- Default is `None` (no timeout, fully backwards compatible). Docstring recommends 1800s (30 min) for most deployments.

## How Has This Been Tested?

Tests added to `tests/server/test_streamable_http_manager.py`: idle session reaping (deterministic, no sleeps), terminate idempotency, and parameterized input validation. All existing tests pass unchanged.

## Breaking Changes

None. `session_idle_timeout` defaults to `None` (no timeout).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Based on the approach from PR #1159 by @hopeful0, reworked to use cancel scope deadlines instead of transport-level timeout logic.

Closes #1283
