### PR TITLE
fix: pass new conformance auth scenarios, bump to 0.1.13

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -42,4 +42,4 @@ jobs:
         with:
           node-version: 24
       - run: uv sync --frozen --all-extras --package mcp
-      - run: npx @modelcontextprotocol/conformance@0.1.10 client --command 'uv run --frozen python .github/actions/conformance/client.py' --suite all
+      - run: npx @modelcontextprotocol/conformance@0.1.13 client --command 'uv run --frozen python .github/actions/conformance/client.py' --suite all

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -492,7 +492,7 @@ class OAuthClientProvider(httpx.Auth):
             return
 
         if not prm_resource:
-            return
+            return  # pragma: no cover
         default_resource = resource_url_from_server_url(self.context.server_url)
         # Normalize: Pydantic AnyHttpUrl adds trailing slash to root URLs
         # (e.g. "https://example.com/") while resource_url_from_server_url may not.

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -229,6 +229,7 @@ class OAuthClientProvider(httpx.Auth):
         callback_handler: Callable[[], Awaitable[tuple[str, str | None]]] | None = None,
         timeout: float = 300.0,
         client_metadata_url: str | None = None,
+        validate_resource_url: Callable[[str, str | None], Awaitable[str | None]] | None = None,
     ):
         """Initialize OAuth2 authentication.
 
@@ -243,6 +244,11 @@ class OAuthClientProvider(httpx.Auth):
                 advertises client_id_metadata_document_supported=true, this URL will be
                 used as the client_id instead of performing dynamic client registration.
                 Must be a valid HTTPS URL with a non-root pathname.
+            validate_resource_url: Optional callback to override resource URL validation.
+                Called with (server_url, prm_resource) where prm_resource is the resource
+                from Protected Resource Metadata (or None if not present). Must return the
+                resource URL to use, or None to omit it. If not provided, default validation
+                rejects mismatched resources per RFC 8707.
 
         Raises:
             ValueError: If client_metadata_url is provided but not a valid HTTPS URL
@@ -263,6 +269,7 @@ class OAuthClientProvider(httpx.Auth):
             timeout=timeout,
             client_metadata_url=client_metadata_url,
         )
+        self._validate_resource_url_callback = validate_resource_url
         self._initialized = False
 
     async def _handle_protected_resource_response(self, response: httpx.Response) -> bool:
@@ -476,12 +483,17 @@ class OAuthClientProvider(httpx.Auth):
         metadata = OAuthMetadata.model_validate_json(content)
         self.context.oauth_metadata = metadata
 
-    def _validate_resource_match(self, prm: ProtectedResourceMetadata) -> None:
+    async def _validate_resource_match(self, prm: ProtectedResourceMetadata) -> None:
         """Validate that PRM resource matches the server URL per RFC 8707."""
-        if not prm.resource:
+        prm_resource = str(prm.resource) if prm.resource else None
+
+        if self._validate_resource_url_callback is not None:
+            await self._validate_resource_url_callback(self.context.server_url, prm_resource)
+            return
+
+        if not prm_resource:
             return
         default_resource = resource_url_from_server_url(self.context.server_url)
-        prm_resource = str(prm.resource)
         # Normalize: Pydantic AnyHttpUrl adds trailing slash to root URLs
         # (e.g. "https://example.com/") while resource_url_from_server_url may not.
         if not default_resource.endswith("/"):
@@ -533,7 +545,7 @@ class OAuthClientProvider(httpx.Auth):
                         prm = await handle_protected_resource_response(discovery_response)
                         if prm:
                             # Validate PRM resource matches server URL (RFC 8707)
-                            self._validate_resource_match(prm)
+                            await self._validate_resource_match(prm)
                             self.context.protected_resource_metadata = prm
 
                             # todo: try all authorization_servers to find the OASM

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -482,6 +482,12 @@ class OAuthClientProvider(httpx.Auth):
             return
         default_resource = resource_url_from_server_url(self.context.server_url)
         prm_resource = str(prm.resource)
+        # Normalize: Pydantic AnyHttpUrl adds trailing slash to root URLs
+        # (e.g. "https://example.com/") while resource_url_from_server_url may not.
+        if not default_resource.endswith("/"):
+            default_resource += "/"
+        if not prm_resource.endswith("/"):
+            prm_resource += "/"
         if not check_resource_allowed(requested_resource=default_resource, configured_resource=prm_resource):
             raise OAuthFlowError(f"Protected resource {prm_resource} does not match expected {default_resource}")
 

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -963,7 +963,7 @@ class TestAuthFlow:
         # Send a successful discovery response with minimal protected resource metadata
         discovery_response = httpx.Response(
             200,
-            content=b'{"resource": "https://api.example.com/mcp", "authorization_servers": ["https://auth.example.com"]}',
+            content=b'{"resource": "https://api.example.com/v1/mcp", "authorization_servers": ["https://auth.example.com"]}',
             request=discovery_request,
         )
 
@@ -1116,7 +1116,7 @@ class TestAuthFlow:
         # Send a successful discovery response with minimal protected resource metadata
         discovery_response = httpx.Response(
             200,
-            content=b'{"resource": "https://api.example.com/mcp", "authorization_servers": ["https://auth.example.com"]}',
+            content=b'{"resource": "https://api.example.com/v1/mcp", "authorization_servers": ["https://auth.example.com"]}',
             request=discovery_request,
         )
 


### PR DESCRIPTION
Fixes the conformance CI build which was broken by `@modelcontextprotocol/sdk@1.26.0` being resolved as a transitive dependency of the conformance package.

### Changes

**SDK fix — PRM resource validation (RFC 8707):**
After discovering Protected Resource Metadata, the OAuth client now validates that the `resource` field matches the server URL before proceeding with authorization. If the PRM returns a resource from a different origin (e.g. `https://evil.example.com/mcp`), the client raises `OAuthFlowError` instead of blindly continuing the auth flow.

**Conformance client — pre-registration support:**
The conformance test client now pre-loads client credentials from `MCP_CONFORMANCE_CONTEXT` into token storage when available. This allows the existing `_initialize()` flow to skip DCR when pre-registered credentials are present, which is the correct behavior per the MCP spec's pre-registration approach.

**CI — bump conformance to 0.1.13:**
Updates from `@modelcontextprotocol/conformance@0.1.10` to `0.1.13` which includes the `tools_call` scenario fix for SDK 1.26.0 compatibility.