### PR TITLE
fix: Remove logging initialization from `MCPServer.__init__`

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -36,7 +36,7 @@ from mcp.server.mcpserver.prompts import Prompt, PromptManager
 from mcp.server.mcpserver.resources import FunctionResource, Resource, ResourceManager
 from mcp.server.mcpserver.tools import Tool, ToolManager
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
-from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
+from mcp.server.mcpserver.utilities.logging import get_logger
 from mcp.server.sse import SseServerTransport
 from mcp.server.stdio import stdio_server
 from mcp.server.streamable_http import EventStore
@@ -166,9 +166,6 @@ class MCPServer(Generic[LifespanResultT]):
 
         # Set up MCP protocol handlers
         self._setup_handlers()
-
-        # Configure logging
-        configure_logging(self.settings.log_level)
 
     @property
     def name(self) -> str:

--- a/src/mcp/server/mcpserver/utilities/logging.py
+++ b/src/mcp/server/mcpserver/utilities/logging.py
@@ -1,7 +1,6 @@
 """Logging utilities for MCPServer."""
 
 import logging
-from typing import Literal
 
 
 def get_logger(name: str) -> logging.Logger:
@@ -14,26 +13,3 @@ def get_logger(name: str) -> logging.Logger:
         a configured logger instance
     """
     return logging.getLogger(name)
-
-
-def configure_logging(
-    level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO",
-) -> None:
-    """Configure logging for MCP.
-
-    Args:
-        level: the log level to use
-    """
-    handlers: list[logging.Handler] = []
-    try:
-        from rich.console import Console
-        from rich.logging import RichHandler
-
-        handlers.append(RichHandler(console=Console(stderr=True), rich_tracebacks=True))
-    except ImportError:  # pragma: no cover
-        pass
-
-    if not handlers:  # pragma: no cover
-        handlers.append(logging.StreamHandler())
-
-    logging.basicConfig(level=level, format="%(message)s", handlers=handlers)


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Fixes #1656

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Removed `mcp.server.mcpserver.utilities.logging.configure_logging`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
I removed `mcp.server.mcpserver.utilities.logging.configure_logging`, as this was the only usage.
I also checked the examples, and most of them had `logging.basicConfig` in them or no logging at all.

I was uncertain about moving the call to `configure_logging` to `MCPServer.run_sse_async` or `MCPServer.run_streamable_http_async` because they set up uvicorn with logging. However, I ultimately decided against it.