### PR TITLE
Docs/examples: avoid wildcard CORS for StreamableHTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1363,7 +1363,9 @@ starlette_app = Starlette(routes=[...])
 # Then wrap it with CORS middleware
 starlette_app = CORSMiddleware(
     starlette_app,
-    allow_origins=["*"],  # Configure appropriately for production
+    # Allow browser-based clients (ChatGPT + local dev). For production, prefer
+    # a strict allowlist of known UI origins.
+    allow_origin_regex=r"^https://(chatgpt\.com|chat\.openai\.com)$|^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
     expose_headers=["Mcp-Session-Id"],
 )

--- a/README.v2.md
+++ b/README.v2.md
@@ -1364,7 +1364,9 @@ starlette_app = Starlette(routes=[...])
 # Then wrap it with CORS middleware
 starlette_app = CORSMiddleware(
     starlette_app,
-    allow_origins=["*"],  # Configure appropriately for production
+    # Allow browser-based clients (ChatGPT + local dev). For production, prefer
+    # a strict allowlist of known UI origins.
+    allow_origin_regex=r"^https://(chatgpt\.com|chat\.openai\.com)$|^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
     allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
     expose_headers=["Mcp-Session-Id"],
 )

--- a/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
+++ b/examples/servers/simple-streamablehttp-stateless/mcp_simple_streamablehttp_stateless/server.py
@@ -127,7 +127,9 @@ def main(
     # for browser-based clients (ensures 500 errors get proper CORS headers)
     starlette_app = CORSMiddleware(
         starlette_app,
-        allow_origins=["*"],  # Allow all origins - adjust as needed for production
+        # Allow browser-based clients (ChatGPT + local dev). For production, prefer
+        # a strict allowlist of known UI origins.
+        allow_origin_regex=r"^https://(chatgpt\.com|chat\.openai\.com)$|^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
         allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
         expose_headers=["Mcp-Session-Id"],
     )

--- a/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
+++ b/examples/servers/simple-streamablehttp/mcp_simple_streamablehttp/server.py
@@ -152,7 +152,9 @@ def main(
     # for browser-based clients (ensures 500 errors get proper CORS headers)
     starlette_app = CORSMiddleware(
         starlette_app,
-        allow_origins=["*"],  # Allow all origins - adjust as needed for production
+        # Allow browser-based clients (ChatGPT + local dev). For production, prefer
+        # a strict allowlist of known UI origins.
+        allow_origin_regex=r"^https://(chatgpt\.com|chat\.openai\.com)$|^https?://(localhost|127\.0\.0\.1)(:\d+)?$",
         allow_methods=["GET", "POST", "DELETE"],  # MCP streamable HTTP methods
         expose_headers=["Mcp-Session-Id"],
     )


### PR DESCRIPTION
Updates the StreamableHTTP docs snippet + low-level examples to avoid `allow_origins=["*"]`.

- Uses `allow_origin_regex` to allow browser clients from ChatGPT origins (`https://chatgpt.com`, `https://chat.openai.com`) and localhost dev (`http(s)://localhost|127.0.0.1(:port)`)
- Keeps the intent of exposing `Mcp-Session-Id` for browser-based clients
- Docs/examples only; no runtime behavior changes to the SDK

This reduces the risk of copy/paste wildcard-CORS configs in MCP servers.