### PR TITLE
fix: strip trailing slash from issuer URL in OAuth metadata serialization

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1414,6 +1414,7 @@ class TestAuthFlow:
 @pytest.mark.parametrize(
     (
         "issuer_url",
+        "expected_issuer",
         "service_documentation_url",
         "authorization_endpoint",
         "token_endpoint",
@@ -1421,9 +1422,8 @@ class TestAuthFlow:
         "revocation_endpoint",
     ),
     (
-        # Pydantic's AnyUrl incorrectly adds trailing slash to base URLs
-        # This is being fixed in https://github.com/pydantic/pydantic-core/pull/1719 (Pydantic 2.12+)
         pytest.param(
+            "https://auth.example.com",
             "https://auth.example.com",
             "https://auth.example.com/docs",
             "https://auth.example.com/authorize",
@@ -1431,12 +1431,10 @@ class TestAuthFlow:
             "https://auth.example.com/register",
             "https://auth.example.com/revoke",
             id="simple-url",
-            marks=pytest.mark.xfail(
-                reason="Pydantic AnyUrl adds trailing slash to base URLs - fixed in Pydantic 2.12+"
-            ),
         ),
         pytest.param(
             "https://auth.example.com/",
+            "https://auth.example.com",  # trailing slash stripped per RFC 8414
             "https://auth.example.com/docs",
             "https://auth.example.com/authorize",
             "https://auth.example.com/token",
@@ -1445,6 +1443,7 @@ class TestAuthFlow:
             id="with-trailing-slash",
         ),
         pytest.param(
+            "https://auth.example.com/v1/mcp",
             "https://auth.example.com/v1/mcp",
             "https://auth.example.com/v1/mcp/docs",
             "https://auth.example.com/v1/mcp/authorize",
@@ -1457,6 +1456,7 @@ class TestAuthFlow:
 )
 def test_build_metadata(
     issuer_url: str,
+    expected_issuer: str,
     service_documentation_url: str,
     authorization_endpoint: str,
     token_endpoint: str,
@@ -1472,7 +1472,7 @@ def test_build_metadata(
 
     assert metadata.model_dump(exclude_defaults=True, mode="json") == snapshot(
         {
-            "issuer": Is(issuer_url),
+            "issuer": Is(expected_issuer),
             "authorization_endpoint": Is(authorization_endpoint),
             "token_endpoint": Is(token_endpoint),
             "registration_endpoint": Is(registration_endpoint),

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -94,10 +94,11 @@ async def test_metadata_endpoint_without_path(root_resource_client: httpx.AsyncC
     # For root resource, metadata should be at standard location
     response = await root_resource_client.get("/.well-known/oauth-protected-resource")
     assert response.status_code == 200
+    # Note: URLs should NOT have trailing slashes per RFC 8414/9728 (see issue #1919)
     assert response.json() == snapshot(
         {
-            "resource": "https://example.com/",
-            "authorization_servers": ["https://auth.example.com/"],
+            "resource": "https://example.com",
+            "authorization_servers": ["https://auth.example.com"],
             "scopes_supported": ["read"],
             "resource_name": "Root Resource",
             "bearer_methods_supported": ["header"],

--- a/tests/server/mcpserver/auth/test_auth_integration.py
+++ b/tests/server/mcpserver/auth/test_auth_integration.py
@@ -312,7 +312,7 @@ class TestAuthEndpoints:
         assert response.status_code == 200
 
         metadata = response.json()
-        assert metadata["issuer"] == "https://auth.example.com/"
+        assert metadata["issuer"] == "https://auth.example.com"
         assert metadata["authorization_endpoint"] == "https://auth.example.com/authorize"
         assert metadata["token_endpoint"] == "https://auth.example.com/token"
         assert metadata["registration_endpoint"] == "https://auth.example.com/register"

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,6 +1,8 @@
 """Tests for OAuth 2.0 shared code."""
 
-from mcp.shared.auth import OAuthMetadata
+import json
+
+from mcp.shared.auth import OAuthMetadata, ProtectedResourceMetadata
 
 
 def test_oauth():
@@ -58,3 +60,72 @@ def test_oauth_with_jarm():
             "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
         }
     )
+
+
+class TestIssuerTrailingSlash:
+    """Tests for issue #1919: trailing slash in issuer URL.
+
+    RFC 8414 examples show issuer URLs without trailing slashes, and some
+    OAuth clients require exact match between discovery URL and returned issuer.
+    Pydantic's AnyHttpUrl automatically adds a trailing slash, so we strip it
+    during serialization.
+    """
+
+    def test_oauth_metadata_issuer_no_trailing_slash_in_json(self):
+        """Serialized issuer should not have trailing slash."""
+        metadata = OAuthMetadata(
+            issuer="https://example.com",
+            authorization_endpoint="https://example.com/oauth2/authorize",
+            token_endpoint="https://example.com/oauth2/token",
+        )
+        serialized = json.loads(metadata.model_dump_json())
+        assert serialized["issuer"] == "https://example.com"
+        assert not serialized["issuer"].endswith("/")
+
+    def test_oauth_metadata_issuer_with_path_preserves_path(self):
+        """Issuer with path should preserve the path, only strip trailing slash."""
+        metadata = OAuthMetadata(
+            issuer="https://example.com/auth",
+            authorization_endpoint="https://example.com/oauth2/authorize",
+            token_endpoint="https://example.com/oauth2/token",
+        )
+        serialized = json.loads(metadata.model_dump_json())
+        assert serialized["issuer"] == "https://example.com/auth"
+        assert not serialized["issuer"].endswith("/")
+
+    def test_oauth_metadata_issuer_with_path_and_trailing_slash(self):
+        """Issuer with path and trailing slash should only strip the trailing slash."""
+        metadata = OAuthMetadata(
+            issuer="https://example.com/auth/",
+            authorization_endpoint="https://example.com/oauth2/authorize",
+            token_endpoint="https://example.com/oauth2/token",
+        )
+        serialized = json.loads(metadata.model_dump_json())
+        assert serialized["issuer"] == "https://example.com/auth"
+
+    def test_protected_resource_metadata_no_trailing_slash(self):
+        """ProtectedResourceMetadata.resource should not have trailing slash."""
+        metadata = ProtectedResourceMetadata(
+            resource="https://example.com",
+            authorization_servers=["https://auth.example.com"],
+        )
+        serialized = json.loads(metadata.model_dump_json())
+        assert serialized["resource"] == "https://example.com"
+        assert not serialized["resource"].endswith("/")
+
+    def test_protected_resource_metadata_auth_servers_no_trailing_slash(self):
+        """ProtectedResourceMetadata.authorization_servers should not have trailing slashes."""
+        metadata = ProtectedResourceMetadata(
+            resource="https://example.com",
+            authorization_servers=[
+                "https://auth1.example.com",
+                "https://auth2.example.com/path",
+            ],
+        )
+        serialized = json.loads(metadata.model_dump_json())
+        assert serialized["authorization_servers"] == [
+            "https://auth1.example.com",
+            "https://auth2.example.com/path",
+        ]
+        for url in serialized["authorization_servers"]:
+            assert not url.endswith("/")

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -2,6 +2,8 @@
 
 import json
 
+from pydantic import AnyHttpUrl
+
 from mcp.shared.auth import OAuthMetadata, ProtectedResourceMetadata
 
 
@@ -74,9 +76,9 @@ class TestIssuerTrailingSlash:
     def test_oauth_metadata_issuer_no_trailing_slash_in_json(self):
         """Serialized issuer should not have trailing slash."""
         metadata = OAuthMetadata(
-            issuer="https://example.com",
-            authorization_endpoint="https://example.com/oauth2/authorize",
-            token_endpoint="https://example.com/oauth2/token",
+            issuer=AnyHttpUrl("https://example.com"),
+            authorization_endpoint=AnyHttpUrl("https://example.com/oauth2/authorize"),
+            token_endpoint=AnyHttpUrl("https://example.com/oauth2/token"),
         )
         serialized = json.loads(metadata.model_dump_json())
         assert serialized["issuer"] == "https://example.com"
@@ -85,9 +87,9 @@ class TestIssuerTrailingSlash:
     def test_oauth_metadata_issuer_with_path_preserves_path(self):
         """Issuer with path should preserve the path, only strip trailing slash."""
         metadata = OAuthMetadata(
-            issuer="https://example.com/auth",
-            authorization_endpoint="https://example.com/oauth2/authorize",
-            token_endpoint="https://example.com/oauth2/token",
+            issuer=AnyHttpUrl("https://example.com/auth"),
+            authorization_endpoint=AnyHttpUrl("https://example.com/oauth2/authorize"),
+            token_endpoint=AnyHttpUrl("https://example.com/oauth2/token"),
         )
         serialized = json.loads(metadata.model_dump_json())
         assert serialized["issuer"] == "https://example.com/auth"
@@ -96,9 +98,9 @@ class TestIssuerTrailingSlash:
     def test_oauth_metadata_issuer_with_path_and_trailing_slash(self):
         """Issuer with path and trailing slash should only strip the trailing slash."""
         metadata = OAuthMetadata(
-            issuer="https://example.com/auth/",
-            authorization_endpoint="https://example.com/oauth2/authorize",
-            token_endpoint="https://example.com/oauth2/token",
+            issuer=AnyHttpUrl("https://example.com/auth/"),
+            authorization_endpoint=AnyHttpUrl("https://example.com/oauth2/authorize"),
+            token_endpoint=AnyHttpUrl("https://example.com/oauth2/token"),
         )
         serialized = json.loads(metadata.model_dump_json())
         assert serialized["issuer"] == "https://example.com/auth"
@@ -106,8 +108,8 @@ class TestIssuerTrailingSlash:
     def test_protected_resource_metadata_no_trailing_slash(self):
         """ProtectedResourceMetadata.resource should not have trailing slash."""
         metadata = ProtectedResourceMetadata(
-            resource="https://example.com",
-            authorization_servers=["https://auth.example.com"],
+            resource=AnyHttpUrl("https://example.com"),
+            authorization_servers=[AnyHttpUrl("https://auth.example.com")],
         )
         serialized = json.loads(metadata.model_dump_json())
         assert serialized["resource"] == "https://example.com"
@@ -116,10 +118,10 @@ class TestIssuerTrailingSlash:
     def test_protected_resource_metadata_auth_servers_no_trailing_slash(self):
         """ProtectedResourceMetadata.authorization_servers should not have trailing slashes."""
         metadata = ProtectedResourceMetadata(
-            resource="https://example.com",
+            resource=AnyHttpUrl("https://example.com"),
             authorization_servers=[
-                "https://auth1.example.com",
-                "https://auth2.example.com/path",
+                AnyHttpUrl("https://auth1.example.com"),
+                AnyHttpUrl("https://auth2.example.com/path"),
             ],
         )
         serialized = json.loads(metadata.model_dump_json())


### PR DESCRIPTION
## Summary

Fixes #1919

This PR fixes the OAuth trailing slash issue where Pydantic's `AnyHttpUrl` automatically adds a trailing slash to URLs without path components, breaking OAuth discovery for clients like Google ADK and IBM MCP Context Forge that require exact URL matching per RFC 8414 Section 3.3.

### Changes
- Added `@field_serializer("issuer")` to `OAuthMetadata` to strip trailing slashes during JSON serialization
- Added `@field_serializer("resource")` to `ProtectedResourceMetadata` for the same reason
- Added `@field_serializer("authorization_servers")` to strip trailing slashes from all auth server URLs
- Added comprehensive tests for the trailing slash behavior

### Technical Details
- RFC 8414 examples show issuer URLs without trailing slashes
- The fix only affects JSON serialization output, not internal type handling
- Paths are preserved (e.g., `https://example.com/auth` stays as-is)
- Only lone trailing slashes are stripped (e.g., `https://example.com/` → `https://example.com`)

## Test plan
- [x] Added tests in `tests/shared/test_auth.py` for `OAuthMetadata.issuer` serialization
- [x] Added tests for `ProtectedResourceMetadata.resource` and `authorization_servers`
- [x] Updated snapshot test in `tests/server/auth/test_protected_resource.py`
- [x] All 52 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)