### PR TITLE
fix: handle callable class instances in find_context_parameter()

### DIFF
--- a/src/mcp/server/mcpserver/utilities/context_injection.py
+++ b/src/mcp/server/mcpserver/utilities/context_injection.py
@@ -22,9 +22,17 @@ def find_context_parameter(fn: Callable[..., Any]) -> str | None:
     """
     from mcp.server.mcpserver.server import Context
 
+    # Handle callable class instances by using __call__ method,
+    # since typing.get_type_hints() doesn't introspect __call__
+    # on class instances.
+    target = fn
+    if not (inspect.isfunction(fn) or inspect.ismethod(fn)):
+        if callable(fn) and hasattr(fn, "__call__"):
+            target = fn.__call__
+
     # Get type hints to properly resolve string annotations
     try:
-        hints = typing.get_type_hints(fn)
+        hints = typing.get_type_hints(target)
     except Exception:  # pragma: lax no cover
         # If we can't resolve type hints, we can't find the context parameter
         return None


### PR DESCRIPTION
## Summary
Fix `find_context_parameter()` to correctly detect `Context` parameters in callable class instances registered via `FastMCP.add_tool()`.

## Motivation and Context
When registering a callable class instance as an MCP tool, the `ctx: Context` parameter is incorrectly exposed as an externally visible tool parameter in the JSON schema instead of being injected by the framework.

**Root cause**: `typing.get_type_hints(fn)` is called on the class instance rather than its `__call__` method, so the Context type hint is not resolved.

**Fix**: Detect non-function/non-method callables and target their `__call__` method for type hint resolution. This mirrors the existing pattern in [`_is_async_callable()`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/mcpserver/tools/base.py#L119-L125).

Resolves #1974

## What Has Been Changed?
- `src/mcp/server/mcpserver/utilities/context_injection.py`: Added callable class instance handling before `get_type_hints()` call
- `tests/server/mcpserver/test_tool_manager.py`: Added 3 tests:
  - `test_context_parameter_detection_callable_class` — sync callable class
  - `test_context_parameter_detection_async_callable_class` — async callable class
  - `test_context_injection_callable_class` — full injection + schema exclusion

## How Has This Been Tested?
- All 54 tests in `test_tool_manager.py` pass (including 3 new tests)
- Ruff linting passes
- New tests verify:
  - `context_kwarg` is correctly set to `"ctx"`
  - `ctx` is excluded from tool parameters JSON schema
  - Context is properly injected during tool execution

## Breaking Changes
No breaking changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed