### PR TITLE
docs: add ROADMAP, VERSIONING, and dependency policy for SEP-1730 compliance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,45 @@
+# Roadmap
+
+This document tracks planned work for the MCP Python SDK, organized by priority.
+
+## Tier 1 Compliance (SEP-1730)
+
+Track: achieving and maintaining Tier 1 SDK status per the [SDK Tiering System](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1730).
+
+### Conformance
+- [ ] Reach 100% client conformance pass rate (currently 94.7% — `auth/resource-mismatch` scenario fails)
+- [ ] Maintain 100% server conformance pass rate
+
+### Documentation
+- [ ] Document all non-experimental MCP features with examples
+- [ ] Add documentation for roots (listing and change notifications)
+- [ ] Add documentation for cancellation
+- [ ] Add documentation for protocol version negotiation
+- [ ] Add documentation for JSON Schema 2020-12 support
+- [ ] Add examples for resource subscribing/unsubscribing
+- [ ] Improve elicitation documentation (enum values, complete notification, default values)
+- [ ] Document ping, audio content, prompts with embedded resources and images
+
+### Process
+- [ ] Audit P0 labels to ensure they represent genuine critical bugs
+- [ ] Maintain issue triage SLA (>= 90% within 2 business days)
+
+## Spec Tracking
+
+The SDK tracks the MCP specification and targets a release within 30 days of each new spec version.
+
+| Spec Version | SDK Support | Notes |
+|---|---|---|
+| 2025-11-25 | v1.26.0 | Current stable spec |
+| draft | In progress | Tracking via `main` branch |
+
+### Upcoming Spec Features
+- [ ] Structured content (`structuredContent` in tool results)
+- [ ] JSON-RPC batching support
+- [ ] Additional transport improvements
+
+## SDK Improvements
+
+- [ ] Improve low-level server API ergonomics
+- [ ] Expand testing coverage for edge cases
+- [ ] Performance improvements for high-throughput servers

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,48 @@
+# Versioning Policy
+
+## Versioning Scheme
+
+The MCP Python SDK follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+- **Major** (X.0.0): Breaking changes to the public API
+- **Minor** (0.X.0): New features, backward-compatible additions
+- **Patch** (0.0.X): Bug fixes, backward-compatible corrections
+
+## What Constitutes a Breaking Change
+
+The following are considered breaking changes and require a major version bump:
+
+- Removing or renaming a public function, class, method, or module
+- Changing the signature of a public function or method in a non-backward-compatible way (removing parameters, changing required parameters, changing return types)
+- Changing the behavior of a public API in a way that existing callers would not expect
+- Dropping support for a Python version
+- Changing the minimum required version of a dependency in a way that is incompatible with previously supported ranges
+- Removing or renaming protocol message types or fields from the public schema
+
+The following are **not** considered breaking changes:
+
+- Adding new optional parameters with default values
+- Adding new public functions, classes, or methods
+- Adding new fields to response types
+- Deprecating (but not removing) existing APIs
+- Changes to private/internal APIs (prefixed with `_`)
+- Bug fixes that correct behavior to match documented intent
+- Adding support for new protocol versions while maintaining backward compatibility
+
+## How Breaking Changes Are Communicated
+
+1. **Deprecation warnings**: Before removal, public APIs are deprecated for at least one minor release with `DeprecationWarning` and migration guidance.
+2. **Release notes**: All breaking changes are documented in GitHub Release notes with migration instructions.
+3. **PR labels**: Pull requests containing breaking changes are labeled accordingly.
+
+## Release Branches
+
+- **`main`**: Development branch for the next major version
+- **`v1.x`**: Stable release branch for the 1.x series; receives bug fixes and backward-compatible features
+- **`v1.Y.x`** (e.g., `v1.7.x`): Patch release branches for specific minor versions when needed
+
+Bug fixes target the latest release branch and are forward-merged into `main`. New features target `main` and may be backported to the release branch if appropriate.
+
+## Protocol Version Tracking
+
+The SDK tracks the MCP specification. When a new spec version is released, the SDK targets a corresponding release within 30 days. Protocol version support is documented in the README.


### PR DESCRIPTION
Adds three policy files required for SEP-1730 SDK tiering:

## Motivation and Context
SEP-1730 defines requirements for SDK tier classification. These policy files address the roadmap, versioning policy, and dependency update policy requirements.

## How Has This Been Tested?
Documentation-only change, no code changes.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Part 1 of 2 in a stack. See also the stacked PR for feature documentation.

**Files added:**
- `ROADMAP.md` — tracks Tier 1 compliance work, spec tracking, and SDK improvements
- `VERSIONING.md` — documents semver scheme, breaking change policy, release branches
- `.github/dependabot.yml` — adds pip ecosystem alongside github-actions for dependency updates