### PR TITLE
fix: skip readme-v1-frozen in CI and add diff-based README.md check

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -26,7 +26,19 @@ jobs:
         with:
           extra_args: --all-files --verbose
         env:
-          SKIP: no-commit-to-branch
+          SKIP: no-commit-to-branch,readme-v1-frozen
+
+      # TODO(Max): Drop this in v2.
+      - name: Check README.md is not modified
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          if git diff --name-only "$BASE_SHA" -- README.md | grep -q .; then
+            echo "::error::README.md is frozen at v1. Edit README.v2.md instead."
+            exit 1
+          fi
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
   test:
     name: test (${{ matrix.python-version }}, ${{ matrix.dep-resolution.name }}, ${{ matrix.os }})


### PR DESCRIPTION
## Problem

The `readme-v1-frozen` pre-commit hook (added in #2045) uses `language: fail`, which unconditionally fails when its `files` pattern matches any file in the candidate set. Since CI runs pre-commit with `--all-files`, `README.md` always matches and the hook always fails — breaking CI on `main` and all PRs.

This also blocks unrelated PRs like #2041 from merging.

## Solution

A two-part fix that provides protection in both local and CI contexts:

1. **Skip `readme-v1-frozen` in the pre-commit `--all-files` run** via the `SKIP` env var — the same mechanism already used for `no-commit-to-branch`. The hook continues to work locally where pre-commit only checks staged files.

2. **Add a standalone CI step** that uses `git diff` against the PR base to check whether `README.md` was actually modified. This provides CI-level enforcement that the `language: fail` hook cannot offer in `--all-files` mode.

### Why this approach?

`language: fail` and `--all-files` are fundamentally incompatible — `language: fail` fires whenever the file *exists* in the set, not when it was *changed*. Local pre-commit and CI have different semantics: locally you check "is this file staged?", in CI you check "was this file changed in this PR?" This fix uses the right tool for each context rather than forcing one mechanism to do both jobs.

Both the `SKIP` entry and the CI step are tagged with the existing `TODO(Max): Drop this in v2` comment for easy cleanup.