### PR TITLE
fix: explicitly load required pytest plugins in addopts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,8 @@ xfail_strict = true
 addopts = """
     --color=yes
     --capture=fd
+    -p anyio
+    -p examples
 """
 filterwarnings = [
     "error",


### PR DESCRIPTION
## Problem

The test suite silently depends on pytest's plugin autoloading to discover `anyio` and `pytest-examples`. When `PYTEST_DISABLE_PLUGIN_AUTOLOAD=true` is set in the environment (a documented pytest feature), tests fail:

```
pytest.PytestUnknownMarkWarning: Unknown pytest.mark.anyio - is this a typo?
```

This affects any developer or CI environment that disables plugin autoloading.

## Fix

Add `-p anyio` and `-p pytest_examples` to `addopts` in `pyproject.toml`. The `-p` flag is the standard pytest mechanism for explicitly loading plugins. It is processed before the autoload check, so it works regardless of `PYTEST_DISABLE_PLUGIN_AUTOLOAD`. It is also idempotent — when autoloading is enabled (the default), `-p` is a no-op.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>