### PR TITLE
fix(tests): remove dead sleep in test_url_elicitation

### DIFF
--- a/tests/server/mcpserver/test_url_elicitation.py
+++ b/tests/server/mcpserver/test_url_elicitation.py
@@ -1,6 +1,5 @@
 """Test URL mode elicitation feature (SEP 1036)."""
 
-import anyio
 import pytest
 from pydantic import BaseModel, Field
 
@@ -216,10 +215,8 @@ async def test_elicit_complete_notification():
         assert isinstance(result.content[0], TextContent)
         assert result.content[0].text == "Elicitation completed"
 
-        # Give time for notification to be processed
-        await anyio.sleep(0.1)
-
-        # Verify the notification was sent
+        # Verify the notification was sent (flag is set inside the tool handler
+        # which completes before call_tool returns, so no wait needed)
         assert notification_sent
 
 


### PR DESCRIPTION
## Summary

- Remove unnecessary `await anyio.sleep(0.1)` after `call_tool` returns in `test_send_elicit_complete_notification`
- The `notification_sent` flag is set inside the tool handler before it returns, so it's already `True` when `call_tool` completes — the sleep was dead code
- Also removes the now-unused `import anyio`

## Test plan

- [x] `uv run --frozen pytest tests/server/mcpserver/test_url_elicitation.py -x -q` passes (11/11)