### PR TITLE
fix: relax MIME type validation to accept all RFC 2045 types

### DIFF
--- a/src/mcp/server/mcpserver/resources/base.py
+++ b/src/mcp/server/mcpserver/resources/base.py
@@ -26,11 +26,27 @@ class Resource(BaseModel, abc.ABC):
     mime_type: str = Field(
         default="text/plain",
         description="MIME type of the resource content",
-        pattern=r"^[a-zA-Z0-9]+/[a-zA-Z0-9\-+.]+(;\s*[a-zA-Z0-9\-_.]+=[a-zA-Z0-9\-_.]+)*$",
     )
     icons: list[Icon] | None = Field(default=None, description="Optional list of icons for this resource")
     annotations: Annotations | None = Field(default=None, description="Optional annotations for the resource")
     meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for this resource")
+
+    @field_validator("mime_type")
+    @classmethod
+    def validate_mime_type(cls, value: str) -> str:
+        """Validate that mime_type has a basic type/subtype structure.
+
+        The MCP spec defines mimeType as an optional string with no format
+        constraints. This validator only checks for the minimal type/subtype
+        structure to catch obvious mistakes, without restricting valid MIME
+        types per RFC 2045.
+        """
+        if "/" not in value:
+            raise ValueError(
+                f"Invalid MIME type '{value}': must contain a '/' separating type and subtype "
+                f"(e.g. 'text/plain', 'application/json')"
+            )
+        return value
 
     @field_validator("name", mode="before")
     @classmethod

--- a/tests/issues/test_1756_mime_type_relaxed.py
+++ b/tests/issues/test_1756_mime_type_relaxed.py
@@ -1,0 +1,114 @@
+"""Test for GitHub issue #1756: Relax MIME type validation in FastMCP resources.
+
+The previous MIME type validation used a restrictive regex pattern that rejected
+valid MIME types per RFC 2045. For example, quoted parameter values like
+'text/plain; charset="utf-8"' were rejected.
+
+The fix replaces the regex with a lightweight validator that only checks for the
+minimal type/subtype structure (presence of '/'), aligning with the MCP spec
+which defines mimeType as an optional string with no format constraints.
+"""
+
+import pytest
+
+from mcp.server.mcpserver.resources.types import FunctionResource
+
+
+def _dummy() -> str:  # pragma: no cover
+    return "data"
+
+
+class TestRelaxedMimeTypeValidation:
+    """Test that MIME type validation accepts all RFC 2045 valid types."""
+
+    def test_basic_mime_types(self):
+        """Standard MIME types should be accepted."""
+        for mime in [
+            "text/plain",
+            "application/json",
+            "application/octet-stream",
+            "image/png",
+            "text/html",
+            "text/csv",
+            "application/xml",
+        ]:
+            r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+            assert r.mime_type == mime
+
+    def test_mime_type_with_quoted_parameter_value(self):
+        """Quoted parameter values are valid per RFC 2045 (the original issue)."""
+        mime = 'text/plain; charset="utf-8"'
+        r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+        assert r.mime_type == mime
+
+    def test_mime_type_with_unquoted_parameter(self):
+        """Unquoted parameter values should still work."""
+        mime = "text/plain; charset=utf-8"
+        r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+        assert r.mime_type == mime
+
+    def test_mime_type_with_profile_parameter(self):
+        """Profile parameter used by MCP-UI (from issue #1754)."""
+        mime = "text/html;profile=mcp-app"
+        r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+        assert r.mime_type == mime
+
+    def test_mime_type_with_multiple_parameters(self):
+        """Multiple parameters should be accepted."""
+        mime = "text/plain; charset=utf-8; format=fixed"
+        r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+        assert r.mime_type == mime
+
+    def test_mime_type_with_vendor_type(self):
+        """Vendor-specific MIME types (x- prefix, vnd.) should be accepted."""
+        for mime in [
+            "application/vnd.api+json",
+            "application/x-www-form-urlencoded",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ]:
+            r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+            assert r.mime_type == mime
+
+    def test_mime_type_with_suffix(self):
+        """Structured syntax suffix types should be accepted."""
+        for mime in [
+            "application/ld+json",
+            "application/soap+xml",
+            "image/svg+xml",
+        ]:
+            r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+            assert r.mime_type == mime
+
+    def test_mime_type_with_wildcard(self):
+        """Wildcard MIME types should be accepted."""
+        for mime in [
+            "application/*",
+            "*/*",
+        ]:
+            r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+            assert r.mime_type == mime
+
+    def test_mime_type_with_complex_parameters(self):
+        """Complex parameter values per RFC 2045."""
+        for mime in [
+            'multipart/form-data; boundary="----WebKitFormBoundary"',
+            "text/html; charset=ISO-8859-1",
+            'application/json; profile="https://example.com/schema"',
+        ]:
+            r = FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type=mime)
+            assert r.mime_type == mime
+
+    def test_invalid_mime_type_no_slash(self):
+        """MIME types without '/' should be rejected."""
+        with pytest.raises(ValueError, match="must contain a '/'"):
+            FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type="plaintext")
+
+    def test_invalid_mime_type_empty_string(self):
+        """Empty string should be rejected (no '/')."""
+        with pytest.raises(ValueError, match="must contain a '/'"):
+            FunctionResource(uri="test://x", name="t", fn=_dummy, mime_type="")
+
+    def test_default_mime_type(self):
+        """Default MIME type should be text/plain."""
+        r = FunctionResource(uri="test://x", name="t", fn=_dummy)
+        assert r.mime_type == "text/plain"

--- a/tests/server/mcpserver/resources/test_resources.py
+++ b/tests/server/mcpserver/resources/test_resources.py
@@ -91,6 +91,19 @@ class TestResourceValidation:
         )
         assert resource.mime_type == "application/json"
 
+    def test_resource_mime_type_validation(self):
+        """Test that MIME types without '/' are rejected."""
+
+        def dummy_func() -> str:  # pragma: no cover
+            return "data"
+
+        with pytest.raises(ValueError, match="must contain a '/'"):
+            FunctionResource(
+                uri="resource://test",
+                fn=dummy_func,
+                mime_type="invalid",
+            )
+
     @pytest.mark.anyio
     async def test_resource_read_abstract(self):
         """Test that Resource.read() is abstract."""


### PR DESCRIPTION
## Summary

Closes #1756

- **Replaced** the restrictive regex pattern on `Resource.mime_type` with a lightweight `field_validator` that only checks for the presence of `/` (type/subtype structure)
- **Aligns** with the MCP spec which defines `mimeType` as an optional string with no format constraints, and matches the TypeScript SDK behavior (no validation)
- **Fixes** rejection of valid RFC 2045 MIME types including quoted parameter values (e.g. `text/plain; charset="utf-8"`), wildcard types (`*/*`), and complex boundary parameters

### What changed

**`src/mcp/server/mcpserver/resources/base.py`**
- Removed `pattern=r"^[a-zA-Z0-9]+/[a-zA-Z0-9\-+.]+(;\s*[a-zA-Z0-9\-_.]+=[a-zA-Z0-9\-_.]+)*$"` from the `mime_type` Field
- Added `validate_mime_type` field_validator that only rejects values without a `/` separator

### Why this approach

The previous regex was too restrictive for RFC 2045 compliance. Rather than trying to write a more complex regex that covers all edge cases (quoted strings, special characters, wildcards, etc.), this PR follows the MCP spec's intent: `mimeType` is a plain string, and validation should only catch obvious mistakes (like passing `"plaintext"` instead of `"text/plain"`). This is consistent with:
- The TypeScript SDK (no MIME validation)
- `ResourceTemplate` in this SDK (already had no pattern constraint)
- Protocol-level types in `_types.py` (no validation)

## Test plan

- [x] Added `tests/issues/test_1756_mime_type_relaxed.py` with 12 test cases covering:
  - Basic MIME types, quoted parameter values, vendor types, wildcards, complex parameters
  - Invalid MIME types (no `/`, empty string)
  - Default MIME type preservation
- [x] Added `test_resource_mime_type_validation` to existing `test_resources.py`
- [x] All existing tests pass (including `test_1754_mime_type_parameters.py`)
- [x] 100% code coverage on `base.py`
- [x] ruff + pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)