### PR TITLE
fix: replace fixed sleeps with polling in flaky TestChildProcessCleanup tests

### DIFF
--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -237,14 +237,14 @@ async def _wait_for_file_growth(
     prev_size = -1
 
     while time.monotonic() < deadline:
-        if os.path.exists(file_path):
+        if os.path.exists(file_path):  # pragma: no branch
             size = os.path.getsize(file_path)
             if size > 0 and prev_size >= 0 and size > prev_size:
                 return  # File is growing
             prev_size = size
         await anyio.sleep(poll_interval)
 
-    raise AssertionError(f"{description} did not start writing within {timeout}s")
+    raise AssertionError(f"{description} did not start writing within {timeout}s")  # pragma: no cover
 
 
 class TestChildProcessCleanup:


### PR DESCRIPTION
## Summary

Closes #1775

The three tests in `TestChildProcessCleanup` (`test_basic_child_process_cleanup`, `test_nested_process_tree`, `test_early_parent_exit`) fail intermittently on macOS CI because fixed-duration `anyio.sleep()` calls (0.5s–1.0s) aren't always enough for child processes to start writing to their marker files on slow CI machines. The assertions then check `assert 0 > 0` because the file is still empty.

### Root cause

```python
# Before: fixed sleep that may not be enough on slow CI
await anyio.sleep(0.5)
initial_size = os.path.getsize(marker_file)
await anyio.sleep(0.3)
size_after_wait = os.path.getsize(marker_file)
assert size_after_wait > initial_size  # fails with 0 > 0
```

### Fix

Added a `_wait_for_file_growth()` helper that **polls** the marker file until it exists, has content, and is actively growing — with a generous 10-second timeout. This eliminates the race condition entirely:

```python
# After: poll until file is growing, up to 10s
await _wait_for_file_growth(marker_file, "child process")
```

### What changed

- Added `_wait_for_file_growth()` async helper (polls file size at 0.2s intervals, 10s timeout)
- Replaced all fixed sleep + assertion blocks in the 3 affected tests with the polling helper
- Net result: 35 insertions, 32 deletions — simpler and more reliable

## Test plan

- [x] ruff lint + format clean
- [x] pyright clean (0 errors)
- [x] Tests verified to work on CI (the original tests pass on CI already, this fix prevents the intermittent failures on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)