### PR TITLE
fix: handle ClosedResourceError in _handle_message error recovery path

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -414,11 +414,16 @@ class Server(Generic[LifespanResultT]):
                         )
                 case Exception():
                     logger.error(f"Received exception from stream: {message}")
-                    await session.send_log_message(
-                        level="error",
-                        data="Internal Server Error",
-                        logger="mcp.server.exception_handler",
-                    )
+                    try:
+                        await session.send_log_message(
+                            level="error",
+                            data="Internal Server Error",
+                            logger="mcp.server.exception_handler",
+                        )
+                    except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                        # Client already disconnected; logging back to
+                        # the client is impossible and harmless to skip.
+                        logger.debug("Could not send error log: client disconnected")
                     if raise_exceptions:
                         raise message
                 case _:


### PR DESCRIPTION
## Summary

Closes #2064

When a client disconnects while a stateless streamable-HTTP server is processing a request, the error handler in `_handle_message` tries to `send_log_message()` back to the client. Since the session was already terminated and the write stream closed, this raises `ClosedResourceError`, which is unhandled and crashes the stateless session with an `ExceptionGroup`.

This is a **different code path** from what PR #1384 fixed. That PR addressed `ClosedResourceError` in the message router loop. This bug is in the error recovery path: catch exception → try to log it to client → write stream already closed → crash.

### Fix

Wrap the `send_log_message()` call in `_handle_message`'s exception handler with a `try/except` that catches `anyio.ClosedResourceError` and `anyio.BrokenResourceError`. Failing to notify a disconnected client is expected and harmless — we just log it at debug level and move on.

```python
# Before: crashes if client disconnected
await session.send_log_message(level="error", ...)

# After: gracefully handles disconnected client
try:
    await session.send_log_message(level="error", ...)
except (anyio.ClosedResourceError, anyio.BrokenResourceError):
    logger.debug("Could not send error log: client disconnected")
```

This follows the same pattern already used elsewhere in the codebase (`session.py:406`, `streamable_http.py:587`, `streamable_http.py:1009`, etc.).

## Test plan

- [x] Added 4 new tests in `test_lowlevel_exception_handling.py`:
  - `test_exception_handling_with_disconnected_client[ClosedResourceError]`
  - `test_exception_handling_with_disconnected_client[BrokenResourceError]`
  - `test_exception_handling_with_disconnected_client_raise_exceptions[ClosedResourceError]`
  - `test_exception_handling_with_disconnected_client_raise_exceptions[BrokenResourceError]`
- [x] All 10 existing + new tests pass
- [x] ruff lint + format clean
- [x] pyright clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)