### PR TITLE
fix: normalize trailing slashes before length check in check_resource_allowed

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -493,12 +493,6 @@ class OAuthClientProvider(httpx.Auth):
         if not prm_resource:
             return  # pragma: no cover
         default_resource = resource_url_from_server_url(self.context.server_url)
-        # Normalize: Pydantic AnyHttpUrl adds trailing slash to root URLs
-        # (e.g. "https://example.com/") while resource_url_from_server_url may not.
-        if not default_resource.endswith("/"):
-            default_resource += "/"
-        if not prm_resource.endswith("/"):
-            prm_resource += "/"
         if not check_resource_allowed(requested_resource=default_resource, configured_resource=prm_resource):
             raise OAuthFlowError(f"Protected resource {prm_resource} does not match expected {default_resource}")
 

--- a/src/mcp/shared/auth_utils.py
+++ b/src/mcp/shared/auth_utils.py
@@ -51,22 +51,17 @@ def check_resource_allowed(requested_resource: str, configured_resource: str) ->
     if requested.scheme.lower() != configured.scheme.lower() or requested.netloc.lower() != configured.netloc.lower():
         return False
 
-    # Handle cases like requested=/foo and configured=/foo/
+    # Normalize trailing slashes before comparison so that
+    # "/foo" and "/foo/" are treated as equivalent.
     requested_path = requested.path
     configured_path = configured.path
-
-    # If requested path is shorter, it cannot be a child
-    if len(requested_path) < len(configured_path):
-        return False
-
-    # Check if the requested path starts with the configured path
-    # Ensure both paths end with / for proper comparison
-    # This ensures that paths like "/api123" don't incorrectly match "/api"
     if not requested_path.endswith("/"):
         requested_path += "/"
     if not configured_path.endswith("/"):
         configured_path += "/"
 
+    # Check hierarchical match: requested must start with configured path.
+    # The trailing-slash normalization ensures "/api123/" won't match "/api/".
     return requested_path.startswith(configured_path)
 
 

--- a/tests/shared/test_auth_utils.py
+++ b/tests/shared/test_auth_utils.py
@@ -104,7 +104,7 @@ def test_check_resource_allowed_trailing_slash_handling():
     """Trailing slashes should be handled correctly."""
     # With and without trailing slashes
     assert check_resource_allowed("https://example.com/api/", "https://example.com/api") is True
-    assert check_resource_allowed("https://example.com/api", "https://example.com/api/") is False
+    assert check_resource_allowed("https://example.com/api", "https://example.com/api/") is True
     assert check_resource_allowed("https://example.com/api/v1", "https://example.com/api") is True
     assert check_resource_allowed("https://example.com/api/v1", "https://example.com/api/") is True
 


### PR DESCRIPTION
<!-- Fix trailing slash bug in resource URL comparison -->

## Motivation and Context

`check_resource_allowed` incorrectly rejected equivalent paths like `/api` vs `/api/` because the length check ran before trailing slash normalization. For example, `check_resource_allowed("https://example.com/api", "https://example.com/api/")` returned `False` even though these should be equivalent.

This also caused redundant normalization in `_validate_resource_match` which worked around the bug.

Found during review of #2069 (v1.x backport).

## How Has This Been Tested?

- Existing test assertion flipped from `False` to `True` for the `/api` vs `/api/` case
- Full test suite passes with 100% branch coverage

## Breaking Changes

None — this is a bug fix that makes the function more permissive.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed