### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@2f8ba26a219c06cfb0f468eef8d97055fa814f97 # v1.0.53
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,13 +27,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@2f8ba26a219c06cfb0f468eef8d97055fa814f97 # v1.0.53
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_commit_signing: true

--- a/.github/workflows/weekly-lockfile-update.yml
+++ b/.github/workflows/weekly-lockfile-update.yml
@@ -14,9 +14,9 @@ jobs:
   update-lockfile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: astral-sh/setup-uv@v7.2.1
+      - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:
           version: 0.9.5
 


### PR DESCRIPTION
Pin remaining GitHub Actions that were using mutable tags to specific commit SHAs for supply chain security. This ensures CI runs are reproducible and not vulnerable to tag hijacking.

### Actions pinned

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v6` | `@de0fac2e` (v6.0.2) |
| `astral-sh/setup-uv` | `@v7.2.1` | `@803947b9` (v7.2.1) |
| `anthropics/claude-code-action` | `@v1` | `@2f8ba26a` (v1.0.53) |

### Affected workflows

- `weekly-lockfile-update.yml`
- `claude.yml`
- `claude-code-review.yml`

All other workflows were already pinned to SHAs.