### PR TITLE
Fix the session binding logic for tasks.

### DIFF
--- a/src/mcp/client/_memory.py
+++ b/src/mcp/client/_memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from types import TracebackType
@@ -50,12 +51,14 @@ class InMemoryTransport:
 
             async with anyio.create_task_group() as tg:
                 # Start server in background
+                memory_session_id = uuid.uuid4().hex
                 tg.start_soon(
                     lambda: actual_server.run(
                         server_read,
                         server_write,
                         actual_server.create_initialization_options(),
                         raise_exceptions=self._raise_exceptions,
+                        session_id=memory_session_id,
                     )
                 )
 

--- a/src/mcp/client/_memory.py
+++ b/src/mcp/client/_memory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from types import TracebackType
@@ -51,14 +50,12 @@ class InMemoryTransport:
 
             async with anyio.create_task_group() as tg:
                 # Start server in background
-                memory_session_id = uuid.uuid4().hex
                 tg.start_soon(
                     lambda: actual_server.run(
                         server_read,
                         server_write,
                         actual_server.create_initialization_options(),
                         raise_exceptions=self._raise_exceptions,
-                        session_id=memory_session_id,
                     )
                 )
 

--- a/src/mcp/server/experimental/request_context.py
+++ b/src/mcp/server/experimental/request_context.py
@@ -187,7 +187,7 @@ class Experimental:
         # Access task_group via TaskSupport - raises if not in run() context
         task_group = support.task_group
 
-        session_id = str(id(self._session))
+        session_id = self._session.session_id
         task = await support.store.create_task(self.task_metadata, task_id, session_id=session_id)
 
         task_ctx = ServerTaskContext(

--- a/src/mcp/server/experimental/request_context.py
+++ b/src/mcp/server/experimental/request_context.py
@@ -188,6 +188,8 @@ class Experimental:
         task_group = support.task_group
 
         session_id = self._session.session_id
+        if session_id is None:
+            raise RuntimeError("Session ID is required for task operations but session has no ID.")
         task = await support.store.create_task(self.task_metadata, task_id, session_id=session_id)
 
         task_ctx = ServerTaskContext(

--- a/src/mcp/server/experimental/request_context.py
+++ b/src/mcp/server/experimental/request_context.py
@@ -187,7 +187,8 @@ class Experimental:
         # Access task_group via TaskSupport - raises if not in run() context
         task_group = support.task_group
 
-        task = await support.store.create_task(self.task_metadata, task_id)
+        session_id = str(id(self._session))
+        task = await support.store.create_task(self.task_metadata, task_id, session_id=session_id)
 
         task_ctx = ServerTaskContext(
             task=task,

--- a/src/mcp/server/experimental/request_context.py
+++ b/src/mcp/server/experimental/request_context.py
@@ -189,9 +189,11 @@ class Experimental:
         # Access task_group via TaskSupport - raises if not in run() context
         task_group = support.task_group
 
+        if self._session.stateless:
+            raise RuntimeError(
+                "run_task() does not support stateless mode. Tasks require a persistent session for result retrieval."
+            )
         session_id = self._session.session_id
-        if session_id is None:
-            raise RuntimeError("Session ID is required for task operations but session has no ID.")
         task = await support.store.create_task(self.task_metadata, task_id, session_id=session_id)
 
         task_ctx = ServerTaskContext(

--- a/src/mcp/server/experimental/task_context.py
+++ b/src/mcp/server/experimental/task_context.py
@@ -90,11 +90,8 @@ class ServerTaskContext:
             queue: The message queue for elicitation/sampling
             handler: The result handler for response routing (required for elicit/create_message)
         """
-        session_id = session.session_id
-        if session_id is None:
-            raise RuntimeError("Session ID is required for task operations but session has no ID.")
-        self._session_id = session_id
-        self._ctx = TaskContext(task=task, store=store, session_id=session_id)
+        self._session_id = session.session_id
+        self._ctx = TaskContext(task=task, store=store, session_id=self._session_id)
         self._session = session
         self._queue = queue
         self._handler = handler

--- a/src/mcp/server/experimental/task_result_handler.py
+++ b/src/mcp/server/experimental/task_result_handler.py
@@ -80,6 +80,7 @@ class TaskResultHandler:
         request: GetTaskPayloadRequest,
         session: ServerSession,
         request_id: RequestId,
+        session_id: str | None = None,
     ) -> GetTaskPayloadResult:
         """Handle a tasks/result request.
 
@@ -94,6 +95,7 @@ class TaskResultHandler:
             request: The GetTaskPayloadRequest
             session: The server session for sending messages
             request_id: The request ID for relatedRequestId routing
+            session_id: Optional session identifier for access control.
 
         Returns:
             GetTaskPayloadResult with the task's final payload
@@ -101,7 +103,7 @@ class TaskResultHandler:
         task_id = request.params.task_id
 
         while True:
-            task = await self._store.get_task(task_id)
+            task = await self._store.get_task(task_id, session_id=session_id)
             if task is None:
                 raise MCPError(code=INVALID_PARAMS, message=f"Task not found: {task_id}")
 
@@ -109,7 +111,7 @@ class TaskResultHandler:
 
             # If task is terminal, return result
             if is_terminal(task.status):
-                result = await self._store.get_result(task_id)
+                result = await self._store.get_result(task_id, session_id=session_id)
                 # GetTaskPayloadResult is a Result with extra="allow"
                 # The stored result contains the actual payload data
                 # Per spec: tasks/result MUST include _meta with related-task metadata

--- a/src/mcp/server/experimental/task_result_handler.py
+++ b/src/mcp/server/experimental/task_result_handler.py
@@ -80,7 +80,7 @@ class TaskResultHandler:
         request: GetTaskPayloadRequest,
         session: ServerSession,
         request_id: RequestId,
-        session_id: str | None = None,
+        session_id: str,
     ) -> GetTaskPayloadResult:
         """Handle a tasks/result request.
 
@@ -95,7 +95,7 @@ class TaskResultHandler:
             request: The GetTaskPayloadRequest
             session: The server session for sending messages
             request_id: The request ID for relatedRequestId routing
-            session_id: Optional session identifier for access control.
+            session_id: Session identifier for access control.
 
         Returns:
             GetTaskPayloadResult with the task's final payload

--- a/src/mcp/server/experimental/task_result_handler.py
+++ b/src/mcp/server/experimental/task_result_handler.py
@@ -80,7 +80,7 @@ class TaskResultHandler:
         request: GetTaskPayloadRequest,
         session: ServerSession,
         request_id: RequestId,
-        session_id: str,
+        session_id: str | None,
     ) -> GetTaskPayloadResult:
         """Handle a tasks/result request.
 
@@ -95,7 +95,8 @@ class TaskResultHandler:
             request: The GetTaskPayloadRequest
             session: The server session for sending messages
             request_id: The request ID for relatedRequestId routing
-            session_id: Session identifier for access control.
+            session_id: Session identifier for access control. Must exactly
+                match the session_id the task was created with (including None).
 
         Returns:
             GetTaskPayloadResult with the task's final payload

--- a/src/mcp/server/lowlevel/experimental.py
+++ b/src/mcp/server/lowlevel/experimental.py
@@ -153,7 +153,7 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
             async def _default_get_task(
                 ctx: ServerRequestContext[LifespanResultT], params: GetTaskRequestParams
             ) -> GetTaskResult:
-                session_id = str(id(ctx.session))
+                session_id = ctx.session.session_id
                 task = await task_support.store.get_task(params.task_id, session_id=session_id)
                 if task is None:
                     raise MCPError(code=INVALID_PARAMS, message=f"Task not found: {params.task_id}")
@@ -175,7 +175,7 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
                 ctx: ServerRequestContext[LifespanResultT], params: GetTaskPayloadRequestParams
             ) -> GetTaskPayloadResult:
                 assert ctx.request_id is not None
-                session_id = str(id(ctx.session))
+                session_id = ctx.session.session_id
                 req = GetTaskPayloadRequest(params=params)
                 result = await task_support.handler.handle(req, ctx.session, ctx.request_id, session_id=session_id)
                 return result
@@ -188,7 +188,7 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
                 ctx: ServerRequestContext[LifespanResultT], params: PaginatedRequestParams | None
             ) -> ListTasksResult:
                 cursor = params.cursor if params else None
-                session_id = str(id(ctx.session))
+                session_id = ctx.session.session_id
                 tasks, next_cursor = await task_support.store.list_tasks(cursor, session_id=session_id)
                 return ListTasksResult(tasks=tasks, next_cursor=next_cursor)
 
@@ -199,7 +199,7 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
             async def _default_cancel_task(
                 ctx: ServerRequestContext[LifespanResultT], params: CancelTaskRequestParams
             ) -> CancelTaskResult:
-                session_id = str(id(ctx.session))
+                session_id = ctx.session.session_id
                 result = await cancel_task(task_support.store, params.task_id, session_id=session_id)
                 return result
 

--- a/src/mcp/server/lowlevel/experimental.py
+++ b/src/mcp/server/lowlevel/experimental.py
@@ -153,14 +153,15 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
         if on_cancel_task is not None:
             self._add_request_handler("tasks/cancel", on_cancel_task)
 
-        def _require_session_id(ctx: ServerRequestContext[LifespanResultT]) -> str:
-            session_id = ctx.session.session_id
-            if session_id is None:
+        def _check_stateless(ctx: ServerRequestContext[LifespanResultT]) -> None:
+            if ctx.session.stateless:
                 raise MCPError(
                     code=INVALID_PARAMS,
-                    message="Session ID is required for task operations.",
+                    message=(
+                        "Default task handlers do not support stateless mode. "
+                        "Provide custom task handlers if you need stateless task support."
+                    ),
                 )
-            return session_id
 
         # Fill in defaults for any not provided
         if not self._has_handler("tasks/get"):
@@ -168,8 +169,8 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
             async def _default_get_task(
                 ctx: ServerRequestContext[LifespanResultT], params: GetTaskRequestParams
             ) -> GetTaskResult:
-                session_id = _require_session_id(ctx)
-                task = await task_support.store.get_task(params.task_id, session_id=session_id)
+                _check_stateless(ctx)
+                task = await task_support.store.get_task(params.task_id, session_id=ctx.session.session_id)
                 if task is None:
                     raise MCPError(code=INVALID_PARAMS, message=f"Task not found: {params.task_id}")
                 return GetTaskResult(
@@ -190,9 +191,11 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
                 ctx: ServerRequestContext[LifespanResultT], params: GetTaskPayloadRequestParams
             ) -> GetTaskPayloadResult:
                 assert ctx.request_id is not None
-                session_id = _require_session_id(ctx)
+                _check_stateless(ctx)
                 req = GetTaskPayloadRequest(params=params)
-                result = await task_support.handler.handle(req, ctx.session, ctx.request_id, session_id=session_id)
+                result = await task_support.handler.handle(
+                    req, ctx.session, ctx.request_id, session_id=ctx.session.session_id
+                )
                 return result
 
             self._add_request_handler("tasks/result", _default_get_task_result)
@@ -202,9 +205,9 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
             async def _default_list_tasks(
                 ctx: ServerRequestContext[LifespanResultT], params: PaginatedRequestParams | None
             ) -> ListTasksResult:
+                _check_stateless(ctx)
                 cursor = params.cursor if params else None
-                session_id = _require_session_id(ctx)
-                tasks, next_cursor = await task_support.store.list_tasks(cursor, session_id=session_id)
+                tasks, next_cursor = await task_support.store.list_tasks(cursor, session_id=ctx.session.session_id)
                 return ListTasksResult(tasks=tasks, next_cursor=next_cursor)
 
             self._add_request_handler("tasks/list", _default_list_tasks)
@@ -214,8 +217,8 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
             async def _default_cancel_task(
                 ctx: ServerRequestContext[LifespanResultT], params: CancelTaskRequestParams
             ) -> CancelTaskResult:
-                session_id = _require_session_id(ctx)
-                result = await cancel_task(task_support.store, params.task_id, session_id=session_id)
+                _check_stateless(ctx)
+                result = await cancel_task(task_support.store, params.task_id, session_id=ctx.session.session_id)
                 return result
 
             self._add_request_handler("tasks/cancel", _default_cancel_task)

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -374,6 +374,9 @@ class Server(Generic[LifespanResultT]):
         # the initialization lifecycle, but can do so with any available node
         # rather than requiring initialization for each connection.
         stateless: bool = False,
+        # Optional session identifier for task isolation. When provided (e.g.,
+        # from the transport's mcp_session_id), tasks are bound to this ID.
+        session_id: str | None = None,
     ):
         async with AsyncExitStack() as stack:
             lifespan_context = await stack.enter_async_context(self.lifespan(self))
@@ -383,6 +386,7 @@ class Server(Generic[LifespanResultT]):
                     write_stream,
                     initialization_options,
                     stateless=stateless,
+                    session_id=session_id,
                 )
             )
 

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -374,8 +374,6 @@ class Server(Generic[LifespanResultT]):
         # the initialization lifecycle, but can do so with any available node
         # rather than requiring initialization for each connection.
         stateless: bool = False,
-        # Optional session identifier for task isolation. When provided (e.g.,
-        # from the transport's mcp_session_id), tasks are bound to this ID.
         session_id: str | None = None,
     ):
         async with AsyncExitStack() as stack:

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -83,6 +83,7 @@ class ServerSession(
         write_stream: MemoryObjectSendStream[SessionMessage],
         init_options: InitializationOptions,
         stateless: bool = False,
+        *,
         session_id: str | None = None,
     ) -> None:
         super().__init__(read_stream, write_stream)

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -83,9 +83,11 @@ class ServerSession(
         write_stream: MemoryObjectSendStream[SessionMessage],
         init_options: InitializationOptions,
         stateless: bool = False,
+        session_id: str | None = None,
     ) -> None:
         super().__init__(read_stream, write_stream)
         self._stateless = stateless
+        self.session_id = session_id
         self._initialization_state = (
             InitializationState.Initialized if stateless else InitializationState.NotInitialized
         )

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -112,6 +112,11 @@ class ServerSession(
         return self._client_params
 
     @property
+    def stateless(self) -> bool:
+        """Whether this session is in stateless mode (no persistent server-side state)."""
+        return self._stateless
+
+    @property
     def experimental(self) -> ExperimentalServerSessionFeatures:
         """Experimental APIs for server→client task operations.
 

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -172,7 +172,7 @@ class StreamableHTTPSessionManager:
                         write_stream,
                         self.app.create_initialization_options(),
                         stateless=True,
-                        session_id=http_transport.mcp_session_id,
+                        session_id=None,  # No session in stateless mode
                     )
                 except Exception:  # pragma: no cover
                     logger.exception("Stateless session crashed")

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -172,6 +172,7 @@ class StreamableHTTPSessionManager:
                         write_stream,
                         self.app.create_initialization_options(),
                         stateless=True,
+                        session_id=http_transport.mcp_session_id,
                     )
                 except Exception:  # pragma: no cover
                     logger.exception("Stateless session crashed")
@@ -240,6 +241,7 @@ class StreamableHTTPSessionManager:
                                     write_stream,
                                     self.app.create_initialization_options(),
                                     stateless=False,
+                                    session_id=http_transport.mcp_session_id,
                                 )
 
                             if idle_scope.cancelled_caught:

--- a/src/mcp/shared/experimental/tasks/context.py
+++ b/src/mcp/shared/experimental/tasks/context.py
@@ -21,7 +21,7 @@ class TaskContext:
     use ServerTaskContext from mcp.server.experimental.
 
     Example (distributed worker):
-        async def worker_job(task_id: str, session_id: str):
+        async def worker_job(task_id: str, session_id: str | None):
             store = RedisTaskStore(redis_url)
             task = await store.get_task(task_id, session_id=session_id)
             ctx = TaskContext(task=task, store=store, session_id=session_id)
@@ -31,7 +31,7 @@ class TaskContext:
             await ctx.complete(result)
     """
 
-    def __init__(self, task: Task, store: TaskStore, *, session_id: str):
+    def __init__(self, task: Task, store: TaskStore, *, session_id: str | None):
         self._task = task
         self._store = store
         self._session_id = session_id

--- a/src/mcp/shared/experimental/tasks/helpers.py
+++ b/src/mcp/shared/experimental/tasks/helpers.py
@@ -50,7 +50,8 @@ def is_terminal(status: TaskStatus) -> bool:
 async def cancel_task(
     store: TaskStore,
     task_id: str,
-    session_id: str | None = None,
+    *,
+    session_id: str,
 ) -> CancelTaskResult:
     """Cancel a task with spec-compliant validation.
 
@@ -63,7 +64,7 @@ async def cancel_task(
     Args:
         store: The task store
         task_id: The task identifier to cancel
-        session_id: Optional session identifier for access control.
+        session_id: Session identifier for access control.
 
     Returns:
         CancelTaskResult with the cancelled task state
@@ -75,7 +76,7 @@ async def cancel_task(
 
     Example:
         async def handle_cancel(ctx, params: CancelTaskRequestParams) -> CancelTaskResult:
-            return await cancel_task(store, params.task_id)
+            return await cancel_task(store, params.task_id, session_id=ctx.session.session_id)
     """
     task = await store.get_task(task_id, session_id=session_id)
     if task is None:
@@ -124,6 +125,8 @@ def create_task_state(
 async def task_execution(
     task_id: str,
     store: TaskStore,
+    *,
+    session_id: str,
 ) -> AsyncIterator[TaskContext]:
     """Context manager for safe task execution (pure, no server dependencies).
 
@@ -136,6 +139,7 @@ async def task_execution(
     Args:
         task_id: The task identifier to execute
         store: The task store (must be accessible by the worker)
+        session_id: Session identifier for access control.
 
     Yields:
         TaskContext for updating status and completing/failing the task
@@ -144,18 +148,18 @@ async def task_execution(
         ValueError: If the task is not found in the store
 
     Example (distributed worker):
-        async def worker_process(task_id: str):
+        async def worker_process(task_id: str, session_id: str):
             store = RedisTaskStore(redis_url)
-            async with task_execution(task_id, store) as ctx:
+            async with task_execution(task_id, store, session_id=session_id) as ctx:
                 await ctx.update_status("Working...")
                 result = await do_work()
                 await ctx.complete(result)
     """
-    task = await store.get_task(task_id)
+    task = await store.get_task(task_id, session_id=session_id)
     if task is None:
         raise ValueError(f"Task {task_id} not found")
 
-    ctx = TaskContext(task, store)
+    ctx = TaskContext(task, store, session_id=session_id)
     try:
         yield ctx
     except Exception as e:

--- a/src/mcp/shared/experimental/tasks/helpers.py
+++ b/src/mcp/shared/experimental/tasks/helpers.py
@@ -51,7 +51,7 @@ async def cancel_task(
     store: TaskStore,
     task_id: str,
     *,
-    session_id: str,
+    session_id: str | None,
 ) -> CancelTaskResult:
     """Cancel a task with spec-compliant validation.
 
@@ -64,7 +64,8 @@ async def cancel_task(
     Args:
         store: The task store
         task_id: The task identifier to cancel
-        session_id: Session identifier for access control.
+        session_id: Session identifier for access control. Must exactly match
+            the session_id the task was created with (including None).
 
     Returns:
         CancelTaskResult with the cancelled task state
@@ -128,7 +129,7 @@ async def task_execution(
     task_id: str,
     store: TaskStore,
     *,
-    session_id: str,
+    session_id: str | None,
 ) -> AsyncIterator[TaskContext]:
     """Context manager for safe task execution (pure, no server dependencies).
 
@@ -141,7 +142,8 @@ async def task_execution(
     Args:
         task_id: The task identifier to execute
         store: The task store (must be accessible by the worker)
-        session_id: Session identifier for access control.
+        session_id: Session identifier for access control. Must exactly match
+            the session_id the task was created with (including None).
 
     Yields:
         TaskContext for updating status and completing/failing the task
@@ -150,7 +152,7 @@ async def task_execution(
         ValueError: If the task is not found in the store
 
     Example (distributed worker):
-        async def worker_process(task_id: str, session_id: str):
+        async def worker_process(task_id: str, session_id: str | None):
             store = RedisTaskStore(redis_url)
             async with task_execution(task_id, store, session_id=session_id) as ctx:
                 await ctx.update_status("Working...")

--- a/src/mcp/shared/experimental/tasks/in_memory_task_store.py
+++ b/src/mcp/shared/experimental/tasks/in_memory_task_store.py
@@ -22,6 +22,7 @@ class StoredTask:
     """Internal storage representation of a task."""
 
     task: Task
+    session_id: str | None = None
     result: Result | None = None
     # Time when this task should be removed (None = never)
     expires_at: datetime | None = field(default=None)
@@ -32,6 +33,7 @@ class InMemoryTaskStore(TaskStore):
 
     Features:
     - Automatic TTL-based cleanup (lazy expiration)
+    - Session isolation (tasks are scoped to their creating session)
     - Thread-safe for single-process async use
     - Pagination support for list_tasks
 
@@ -66,10 +68,25 @@ class InMemoryTaskStore(TaskStore):
         for task_id in expired_ids:
             del self._tasks[task_id]
 
+    def _get_stored_task(self, task_id: str, session_id: str | None = None) -> StoredTask | None:
+        """Retrieve a stored task, enforcing session ownership when a session_id is provided.
+
+        Returns None if the task does not exist or belongs to a different session.
+        When either the caller's session_id or the stored task's session_id is None,
+        no filtering occurs (backward compatibility).
+        """
+        stored = self._tasks.get(task_id)
+        if stored is None:
+            return None
+        if session_id is not None and stored.session_id is not None and stored.session_id != session_id:
+            return None
+        return stored
+
     async def create_task(
         self,
         metadata: TaskMetadata,
         task_id: str | None = None,
+        session_id: str | None = None,
     ) -> Task:
         """Create a new task with the given metadata."""
         # Cleanup expired tasks on access
@@ -82,6 +99,7 @@ class InMemoryTaskStore(TaskStore):
 
         stored = StoredTask(
             task=task,
+            session_id=session_id,
             expires_at=self._calculate_expiry(metadata.ttl),
         )
         self._tasks[task.task_id] = stored
@@ -89,12 +107,12 @@ class InMemoryTaskStore(TaskStore):
         # Return a copy to prevent external modification
         return Task(**task.model_dump())
 
-    async def get_task(self, task_id: str) -> Task | None:
+    async def get_task(self, task_id: str, session_id: str | None = None) -> Task | None:
         """Get a task by ID."""
         # Cleanup expired tasks on access
         self._cleanup_expired()
 
-        stored = self._tasks.get(task_id)
+        stored = self._get_stored_task(task_id, session_id)
         if stored is None:
             return None
 
@@ -106,9 +124,10 @@ class InMemoryTaskStore(TaskStore):
         task_id: str,
         status: TaskStatus | None = None,
         status_message: str | None = None,
+        session_id: str | None = None,
     ) -> Task:
         """Update a task's status and/or message."""
-        stored = self._tasks.get(task_id)
+        stored = self._get_stored_task(task_id, session_id)
         if stored is None:
             raise ValueError(f"Task with ID {task_id} not found")
 
@@ -137,17 +156,17 @@ class InMemoryTaskStore(TaskStore):
 
         return Task(**stored.task.model_dump())
 
-    async def store_result(self, task_id: str, result: Result) -> None:
+    async def store_result(self, task_id: str, result: Result, session_id: str | None = None) -> None:
         """Store the result for a task."""
-        stored = self._tasks.get(task_id)
+        stored = self._get_stored_task(task_id, session_id)
         if stored is None:
             raise ValueError(f"Task with ID {task_id} not found")
 
         stored.result = result
 
-    async def get_result(self, task_id: str) -> Result | None:
+    async def get_result(self, task_id: str, session_id: str | None = None) -> Result | None:
         """Get the stored result for a task."""
-        stored = self._tasks.get(task_id)
+        stored = self._get_stored_task(task_id, session_id)
         if stored is None:
             return None
 
@@ -156,34 +175,41 @@ class InMemoryTaskStore(TaskStore):
     async def list_tasks(
         self,
         cursor: str | None = None,
+        session_id: str | None = None,
     ) -> tuple[list[Task], str | None]:
         """List tasks with pagination."""
         # Cleanup expired tasks on access
         self._cleanup_expired()
 
-        all_task_ids = list(self._tasks.keys())
+        # Filter tasks by session ownership before pagination
+        filtered_task_ids = [
+            task_id
+            for task_id, stored in self._tasks.items()
+            if session_id is None or stored.session_id is None or stored.session_id == session_id
+        ]
 
         start_index = 0
         if cursor is not None:
             try:
-                cursor_index = all_task_ids.index(cursor)
+                cursor_index = filtered_task_ids.index(cursor)
                 start_index = cursor_index + 1
             except ValueError:
                 raise ValueError(f"Invalid cursor: {cursor}")
 
-        page_task_ids = all_task_ids[start_index : start_index + self._page_size]
+        page_task_ids = filtered_task_ids[start_index : start_index + self._page_size]
         tasks = [Task(**self._tasks[tid].task.model_dump()) for tid in page_task_ids]
 
         # Determine next cursor
         next_cursor = None
-        if start_index + self._page_size < len(all_task_ids) and page_task_ids:
+        if start_index + self._page_size < len(filtered_task_ids) and page_task_ids:
             next_cursor = page_task_ids[-1]
 
         return tasks, next_cursor
 
-    async def delete_task(self, task_id: str) -> bool:
+    async def delete_task(self, task_id: str, session_id: str | None = None) -> bool:
         """Delete a task."""
-        if task_id not in self._tasks:
+        stored = self._get_stored_task(task_id, session_id)
+        if stored is None:
             return False
 
         del self._tasks[task_id]

--- a/src/mcp/shared/experimental/tasks/in_memory_task_store.py
+++ b/src/mcp/shared/experimental/tasks/in_memory_task_store.py
@@ -22,7 +22,7 @@ class StoredTask:
     """Internal storage representation of a task."""
 
     task: Task
-    session_id: str
+    session_id: str | None
     result: Result | None = None
     # Time when this task should be removed (None = never)
     expires_at: datetime | None = field(default=None)
@@ -68,10 +68,13 @@ class InMemoryTaskStore(TaskStore):
         for task_id in expired_ids:
             del self._tasks[task_id]
 
-    def _get_stored_task(self, task_id: str, *, session_id: str) -> StoredTask | None:
+    def _get_stored_task(self, task_id: str, *, session_id: str | None) -> StoredTask | None:
         """Retrieve a stored task, enforcing session ownership.
 
         Returns None if the task does not exist or belongs to a different session.
+        Isolation uses strict equality: None only matches None, so tasks created
+        by sessionless transports (stdio) are not visible to session-scoped
+        transports (HTTP) and vice versa.
         """
         stored = self._tasks.get(task_id)
         if stored is None:
@@ -85,7 +88,7 @@ class InMemoryTaskStore(TaskStore):
         metadata: TaskMetadata,
         task_id: str | None = None,
         *,
-        session_id: str,
+        session_id: str | None,
     ) -> Task:
         """Create a new task with the given metadata."""
         # Cleanup expired tasks on access
@@ -106,7 +109,7 @@ class InMemoryTaskStore(TaskStore):
         # Return a copy to prevent external modification
         return Task(**task.model_dump())
 
-    async def get_task(self, task_id: str, *, session_id: str) -> Task | None:
+    async def get_task(self, task_id: str, *, session_id: str | None) -> Task | None:
         """Get a task by ID."""
         # Cleanup expired tasks on access
         self._cleanup_expired()
@@ -124,7 +127,7 @@ class InMemoryTaskStore(TaskStore):
         status: TaskStatus | None = None,
         status_message: str | None = None,
         *,
-        session_id: str,
+        session_id: str | None,
     ) -> Task:
         """Update a task's status and/or message."""
         stored = self._get_stored_task(task_id, session_id=session_id)
@@ -156,7 +159,7 @@ class InMemoryTaskStore(TaskStore):
 
         return Task(**stored.task.model_dump())
 
-    async def store_result(self, task_id: str, result: Result, *, session_id: str) -> None:
+    async def store_result(self, task_id: str, result: Result, *, session_id: str | None) -> None:
         """Store the result for a task."""
         stored = self._get_stored_task(task_id, session_id=session_id)
         if stored is None:
@@ -164,7 +167,7 @@ class InMemoryTaskStore(TaskStore):
 
         stored.result = result
 
-    async def get_result(self, task_id: str, *, session_id: str) -> Result | None:
+    async def get_result(self, task_id: str, *, session_id: str | None) -> Result | None:
         """Get the stored result for a task."""
         stored = self._get_stored_task(task_id, session_id=session_id)
         if stored is None:
@@ -176,13 +179,14 @@ class InMemoryTaskStore(TaskStore):
         self,
         cursor: str | None = None,
         *,
-        session_id: str,
+        session_id: str | None,
     ) -> tuple[list[Task], str | None]:
         """List tasks with pagination."""
         # Cleanup expired tasks on access
         self._cleanup_expired()
 
-        # Filter tasks by session ownership before pagination
+        # Filter tasks by session ownership before pagination.
+        # Strict equality: None only matches None (sessionless transports).
         filtered_task_ids = [task_id for task_id, stored in self._tasks.items() if stored.session_id == session_id]
 
         start_index = 0
@@ -203,7 +207,7 @@ class InMemoryTaskStore(TaskStore):
 
         return tasks, next_cursor
 
-    async def delete_task(self, task_id: str, *, session_id: str) -> bool:
+    async def delete_task(self, task_id: str, *, session_id: str | None) -> bool:
         """Delete a task."""
         stored = self._get_stored_task(task_id, session_id=session_id)
         if stored is None:

--- a/src/mcp/shared/experimental/tasks/store.py
+++ b/src/mcp/shared/experimental/tasks/store.py
@@ -19,15 +19,16 @@ class TaskStore(ABC):
         self,
         metadata: TaskMetadata,
         task_id: str | None = None,
-        session_id: str | None = None,
+        *,
+        session_id: str,
     ) -> Task:
         """Create a new task.
 
         Args:
             metadata: Task metadata (ttl, etc.)
             task_id: Optional task ID. If None, implementation should generate one.
-            session_id: Optional session identifier. When provided, the task is
-                bound to this session for isolation purposes.
+            session_id: Session identifier. The task is bound to this session
+                for isolation purposes.
 
         Returns:
             The created Task with status="working"
@@ -37,12 +38,12 @@ class TaskStore(ABC):
         """
 
     @abstractmethod
-    async def get_task(self, task_id: str, session_id: str | None = None) -> Task | None:
+    async def get_task(self, task_id: str, *, session_id: str) -> Task | None:
         """Get a task by ID.
 
         Args:
             task_id: The task identifier
-            session_id: Optional session identifier for access control.
+            session_id: Session identifier for access control.
 
         Returns:
             The Task, or None if not found or not accessible by this session.
@@ -54,7 +55,8 @@ class TaskStore(ABC):
         task_id: str,
         status: TaskStatus | None = None,
         status_message: str | None = None,
-        session_id: str | None = None,
+        *,
+        session_id: str,
     ) -> Task:
         """Update a task's status and/or message.
 
@@ -62,7 +64,7 @@ class TaskStore(ABC):
             task_id: The task identifier
             status: New status (if changing)
             status_message: New status message (if changing)
-            session_id: Optional session identifier for access control.
+            session_id: Session identifier for access control.
 
         Returns:
             The updated Task
@@ -75,25 +77,25 @@ class TaskStore(ABC):
         """
 
     @abstractmethod
-    async def store_result(self, task_id: str, result: Result, session_id: str | None = None) -> None:
+    async def store_result(self, task_id: str, result: Result, *, session_id: str) -> None:
         """Store the result for a task.
 
         Args:
             task_id: The task identifier
             result: The result to store
-            session_id: Optional session identifier for access control.
+            session_id: Session identifier for access control.
 
         Raises:
             ValueError: If task not found or not accessible by this session.
         """
 
     @abstractmethod
-    async def get_result(self, task_id: str, session_id: str | None = None) -> Result | None:
+    async def get_result(self, task_id: str, *, session_id: str) -> Result | None:
         """Get the stored result for a task.
 
         Args:
             task_id: The task identifier
-            session_id: Optional session identifier for access control.
+            session_id: Session identifier for access control.
 
         Returns:
             The stored Result, or None if not available.
@@ -103,26 +105,27 @@ class TaskStore(ABC):
     async def list_tasks(
         self,
         cursor: str | None = None,
-        session_id: str | None = None,
+        *,
+        session_id: str,
     ) -> tuple[list[Task], str | None]:
         """List tasks with pagination.
 
         Args:
             cursor: Optional cursor for pagination
-            session_id: Optional session identifier. When provided, only tasks
-                belonging to this session are returned.
+            session_id: Session identifier. Only tasks belonging to this
+                session are returned.
 
         Returns:
             Tuple of (tasks, next_cursor). next_cursor is None if no more pages.
         """
 
     @abstractmethod
-    async def delete_task(self, task_id: str, session_id: str | None = None) -> bool:
+    async def delete_task(self, task_id: str, *, session_id: str) -> bool:
         """Delete a task.
 
         Args:
             task_id: The task identifier
-            session_id: Optional session identifier for access control.
+            session_id: Session identifier for access control.
 
         Returns:
             True if deleted, False if not found or not accessible by this session.

--- a/src/mcp/shared/experimental/tasks/store.py
+++ b/src/mcp/shared/experimental/tasks/store.py
@@ -20,15 +20,17 @@ class TaskStore(ABC):
         metadata: TaskMetadata,
         task_id: str | None = None,
         *,
-        session_id: str,
+        session_id: str | None,
     ) -> Task:
         """Create a new task.
 
         Args:
             metadata: Task metadata (ttl, etc.)
             task_id: Optional task ID. If None, implementation should generate one.
-            session_id: Session identifier. The task is bound to this session
-                for isolation purposes.
+            session_id: Session identifier for isolation. If None, the task is
+                not bound to a session (single-client transports like stdio).
+                If a string, the task is scoped to that session and only
+                accessible with the same session_id.
 
         Returns:
             The created Task with status="working"
@@ -38,12 +40,13 @@ class TaskStore(ABC):
         """
 
     @abstractmethod
-    async def get_task(self, task_id: str, *, session_id: str) -> Task | None:
+    async def get_task(self, task_id: str, *, session_id: str | None) -> Task | None:
         """Get a task by ID.
 
         Args:
             task_id: The task identifier
-            session_id: Session identifier for access control.
+            session_id: Session identifier for access control. Must exactly
+                match the session_id the task was created with (including None).
 
         Returns:
             The Task, or None if not found or not accessible by this session.
@@ -56,7 +59,7 @@ class TaskStore(ABC):
         status: TaskStatus | None = None,
         status_message: str | None = None,
         *,
-        session_id: str,
+        session_id: str | None,
     ) -> Task:
         """Update a task's status and/or message.
 
@@ -64,7 +67,8 @@ class TaskStore(ABC):
             task_id: The task identifier
             status: New status (if changing)
             status_message: New status message (if changing)
-            session_id: Session identifier for access control.
+            session_id: Session identifier for access control. Must exactly
+                match the session_id the task was created with (including None).
 
         Returns:
             The updated Task
@@ -77,25 +81,27 @@ class TaskStore(ABC):
         """
 
     @abstractmethod
-    async def store_result(self, task_id: str, result: Result, *, session_id: str) -> None:
+    async def store_result(self, task_id: str, result: Result, *, session_id: str | None) -> None:
         """Store the result for a task.
 
         Args:
             task_id: The task identifier
             result: The result to store
-            session_id: Session identifier for access control.
+            session_id: Session identifier for access control. Must exactly
+                match the session_id the task was created with (including None).
 
         Raises:
             ValueError: If task not found or not accessible by this session.
         """
 
     @abstractmethod
-    async def get_result(self, task_id: str, *, session_id: str) -> Result | None:
+    async def get_result(self, task_id: str, *, session_id: str | None) -> Result | None:
         """Get the stored result for a task.
 
         Args:
             task_id: The task identifier
-            session_id: Session identifier for access control.
+            session_id: Session identifier for access control. Must exactly
+                match the session_id the task was created with (including None).
 
         Returns:
             The stored Result, or None if not available.
@@ -106,26 +112,27 @@ class TaskStore(ABC):
         self,
         cursor: str | None = None,
         *,
-        session_id: str,
+        session_id: str | None,
     ) -> tuple[list[Task], str | None]:
         """List tasks with pagination.
 
         Args:
             cursor: Optional cursor for pagination
-            session_id: Session identifier. Only tasks belonging to this
-                session are returned.
+            session_id: Session identifier. Only tasks with an exactly matching
+                session_id are returned (None only matches tasks created with None).
 
         Returns:
             Tuple of (tasks, next_cursor). next_cursor is None if no more pages.
         """
 
     @abstractmethod
-    async def delete_task(self, task_id: str, *, session_id: str) -> bool:
+    async def delete_task(self, task_id: str, *, session_id: str | None) -> bool:
         """Delete a task.
 
         Args:
             task_id: The task identifier
-            session_id: Session identifier for access control.
+            session_id: Session identifier for access control. Must exactly
+                match the session_id the task was created with (including None).
 
         Returns:
             True if deleted, False if not found or not accessible by this session.

--- a/tests/experimental/tasks/server/test_run_task_flow.py
+++ b/tests/experimental/tasks/server/test_run_task_flow.py
@@ -369,12 +369,13 @@ async def test_run_task_doesnt_fail_if_already_terminal() -> None:
 
 
 @pytest.mark.anyio
-async def test_run_task_without_session_id_raises() -> None:
-    """Test that run_task raises when session has no session_id."""
+async def test_run_task_in_stateless_mode_raises() -> None:
+    """Test that run_task raises when the session is in stateless mode."""
     task_support = TaskSupport.in_memory()
 
     mock_session = Mock()
     mock_session.session_id = None
+    mock_session.stateless = True
 
     experimental = Experimental(
         task_metadata=TaskMetadata(ttl=60000),
@@ -387,5 +388,5 @@ async def test_run_task_without_session_id_raises() -> None:
         raise NotImplementedError
 
     async with task_support.run():
-        with pytest.raises(RuntimeError, match="Session ID is required"):
+        with pytest.raises(RuntimeError, match="does not support stateless mode"):
             await experimental.run_task(work)

--- a/tests/experimental/tasks/server/test_server.py
+++ b/tests/experimental/tasks/server/test_server.py
@@ -340,6 +340,7 @@ async def test_default_task_handlers_via_enable_tasks() -> None:
                         experimental_capabilities={},
                     ),
                 ),
+                session_id="test-session",
             ) as server_session:
                 task_support.configure_session(server_session)
                 async for message in server_session.incoming_messages:
@@ -356,7 +357,7 @@ async def test_default_task_handlers_via_enable_tasks() -> None:
             await client_session.initialize()
 
             # Create a task directly in the store for testing
-            task = await store.create_task(TaskMetadata(ttl=60000))
+            task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
             # Test list_tasks (default handler)
             list_result = await client_session.experimental.list_tasks()
@@ -373,11 +374,13 @@ async def test_default_task_handlers_via_enable_tasks() -> None:
                 await client_session.experimental.get_task("nonexistent-task")
 
             # Create a completed task to test get_task_result
-            completed_task = await store.create_task(TaskMetadata(ttl=60000))
+            completed_task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
             await store.store_result(
-                completed_task.task_id, CallToolResult(content=[TextContent(type="text", text="Test result")])
+                completed_task.task_id,
+                CallToolResult(content=[TextContent(type="text", text="Test result")]),
+                session_id="test-session",
             )
-            await store.update_task(completed_task.task_id, status="completed")
+            await store.update_task(completed_task.task_id, status="completed", session_id="test-session")
 
             # Test get_task_result (default handler)
             payload_result = await client_session.send_request(

--- a/tests/experimental/tasks/server/test_server.py
+++ b/tests/experimental/tasks/server/test_server.py
@@ -400,9 +400,13 @@ async def test_default_task_handlers_via_enable_tasks() -> None:
 
 
 @pytest.mark.anyio
-async def test_default_task_handlers_require_session_id() -> None:
-    """Test that default task handlers reject requests when session has no session_id."""
-    server = Server("test-no-session-id")
+async def test_default_task_handlers_reject_stateless_mode() -> None:
+    """Test that default task handlers reject requests in stateless mode.
+
+    Task operations require a persistent session for result retrieval; stateless
+    mode creates a fresh session per request, so tasks cannot survive across requests.
+    """
+    server = Server("test-stateless")
     server.experimental.enable_tasks()
 
     server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](10)
@@ -424,8 +428,8 @@ async def test_default_task_handlers_require_session_id() -> None:
                     experimental_capabilities={},
                 ),
             ),
+            stateless=True,
         ) as server_session:
-            # session_id is None (no session_id passed)
             async for message in server_session.incoming_messages:
                 await server._handle_message(message, server_session, {}, False)
 
@@ -439,8 +443,7 @@ async def test_default_task_handlers_require_session_id() -> None:
         ) as client_session:
             await client_session.initialize()
 
-            # All default task handlers should fail with "Session ID is required"
-            with pytest.raises(MCPError, match="Session ID is required"):
+            with pytest.raises(MCPError, match="do not support stateless mode"):
                 await client_session.experimental.list_tasks()
 
             tg.cancel_scope.cancel()

--- a/tests/experimental/tasks/server/test_server_task_context.py
+++ b/tests/experimental/tasks/server/test_server_task_context.py
@@ -725,3 +725,19 @@ async def test_create_message_as_task_raises_without_handler() -> None:
         )
 
     store.cleanup()
+
+
+@pytest.mark.anyio
+async def test_server_task_context_requires_session_id() -> None:
+    """Test that ServerTaskContext raises when session has no session_id."""
+    store = InMemoryTaskStore()
+    queue = InMemoryTaskMessageQueue()
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
+
+    mock_session = Mock()
+    mock_session.session_id = None
+
+    with pytest.raises(RuntimeError, match="Session ID is required for task operations"):
+        ServerTaskContext(task=task, store=store, session=mock_session, queue=queue)
+
+    store.cleanup()

--- a/tests/experimental/tasks/server/test_server_task_context.py
+++ b/tests/experimental/tasks/server/test_server_task_context.py
@@ -34,8 +34,9 @@ async def test_server_task_context_properties() -> None:
     """Test ServerTaskContext property accessors."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000), task_id="test-123")
+    task = await store.create_task(TaskMetadata(ttl=60000), task_id="test-123", session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -56,8 +57,9 @@ async def test_server_task_context_request_cancellation() -> None:
     """Test ServerTaskContext.request_cancellation()."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -78,9 +80,10 @@ async def test_server_task_context_update_status_with_notify() -> None:
     """Test update_status sends notification when notify=True."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.send_notification = AsyncMock()
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -100,9 +103,10 @@ async def test_server_task_context_update_status_without_notify() -> None:
     """Test update_status skips notification when notify=False."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.send_notification = AsyncMock()
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -122,9 +126,10 @@ async def test_server_task_context_complete_with_notify() -> None:
     """Test complete sends notification when notify=True."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.send_notification = AsyncMock()
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -145,9 +150,10 @@ async def test_server_task_context_fail_with_notify() -> None:
     """Test fail sends notification when notify=True."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.send_notification = AsyncMock()
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -167,10 +173,11 @@ async def test_elicit_raises_when_client_lacks_capability() -> None:
     """Test that elicit() raises MCPError when client doesn't support elicitation."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=False)
     queue = InMemoryTaskMessageQueue()
     handler = TaskResultHandler(store, queue)
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -193,10 +200,11 @@ async def test_create_message_raises_when_client_lacks_capability() -> None:
     """Test that create_message() raises MCPError when client doesn't support sampling."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=False)
     queue = InMemoryTaskMessageQueue()
     handler = TaskResultHandler(store, queue)
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -219,9 +227,10 @@ async def test_elicit_raises_without_handler() -> None:
     """Test that elicit() raises when handler is not provided."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -242,9 +251,10 @@ async def test_elicit_url_raises_without_handler() -> None:
     """Test that elicit_url() raises when handler is not provided."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -269,9 +279,10 @@ async def test_create_message_raises_without_handler() -> None:
     """Test that create_message() raises when handler is not provided."""
     store = InMemoryTaskStore()
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     ctx = ServerTaskContext(
         task=task,
@@ -293,9 +304,10 @@ async def test_elicit_queues_request_and_waits_for_response() -> None:
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
     handler = TaskResultHandler(store, queue)
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     mock_session._build_elicit_form_request = Mock(
         return_value=JSONRPCRequest(
@@ -330,7 +342,7 @@ async def test_elicit_queues_request_and_waits_for_response() -> None:
         await queue.wait_for_message(task.task_id)
 
         # Verify task is in input_required status
-        updated_task = await store.get_task(task.task_id)
+        updated_task = await store.get_task(task.task_id, session_id="test-session")
         assert updated_task is not None
         assert updated_task.status == "input_required"
 
@@ -348,7 +360,7 @@ async def test_elicit_queues_request_and_waits_for_response() -> None:
     assert elicit_result.content == {"name": "Alice"}
 
     # Verify task is back to working
-    final_task = await store.get_task(task.task_id)
+    final_task = await store.get_task(task.task_id, session_id="test-session")
     assert final_task is not None
     assert final_task.status == "working"
 
@@ -361,9 +373,10 @@ async def test_elicit_url_queues_request_and_waits_for_response() -> None:
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
     handler = TaskResultHandler(store, queue)
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     mock_session._build_elicit_url_request = Mock(
         return_value=JSONRPCRequest(
@@ -399,7 +412,7 @@ async def test_elicit_url_queues_request_and_waits_for_response() -> None:
         await queue.wait_for_message(task.task_id)
 
         # Verify task is in input_required status
-        updated_task = await store.get_task(task.task_id)
+        updated_task = await store.get_task(task.task_id, session_id="test-session")
         assert updated_task is not None
         assert updated_task.status == "input_required"
 
@@ -416,7 +429,7 @@ async def test_elicit_url_queues_request_and_waits_for_response() -> None:
     assert elicit_result.action == "accept"
 
     # Verify task is back to working
-    final_task = await store.get_task(task.task_id)
+    final_task = await store.get_task(task.task_id, session_id="test-session")
     assert final_task is not None
     assert final_task.status == "working"
 
@@ -429,9 +442,10 @@ async def test_create_message_queues_request_and_waits_for_response() -> None:
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
     handler = TaskResultHandler(store, queue)
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     mock_session._build_create_message_request = Mock(
         return_value=JSONRPCRequest(
@@ -466,7 +480,7 @@ async def test_create_message_queues_request_and_waits_for_response() -> None:
         await queue.wait_for_message(task.task_id)
 
         # Verify task is in input_required status
-        updated_task = await store.get_task(task.task_id)
+        updated_task = await store.get_task(task.task_id, session_id="test-session")
         assert updated_task is not None
         assert updated_task.status == "input_required"
 
@@ -491,7 +505,7 @@ async def test_create_message_queues_request_and_waits_for_response() -> None:
     assert sampling_result.model == "test-model"
 
     # Verify task is back to working
-    final_task = await store.get_task(task.task_id)
+    final_task = await store.get_task(task.task_id, session_id="test-session")
     assert final_task is not None
     assert final_task.status == "working"
 
@@ -504,9 +518,10 @@ async def test_elicit_restores_status_on_cancellation() -> None:
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
     handler = TaskResultHandler(store, queue)
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     mock_session._build_elicit_form_request = Mock(
         return_value=JSONRPCRequest(
@@ -546,7 +561,7 @@ async def test_elicit_restores_status_on_cancellation() -> None:
         await queue.wait_for_message(task.task_id)
 
         # Verify task is in input_required status
-        updated_task = await store.get_task(task.task_id)
+        updated_task = await store.get_task(task.task_id, session_id="test-session")
         assert updated_task is not None
         assert updated_task.status == "input_required"
 
@@ -559,7 +574,7 @@ async def test_elicit_restores_status_on_cancellation() -> None:
         msg.resolver.set_exception(asyncio.CancelledError())
 
     # Verify task is back to working after cancellation
-    final_task = await store.get_task(task.task_id)
+    final_task = await store.get_task(task.task_id, session_id="test-session")
     assert final_task is not None
     assert final_task.status == "working"
     assert cancelled_error_raised
@@ -573,9 +588,10 @@ async def test_create_message_restores_status_on_cancellation() -> None:
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
     handler = TaskResultHandler(store, queue)
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.check_client_capability = Mock(return_value=True)
     mock_session._build_create_message_request = Mock(
         return_value=JSONRPCRequest(
@@ -615,7 +631,7 @@ async def test_create_message_restores_status_on_cancellation() -> None:
         await queue.wait_for_message(task.task_id)
 
         # Verify task is in input_required status
-        updated_task = await store.get_task(task.task_id)
+        updated_task = await store.get_task(task.task_id, session_id="test-session")
         assert updated_task is not None
         assert updated_task.status == "input_required"
 
@@ -628,7 +644,7 @@ async def test_create_message_restores_status_on_cancellation() -> None:
         msg.resolver.set_exception(asyncio.CancelledError())
 
     # Verify task is back to working after cancellation
-    final_task = await store.get_task(task.task_id)
+    final_task = await store.get_task(task.task_id, session_id="test-session")
     assert final_task is not None
     assert final_task.status == "working"
     assert cancelled_error_raised
@@ -641,10 +657,11 @@ async def test_elicit_as_task_raises_without_handler() -> None:
     """Test that elicit_as_task() raises when handler is not provided."""
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     # Create mock session with proper client capabilities
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.client_params = InitializeRequestParams(
         protocol_version="2025-01-01",
         capabilities=ClientCapabilities(
@@ -676,10 +693,11 @@ async def test_create_message_as_task_raises_without_handler() -> None:
     """Test that create_message_as_task() raises when handler is not provided."""
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000))
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
 
     # Create mock session with proper client capabilities
     mock_session = Mock()
+    mock_session.session_id = "test-session"
     mock_session.client_params = InitializeRequestParams(
         protocol_version="2025-01-01",
         capabilities=ClientCapabilities(

--- a/tests/experimental/tasks/server/test_server_task_context.py
+++ b/tests/experimental/tasks/server/test_server_task_context.py
@@ -728,16 +728,21 @@ async def test_create_message_as_task_raises_without_handler() -> None:
 
 
 @pytest.mark.anyio
-async def test_server_task_context_requires_session_id() -> None:
-    """Test that ServerTaskContext raises when session has no session_id."""
+async def test_server_task_context_accepts_none_session_id() -> None:
+    """Test that ServerTaskContext works with session_id=None (sessionless transports like stdio)."""
     store = InMemoryTaskStore()
     queue = InMemoryTaskMessageQueue()
-    task = await store.create_task(TaskMetadata(ttl=60000), session_id="test-session")
+    task = await store.create_task(TaskMetadata(ttl=60000), session_id=None)
 
     mock_session = Mock()
     mock_session.session_id = None
+    mock_session.send_notification = AsyncMock()
 
-    with pytest.raises(RuntimeError, match="Session ID is required for task operations"):
-        ServerTaskContext(task=task, store=store, session=mock_session, queue=queue)
+    ctx = ServerTaskContext(task=task, store=store, session=mock_session, queue=queue)
+    await ctx.update_status("Working...")
+
+    retrieved = await store.get_task(task.task_id, session_id=None)
+    assert retrieved is not None
+    assert retrieved.status_message == "Working..."
 
     store.cleanup()

--- a/tests/experimental/tasks/server/test_store.py
+++ b/tests/experimental/tasks/server/test_store.py
@@ -22,13 +22,13 @@ async def store() -> AsyncIterator[InMemoryTaskStore]:
 @pytest.mark.anyio
 async def test_create_and_get(store: InMemoryTaskStore) -> None:
     """Test InMemoryTaskStore create and get operations."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
     assert task.task_id is not None
     assert task.status == "working"
     assert task.ttl == 60000
 
-    retrieved = await store.get_task(task.task_id)
+    retrieved = await store.get_task(task.task_id, session_id="test-session")
     assert retrieved is not None
     assert retrieved.task_id == task.task_id
     assert retrieved.status == "working"
@@ -40,12 +40,13 @@ async def test_create_with_custom_id(store: InMemoryTaskStore) -> None:
     task = await store.create_task(
         metadata=TaskMetadata(ttl=60000),
         task_id="my-custom-id",
+        session_id="test-session",
     )
 
     assert task.task_id == "my-custom-id"
     assert task.status == "working"
 
-    retrieved = await store.get_task("my-custom-id")
+    retrieved = await store.get_task("my-custom-id", session_id="test-session")
     assert retrieved is not None
     assert retrieved.task_id == "my-custom-id"
 
@@ -53,30 +54,32 @@ async def test_create_with_custom_id(store: InMemoryTaskStore) -> None:
 @pytest.mark.anyio
 async def test_create_duplicate_id_raises(store: InMemoryTaskStore) -> None:
     """Test that creating a task with duplicate ID raises."""
-    await store.create_task(metadata=TaskMetadata(ttl=60000), task_id="duplicate")
+    await store.create_task(metadata=TaskMetadata(ttl=60000), task_id="duplicate", session_id="test-session")
 
     with pytest.raises(ValueError, match="already exists"):
-        await store.create_task(metadata=TaskMetadata(ttl=60000), task_id="duplicate")
+        await store.create_task(metadata=TaskMetadata(ttl=60000), task_id="duplicate", session_id="test-session")
 
 
 @pytest.mark.anyio
 async def test_get_nonexistent_returns_none(store: InMemoryTaskStore) -> None:
     """Test that getting a nonexistent task returns None."""
-    retrieved = await store.get_task("nonexistent")
+    retrieved = await store.get_task("nonexistent", session_id="test-session")
     assert retrieved is None
 
 
 @pytest.mark.anyio
 async def test_update_status(store: InMemoryTaskStore) -> None:
     """Test InMemoryTaskStore status updates."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
-    updated = await store.update_task(task.task_id, status="completed", status_message="All done!")
+    updated = await store.update_task(
+        task.task_id, status="completed", status_message="All done!", session_id="test-session"
+    )
 
     assert updated.status == "completed"
     assert updated.status_message == "All done!"
 
-    retrieved = await store.get_task(task.task_id)
+    retrieved = await store.get_task(task.task_id, session_id="test-session")
     assert retrieved is not None
     assert retrieved.status == "completed"
     assert retrieved.status_message == "All done!"
@@ -86,35 +89,35 @@ async def test_update_status(store: InMemoryTaskStore) -> None:
 async def test_update_nonexistent_raises(store: InMemoryTaskStore) -> None:
     """Test that updating a nonexistent task raises."""
     with pytest.raises(ValueError, match="not found"):
-        await store.update_task("nonexistent", status="completed")
+        await store.update_task("nonexistent", status="completed", session_id="test-session")
 
 
 @pytest.mark.anyio
 async def test_store_and_get_result(store: InMemoryTaskStore) -> None:
     """Test InMemoryTaskStore result storage and retrieval."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
     # Store result
     result = CallToolResult(content=[TextContent(type="text", text="Result data")])
-    await store.store_result(task.task_id, result)
+    await store.store_result(task.task_id, result, session_id="test-session")
 
     # Retrieve result
-    retrieved_result = await store.get_result(task.task_id)
+    retrieved_result = await store.get_result(task.task_id, session_id="test-session")
     assert retrieved_result == result
 
 
 @pytest.mark.anyio
 async def test_get_result_nonexistent_returns_none(store: InMemoryTaskStore) -> None:
     """Test that getting result for nonexistent task returns None."""
-    result = await store.get_result("nonexistent")
+    result = await store.get_result("nonexistent", session_id="test-session")
     assert result is None
 
 
 @pytest.mark.anyio
 async def test_get_result_no_result_returns_none(store: InMemoryTaskStore) -> None:
     """Test that getting result when none stored returns None."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
-    result = await store.get_result(task.task_id)
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
+    result = await store.get_result(task.task_id, session_id="test-session")
     assert result is None
 
 
@@ -123,9 +126,9 @@ async def test_list_tasks(store: InMemoryTaskStore) -> None:
     """Test InMemoryTaskStore list operation."""
     # Create multiple tasks
     for _ in range(3):
-        await store.create_task(metadata=TaskMetadata(ttl=60000))
+        await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
-    tasks, next_cursor = await store.list_tasks()
+    tasks, next_cursor = await store.list_tasks(session_id="test-session")
     assert len(tasks) == 3
     assert next_cursor is None  # Less than page size
 
@@ -138,20 +141,20 @@ async def test_list_tasks_pagination() -> None:
 
     # Create 5 tasks
     for _ in range(5):
-        await store.create_task(metadata=TaskMetadata(ttl=60000))
+        await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
     # First page
-    tasks, next_cursor = await store.list_tasks()
+    tasks, next_cursor = await store.list_tasks(session_id="test-session")
     assert len(tasks) == 2
     assert next_cursor is not None
 
     # Second page
-    tasks, next_cursor = await store.list_tasks(cursor=next_cursor)
+    tasks, next_cursor = await store.list_tasks(cursor=next_cursor, session_id="test-session")
     assert len(tasks) == 2
     assert next_cursor is not None
 
     # Third page (last)
-    tasks, next_cursor = await store.list_tasks(cursor=next_cursor)
+    tasks, next_cursor = await store.list_tasks(cursor=next_cursor, session_id="test-session")
     assert len(tasks) == 1
     assert next_cursor is None
 
@@ -161,33 +164,33 @@ async def test_list_tasks_pagination() -> None:
 @pytest.mark.anyio
 async def test_list_tasks_invalid_cursor(store: InMemoryTaskStore) -> None:
     """Test that invalid cursor raises."""
-    await store.create_task(metadata=TaskMetadata(ttl=60000))
+    await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
     with pytest.raises(ValueError, match="Invalid cursor"):
-        await store.list_tasks(cursor="invalid-cursor")
+        await store.list_tasks(cursor="invalid-cursor", session_id="test-session")
 
 
 @pytest.mark.anyio
 async def test_delete_task(store: InMemoryTaskStore) -> None:
     """Test InMemoryTaskStore delete operation."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
-    deleted = await store.delete_task(task.task_id)
+    deleted = await store.delete_task(task.task_id, session_id="test-session")
     assert deleted is True
 
-    retrieved = await store.get_task(task.task_id)
+    retrieved = await store.get_task(task.task_id, session_id="test-session")
     assert retrieved is None
 
     # Delete non-existent
-    deleted = await store.delete_task(task.task_id)
+    deleted = await store.delete_task(task.task_id, session_id="test-session")
     assert deleted is False
 
 
 @pytest.mark.anyio
 async def test_get_all_tasks_helper(store: InMemoryTaskStore) -> None:
     """Test the get_all_tasks debugging helper."""
-    await store.create_task(metadata=TaskMetadata(ttl=60000))
-    await store.create_task(metadata=TaskMetadata(ttl=60000))
+    await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
+    await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
     all_tasks = store.get_all_tasks()
     assert len(all_tasks) == 2
@@ -199,18 +202,18 @@ async def test_store_result_nonexistent_raises(store: InMemoryTaskStore) -> None
     result = CallToolResult(content=[TextContent(type="text", text="Result")])
 
     with pytest.raises(ValueError, match="not found"):
-        await store.store_result("nonexistent-id", result)
+        await store.store_result("nonexistent-id", result, session_id="test-session")
 
 
 @pytest.mark.anyio
 async def test_create_task_with_null_ttl(store: InMemoryTaskStore) -> None:
     """Test creating task with null TTL (never expires)."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=None))
+    task = await store.create_task(metadata=TaskMetadata(ttl=None), session_id="test-session")
 
     assert task.ttl is None
 
     # Task should persist (not expire)
-    retrieved = await store.get_task(task.task_id)
+    retrieved = await store.get_task(task.task_id, session_id="test-session")
     assert retrieved is not None
 
 
@@ -218,7 +221,7 @@ async def test_create_task_with_null_ttl(store: InMemoryTaskStore) -> None:
 async def test_task_expiration_cleanup(store: InMemoryTaskStore) -> None:
     """Test that expired tasks are cleaned up lazily."""
     # Create a task with very short TTL
-    task = await store.create_task(metadata=TaskMetadata(ttl=1))  # 1ms TTL
+    task = await store.create_task(metadata=TaskMetadata(ttl=1), session_id="test-session")  # 1ms TTL
 
     # Manually force the expiry to be in the past
     stored = store._tasks.get(task.task_id)
@@ -230,7 +233,7 @@ async def test_task_expiration_cleanup(store: InMemoryTaskStore) -> None:
 
     # Any access operation should clean up expired tasks
     # list_tasks triggers cleanup
-    tasks, _ = await store.list_tasks()
+    tasks, _ = await store.list_tasks(session_id="test-session")
 
     # Expired task should be cleaned up
     assert task.task_id not in store._tasks
@@ -241,7 +244,7 @@ async def test_task_expiration_cleanup(store: InMemoryTaskStore) -> None:
 async def test_task_with_null_ttl_never_expires(store: InMemoryTaskStore) -> None:
     """Test that tasks with null TTL never expire during cleanup."""
     # Create task with null TTL
-    task = await store.create_task(metadata=TaskMetadata(ttl=None))
+    task = await store.create_task(metadata=TaskMetadata(ttl=None), session_id="test-session")
 
     # Verify internal storage has no expiry
     stored = store._tasks.get(task.task_id)
@@ -249,12 +252,12 @@ async def test_task_with_null_ttl_never_expires(store: InMemoryTaskStore) -> Non
     assert stored.expires_at is None
 
     # Access operations should NOT remove this task
-    await store.list_tasks()
-    await store.get_task(task.task_id)
+    await store.list_tasks(session_id="test-session")
+    await store.get_task(task.task_id, session_id="test-session")
 
     # Task should still exist
     assert task.task_id in store._tasks
-    retrieved = await store.get_task(task.task_id)
+    retrieved = await store.get_task(task.task_id, session_id="test-session")
     assert retrieved is not None
 
 
@@ -262,7 +265,7 @@ async def test_task_with_null_ttl_never_expires(store: InMemoryTaskStore) -> Non
 async def test_terminal_task_ttl_reset(store: InMemoryTaskStore) -> None:
     """Test that TTL is reset when task enters terminal state."""
     # Create task with short TTL
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))  # 60s
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")  # 60s
 
     # Get the initial expiry
     stored = store._tasks.get(task.task_id)
@@ -271,7 +274,7 @@ async def test_terminal_task_ttl_reset(store: InMemoryTaskStore) -> None:
     assert initial_expiry is not None
 
     # Update to terminal state (completed)
-    await store.update_task(task.task_id, status="completed")
+    await store.update_task(task.task_id, status="completed", session_id="test-session")
 
     # Expiry should be reset to a new time (from now + TTL)
     new_expiry = stored.expires_at
@@ -288,19 +291,19 @@ async def test_terminal_status_transition_rejected(store: InMemoryTaskStore) -> 
     """
     # Test each terminal status
     for terminal_status in ("completed", "failed", "cancelled"):
-        task = await store.create_task(metadata=TaskMetadata(ttl=60000))
+        task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
 
         # Move to terminal state
-        await store.update_task(task.task_id, status=terminal_status)
+        await store.update_task(task.task_id, status=terminal_status, session_id="test-session")
 
         # Attempting to transition to any other status should raise
         with pytest.raises(ValueError, match="Cannot transition from terminal status"):
-            await store.update_task(task.task_id, status="working")
+            await store.update_task(task.task_id, status="working", session_id="test-session")
 
         # Also test transitioning to another terminal state
         other_terminal = "failed" if terminal_status != "failed" else "completed"
         with pytest.raises(ValueError, match="Cannot transition from terminal status"):
-            await store.update_task(task.task_id, status=other_terminal)
+            await store.update_task(task.task_id, status=other_terminal, session_id="test-session")
 
 
 @pytest.mark.anyio
@@ -309,15 +312,15 @@ async def test_terminal_status_allows_same_status(store: InMemoryTaskStore) -> N
 
     This is not a transition, so it should be allowed (no-op).
     """
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
-    await store.update_task(task.task_id, status="completed")
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
+    await store.update_task(task.task_id, status="completed", session_id="test-session")
 
     # Setting the same status should not raise
-    updated = await store.update_task(task.task_id, status="completed")
+    updated = await store.update_task(task.task_id, status="completed", session_id="test-session")
     assert updated.status == "completed"
 
     # Updating just the message should also work
-    updated = await store.update_task(task.task_id, status_message="Updated message")
+    updated = await store.update_task(task.task_id, status_message="Updated message", session_id="test-session")
     assert updated.status_message == "Updated message"
 
 
@@ -331,16 +334,16 @@ async def test_wait_for_update_nonexistent_raises(store: InMemoryTaskStore) -> N
 @pytest.mark.anyio
 async def test_cancel_task_succeeds_for_working_task(store: InMemoryTaskStore) -> None:
     """Test cancel_task helper succeeds for a working task."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
     assert task.status == "working"
 
-    result = await cancel_task(store, task.task_id)
+    result = await cancel_task(store, task.task_id, session_id="test-session")
 
     assert result.task_id == task.task_id
     assert result.status == "cancelled"
 
     # Verify store is updated
-    retrieved = await store.get_task(task.task_id)
+    retrieved = await store.get_task(task.task_id, session_id="test-session")
     assert retrieved is not None
     assert retrieved.status == "cancelled"
 
@@ -349,7 +352,7 @@ async def test_cancel_task_succeeds_for_working_task(store: InMemoryTaskStore) -
 async def test_cancel_task_rejects_nonexistent_task(store: InMemoryTaskStore) -> None:
     """Test cancel_task raises MCPError with INVALID_PARAMS for nonexistent task."""
     with pytest.raises(MCPError) as exc_info:
-        await cancel_task(store, "nonexistent-task-id")
+        await cancel_task(store, "nonexistent-task-id", session_id="test-session")
 
     assert exc_info.value.error.code == INVALID_PARAMS
     assert "not found" in exc_info.value.error.message
@@ -358,11 +361,11 @@ async def test_cancel_task_rejects_nonexistent_task(store: InMemoryTaskStore) ->
 @pytest.mark.anyio
 async def test_cancel_task_rejects_completed_task(store: InMemoryTaskStore) -> None:
     """Test cancel_task raises MCPError with INVALID_PARAMS for completed task."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
-    await store.update_task(task.task_id, status="completed")
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
+    await store.update_task(task.task_id, status="completed", session_id="test-session")
 
     with pytest.raises(MCPError) as exc_info:
-        await cancel_task(store, task.task_id)
+        await cancel_task(store, task.task_id, session_id="test-session")
 
     assert exc_info.value.error.code == INVALID_PARAMS
     assert "terminal state 'completed'" in exc_info.value.error.message
@@ -371,11 +374,11 @@ async def test_cancel_task_rejects_completed_task(store: InMemoryTaskStore) -> N
 @pytest.mark.anyio
 async def test_cancel_task_rejects_failed_task(store: InMemoryTaskStore) -> None:
     """Test cancel_task raises MCPError with INVALID_PARAMS for failed task."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
-    await store.update_task(task.task_id, status="failed")
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
+    await store.update_task(task.task_id, status="failed", session_id="test-session")
 
     with pytest.raises(MCPError) as exc_info:
-        await cancel_task(store, task.task_id)
+        await cancel_task(store, task.task_id, session_id="test-session")
 
     assert exc_info.value.error.code == INVALID_PARAMS
     assert "terminal state 'failed'" in exc_info.value.error.message
@@ -384,11 +387,11 @@ async def test_cancel_task_rejects_failed_task(store: InMemoryTaskStore) -> None
 @pytest.mark.anyio
 async def test_cancel_task_rejects_already_cancelled_task(store: InMemoryTaskStore) -> None:
     """Test cancel_task raises MCPError with INVALID_PARAMS for already cancelled task."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
-    await store.update_task(task.task_id, status="cancelled")
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
+    await store.update_task(task.task_id, status="cancelled", session_id="test-session")
 
     with pytest.raises(MCPError) as exc_info:
-        await cancel_task(store, task.task_id)
+        await cancel_task(store, task.task_id, session_id="test-session")
 
     assert exc_info.value.error.code == INVALID_PARAMS
     assert "terminal state 'cancelled'" in exc_info.value.error.message
@@ -397,10 +400,10 @@ async def test_cancel_task_rejects_already_cancelled_task(store: InMemoryTaskSto
 @pytest.mark.anyio
 async def test_cancel_task_succeeds_for_input_required_task(store: InMemoryTaskStore) -> None:
     """Test cancel_task helper succeeds for a task in input_required status."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
-    await store.update_task(task.task_id, status="input_required")
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="test-session")
+    await store.update_task(task.task_id, status="input_required", session_id="test-session")
 
-    result = await cancel_task(store, task.task_id)
+    result = await cancel_task(store, task.task_id, session_id="test-session")
 
     assert result.task_id == task.task_id
     assert result.status == "cancelled"
@@ -493,26 +496,6 @@ async def test_list_only_tasks_belonging_to_requesting_session(store: InMemoryTa
 
     tasks_b, _ = await store.list_tasks(session_id="session-b")
     assert len(tasks_b) == 1
-
-
-@pytest.mark.anyio
-async def test_no_session_id_allows_access_backward_compat(store: InMemoryTaskStore) -> None:
-    """Test backward compatibility: no session_id on read allows access to all tasks."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="session-a")
-
-    # No session_id on read = no filtering
-    retrieved = await store.get_task(task.task_id)
-    assert retrieved is not None
-
-
-@pytest.mark.anyio
-async def test_task_created_without_session_id_accessible_by_any_session(store: InMemoryTaskStore) -> None:
-    """Test that tasks created without session_id are accessible by any session."""
-    task = await store.create_task(metadata=TaskMetadata(ttl=60000))
-
-    # Any session_id on read should still see the task
-    retrieved = await store.get_task(task.task_id, session_id="session-b")
-    assert retrieved is not None
 
 
 @pytest.mark.anyio

--- a/tests/experimental/tasks/server/test_store.py
+++ b/tests/experimental/tasks/server/test_store.py
@@ -541,3 +541,76 @@ async def test_cancel_task_with_session_isolation(store: InMemoryTaskStore) -> N
     # session-a should be able to cancel its own task
     result = await cancel_task(store, task.task_id, session_id="session-a")
     assert result.status == "cancelled"
+
+
+# --- None session_id (sessionless transports like stdio) ---
+
+
+@pytest.mark.anyio
+async def test_none_session_id_can_access_own_tasks(store: InMemoryTaskStore) -> None:
+    """Test that a None session_id (sessionless transport) can access tasks it created.
+
+    This verifies stdio/memory transports work: they have no session concept, so
+    they create and retrieve tasks with session_id=None.
+    """
+    task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id=None)
+
+    retrieved = await store.get_task(task.task_id, session_id=None)
+    assert retrieved is not None
+    assert retrieved.task_id == task.task_id
+
+    tasks, _ = await store.list_tasks(session_id=None)
+    assert len(tasks) == 1
+    assert tasks[0].task_id == task.task_id
+
+
+@pytest.mark.anyio
+async def test_none_session_cannot_read_session_scoped_task(store: InMemoryTaskStore) -> None:
+    """Test that a None session_id cannot read tasks created with a real session_id.
+
+    Strict equality isolation: a sessionless client (stdio) cannot see tasks
+    created by a session-scoped client (HTTP), even when sharing a store.
+    """
+    http_task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="http-session-1")
+
+    assert await store.get_task(http_task.task_id, session_id=None) is None
+    assert await store.get_result(http_task.task_id, session_id=None) is None
+    assert await store.delete_task(http_task.task_id, session_id=None) is False
+
+    tasks, _ = await store.list_tasks(session_id=None)
+    assert len(tasks) == 0
+
+
+@pytest.mark.anyio
+async def test_session_cannot_read_none_session_task(store: InMemoryTaskStore) -> None:
+    """Test that a real session_id cannot read tasks created with session_id=None.
+
+    Strict equality isolation: an HTTP session cannot see tasks created by a
+    sessionless client (stdio), closing the gap present in the TypeScript SDK.
+    """
+    stdio_task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id=None)
+
+    assert await store.get_task(stdio_task.task_id, session_id="http-session-1") is None
+    assert await store.get_result(stdio_task.task_id, session_id="http-session-1") is None
+    assert await store.delete_task(stdio_task.task_id, session_id="http-session-1") is False
+
+    tasks, _ = await store.list_tasks(session_id="http-session-1")
+    assert len(tasks) == 0
+
+
+@pytest.mark.anyio
+async def test_none_and_session_scoped_tasks_coexist(store: InMemoryTaskStore) -> None:
+    """Test that None-session and session-scoped tasks coexist without leaking."""
+    stdio_task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id=None)
+    http_a_task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="http-a")
+    http_b_task = await store.create_task(metadata=TaskMetadata(ttl=60000), session_id="http-b")
+
+    # Each scope sees exactly its own task
+    stdio_tasks, _ = await store.list_tasks(session_id=None)
+    assert [t.task_id for t in stdio_tasks] == [stdio_task.task_id]
+
+    http_a_tasks, _ = await store.list_tasks(session_id="http-a")
+    assert [t.task_id for t in http_a_tasks] == [http_a_task.task_id]
+
+    http_b_tasks, _ = await store.list_tasks(session_id="http-b")
+    assert [t.task_id for t in http_b_tasks] == [http_b_task.task_id]


### PR DESCRIPTION
Ensures that session IDs are used for tasks, avoiding cross-polination.