### PR TITLE
feat: expand InitializationState with explicit lifecycle state machine

### DIFF
--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -267,7 +267,7 @@ class ServerSession(
                 InitializationState.Closing,
             ):
                 self._transition_state(InitializationState.Closing)
-        except RuntimeError:
+        except RuntimeError:  # pragma: no cover
             logger.debug("Could not transition to Closing from %s", self._initialization_state.name)
         try:
             return await super().__aexit__(exc_type, exc_val, exc_tb)

--- a/tests/server/test_session_lifecycle.py
+++ b/tests/server/test_session_lifecycle.py
@@ -220,6 +220,25 @@ async def test_aexit_stateless_transitions_to_closed() -> None:
         assert session.initialization_state == InitializationState.Closed
 
 
+async def test_aexit_already_closing() -> None:
+    """__aexit__ skips Closing transition when already in Closing state."""
+    async with _session_context() as session:
+        async with session:
+            session._transition_state(InitializationState.Closing)
+
+        assert session.initialization_state == InitializationState.Closed
+
+
+async def test_aexit_already_closed() -> None:
+    """__aexit__ handles already-Closed sessions gracefully."""
+    async with _session_context() as session:
+        async with session:
+            session._transition_state(InitializationState.Closing)
+            session._transition_state(InitializationState.Closed)
+
+        assert session.initialization_state == InitializationState.Closed
+
+
 # ---------------------------------------------------------------------------
 # Integration: full handshake lifecycle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses [#1691](https://github.com/modelcontextprotocol/python-sdk/issues/1691) — Phase 1: expand the `InitializationState` enum with an explicit lifecycle state machine and add centralized transition validation.

## Problem

The current `ServerSession` lifecycle management uses a simple three-state enum (`NotInitialized`, `Initializing`, `Initialized`) with direct state assignment. This makes it difficult to reason about session lifecycle, provides no protection against invalid transitions, and lacks visibility into shutdown states. Stateless sessions were handled by jumping directly to `Initialized`, conflating two conceptually different modes.

## Solution

### Expanded `InitializationState` enum
- **`Stateless`** — sessions that skip the initialization handshake (previously mapped to `Initialized`)
- **`Closing`** — session is shutting down, entered during `__aexit__`
- **`Closed`** — terminal state after shutdown completes

An `Error` state for unrecoverable failures is planned for Phase 2 of #1691.

### Centralized transition validation
- **`_VALID_TRANSITIONS`** dict — maps each state to its valid target states, documenting the state machine in one place
- **`_transition_state()`** method — validates transitions and raises `RuntimeError` on invalid ones, with debug logging
- Re-initialization (`Initialized → Initializing`) is explicitly allowed for backward compatibility
- `NotInitialized → Initialized` is allowed to handle cases where the client sends an `InitializedNotification` without a prior `InitializeRequest` round-trip

### Concurrency documentation
- Class-level docstring on `ServerSession` documents the single-consumer concurrency model: incoming messages are processed sequentially by `_receive_loop`, so `_transition_state()` needs no external synchronization
- `_transition_state()` docstring explains why cooperative scheduling makes the method safe without locks

### New properties
- **`initialization_state`** — read-only access to current state
- **`is_initialized`** — returns `True` for both `Initialized` and `Stateless` (replaces direct comparisons)

### `__aexit__` override
- Transitions through `Closing → Closed` on session exit
- Gracefully handles edge cases (already closing/closed)

### Updated handlers
- `_received_request` and `_received_notification` now use `_transition_state()` instead of direct assignment
- `_received_notification` guards against redundant `InitializedNotification` in stateless mode

## Tests

20 new tests in `tests/server/test_session_lifecycle.py` covering:
- Enum completeness and value uniqueness
- Transition table correctness (all states have entries, `Closed` is terminal)
- Valid and invalid state transitions via `_transition_state()`
- `is_initialized` property for all states
- `__aexit__` lifecycle transitions (including already-closing and already-closed edge cases)
- Full client/server handshake integration test