### PR TITLE
docs: fix GitHub links to point to v1.x branch

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -61,10 +61,10 @@ if __name__ == "__main__":
     mcp.run(transport="streamable-http")
 ```
 
-_Full example: [examples/snippets/servers/oauth_server.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/oauth_server.py)_
+_Full example: [examples/snippets/servers/oauth_server.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/oauth_server.py)_
 <!-- /snippet-source -->
 
-For a complete example with separate Authorization Server and Resource Server implementations, see [`examples/servers/simple-auth/`](examples/servers/simple-auth/).
+For a complete example with separate Authorization Server and Resource Server implementations, see [`examples/servers/simple-auth/`](https://github.com/modelcontextprotocol/python-sdk/tree/v1.x/examples/servers/simple-auth).
 
 **Architecture:**
 
@@ -72,7 +72,7 @@ For a complete example with separate Authorization Server and Resource Server im
 - **Resource Server (RS)**: Your MCP server that validates tokens and serves protected resources
 - **Client**: Discovers AS through RFC 9728, obtains tokens, and uses them with the MCP server
 
-See [TokenVerifier](src/mcp/server/auth/provider.py) for more details on implementing token validation.
+See [TokenVerifier](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/src/mcp/server/auth/provider.py) for more details on implementing token validation.
 
 ## Client-Side Authentication
 
@@ -171,7 +171,7 @@ if __name__ == "__main__":
     run()
 ```
 
-_Full example: [examples/snippets/clients/oauth_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/clients/oauth_client.py)_
+_Full example: [examples/snippets/clients/oauth_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/clients/oauth_client.py)_
 <!-- /snippet-source -->
 
-For a complete working example, see [`examples/clients/simple-auth-client/`](examples/clients/simple-auth-client/).
+For a complete working example, see [`examples/clients/simple-auth-client/`](https://github.com/modelcontextprotocol/python-sdk/tree/v1.x/examples/clients/simple-auth-client).

--- a/docs/client.md
+++ b/docs/client.md
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     main()
 ```
 
-_Full example: [examples/snippets/clients/stdio_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/clients/stdio_client.py)_
+_Full example: [examples/snippets/clients/stdio_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/clients/stdio_client.py)_
 <!-- /snippet-source -->
 
 Clients can also connect using [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http):
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-_Full example: [examples/snippets/clients/streamable_basic.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/clients/streamable_basic.py)_
+_Full example: [examples/snippets/clients/streamable_basic.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/clients/streamable_basic.py)_
 <!-- /snippet-source -->
 
 ## Client Display Utilities
@@ -205,7 +205,7 @@ if __name__ == "__main__":
     main()
 ```
 
-_Full example: [examples/snippets/clients/display_utilities.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/clients/display_utilities.py)_
+_Full example: [examples/snippets/clients/display_utilities.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/clients/display_utilities.py)_
 <!-- /snippet-source -->
 
 The `get_display_name()` function implements the proper precedence rules for displaying names:

--- a/docs/low-level-server.md
+++ b/docs/low-level-server.md
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     asyncio.run(run())
 ```
 
-_Full example: [examples/snippets/servers/lowlevel/lifespan.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/lowlevel/lifespan.py)_
+_Full example: [examples/snippets/servers/lowlevel/lifespan.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/lowlevel/lifespan.py)_
 <!-- /snippet-source -->
 
 The lifespan API provides:
@@ -193,7 +193,7 @@ if __name__ == "__main__":
     asyncio.run(run())
 ```
 
-_Full example: [examples/snippets/servers/lowlevel/basic.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/lowlevel/basic.py)_
+_Full example: [examples/snippets/servers/lowlevel/basic.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/lowlevel/basic.py)_
 <!-- /snippet-source -->
 
 Caution: The `uv run mcp run` and `uv run mcp dev` tool doesn't support low-level server.
@@ -289,7 +289,7 @@ if __name__ == "__main__":
     asyncio.run(run())
 ```
 
-_Full example: [examples/snippets/servers/lowlevel/structured_output.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/lowlevel/structured_output.py)_
+_Full example: [examples/snippets/servers/lowlevel/structured_output.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/lowlevel/structured_output.py)_
 <!-- /snippet-source -->
 
 Tools can return data in four ways:
@@ -374,7 +374,7 @@ if __name__ == "__main__":
     asyncio.run(run())
 ```
 
-_Full example: [examples/snippets/servers/lowlevel/direct_call_tool_result.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/lowlevel/direct_call_tool_result.py)_
+_Full example: [examples/snippets/servers/lowlevel/direct_call_tool_result.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/lowlevel/direct_call_tool_result.py)_
 <!-- /snippet-source -->
 
 **Note:** When returning `CallToolResult`, you bypass the automatic content/structured conversion. You must construct the complete response yourself.
@@ -427,7 +427,7 @@ async def list_resources_paginated(request: types.ListResourcesRequest) -> types
     return types.ListResourcesResult(resources=page_items, nextCursor=next_cursor)
 ```
 
-_Full example: [examples/snippets/servers/pagination_example.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/pagination_example.py)_
+_Full example: [examples/snippets/servers/pagination_example.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/pagination_example.py)_
 <!-- /snippet-source -->
 
 ### Client-side Consumption
@@ -477,7 +477,7 @@ if __name__ == "__main__":
     asyncio.run(list_all_resources())
 ```
 
-_Full example: [examples/snippets/clients/pagination_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/clients/pagination_client.py)_
+_Full example: [examples/snippets/clients/pagination_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/clients/pagination_client.py)_
 <!-- /snippet-source -->
 
 ### Key Points
@@ -487,4 +487,4 @@ _Full example: [examples/snippets/clients/pagination_client.py](https://github.c
 - **Backward compatible** - clients that don't support pagination will still work (they'll just get the first page)
 - **Flexible page sizes** - Each endpoint can define its own page size based on data characteristics
 
-See the [simple-pagination example](examples/servers/simple-pagination) for a complete implementation.
+See the [simple-pagination example](https://github.com/modelcontextprotocol/python-sdk/tree/v1.x/examples/servers/simple-pagination) for a complete implementation.

--- a/docs/server.md
+++ b/docs/server.md
@@ -67,7 +67,7 @@ def query_db(ctx: Context[ServerSession, AppContext]) -> str:
     return db.query()
 ```
 
-_Full example: [examples/snippets/servers/lifespan_example.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/lifespan_example.py)_
+_Full example: [examples/snippets/servers/lifespan_example.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/lifespan_example.py)_
 <!-- /snippet-source -->
 
 ### Resources
@@ -98,7 +98,7 @@ def get_settings() -> str:
 }"""
 ```
 
-_Full example: [examples/snippets/servers/basic_resource.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/basic_resource.py)_
+_Full example: [examples/snippets/servers/basic_resource.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/basic_resource.py)_
 <!-- /snippet-source -->
 
 #### Resource Templates and Template Reading
@@ -211,7 +211,7 @@ def get_weather(city: str, unit: str = "celsius") -> str:
     return f"Weather in {city}: 22degrees{unit[0].upper()}"
 ```
 
-_Full example: [examples/snippets/servers/basic_tool.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/basic_tool.py)_
+_Full example: [examples/snippets/servers/basic_tool.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/basic_tool.py)_
 <!-- /snippet-source -->
 
 Tools can optionally receive a Context object by including a parameter with the `Context` type annotation. This context is automatically injected by the FastMCP framework and provides access to MCP capabilities:
@@ -241,7 +241,7 @@ async def long_running_task(task_name: str, ctx: Context[ServerSession, None], s
     return f"Task '{task_name}' completed"
 ```
 
-_Full example: [examples/snippets/servers/tool_progress.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/tool_progress.py)_
+_Full example: [examples/snippets/servers/tool_progress.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/tool_progress.py)_
 <!-- /snippet-source -->
 
 #### Structured Output
@@ -326,7 +326,7 @@ def empty_result_tool() -> CallToolResult:
     return CallToolResult(content=[])
 ```
 
-_Full example: [examples/snippets/servers/direct_call_tool_result.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/direct_call_tool_result.py)_
+_Full example: [examples/snippets/servers/direct_call_tool_result.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/direct_call_tool_result.py)_
 <!-- /snippet-source -->
 
 **Important:** `CallToolResult` must always be returned (no `Optional` or `Union`). For empty results, use `CallToolResult(content=[])`. For optional simple types, use `str | None` without `CallToolResult`.
@@ -432,7 +432,7 @@ def get_temperature(city: str) -> float:
     # Returns: {"result": 22.5}
 ```
 
-_Full example: [examples/snippets/servers/structured_output.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/structured_output.py)_
+_Full example: [examples/snippets/servers/structured_output.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/structured_output.py)_
 <!-- /snippet-source -->
 
 ### Prompts
@@ -461,7 +461,7 @@ def debug_error(error: str) -> list[base.Message]:
     ]
 ```
 
-_Full example: [examples/snippets/servers/basic_prompt.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/basic_prompt.py)_
+_Full example: [examples/snippets/servers/basic_prompt.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/basic_prompt.py)_
 <!-- /snippet-source -->
 
 #### Prompts with Embedded Resources
@@ -576,7 +576,7 @@ def my_resource():
     return "content"
 ```
 
-_Full example: [examples/fastmcp/icons_demo.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/fastmcp/icons_demo.py)_
+_Full example: [examples/fastmcp/icons_demo.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/fastmcp/icons_demo.py)_
 
 ### Images
 
@@ -601,7 +601,7 @@ def create_thumbnail(image_path: str) -> Image:
     return Image(data=img.tobytes(), format="png")
 ```
 
-_Full example: [examples/snippets/servers/images.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/images.py)_
+_Full example: [examples/snippets/servers/images.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/images.py)_
 <!-- /snippet-source -->
 
 ### Audio
@@ -764,7 +764,7 @@ async def long_running_task(task_name: str, ctx: Context[ServerSession, None], s
     return f"Task '{task_name}' completed"
 ```
 
-_Full example: [examples/snippets/servers/tool_progress.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/tool_progress.py)_
+_Full example: [examples/snippets/servers/tool_progress.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/tool_progress.py)_
 <!-- /snippet-source -->
 
 ### Completions
@@ -855,7 +855,7 @@ if __name__ == "__main__":
     main()
 ```
 
-_Full example: [examples/snippets/clients/completion_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/clients/completion_client.py)_
+_Full example: [examples/snippets/clients/completion_client.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/clients/completion_client.py)_
 <!-- /snippet-source -->
 ### Elicitation
 
@@ -964,7 +964,7 @@ async def connect_service(service_name: str, ctx: Context[ServerSession, None]) 
     )
 ```
 
-_Full example: [examples/snippets/servers/elicitation.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/elicitation.py)_
+_Full example: [examples/snippets/servers/elicitation.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/elicitation.py)_
 <!-- /snippet-source -->
 
 Elicitation schemas support default values for all field types. Default values are automatically included in the JSON schema sent to clients, allowing them to pre-populate forms.
@@ -1064,7 +1064,7 @@ async def generate_poem(topic: str, ctx: Context[ServerSession, None]) -> str:
     return str(result.content)
 ```
 
-_Full example: [examples/snippets/servers/sampling.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/sampling.py)_
+_Full example: [examples/snippets/servers/sampling.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/sampling.py)_
 <!-- /snippet-source -->
 
 ### Logging and Notifications
@@ -1094,7 +1094,7 @@ async def process_data(data: str, ctx: Context[ServerSession, None]) -> str:
     return f"Processed: {data}"
 ```
 
-_Full example: [examples/snippets/servers/notifications.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/notifications.py)_
+_Full example: [examples/snippets/servers/notifications.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/notifications.py)_
 <!-- /snippet-source -->
 
 #### Setting the Logging Level
@@ -1216,7 +1216,7 @@ def query_with_config(query: str, ctx: Context) -> str:
     return str(result)
 ```
 
-_Full lifespan example: [examples/snippets/servers/lifespan_example.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/lifespan_example.py)_
+_Full lifespan example: [examples/snippets/servers/lifespan_example.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/lifespan_example.py)_
 
 ## Running Your Server
 
@@ -1284,7 +1284,7 @@ if __name__ == "__main__":
     main()
 ```
 
-_Full example: [examples/snippets/servers/direct_execution.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/direct_execution.py)_
+_Full example: [examples/snippets/servers/direct_execution.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/direct_execution.py)_
 <!-- /snippet-source -->
 
 Run it with:
@@ -1333,7 +1333,7 @@ if __name__ == "__main__":
     mcp.run(transport="streamable-http")
 ```
 
-_Full example: [examples/snippets/servers/streamable_config.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/streamable_config.py)_
+_Full example: [examples/snippets/servers/streamable_config.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/streamable_config.py)_
 <!-- /snippet-source -->
 
 You can mount multiple FastMCP servers in a Starlette application:
@@ -1396,13 +1396,13 @@ app = Starlette(
 # math_mcp.settings.streamable_http_path = "/"
 ```
 
-_Full example: [examples/snippets/servers/streamable_starlette_mount.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/streamable_starlette_mount.py)_
+_Full example: [examples/snippets/servers/streamable_starlette_mount.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/streamable_starlette_mount.py)_
 <!-- /snippet-source -->
 
 For low level server with Streamable HTTP implementations, see:
 
-- Stateful server: [`examples/servers/simple-streamablehttp/`](examples/servers/simple-streamablehttp/)
-- Stateless server: [`examples/servers/simple-streamablehttp-stateless/`](examples/servers/simple-streamablehttp-stateless/)
+- Stateful server: [`examples/servers/simple-streamablehttp/`](https://github.com/modelcontextprotocol/python-sdk/tree/v1.x/examples/servers/simple-streamablehttp)
+- Stateless server: [`examples/servers/simple-streamablehttp-stateless/`](https://github.com/modelcontextprotocol/python-sdk/tree/v1.x/examples/servers/simple-streamablehttp-stateless)
 
 The streamable HTTP transport supports:
 
@@ -1491,7 +1491,7 @@ app = Starlette(
 )
 ```
 
-_Full example: [examples/snippets/servers/streamable_http_basic_mounting.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/streamable_http_basic_mounting.py)_
+_Full example: [examples/snippets/servers/streamable_http_basic_mounting.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/streamable_http_basic_mounting.py)_
 <!-- /snippet-source -->
 
 ##### Host-based routing
@@ -1538,7 +1538,7 @@ app = Starlette(
 )
 ```
 
-_Full example: [examples/snippets/servers/streamable_http_host_mounting.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/streamable_http_host_mounting.py)_
+_Full example: [examples/snippets/servers/streamable_http_host_mounting.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/streamable_http_host_mounting.py)_
 <!-- /snippet-source -->
 
 ##### Multiple servers with path configuration
@@ -1601,7 +1601,7 @@ app = Starlette(
 )
 ```
 
-_Full example: [examples/snippets/servers/streamable_http_multiple_servers.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/streamable_http_multiple_servers.py)_
+_Full example: [examples/snippets/servers/streamable_http_multiple_servers.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/streamable_http_multiple_servers.py)_
 <!-- /snippet-source -->
 
 ##### Path configuration at initialization
@@ -1643,7 +1643,7 @@ app = Starlette(
 )
 ```
 
-_Full example: [examples/snippets/servers/streamable_http_path_config.py](https://github.com/modelcontextprotocol/python-sdk/blob/main/examples/snippets/servers/streamable_http_path_config.py)_
+_Full example: [examples/snippets/servers/streamable_http_path_config.py](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/streamable_http_path_config.py)_
 <!-- /snippet-source -->
 
 #### SSE servers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ strict: true
 
 repo_name: modelcontextprotocol/python-sdk
 repo_url: https://github.com/modelcontextprotocol/python-sdk
-edit_uri: edit/main/docs/
+edit_uri: edit/v1.x/docs/
 site_url: https://modelcontextprotocol.github.io/python-sdk
 
 # TODO(Marcelo): Add Anthropic copyright?

--- a/scripts/update_readme_snippets.py
+++ b/scripts/update_readme_snippets.py
@@ -25,7 +25,7 @@ def get_github_url(file_path: str) -> str:
     Returns:
         GitHub URL
     """
-    base_url = "https://github.com/modelcontextprotocol/python-sdk/blob/main"
+    base_url = "https://github.com/modelcontextprotocol/python-sdk/blob/v1.x"
     return f"{base_url}/{file_path}"
 
 


### PR DESCRIPTION
Stacked on #2101.

## Motivation and Context

All documentation links pointed to `blob/main` but these docs are published from the v1.x branch. Also fixes 5 bare relative links that break mkdocs strict mode.

## How Has This Been Tested?

`mkdocs build` passes clean in strict mode (no warnings).

## Breaking Changes

None.

## Types of changes

- [x] Documentation update

## Additional context

- 34 GitHub URLs: `blob/main` -> `blob/v1.x`
- 5 bare relative links converted to absolute GitHub URLs  
- `mkdocs.yml` edit_uri: `edit/main/docs/` -> `edit/v1.x/docs/`
- `scripts/update_readme_snippets.py` base URL updated
- Net zero: +41/-41 lines