### PR TITLE
fix(client): propagate HTTP transport exceptions to caller

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -144,8 +144,9 @@ async def sse_client(
                                     )
                                     response.raise_for_status()
                                     logger.debug(f"Client message sent successfully: {response.status_code}")
-                        except Exception:  # pragma: lax no cover
+                        except Exception as exc:  # pragma: lax no cover
                             logger.exception("Error in post_writer")
+                            await read_stream_writer.send(exc)
                         finally:
                             await write_stream.aclose()
 

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -478,8 +478,9 @@ class StreamableHTTPTransport:
                     else:
                         await handle_request_async()
 
-        except Exception:  # pragma: lax no cover
+        except Exception as exc:  # pragma: lax no cover
             logger.exception("Error in post_writer")
+            await read_stream_writer.send(exc)
         finally:
             await read_stream_writer.aclose()
             await write_stream.aclose()


### PR DESCRIPTION
## Summary

Fixes #2110 - HTTP transport swallows non-2xx status codes causing client to hang

When an MCP server returns non-2xx HTTP status codes (401/403/404/5xx), the Streamable HTTP and SSE transports catch exceptions in `post_writer` but only log them without forwarding them through the read stream. This causes callers to hang indefinitely waiting for a response that will never arrive.

## Root Cause

In both `sse.py` and `streamable_http.py`, the `post_writer` function catches exceptions but never sends them to `read_stream_writer`, breaking the exception propagation pattern that works correctly in other transports (stdio, websocket).

## Changes

- **src/mcp/client/sse.py**: Modified exception handler in `post_writer` to send exceptions to `read_stream_writer`
- **src/mcp/client/streamable_http.py**: Modified exception handler in `post_writer` to send exceptions to `read_stream_writer`

This aligns with the pattern used in working transports:
- `stdio.py` line 156: `await read_stream_writer.send(exc)`  
- `websocket.py` line 59: `await read_stream_writer.send(exc)`

## Testing

- All existing client tests pass (182 passed)
- All shared/SSE tests pass (146 passed, 25 passed respectively)
- Code formatting and linting verified
- Commit includes proper trailers (Reported-by, Github-Issue)