### PR TITLE
Backport: Add missing TasksCallCapability to v1.x

### DIFF
--- a/src/mcp/server/lowlevel/experimental.py
+++ b/src/mcp/server/lowlevel/experimental.py
@@ -31,6 +31,7 @@ from mcp.types import (
     ServerResult,
     ServerTasksCapability,
     ServerTasksRequestsCapability,
+    TasksCallCapability,
     TasksCancelCapability,
     TasksListCapability,
     TasksToolsCapability,
@@ -79,7 +80,7 @@ class ExperimentalHandlers:
             capabilities.tasks.cancel = TasksCancelCapability()
 
         capabilities.tasks.requests = ServerTasksRequestsCapability(
-            tools=TasksToolsCapability()
+            tools=TasksToolsCapability(call=TasksCallCapability())
         )  # assuming always supported for now
 
     def enable_tasks(

--- a/tests/experimental/tasks/server/test_run_task_flow.py
+++ b/tests/experimental/tasks/server/test_run_task_flow.py
@@ -227,6 +227,10 @@ async def test_enable_tasks_auto_registers_handlers() -> None:
     assert caps_after.tasks is not None
     assert caps_after.tasks.list is not None
     assert caps_after.tasks.cancel is not None
+    # Verify nested call capability is present
+    assert caps_after.tasks.requests is not None
+    assert caps_after.tasks.requests.tools is not None
+    assert caps_after.tasks.requests.tools.call is not None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Cherry-pick of #1854 to the `v1.x` release branch.

The fix adds the missing `call=TasksCallCapability()` parameter to `TasksToolsCapability()` in `ExperimentalHandlers.update_capabilities()`. Without this, MCP clients that check for the `call` capability before invoking task-enabled tools will skip them, since the server advertises `tools: {}` instead of `tools: {call: {}}`.

**This fix is on `main` since Jan 15 but was not included in v1.26.0** because the release was cut from `v1.x` before the backport. See #1995 for the user report.

## Changes

- `src/mcp/server/lowlevel/experimental.py`: Add `TasksCallCapability` import and pass `call=TasksCallCapability()` to `TasksToolsCapability()`
- `tests/experimental/tasks/server/test_run_task_flow.py`: Add assertions verifying the nested `call` capability is present

## Test plan

- [x] Cherry-pick applies cleanly (no conflicts)
- [ ] CI passes on `v1.x` branch
- Existing task flow tests cover the capability advertisement

Fixes #1995

🤖 Generated with [Claude Code](https://claude.com/claude-code)