### PR TITLE
Handle BrokenResourceError in stdio client shutdown path

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -158,7 +158,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
 
                         session_message = SessionMessage(message)
                         await read_stream_writer.send(session_message)
-        except anyio.ClosedResourceError:  # pragma: lax no cover
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):  # pragma: lax no cover
             await anyio.lowlevel.checkpoint()
 
     async def stdin_writer():
@@ -174,7 +174,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                             errors=server.encoding_error_handler,
                         )
                     )
-        except anyio.ClosedResourceError:  # pragma: no cover
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):  # pragma: no cover
             await anyio.lowlevel.checkpoint()
 
     async with anyio.create_task_group() as tg, process:


### PR DESCRIPTION
## Summary
- handle `anyio.BrokenResourceError` in stdio client reader/writer loops
- add regression test for an immediately-exiting stdio server path

## Why
Related to #1564.

When the subprocess stdio closes abruptly during client initialization, `BrokenResourceError` may escape from stream tasks and surface as an unhelpful TaskGroup failure instead of a clean MCP connection-closed path.

## Changes
- catch `anyio.BrokenResourceError` alongside `ClosedResourceError` in:
  - `stdout_reader`
  - `stdin_writer`
- add `test_stdio_client_exits_immediately_surfaces_connection_closed`

## Validation
- `. .venv/bin/activate && pytest tests/client/test_stdio.py -q -k "bad_path or exits_immediately or nonexistent_command"`
  - 3 passed
