### PR TITLE
feat: public API for runtime handler registration/deregistration

### DIFF
--- a/src/mcp/server/lowlevel/experimental.py
+++ b/src/mcp/server/lowlevel/experimental.py
@@ -54,7 +54,7 @@ class ExperimentalHandlers(Generic[LifespanResultT]):
 
     def __init__(
         self,
-        server: Server[LifespanResultT, Any],
+        server: Server[LifespanResultT],
     ) -> None:
         self._server = server
         self._task_support: TaskSupport | None = None

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -243,6 +243,72 @@ class Server(Generic[LifespanResultT]):
         """Check if a handler is registered for the given method."""
         return method in self._request_handlers or method in self._notification_handlers
 
+    def add_request_handler(
+        self,
+        method: str,
+        handler: Callable[[ServerRequestContext[LifespanResultT], Any], Awaitable[Any]],
+    ) -> None:
+        """Register a request handler for the given method.
+
+        If a handler is already registered for this method, it will be replaced.
+
+        Args:
+            method: The JSON-RPC method name (e.g., "tools/list", "myextension/query").
+            handler: An async callable that takes (ServerRequestContext, params) and
+                returns the result.
+        """
+        self._request_handlers[method] = handler
+
+    def remove_request_handler(self, method: str) -> None:
+        """Remove the request handler for the given method.
+
+        Args:
+            method: The JSON-RPC method name to deregister.
+
+        Raises:
+            KeyError: If no handler is registered for this method.
+        """
+        del self._request_handlers[method]
+
+    def add_notification_handler(
+        self,
+        method: str,
+        handler: Callable[[ServerRequestContext[LifespanResultT], Any], Awaitable[None]],
+    ) -> None:
+        """Register a notification handler for the given method.
+
+        If a handler is already registered for this method, it will be replaced.
+
+        Args:
+            method: The JSON-RPC notification method name
+                (e.g., "notifications/progress").
+            handler: An async callable that takes (ServerRequestContext, params) and
+                returns None.
+        """
+        self._notification_handlers[method] = handler
+
+    def remove_notification_handler(self, method: str) -> None:
+        """Remove the notification handler for the given method.
+
+        Args:
+            method: The JSON-RPC notification method name to deregister.
+
+        Raises:
+            KeyError: If no handler is registered for this method.
+        """
+        del self._notification_handlers[method]
+
+    def has_handler(self, method: str) -> bool:
+        """Check if a handler is registered for the given request or notification method.
+
+        Args:
+            method: The JSON-RPC method name to check.
+
+        Returns:
+            True if a handler is registered, False otherwise.
+        """
+        return method in self._request_handlers or method in self._notification_handlers
+
     # TODO: Rethink capabilities API. Currently capabilities are derived from registered
     # handlers but require NotificationOptions to be passed externally for list_changed
     # flags, and experimental_capabilities as a separate dict. Consider deriving capabilities
@@ -333,10 +399,7 @@ class Server(Generic[LifespanResultT]):
 
         # We create this inline so we only add these capabilities _if_ they're actually used
         if self._experimental_handlers is None:
-            self._experimental_handlers = ExperimentalHandlers(
-                add_request_handler=self._add_request_handler,
-                has_handler=self._has_handler,
-            )
+            self._experimental_handlers = ExperimentalHandlers(server=self)
         return self._experimental_handlers
 
     @property

--- a/tests/server/lowlevel/test_handler_registration.py
+++ b/tests/server/lowlevel/test_handler_registration.py
@@ -1,0 +1,94 @@
+"""Tests for public handler registration/deregistration API on low-level Server."""
+
+import pytest
+
+from mcp.server.lowlevel.server import Server
+
+
+@pytest.fixture
+def server():
+    return Server(name="test-server")
+
+
+async def _dummy_request_handler(ctx, params):
+    return {"result": "ok"}
+
+
+async def _dummy_notification_handler(ctx, params):
+    pass
+
+
+class TestAddRequestHandler:
+    def test_add_request_handler(self, server):
+        server.add_request_handler("custom/method", _dummy_request_handler)
+        assert server.has_handler("custom/method")
+
+    def test_add_request_handler_replaces_existing(self, server):
+        async def handler_a(ctx, params):
+            return "a"
+
+        async def handler_b(ctx, params):
+            return "b"
+
+        server.add_request_handler("custom/method", handler_a)
+        server.add_request_handler("custom/method", handler_b)
+        # The second handler should replace the first
+        assert server._request_handlers["custom/method"] is handler_b
+
+
+class TestRemoveRequestHandler:
+    def test_remove_request_handler(self, server):
+        server.add_request_handler("custom/method", _dummy_request_handler)
+        assert server.has_handler("custom/method")
+        server.remove_request_handler("custom/method")
+        assert not server.has_handler("custom/method")
+
+    def test_remove_request_handler_not_found(self, server):
+        with pytest.raises(KeyError):
+            server.remove_request_handler("nonexistent/method")
+
+
+class TestAddNotificationHandler:
+    def test_add_notification_handler(self, server):
+        server.add_notification_handler("custom/notify", _dummy_notification_handler)
+        assert server.has_handler("custom/notify")
+
+    def test_add_notification_handler_replaces_existing(self, server):
+        async def handler_a(ctx, params):
+            pass
+
+        async def handler_b(ctx, params):
+            pass
+
+        server.add_notification_handler("custom/notify", handler_a)
+        server.add_notification_handler("custom/notify", handler_b)
+        assert server._notification_handlers["custom/notify"] is handler_b
+
+
+class TestRemoveNotificationHandler:
+    def test_remove_notification_handler(self, server):
+        server.add_notification_handler("custom/notify", _dummy_notification_handler)
+        assert server.has_handler("custom/notify")
+        server.remove_notification_handler("custom/notify")
+        assert not server.has_handler("custom/notify")
+
+    def test_remove_notification_handler_not_found(self, server):
+        with pytest.raises(KeyError):
+            server.remove_notification_handler("nonexistent/notify")
+
+
+class TestHasHandler:
+    def test_has_handler_request(self, server):
+        server.add_request_handler("custom/method", _dummy_request_handler)
+        assert server.has_handler("custom/method")
+
+    def test_has_handler_notification(self, server):
+        server.add_notification_handler("custom/notify", _dummy_notification_handler)
+        assert server.has_handler("custom/notify")
+
+    def test_has_handler_unregistered(self, server):
+        assert not server.has_handler("nonexistent/method")
+
+    def test_has_handler_default_ping(self, server):
+        """The ping handler is registered by default."""
+        assert server.has_handler("ping")

--- a/tests/server/lowlevel/test_handler_registration.py
+++ b/tests/server/lowlevel/test_handler_registration.py
@@ -1,33 +1,36 @@
 """Tests for public handler registration/deregistration API on low-level Server."""
 
+from typing import Any
+
 import pytest
 
+from mcp.server.context import ServerRequestContext
 from mcp.server.lowlevel.server import Server
 
 
 @pytest.fixture
-def server():
+def server() -> Server[None]:
     return Server(name="test-server")
 
 
-async def _dummy_request_handler(ctx, params):
+async def _dummy_request_handler(ctx: ServerRequestContext[None], params: Any) -> dict[str, str]:
     return {"result": "ok"}
 
 
-async def _dummy_notification_handler(ctx, params):
+async def _dummy_notification_handler(ctx: ServerRequestContext[None], params: Any) -> None:
     pass
 
 
 class TestAddRequestHandler:
-    def test_add_request_handler(self, server):
+    def test_add_request_handler(self, server: Server[None]) -> None:
         server.add_request_handler("custom/method", _dummy_request_handler)
         assert server.has_handler("custom/method")
 
-    def test_add_request_handler_replaces_existing(self, server):
-        async def handler_a(ctx, params):
+    def test_add_request_handler_replaces_existing(self, server: Server[None]) -> None:
+        async def handler_a(ctx: ServerRequestContext[None], params: Any) -> str:
             return "a"
 
-        async def handler_b(ctx, params):
+        async def handler_b(ctx: ServerRequestContext[None], params: Any) -> str:
             return "b"
 
         server.add_request_handler("custom/method", handler_a)
@@ -37,27 +40,27 @@ class TestAddRequestHandler:
 
 
 class TestRemoveRequestHandler:
-    def test_remove_request_handler(self, server):
+    def test_remove_request_handler(self, server: Server[None]) -> None:
         server.add_request_handler("custom/method", _dummy_request_handler)
         assert server.has_handler("custom/method")
         server.remove_request_handler("custom/method")
         assert not server.has_handler("custom/method")
 
-    def test_remove_request_handler_not_found(self, server):
+    def test_remove_request_handler_not_found(self, server: Server[None]) -> None:
         with pytest.raises(KeyError):
             server.remove_request_handler("nonexistent/method")
 
 
 class TestAddNotificationHandler:
-    def test_add_notification_handler(self, server):
+    def test_add_notification_handler(self, server: Server[None]) -> None:
         server.add_notification_handler("custom/notify", _dummy_notification_handler)
         assert server.has_handler("custom/notify")
 
-    def test_add_notification_handler_replaces_existing(self, server):
-        async def handler_a(ctx, params):
+    def test_add_notification_handler_replaces_existing(self, server: Server[None]) -> None:
+        async def handler_a(ctx: ServerRequestContext[None], params: Any) -> None:
             pass
 
-        async def handler_b(ctx, params):
+        async def handler_b(ctx: ServerRequestContext[None], params: Any) -> None:
             pass
 
         server.add_notification_handler("custom/notify", handler_a)
@@ -66,29 +69,29 @@ class TestAddNotificationHandler:
 
 
 class TestRemoveNotificationHandler:
-    def test_remove_notification_handler(self, server):
+    def test_remove_notification_handler(self, server: Server[None]) -> None:
         server.add_notification_handler("custom/notify", _dummy_notification_handler)
         assert server.has_handler("custom/notify")
         server.remove_notification_handler("custom/notify")
         assert not server.has_handler("custom/notify")
 
-    def test_remove_notification_handler_not_found(self, server):
+    def test_remove_notification_handler_not_found(self, server: Server[None]) -> None:
         with pytest.raises(KeyError):
             server.remove_notification_handler("nonexistent/notify")
 
 
 class TestHasHandler:
-    def test_has_handler_request(self, server):
+    def test_has_handler_request(self, server: Server[None]) -> None:
         server.add_request_handler("custom/method", _dummy_request_handler)
         assert server.has_handler("custom/method")
 
-    def test_has_handler_notification(self, server):
+    def test_has_handler_notification(self, server: Server[None]) -> None:
         server.add_notification_handler("custom/notify", _dummy_notification_handler)
         assert server.has_handler("custom/notify")
 
-    def test_has_handler_unregistered(self, server):
+    def test_has_handler_unregistered(self, server: Server[None]) -> None:
         assert not server.has_handler("nonexistent/method")
 
-    def test_has_handler_default_ping(self, server):
+    def test_has_handler_default_ping(self, server: Server[None]) -> None:
         """The ping handler is registered by default."""
         assert server.has_handler("ping")

--- a/tests/server/lowlevel/test_handler_registration.py
+++ b/tests/server/lowlevel/test_handler_registration.py
@@ -9,28 +9,28 @@ from mcp.server.lowlevel.server import Server
 
 
 @pytest.fixture
-def server() -> Server[None]:
+def server() -> Server[Any]:
     return Server(name="test-server")
 
 
-async def _dummy_request_handler(ctx: ServerRequestContext[None], params: Any) -> dict[str, str]:
+async def _dummy_request_handler(ctx: ServerRequestContext[Any], params: Any) -> dict[str, str]:  # pragma: no cover
     return {"result": "ok"}
 
 
-async def _dummy_notification_handler(ctx: ServerRequestContext[None], params: Any) -> None:
+async def _dummy_notification_handler(ctx: ServerRequestContext[Any], params: Any) -> None:  # pragma: no cover
     pass
 
 
 class TestAddRequestHandler:
-    def test_add_request_handler(self, server: Server[None]) -> None:
+    def test_add_request_handler(self, server: Server[Any]) -> None:
         server.add_request_handler("custom/method", _dummy_request_handler)
         assert server.has_handler("custom/method")
 
-    def test_add_request_handler_replaces_existing(self, server: Server[None]) -> None:
-        async def handler_a(ctx: ServerRequestContext[None], params: Any) -> str:
+    def test_add_request_handler_replaces_existing(self, server: Server[Any]) -> None:
+        async def handler_a(ctx: ServerRequestContext[Any], params: Any) -> str:  # pragma: no cover
             return "a"
 
-        async def handler_b(ctx: ServerRequestContext[None], params: Any) -> str:
+        async def handler_b(ctx: ServerRequestContext[Any], params: Any) -> str:  # pragma: no cover
             return "b"
 
         server.add_request_handler("custom/method", handler_a)
@@ -40,27 +40,27 @@ class TestAddRequestHandler:
 
 
 class TestRemoveRequestHandler:
-    def test_remove_request_handler(self, server: Server[None]) -> None:
+    def test_remove_request_handler(self, server: Server[Any]) -> None:
         server.add_request_handler("custom/method", _dummy_request_handler)
         assert server.has_handler("custom/method")
         server.remove_request_handler("custom/method")
         assert not server.has_handler("custom/method")
 
-    def test_remove_request_handler_not_found(self, server: Server[None]) -> None:
+    def test_remove_request_handler_not_found(self, server: Server[Any]) -> None:
         with pytest.raises(KeyError):
             server.remove_request_handler("nonexistent/method")
 
 
 class TestAddNotificationHandler:
-    def test_add_notification_handler(self, server: Server[None]) -> None:
+    def test_add_notification_handler(self, server: Server[Any]) -> None:
         server.add_notification_handler("custom/notify", _dummy_notification_handler)
         assert server.has_handler("custom/notify")
 
-    def test_add_notification_handler_replaces_existing(self, server: Server[None]) -> None:
-        async def handler_a(ctx: ServerRequestContext[None], params: Any) -> None:
+    def test_add_notification_handler_replaces_existing(self, server: Server[Any]) -> None:
+        async def handler_a(ctx: ServerRequestContext[Any], params: Any) -> None:  # pragma: no cover
             pass
 
-        async def handler_b(ctx: ServerRequestContext[None], params: Any) -> None:
+        async def handler_b(ctx: ServerRequestContext[Any], params: Any) -> None:  # pragma: no cover
             pass
 
         server.add_notification_handler("custom/notify", handler_a)
@@ -69,29 +69,29 @@ class TestAddNotificationHandler:
 
 
 class TestRemoveNotificationHandler:
-    def test_remove_notification_handler(self, server: Server[None]) -> None:
+    def test_remove_notification_handler(self, server: Server[Any]) -> None:
         server.add_notification_handler("custom/notify", _dummy_notification_handler)
         assert server.has_handler("custom/notify")
         server.remove_notification_handler("custom/notify")
         assert not server.has_handler("custom/notify")
 
-    def test_remove_notification_handler_not_found(self, server: Server[None]) -> None:
+    def test_remove_notification_handler_not_found(self, server: Server[Any]) -> None:
         with pytest.raises(KeyError):
             server.remove_notification_handler("nonexistent/notify")
 
 
 class TestHasHandler:
-    def test_has_handler_request(self, server: Server[None]) -> None:
+    def test_has_handler_request(self, server: Server[Any]) -> None:
         server.add_request_handler("custom/method", _dummy_request_handler)
         assert server.has_handler("custom/method")
 
-    def test_has_handler_notification(self, server: Server[None]) -> None:
+    def test_has_handler_notification(self, server: Server[Any]) -> None:
         server.add_notification_handler("custom/notify", _dummy_notification_handler)
         assert server.has_handler("custom/notify")
 
-    def test_has_handler_unregistered(self, server: Server[None]) -> None:
+    def test_has_handler_unregistered(self, server: Server[Any]) -> None:
         assert not server.has_handler("nonexistent/method")
 
-    def test_has_handler_default_ping(self, server: Server[None]) -> None:
+    def test_has_handler_default_ping(self, server: Server[Any]) -> None:
         """The ping handler is registered by default."""
         assert server.has_handler("ping")


### PR DESCRIPTION
## Summary

Adds public methods for registering and deregistering request/notification handlers at runtime on the low-level `Server` class:

- `add_request_handler(method, handler)` — register a request handler
- `remove_request_handler(method)` — deregister a request handler
- `add_notification_handler(method, handler)` — register a notification handler
- `remove_notification_handler(method)` — deregister a notification handler
- `has_handler(method)` — check if a handler exists for a given method

This enables frameworks and advanced use cases to register handlers for protocol extensions or custom methods after server construction, and to remove or replace handlers dynamically (feature flags, hot-reloading, test fixtures).

Also refactors `ExperimentalHandlers` to use the new public API instead of receiving private method references, validating the API with its first internal consumer.

## Design note

The issue proposed `method: str` as the key — this aligns with the current internal architecture where `_request_handlers` is a `dict[str, ...]` keyed by JSON-RPC method names. The private `_add_request_handler` and `_has_handler` methods remain for backward compatibility but the public API is the recommended path forward.

## Test plan

- [x] 12 new tests covering add/remove/has for both request and notification handlers
- [x] Existing lowlevel server tests pass (24/24)
- [x] Experimental handler tests pass (217 passed, 96 skipped)
- [ ] CI passes

Fixes #2135

🤖 Generated with [Claude Code](https://claude.com/claude-code)