### PR TITLE
ci: sign weekly lockfile commits as github-actions[bot]

### DIFF
--- a/.github/workflows/weekly-lockfile-update.yml
+++ b/.github/workflows/weekly-lockfile-update.yml
@@ -32,7 +32,7 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v7
         with:
           commit-message: "chore: update uv.lock with latest dependencies"
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          sign-commits: true
           title: "chore: weekly dependency update"
           body-path: pr_body.md
           branch: weekly-lockfile-update


### PR DESCRIPTION
The `peter-evans/create-pull-request` action defaults its `author` input to `${{ github.actor }}`. For scheduled workflow runs, GitHub sets `github.actor` to a human user (the "schedule owner"), not `github-actions[bot]`. This causes the weekly lockfile update commits to be incorrectly attributed to a maintainer.

All 6 scheduled runs of this workflow so far have `actor: Kludex`, likely because @Kludex merged the dependabot PR (#1878) that touched the workflow file shortly after it was created — since bots can't own schedules, GitHub attributed the schedule to the human merger.

## Fix

`sign-commits: true` causes the action to create commits via the GitHub REST API rather than local git. When creating commits this way, [no `author`/`committer` fields are passed](https://github.com/peter-evans/create-pull-request/blob/6699836a213cf8b28c4f0408a404a6ac79d4458a/src/github-helper.ts#L375-L380) — GitHub automatically uses the token identity (`github-actions[bot]` for the default `GITHUB_TOKEN`). Per the [action docs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signature-verification-for-bots), the `author`/`committer` inputs are ignored entirely when `sign-commits` is enabled.

This avoids hardcoding the bot email, and commits get a "Verified" badge as a bonus. Force-push to the fixed weekly branch is explicitly supported via `updateRef` with `force: true`. This is the approach used by Gradle, DataDog, Microsoft, and Composer in their scheduled dependency-update workflows.

The only limitations (40MiB per-file, Git LFS incompatibility, SSH deploy keys) don't apply here — `uv.lock` is ~300KB plain text committed via `GITHUB_TOKEN`.

Addresses [question on #2043](https://github.com/modelcontextprotocol/python-sdk/pull/2043).

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>