### PR TITLE
ci: add Slack notification for maintainer PRs

### DIFF
--- a/.github/workflows/pr-notify.yml
+++ b/.github/workflows/pr-notify.yml
@@ -1,0 +1,44 @@
+name: PR Slack Notification
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  notify:
+    name: Notify maintainers
+    runs-on: ubuntu-latest
+    if: >-
+      !github.event.pull_request.draft
+    permissions: {}
+    steps:
+      - name: Notify Slack
+        env:
+          MAINTAINER_MAP: ${{ secrets.MAINTAINER_MAP }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Check if PR author is on the team (triggers list)
+          if ! echo "$MAINTAINER_MAP" | jq -e --arg author "$PR_AUTHOR" '.triggers | index($author)' > /dev/null 2>&1; then
+            echo "PR author $PR_AUTHOR is not on the team, skipping notification"
+            exit 0
+          fi
+
+          # Pick a random reviewer
+          ALL_REVIEWERS=$(echo "$MAINTAINER_MAP" | jq -r '.reviewers | keys[]')
+          REVIEWERS_ARRAY=($ALL_REVIEWERS)
+          if [ ${#REVIEWERS_ARRAY[@]} -eq 0 ]; then
+            echo "No reviewers configured"
+            exit 0
+          fi
+          REVIEWER=${REVIEWERS_ARRAY[$((RANDOM % ${#REVIEWERS_ARRAY[@]}))]}
+          SLACK_ID=$(echo "$MAINTAINER_MAP" | jq -r --arg user "$REVIEWER" '.reviewers[$user].slack')
+
+          # Post to Slack
+          SLACK_TEXT="${PR_URL} \"${PR_TITLE}\" by ${PR_AUTHOR}"
+          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "$SLACK_TEXT" --arg user_id "$SLACK_ID" '{text: $text, user_id: $user_id}')" || echo "::warning::Slack notification failed"


### PR DESCRIPTION
Adds a standalone `pr-notify.yml` workflow that posts a Slack notification when a non-draft PR is opened by a team member, tagging a random reviewer.

## Motivation and Context

We want visibility into incoming PRs from maintainers so reviews happen faster.

## How Has This Been Tested?

Tested the Slack webhook manually with the same payload format.

## Breaking Changes

None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Uses two repo secrets:
- `MAINTAINER_MAP` — JSON with `triggers` (team GitHub usernames) and `reviewers` (username → Slack ID mapping)
- `SLACK_WEBHOOK_URL` — Slack workflow webhook endpoint