### PR TITLE
ci: add Slack notification for maintainer PRs

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -15,3 +15,43 @@ jobs:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
+
+  notify:
+    name: Notify maintainers
+    runs-on: ubuntu-latest
+    needs: [all-green]
+    if: >-
+      !github.event.pull_request.draft &&
+      needs.all-green.result == 'success'
+    permissions: {}
+    steps:
+      - name: Notify Slack
+        env:
+          MAINTAINER_MAP: ${{ secrets.MAINTAINER_MAP }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Check if PR author is on the team (triggers list)
+          if ! echo "$MAINTAINER_MAP" | jq -e --arg author "$PR_AUTHOR" '.triggers | index($author)' > /dev/null 2>&1; then
+            echo "PR author $PR_AUTHOR is not on the team, skipping notification"
+            exit 0
+          fi
+
+          # Pick a random reviewer
+          ALL_REVIEWERS=$(echo "$MAINTAINER_MAP" | jq -r '.reviewers | keys[]')
+          REVIEWERS_ARRAY=($ALL_REVIEWERS)
+          if [ ${#REVIEWERS_ARRAY[@]} -eq 0 ]; then
+            echo "No reviewers configured"
+            exit 0
+          fi
+          REVIEWER=${REVIEWERS_ARRAY[$((RANDOM % ${#REVIEWERS_ARRAY[@]}))]}
+          SLACK_ID=$(echo "$MAINTAINER_MAP" | jq -r --arg user "$REVIEWER" '.reviewers[$user].slack')
+
+          # Post to Slack
+          SLACK_TEXT="${PR_URL} \"${PR_TITLE}\" by ${PR_AUTHOR}"
+          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "$SLACK_TEXT" --arg user_id "$SLACK_ID" '{text: $text, user_id: $user_id}')" || echo "::warning::Slack notification failed"


### PR DESCRIPTION
<!-- Notify maintainers on Slack when a team member opens a PR and CI passes -->

## Motivation and Context

Reduce GitHub notification noise for SDK maintainers by adding a dedicated Slack signal channel. When an MCP team member opens a PR and CI passes, a random reviewer from a configured pool is tagged in `#mcp-sdk-stamps`.

Counterpart of #2154 for the v1.x branch.

## How Has This Been Tested?

Tested the Slack webhook manually with sample payloads — message format and tagging confirmed working.

## Breaking Changes

None. This adds an optional CI job that only runs when repo secrets are configured.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Requires two repo secrets (same as main branch):
- `MAINTAINER_MAP`: JSON with `triggers` (GitHub usernames of team members) and `reviewers` (pool with Slack IDs)
- `SLACK_WEBHOOK_URL`: Slack workflow webhook URL