### PR TITLE
feat: add `execution` parameter to `add_tool()` for task support declaration

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -67,6 +67,7 @@ from mcp.types import (
     TextContent,
     TextResourceContents,
     ToolAnnotations,
+    ToolExecution,
 )
 from mcp.types import Prompt as MCPPrompt
 from mcp.types import PromptArgument as MCPPromptArgument
@@ -383,6 +384,7 @@ class MCPServer(Generic[LifespanResultT]):
                 annotations=info.annotations,
                 icons=info.icons,
                 _meta=info.meta,
+                execution=info.execution,
             )
             for info in tools
         ]
@@ -465,6 +467,7 @@ class MCPServer(Generic[LifespanResultT]):
         icons: list[Icon] | None = None,
         meta: dict[str, Any] | None = None,
         structured_output: bool | None = None,
+        execution: ToolExecution | None = None,
     ) -> None:
         """Add a tool to the server.
 
@@ -483,6 +486,8 @@ class MCPServer(Generic[LifespanResultT]):
                 - If None, auto-detects based on the function's return type annotation
                 - If True, creates a structured tool (return type annotation permitting)
                 - If False, unconditionally creates an unstructured tool
+            execution: Optional ToolExecution for declaring task support per MCP spec
+                (e.g. ToolExecution(taskSupport="optional"))
         """
         self._tool_manager.add_tool(
             fn,
@@ -493,6 +498,7 @@ class MCPServer(Generic[LifespanResultT]):
             icons=icons,
             meta=meta,
             structured_output=structured_output,
+            execution=execution,
         )
 
     def remove_tool(self, name: str) -> None:

--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -13,7 +13,7 @@ from mcp.server.mcpserver.utilities.context_injection import find_context_parame
 from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
 from mcp.shared.exceptions import UrlElicitationRequiredError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
-from mcp.types import Icon, ToolAnnotations
+from mcp.types import Icon, ToolAnnotations, ToolExecution
 
 if TYPE_CHECKING:
     from mcp.server.context import LifespanContextT, RequestT
@@ -36,6 +36,7 @@ class Tool(BaseModel):
     annotations: ToolAnnotations | None = Field(None, description="Optional annotations for the tool")
     icons: list[Icon] | None = Field(default=None, description="Optional list of icons for this tool")
     meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for this tool")
+    execution: ToolExecution | None = Field(default=None, description="Optional execution properties for task support")
 
     @cached_property
     def output_schema(self) -> dict[str, Any] | None:
@@ -53,6 +54,7 @@ class Tool(BaseModel):
         icons: list[Icon] | None = None,
         meta: dict[str, Any] | None = None,
         structured_output: bool | None = None,
+        execution: ToolExecution | None = None,
     ) -> Tool:
         """Create a Tool from a function."""
         func_name = name or fn.__name__
@@ -87,6 +89,7 @@ class Tool(BaseModel):
             annotations=annotations,
             icons=icons,
             meta=meta,
+            execution=execution,
         )
 
     async def run(

--- a/src/mcp/server/mcpserver/tools/tool_manager.py
+++ b/src/mcp/server/mcpserver/tools/tool_manager.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.tools.base import Tool
 from mcp.server.mcpserver.utilities.logging import get_logger
-from mcp.types import Icon, ToolAnnotations
+from mcp.types import Icon, ToolAnnotations, ToolExecution
 
 if TYPE_CHECKING:
     from mcp.server.context import LifespanContextT, RequestT
@@ -51,6 +51,7 @@ class ToolManager:
         icons: list[Icon] | None = None,
         meta: dict[str, Any] | None = None,
         structured_output: bool | None = None,
+        execution: ToolExecution | None = None,
     ) -> Tool:
         """Add a tool to the server."""
         tool = Tool.from_function(
@@ -62,6 +63,7 @@ class ToolManager:
             icons=icons,
             meta=meta,
             structured_output=structured_output,
+            execution=execution,
         )
         existing = self._tools.get(tool.name)
         if existing:


### PR DESCRIPTION
## Summary

Add `execution` parameter to `MCPServer.add_tool()`, `ToolManager.add_tool()`, and `Tool.from_function()` to allow declaring `execution.taskSupport` per tool as required by MCP spec 2025-11-25.

Also pass `execution` through in `MCPServer.list_tools()` when converting internal `Tool` to MCP `types.Tool`.

## Motivation and Context

The MCP spec (2025-11-25) requires tools to declare task support via `execution.taskSupport` in the `tools/list` response:

> In the result of tools/list, tools declare support for tasks via `execution.taskSupport`, which if present can have a value of "required", "optional", or "forbidden".

While `server.experimental.enable_tasks()` correctly handles server-level capabilities and task handler registration, there is currently no way to set `execution.taskSupport` on individual tools through the high-level API. This means tools always appear as `taskSupport: "forbidden"` to clients, even when the server supports tasks.

### Usage

```python
from mcp.types import ToolExecution, TASK_OPTIONAL

mcp.add_tool(
    my_handler,
    name="long_running_tool",
    description="A tool that takes a while",
    execution=ToolExecution(taskSupport=TASK_OPTIONAL),
)
```

## Changes

- `src/mcp/server/mcpserver/tools/base.py` — Add `execution` field to `Tool` model and `execution` parameter to `Tool.from_function()`
- `src/mcp/server/mcpserver/tools/tool_manager.py` — Add `execution` parameter to `ToolManager.add_tool()` and pass through to `Tool.from_function()`
- `src/mcp/server/mcpserver/server.py` — Add `execution` parameter to `MCPServer.add_tool()`, pass through to `ToolManager.add_tool()`, and include `execution=info.execution` in `list_tools()` conversion

## Breaking Changes

None. The `execution` parameter is optional and defaults to `None`, preserving existing behavior.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## References

- Fixes #2156
- [MCP Spec 2025-11-25 — Tasks: Tool-Level Negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)
- [SEP-1686 Tasks implementation PR #1645](https://github.com/modelcontextprotocol/python-sdk/pull/1645)