### PR TITLE
fix: correct return type annotation for MCPServer.call_tool()

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -315,9 +315,6 @@ class MCPServer(Generic[LifespanResultT]):
                 structured_content=structured_content,  # type: ignore[arg-type]
             )
         if isinstance(result, dict):  # pragma: no cover
-            # TODO: this code path is unreachable — convert_result never returns a raw dict.
-            # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong
-            # and needs to be cleaned up.
             return CallToolResult(
                 content=[TextContent(type="text", text=json.dumps(result, indent=2))],
                 structured_content=result,
@@ -399,7 +396,9 @@ class MCPServer(Generic[LifespanResultT]):
             request_context = None
         return Context(request_context=request_context, mcp_server=self)
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Sequence[ContentBlock] | dict[str, Any]:
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]] | CallToolResult:
         """Call a tool by name with arguments."""
         context = self.get_context()
         return await self._tool_manager.call_tool(name, arguments, context=context, convert_result=True)


### PR DESCRIPTION
## Summary

Fixes #1251

The return type annotation for `MCPServer.call_tool()` was `Sequence[ContentBlock] | dict[str, Any]`, but the actual return types from `convert_result()` are:

- `Sequence[ContentBlock]` — when no output schema is defined
- `tuple[Sequence[ContentBlock], dict[str, Any]]` — when an output schema is set
- `CallToolResult` — when the tool function returns a `CallToolResult` directly

The `dict[str, Any]` variant was unreachable, as noted by an inline TODO comment in `_handle_call_tool`. This could mislead subclass authors into returning a bare `dict` from `call_tool()` overrides, which would hit the dead-code fallback path instead of being handled correctly.

## Changes

- Updated the return type on `call_tool()` to `Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]] | CallToolResult`
- Removed the stale TODO comment that documented this exact issue

## Test Results

475 server tests pass (2 consecutive clean runs).