### PR TITLE
fix(stdio): allow configurable memory-stream buffer size

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -30,7 +30,12 @@ from mcp.shared.message import SessionMessage
 
 
 @asynccontextmanager
-async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.AsyncFile[str] | None = None):
+async def stdio_server(
+    stdin: anyio.AsyncFile[str] | None = None,
+    stdout: anyio.AsyncFile[str] | None = None,
+    read_stream_buffer_size: int = 0,
+    write_stream_buffer_size: int = 0,
+):
     """Server transport for stdio: this communicates with an MCP client by reading
     from the current process' stdin and writing to stdout.
     """
@@ -49,8 +54,8 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     write_stream: MemoryObjectSendStream[SessionMessage]
     write_stream_reader: MemoryObjectReceiveStream[SessionMessage]
 
-    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
-    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(read_stream_buffer_size)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(write_stream_buffer_size)
 
     async def stdin_reader():
         try:


### PR DESCRIPTION
## Problem

`stdio_server()` hardcodes `max_buffer_size=0` for both internal memory object streams, creating synchronous hand-off between the stdin reader and the message processor.  When the processor is busy with a slow operation (DB query, API call, file I/O), the stdin reader blocks and the server becomes completely unresponsive to pings and new requests.

Reported in #1333 — a server became unresponsive after 67 minutes of operation with requests every 10 seconds.

## Solution

Add two optional parameters to `stdio_server()`:

| Parameter | Default | Purpose |
|-----------|---------|---------|
| `read_stream_buffer_size` | `0` | Capacity of the stdin → processor stream |
| `write_stream_buffer_size` | `0` | Capacity of the processor → stdout stream |

Defaults preserve current behaviour.  Callers who need responsiveness under load can set a small buffer (e.g. `8`) to decouple reading from processing.

## Testing

Existing `test_stdio_server` passes — the default values keep behaviour identical.

Closes #1333