### PR TITLE
feat(server): expose progress_callback on ServerSession request methods

### DIFF
--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -381,7 +381,9 @@ class ServerSession(
             This method is deprecated in favor of elicit_form(). It remains for
             backward compatibility but new code should use elicit_form().
         """
-        return await self.elicit_form(message, requested_schema, related_request_id, progress_callback=progress_callback)
+        return await self.elicit_form(
+            message, requested_schema, related_request_id, progress_callback=progress_callback
+        )
 
     async def elicit_form(
         self,


### PR DESCRIPTION
## Problem

`BaseSession.send_request()` supports a `progress_callback` parameter for receiving bidirectional progress notifications, and `ClientSession.call_tool()` already exposes it.  However, none of the `ServerSession` convenience methods (`create_message()`, `elicit_form()`, `elicit_url()`) forward this parameter, so server code cannot receive progress updates from clients during sampling and elicitation without dropping down to raw `send_request()`.

The TypeScript SDK already exposes this via `RequestOptions.onprogress` in both `createMessage()` and `elicitInput()`.

## Solution

Add an optional `progress_callback: ProgressFnT | None = None` parameter (defaulting to `None`) to:

- `create_message()` (all overloads + implementation)
- `elicit_form()`
- `elicit_url()`
- `elicit()` (deprecated wrapper — passes through to `elicit_form()`)

The parameter is forwarded to `send_request()`.

## Testing

All 475 server tests pass — the new parameter defaults to `None` (no behavioural change for existing callers).

Closes #1650