### PR TITLE
fix: handle ClosedResourceError when logging errors to disconnected clients

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -417,11 +417,14 @@ class Server(Generic[LifespanResultT]):
                         )
                 case Exception():
                     logger.error(f"Received exception from stream: {message}")
-                    await session.send_log_message(
-                        level="error",
-                        data="Internal Server Error",
-                        logger="mcp.server.exception_handler",
-                    )
+                    try:
+                        await session.send_log_message(
+                            level="error",
+                            data="Internal Server Error",
+                            logger="mcp.server.exception_handler",
+                        )
+                    except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                        logger.debug("Could not send error log: client already disconnected")
                     if raise_exceptions:
                         raise message
                 case _:


### PR DESCRIPTION
## Summary

Fixes #2064

When a client disconnects while a stateless streamable-HTTP server is processing a request, the exception handler in `_handle_message` tries to `send_log_message()` back to the client. Since the session's write stream is already closed, this raises `ClosedResourceError`, which is unhandled and crashes the session with an `ExceptionGroup`.

## Root Cause

`_handle_message` (lowlevel/server.py) has an `Exception` case that:
1. Logs the error ✅
2. Tries `session.send_log_message()` to notify the client ❌ — crashes if the client is gone

## Fix

Wrap the `send_log_message()` call with a try/except for `anyio.ClosedResourceError` and `anyio.BrokenResourceError`. When the write stream is closed (client disconnected), the error is silently discarded with a debug log.

## Tests

All 475 server tests pass (2 consecutive clean runs). `ruff check` and `ruff format` clean.