### PR TITLE
Return `CallToolResult` from `convert_result` instead of a tuple

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -91,9 +91,9 @@ class FuncMetadata(BaseModel):
     def convert_result(self, result: Any) -> Any:
         """Convert a function call result to the format for the lowlevel tool call handler.
 
-        - If output_model is None, return the unstructured content directly.
-        - If output_model is not None, convert the result to structured output format
-            (dict[str, Any]) and return both unstructured and structured content.
+        - If output_model is None, return the unstructured content as a ``Sequence[ContentBlock]``.
+        - If output_model is not None, return a ``CallToolResult`` with both unstructured
+          and structured content.
 
         Note: we return unstructured content here **even though the lowlevel server
         tool call handler provides generic backwards compatibility serialization of
@@ -120,7 +120,7 @@ class FuncMetadata(BaseModel):
             validated = self.output_model.model_validate(result)
             structured_content = validated.model_dump(mode="json", by_alias=True)
 
-            return (unstructured_content, structured_content)
+            return CallToolResult(content=list(unstructured_content), structured_content=structured_content)
 
     def pre_parse_json(self, data: dict[str, Any]) -> dict[str, Any]:
         """Pre-parse data from JSON.

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -91,8 +91,8 @@ class FuncMetadata(BaseModel):
     def convert_result(self, result: Any) -> Any:
         """Convert a function call result to the format for the lowlevel tool call handler.
 
-        - If output_model is None, return the unstructured content as a ``Sequence[ContentBlock]``.
-        - If output_model is not None, return a ``CallToolResult`` with both unstructured
+        - If output_model is None, return the unstructured content as a `Sequence[ContentBlock]`.
+        - If output_model is not None, return a `CallToolResult` with both unstructured
           and structured content.
 
         Note: we return unstructured content here **even though the lowlevel server

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1038,7 +1038,7 @@ def test_structured_output_aliases():
 
     # Check that the actual output uses aliases too
     result = ModelWithAliases(**{"first": "hello", "second": "world"})
-    _, structured_content = meta.convert_result(result)
+    structured_content = meta.convert_result(result).structured_content
 
     # The structured content should use aliases to match the schema
     assert "first" in structured_content
@@ -1050,7 +1050,7 @@ def test_structured_output_aliases():
 
     # Also test the case where we have a model with defaults to ensure aliases work in all cases
     result_with_defaults = ModelWithAliases()  # Uses default None values
-    _, structured_content_defaults = meta.convert_result(result_with_defaults)
+    structured_content_defaults = meta.convert_result(result_with_defaults).structured_content
 
     # Even with defaults, should use aliases in output
     assert "first" in structured_content_defaults

--- a/tests/server/mcpserver/test_tool_manager.py
+++ b/tests/server/mcpserver/test_tool_manager.py
@@ -12,7 +12,7 @@ from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.tools import Tool, ToolManager
 from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
 from mcp.server.session import ServerSessionT
-from mcp.types import TextContent, ToolAnnotations
+from mcp.types import CallToolResult, TextContent, ToolAnnotations
 
 
 class TestAddTools:
@@ -473,7 +473,7 @@ class TestStructuredOutput:
         manager.add_tool(get_user)
         result = await manager.call_tool("get_user", {"user_id": 1}, convert_result=True)
         # don't test unstructured output here, just the structured conversion
-        assert len(result) == 2 and result[1] == {"name": "John", "age": 30}
+        assert isinstance(result, CallToolResult) and result.structured_content == {"name": "John", "age": 30}
 
     @pytest.mark.anyio
     async def test_tool_with_primitive_output(self):
@@ -488,7 +488,8 @@ class TestStructuredOutput:
         result = await manager.call_tool("double_number", {"n": 5})
         assert result == 10
         result = await manager.call_tool("double_number", {"n": 5}, convert_result=True)
-        assert isinstance(result[0][0], TextContent) and result[1] == {"result": 10}
+        assert isinstance(result, CallToolResult)
+        assert isinstance(result.content[0], TextContent) and result.structured_content == {"result": 10}
 
     @pytest.mark.anyio
     async def test_tool_with_typeddict_output(self):
@@ -528,7 +529,7 @@ class TestStructuredOutput:
         manager.add_tool(get_person)
         result = await manager.call_tool("get_person", {}, convert_result=True)
         # don't test unstructured output here, just the structured conversion
-        assert len(result) == 2 and result[1] == expected_output
+        assert isinstance(result, CallToolResult) and result.structured_content == expected_output
 
     @pytest.mark.anyio
     async def test_tool_with_list_output(self):
@@ -546,7 +547,8 @@ class TestStructuredOutput:
         result = await manager.call_tool("get_numbers", {})
         assert result == expected_list
         result = await manager.call_tool("get_numbers", {}, convert_result=True)
-        assert isinstance(result[0][0], TextContent) and result[1] == expected_output
+        assert isinstance(result, CallToolResult)
+        assert isinstance(result.content[0], TextContent) and result.structured_content == expected_output
 
     @pytest.mark.anyio
     async def test_tool_without_structured_output(self):


### PR DESCRIPTION
## Summary

- `convert_result()` now returns a `CallToolResult` directly when structured output is present, instead of a bare `(unstructured, structured)` tuple that leaked through the public API.
- `MCPServer.call_tool` return type corrected from `Sequence[ContentBlock] | dict[str, Any]` to `CallToolResult | Sequence[ContentBlock]`.
- Removed the tuple-unpacking and unreachable `dict` branches from `_handle_call_tool`.

Closes #1251

## Test plan

- [x] Existing tests in `test_func_metadata.py`, `test_tool_manager.py`, and `test_server.py` updated and passing (170 tests)
- [x] `ruff check` and `pyright` clean on all changed files