### PR TITLE
fix: catch ClosedResourceError when sending error log to disconnected client

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -417,11 +417,14 @@ class Server(Generic[LifespanResultT]):
                         )
                 case Exception():
                     logger.error(f"Received exception from stream: {message}")
-                    await session.send_log_message(
-                        level="error",
-                        data="Internal Server Error",
-                        logger="mcp.server.exception_handler",
-                    )
+                    try:
+                        await session.send_log_message(
+                            level="error",
+                            data="Internal Server Error",
+                            logger="mcp.server.exception_handler",
+                        )
+                    except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                        logger.debug("Could not send error log to client: connection already closed")
                     if raise_exceptions:
                         raise message
                 case _:


### PR DESCRIPTION
## Summary

Fixes #2064

When a client disconnects during request handling in a stateless streamable-HTTP server, `_handle_message`'s error handler tries to call `send_log_message()` back to the client. Since the write stream is already closed, this raises `ClosedResourceError`, which is unhandled and crashes the stateless session with an `ExceptionGroup`.

## Root Cause

This is a **different code path** from what PR #1384 fixed. That PR addressed `ClosedResourceError` in the message router loop. This bug is in the **error recovery path**:

```
ClientDisconnect → _handle_message catches Exception
  → tries send_log_message() to notify client
  → write stream already closed → ClosedResourceError
  → unhandled in TaskGroup → ExceptionGroup crash
```

## Fix

Added `try/except` around `send_log_message()` in `_handle_message` to catch both `ClosedResourceError` and `BrokenResourceError`, logging a debug message instead of crashing. Failing to notify a disconnected client is expected and harmless.

## Tests

Added 3 tests to `test_lowlevel_exception_handling.py`:
- `test_exception_handling_tolerates_closed_write_stream[closed]` — ClosedResourceError
- `test_exception_handling_tolerates_closed_write_stream[broken]` — BrokenResourceError  
- `test_exception_handling_reraises_with_closed_stream` — original exception still re-raised when `raise_exceptions=True`

All 9 tests pass.