### PR TITLE
fix: include transport path in Protected Resource Metadata resource URL

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -46,6 +46,7 @@ from typing import Any, Generic
 
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
@@ -595,8 +596,11 @@ class Server(Generic[LifespanResultT]):
             # Determine resource metadata URL
             resource_metadata_url = None
             if auth and auth.resource_server_url:
+                # The protected resource URL must include the transport path
+                # (e.g. http://localhost:8000/mcp) per RFC 9728
+                actual_resource_url = AnyHttpUrl(str(auth.resource_server_url).rstrip("/") + streamable_http_path)
                 # Build compliant metadata URL for WWW-Authenticate header
-                resource_metadata_url = build_resource_metadata_url(auth.resource_server_url)
+                resource_metadata_url = build_resource_metadata_url(actual_resource_url)
 
             routes.append(
                 Route(
@@ -615,9 +619,10 @@ class Server(Generic[LifespanResultT]):
 
         # Add protected resource metadata endpoint if configured as RS
         if auth and auth.resource_server_url:  # pragma: no cover
+            actual_resource_url = AnyHttpUrl(str(auth.resource_server_url).rstrip("/") + streamable_http_path)
             routes.extend(
                 create_protected_resource_routes(
-                    resource_url=auth.resource_server_url,
+                    resource_url=actual_resource_url,
                     authorization_servers=[auth.issuer_url],
                     scopes_supported=auth.required_scopes,
                 )

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -982,10 +982,15 @@ class MCPServer(Generic[LifespanResultT]):
             # Determine resource metadata URL
             resource_metadata_url = None
             if self.settings.auth and self.settings.auth.resource_server_url:
+                from pydantic import AnyHttpUrl
+
                 from mcp.server.auth.routes import build_resource_metadata_url
 
+                # The protected resource URL must include the transport path
+                # (e.g. http://localhost:8000/sse) per RFC 9728
+                actual_resource_url = AnyHttpUrl(str(self.settings.auth.resource_server_url).rstrip("/") + sse_path)
                 # Build compliant metadata URL for WWW-Authenticate header
-                resource_metadata_url = build_resource_metadata_url(self.settings.auth.resource_server_url)
+                resource_metadata_url = build_resource_metadata_url(actual_resource_url)
 
             # Auth is enabled, wrap the endpoints with RequireAuthMiddleware
             routes.append(
@@ -1023,11 +1028,14 @@ class MCPServer(Generic[LifespanResultT]):
             )
         # Add protected resource metadata endpoint if configured as RS
         if self.settings.auth and self.settings.auth.resource_server_url:  # pragma: no cover
+            from pydantic import AnyHttpUrl
+
             from mcp.server.auth.routes import create_protected_resource_routes
 
+            actual_resource_url = AnyHttpUrl(str(self.settings.auth.resource_server_url).rstrip("/") + sse_path)
             routes.extend(
                 create_protected_resource_routes(
-                    resource_url=self.settings.auth.resource_server_url,
+                    resource_url=actual_resource_url,
                     authorization_servers=[self.settings.auth.issuer_url],
                     scopes_supported=self.settings.auth.required_scopes,
                 )


### PR DESCRIPTION
## Summary

Fixes #1264

The `resource` field in `/.well-known/oauth-protected-resource` was set to the base `resource_server_url` (e.g., `http://localhost:8000/`) instead of the actual protected endpoint URL (e.g., `http://localhost:8000/mcp`). Per [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728#PRConfigurationValidation), the resource identifier must match the URL that clients use to access the protected resource.

This caused VS Code Copilot (and other compliant clients) to reject the server with:
> Protected Resource Metadata resource "http://localhost:8000/" does not match MCP server resolved resource "http://localhost:8000/mcp"

## Changes

- **`src/mcp/server/lowlevel/server.py`**: Append `streamable_http_path` to `resource_server_url` when constructing the resource URL for both the protected resource metadata endpoint and the WWW-Authenticate header.
- **`src/mcp/server/mcpserver/server.py`**: Same fix for the SSE transport path.

## Test

```
uv run pytest tests/server/auth/test_protected_resource.py -x  # 14 passed
uv run pytest tests/server/mcpserver/auth/ -x  # 42 passed
uv run ruff check src/mcp/server/lowlevel/server.py src/mcp/server/mcpserver/server.py  # All passed
```