### PR TITLE
fix: remove shell=True from subprocess calls in mcp dev

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -45,9 +45,9 @@ def _get_npx_command():
         # Try both npx.cmd and npx.exe on Windows
         for cmd in ["npx.cmd", "npx.exe", "npx"]:
             try:
-                subprocess.run([cmd, "--version"], check=True, capture_output=True, shell=True)
+                subprocess.run([cmd, "--version"], check=True, capture_output=True)
                 return cmd
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, FileNotFoundError):
                 continue
         return None
     return "npx"  # On Unix-like systems, just use npx
@@ -271,12 +271,10 @@ def dev(
             )
             sys.exit(1)
 
-        # Run the MCP Inspector command with shell=True on Windows
-        shell = sys.platform == "win32"
+        # Run the MCP Inspector command
         process = subprocess.run(
             [npx_cmd, "@modelcontextprotocol/inspector"] + uv_cmd,
             check=True,
-            shell=shell,
             env=dict(os.environ.items()),  # Convert to list of tuples for env update
         )
         sys.exit(process.returncode)


### PR DESCRIPTION
## Summary

Fixes #1257

`mcp dev` used `shell=True` when running `npx` on Windows, exposing a command injection risk via shell metacharacters in file paths (e.g., `server&calc.py`).

## Changes

- **`src/mcp/cli/cli.py`**:
  - Remove `shell=True` from both `subprocess.run` calls (`_get_npx_command` and the Inspector invocation).
  - `_get_npx_command()` already resolves to `npx.cmd`/`npx.exe` on Windows, so `shell=True` is unnecessary.
  - Add `FileNotFoundError` to the exception handler for robustness when the command is not found without shell expansion.

## Test

```
uv run ruff check src/mcp/cli/cli.py  # All checks passed
```