### PR TITLE
fix: resource with only Context param incorrectly classified as template

### DIFF
--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -51,12 +51,18 @@ class FunctionResource(Resource):
     """
 
     fn: Callable[[], Any] = Field(exclude=True)
+    context_kwarg: str | None = Field(default=None, exclude=True)
 
-    async def read(self) -> str | bytes:
+    async def read(self, context: Any | None = None) -> str | bytes:
         """Read the resource by calling the wrapped function."""
         try:
+            # Inject context if needed
+            kwargs: dict[str, Any] = {}
+            if self.context_kwarg is not None and context is not None:
+                kwargs[self.context_kwarg] = context
+
             # Call the function first to see if it returns a coroutine
-            result = self.fn()
+            result = self.fn(**kwargs)
             # If it's a coroutine, await it
             if inspect.iscoroutine(result):
                 result = await result
@@ -84,11 +90,18 @@ class FunctionResource(Resource):
         icons: list[Icon] | None = None,
         annotations: Annotations | None = None,
         meta: dict[str, Any] | None = None,
+        context_kwarg: str | None = None,
     ) -> "FunctionResource":
         """Create a FunctionResource from a function."""
+        from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
+
         func_name = name or fn.__name__
         if func_name == "<lambda>":  # pragma: no cover
             raise ValueError("You must provide a name for lambda functions")
+
+        # Detect context parameter
+        if context_kwarg is None:  # pragma: no branch
+            context_kwarg = find_context_parameter(fn)
 
         # ensure the arguments are properly cast
         fn = validate_call(fn)
@@ -103,6 +116,7 @@ class FunctionResource(Resource):
             icons=icons,
             annotations=annotations,
             meta=meta,
+            context_kwarg=context_kwarg,
         )
 
 

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -448,7 +448,10 @@ class MCPServer(Generic[LifespanResultT]):
             raise ResourceError(f"Unknown resource: {uri}")
 
         try:
-            content = await resource.read()
+            if isinstance(resource, FunctionResource):
+                content = await resource.read(context=context)
+            else:
+                content = await resource.read()
             return [ReadResourceContents(content=content, mime_type=resource.mime_type, meta=resource.meta)]
         except Exception as exc:
             logger.exception(f"Error getting resource {uri}")
@@ -686,12 +689,12 @@ class MCPServer(Generic[LifespanResultT]):
             # Check if this should be a template
             sig = inspect.signature(fn)
             has_uri_params = "{" in uri and "}" in uri
-            has_func_params = bool(sig.parameters)
+
+            # Exclude Context parameter when checking for function params
+            context_param = find_context_parameter(fn)
+            has_func_params = bool({p for p in sig.parameters if p != context_param})
 
             if has_uri_params or has_func_params:
-                # Check for Context parameter to exclude from validation
-                context_param = find_context_parameter(fn)
-
                 # Validate that URI params match function params (excluding context)
                 uri_params = set(re.findall(r"{(\w+)}", uri))
                 # We need to remove the context_param from the resource function if

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1189,6 +1189,29 @@ class TestContextInjection:
                 )
             )
 
+    async def test_resource_with_context_only_not_classified_as_template(self):
+        """Test that a resource with only a Context param is registered as a resource, not a template."""
+        mcp = MCPServer()
+
+        @mcp.resource("time://current")
+        def current_time(ctx: Context[ServerSession, None]) -> str:
+            """Resource with only context parameter."""
+            return "11:41"
+
+        # Should be registered as a regular resource, not a template
+        resources = await mcp.list_resources()
+        templates = mcp._resource_manager.list_templates()
+        assert len(resources) == 1
+        assert str(resources[0].uri) == "time://current"
+        assert len(templates) == 0
+
+        async with Client(mcp) as client:
+            result = await client.read_resource("time://current")
+            assert len(result.contents) == 1
+            content = result.contents[0]
+            assert isinstance(content, TextResourceContents)
+            assert content.text == "11:41"
+
     async def test_prompt_with_context(self):
         """Test that prompts can receive context parameter."""
         mcp = MCPServer()


### PR DESCRIPTION
## Summary

Fixes a bug where a resource handler with only a Context parameter (no URI template params) was incorrectly classified as a resource template instead of a regular resource.

## Problem

When using:
```python
@mcp.resource("time://current")
async def current_time(ctx: Context[ServerSession, AppContext]):
    return "11:41"
```

The resource was registered as a template because ool(sig.parameters) counted the Context parameter. It only appeared in list_resource_templates and could not be invoked via ead_resource.

## Fix

- Exclude Context parameter before checking has_func_params in the resource decorator (server.py)
- Add context_kwarg support to FunctionResource so context-only resources can still access server context when read
- Pass context to FunctionResource.read() in MCPServer.read_resource()

## Test plan

- Added test verifying context-only resource is classified as resource (not template) and readable via Client
- All 87 server tests pass
- All 59 resource-related tests pass

Fixes #1635
