### PR TITLE
fix: clean up SSE session on client disconnect

### DIFF
--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -186,6 +186,7 @@ class SseServerTransport:
                 )
                 await read_stream_writer.aclose()
                 await write_stream_reader.aclose()
+                self._read_stream_writers.pop(session_id, None)
                 logging.debug(f"Client session disconnected {session_id}")
 
             logger.debug("Starting SSE response task")

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -611,3 +611,41 @@ async def test_sse_client_handles_empty_keepalive_pings() -> None:
             assert not isinstance(msg, Exception)
             assert isinstance(msg.message, types.JSONRPCResponse)
             assert msg.message.id == 1
+
+
+@pytest.mark.anyio
+async def test_sse_session_cleanup_on_disconnect(server: None, server_url: str) -> None:
+    """Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/423
+
+    When a client disconnects, the server should remove the session from
+    _read_stream_writers. Without this cleanup, stale sessions accumulate and
+    POST requests to disconnected sessions are incorrectly accepted instead
+    of returning 404.
+    """
+    captured_session_id: str | None = None
+
+    def on_session_created(session_id: str) -> None:
+        nonlocal captured_session_id
+        captured_session_id = session_id
+
+    # Connect a client session, then disconnect
+    async with sse_client(server_url + "/sse", on_session_created=on_session_created) as streams:
+        async with ClientSession(*streams) as session:
+            await session.initialize()
+
+    assert captured_session_id is not None
+
+    # After disconnect, POST to the stale session should return 404
+    # (not 202 as it did before the fix)
+    async with httpx.AsyncClient() as client:
+        with anyio.fail_after(5):
+            while True:
+                response = await client.post(
+                    f"{server_url}/messages/?session_id={captured_session_id}",
+                    json={"jsonrpc": "2.0", "method": "ping", "id": 99},
+                    headers={"Content-Type": "application/json"},
+                )
+                if response.status_code == 404:
+                    break
+                await anyio.sleep(0.1)
+        assert response.status_code == 404

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -615,12 +615,12 @@ async def test_sse_client_handles_empty_keepalive_pings() -> None:
 
 @pytest.mark.anyio
 async def test_sse_session_cleanup_on_disconnect(server: None, server_url: str) -> None:
-    """Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/423
+    """Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/1227
 
     When a client disconnects, the server should remove the session from
     _read_stream_writers. Without this cleanup, stale sessions accumulate and
-    POST requests to disconnected sessions are incorrectly accepted instead
-    of returning 404.
+    POST requests to disconnected sessions return 202 Accepted followed by a
+    ClosedResourceError when the server tries to write to the dead stream.
     """
     captured_session_id: str | None = None
 

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -638,14 +638,9 @@ async def test_sse_session_cleanup_on_disconnect(server: None, server_url: str) 
     # After disconnect, POST to the stale session should return 404
     # (not 202 as it did before the fix)
     async with httpx.AsyncClient() as client:
-        with anyio.fail_after(5):
-            while True:
-                response = await client.post(
-                    f"{server_url}/messages/?session_id={captured_session_id}",
-                    json={"jsonrpc": "2.0", "method": "ping", "id": 99},
-                    headers={"Content-Type": "application/json"},
-                )
-                if response.status_code == 404:
-                    break
-                await anyio.sleep(0.1)
+        response = await client.post(
+            f"{server_url}/messages/?session_id={captured_session_id}",
+            json={"jsonrpc": "2.0", "method": "ping", "id": 99},
+            headers={"Content-Type": "application/json"},
+        )
         assert response.status_code == 404

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -622,24 +622,18 @@ async def test_sse_session_cleanup_on_disconnect(server: None, server_url: str) 
     POST requests to disconnected sessions return 202 Accepted followed by a
     ClosedResourceError when the server tries to write to the dead stream.
     """
-    captured_session_id: str | None = None
-
-    def on_session_created(session_id: str) -> None:
-        nonlocal captured_session_id
-        captured_session_id = session_id
+    captured: list[str] = []
 
     # Connect a client session, then disconnect
-    async with sse_client(server_url + "/sse", on_session_created=on_session_created) as streams:
+    async with sse_client(server_url + "/sse", on_session_created=captured.append) as streams:
         async with ClientSession(*streams) as session:
             await session.initialize()
-
-    assert captured_session_id is not None
 
     # After disconnect, POST to the stale session should return 404
     # (not 202 as it did before the fix)
     async with httpx.AsyncClient() as client:
         response = await client.post(
-            f"{server_url}/messages/?session_id={captured_session_id}",
+            f"{server_url}/messages/?session_id={captured[0]}",
             json={"jsonrpc": "2.0", "method": "ping", "id": 99},
             headers={"Content-Type": "application/json"},
         )


### PR DESCRIPTION
> [!NOTE]
> **EDIT from @maxisbey:** Retargeting to `Fixes #1227` — see https://github.com/modelcontextprotocol/python-sdk/pull/2200#issuecomment-3997883845 for details. The fix is correct and useful, but #423 is a different bug (client-side EventSource auto-reconnect without re-initialize) already mitigated by #822 and #1478. The "server reload" claim below is inaccurate — a uvicorn restart gives a fresh empty dict; this leak only occurs within a single process lifetime.

---

## Summary

Fixes #1227

After a client disconnects from the SSE endpoint, the session entry was never removed from `_read_stream_writers`. This caused stale sessions to accumulate, ~~and after a server reload old session IDs could still be found in the dict (with closed streams),~~ leading to confusing behavior.

## Changes

**`src/mcp/server/sse.py`:**
- Added `self._read_stream_writers.pop(session_id, None)` in the disconnect handler (`response_wrapper`) to clean up the session entry when a client disconnects

This is a one-line fix. The streams were already being closed on disconnect; this ensures the session dict entry is also removed so that subsequent POST requests to the old session ID correctly receive a 404 response.