### PR TITLE
fix: pass related_request_id in Context.report_progress()

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -1177,6 +1177,7 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT, RequestT]):
             progress=progress,
             total=total,
             message=message,
+            related_request_id=self.request_id,
         )
 
     async def read_resource(self, uri: str | AnyUrl) -> Iterable[ReadResourceContents]:

--- a/tests/issues/test_176_progress_token.py
+++ b/tests/issues/test_176_progress_token.py
@@ -36,6 +36,12 @@ async def test_progress_token_zero_first_call():
 
     # Verify progress notifications
     assert mock_session.send_progress_notification.call_count == 3, "All progress notifications should be sent"
-    mock_session.send_progress_notification.assert_any_call(progress_token=0, progress=0.0, total=10.0, message=None)
-    mock_session.send_progress_notification.assert_any_call(progress_token=0, progress=5.0, total=10.0, message=None)
-    mock_session.send_progress_notification.assert_any_call(progress_token=0, progress=10.0, total=10.0, message=None)
+    mock_session.send_progress_notification.assert_any_call(
+        progress_token=0, progress=0.0, total=10.0, message=None, related_request_id="test-request"
+    )
+    mock_session.send_progress_notification.assert_any_call(
+        progress_token=0, progress=5.0, total=10.0, message=None, related_request_id="test-request"
+    )
+    mock_session.send_progress_notification.assert_any_call(
+        progress_token=0, progress=10.0, total=10.0, message=None, related_request_id="test-request"
+    )

--- a/tests/issues/test_2001_progress_related_request_id.py
+++ b/tests/issues/test_2001_progress_related_request_id.py
@@ -1,0 +1,41 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mcp.server.fastmcp import Context
+from mcp.shared.context import RequestContext
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_report_progress_passes_related_request_id():
+    """Test that Context.report_progress() passes related_request_id to
+    send_progress_notification so that progress notifications are correctly
+    routed in stateless HTTP / SSE transports.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2001
+    """
+    mock_session = AsyncMock()
+    mock_session.send_progress_notification = AsyncMock()
+
+    mock_meta = MagicMock()
+    mock_meta.progressToken = "test-progress-token"
+
+    request_context = RequestContext(
+        request_id="req-42",
+        session=mock_session,
+        meta=mock_meta,
+        lifespan_context=None,
+    )
+
+    ctx = Context(request_context=request_context, fastmcp=MagicMock())
+
+    await ctx.report_progress(0.5, total=1.0, message="halfway")
+
+    mock_session.send_progress_notification.assert_called_once_with(
+        progress_token="test-progress-token",
+        progress=0.5,
+        total=1.0,
+        message="halfway",
+        related_request_id="req-42",
+    )


### PR DESCRIPTION
## Summary

`Context.report_progress()` notifications were silently dropped in stateless HTTP / SSE transports because `send_progress_notification()` was called without the `related_request_id` parameter. The transport layer uses this field to route server-initiated notifications back to the correct client SSE stream; without it, progress notifications are discarded.

This adds `related_request_id=self.request_id` to the `send_progress_notification()` call inside `Context.report_progress()`, making it consistent with `send_log_message()` which already passes the field correctly.

## Changes

- **`src/mcp/server/fastmcp/server.py`** -- add `related_request_id=self.request_id` to the `send_progress_notification()` call in `Context.report_progress()`
- **`tests/issues/test_176_progress_token.py`** -- update existing assertions to expect the new `related_request_id` kwarg
- **`tests/issues/test_2001_progress_related_request_id.py`** -- add regression test that verifies `related_request_id` is forwarded

Closes #2001