### PR TITLE
Include client_id in client_credentials token request body

### DIFF
--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -90,6 +90,7 @@ class ClientCredentialsOAuthProvider(OAuthClientProvider):
         """Build token exchange request for client_credentials grant."""
         token_data: dict[str, Any] = {
             "grant_type": "client_credentials",
+            "client_id": self._fixed_client_info.client_id,
         }
 
         headers: dict[str, str] = {"Content-Type": "application/x-www-form-urlencoded"}

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -249,6 +249,7 @@ class TestClientCredentialsOAuthProvider:
 
         content = urllib.parse.unquote_plus(request.content.decode())
         assert "grant_type=client_credentials" in content
+        assert "client_id=test-client-id" in content
         assert "scope=read write" in content
         assert "resource=https://api.example.com/v1/mcp" in content
 
@@ -272,6 +273,7 @@ class TestClientCredentialsOAuthProvider:
 
         content = urllib.parse.unquote_plus(request.content.decode())
         assert "grant_type=client_credentials" in content
+        assert "client_id=test-client-id" in content
         assert "scope=" not in content
         assert "resource=" not in content
 


### PR DESCRIPTION
## Summary
Include `client_id` in the token request body for `ClientCredentialsOAuthProvider`.

## Problem
`ClientCredentialsOAuthProvider._exchange_token_client_credentials()` was missing `client_id` in the `token_data` dict. Per [RFC 6749 §2.3.1](https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1), when using `client_secret_post` authentication, **both** `client_id` and `client_secret` must be in the request body.

The `prepare_token_auth()` method only adds `client_secret` for `client_secret_post`, so `client_id` was never sent — causing authentication failures with OAuth providers that require it.

Note: even for `client_secret_basic`, having `client_id` in the body is harmless per RFC 6749, and many providers expect it.

## Fix
Add `client_id` from `self._fixed_client_info` to the initial `token_data` dict, consistent with how other token exchange methods in the SDK include it (lines 336, 389, 436 of `oauth2.py`).

## Testing
All 13 existing tests pass. Added explicit `client_id` assertions to both `test_exchange_token_client_credentials` and `test_exchange_token_without_scopes` tests.

Fixes #2128