### PR TITLE
fix: ignore closed log streams during shutdown

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -414,11 +414,14 @@ class Server(Generic[LifespanResultT]):
                         )
                 case Exception():
                     logger.error(f"Received exception from stream: {message}")
-                    await session.send_log_message(
-                        level="error",
-                        data="Internal Server Error",
-                        logger="mcp.server.exception_handler",
-                    )
+                    try:
+                        await session.send_log_message(
+                            level="error",
+                            data="Internal Server Error",
+                            logger="mcp.server.exception_handler",
+                        )
+                    except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+                        logger.debug("Skipping exception log message because the session write stream is closed")
                     if raise_exceptions:
                         raise message
                 case _:

--- a/tests/server/test_lowlevel_exception_handling.py
+++ b/tests/server/test_lowlevel_exception_handling.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, Mock
 
+import anyio
 import pytest
 
 from mcp import types
@@ -50,6 +51,19 @@ async def test_exception_handling_with_raise_exceptions_false(exception_class: t
     assert call_args.kwargs["level"] == "error"
     assert call_args.kwargs["data"] == "Internal Server Error"
     assert call_args.kwargs["logger"] == "mcp.server.exception_handler"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("stream_error", [anyio.ClosedResourceError(), anyio.BrokenResourceError()])
+async def test_exception_handling_ignores_closed_log_stream(stream_error: Exception):
+    """Logging an exception should not crash shutdown if the write stream is already gone."""
+    server = Server("test-server")
+    session = Mock(spec=ServerSession)
+    session.send_log_message = AsyncMock(side_effect=stream_error)
+
+    await server._handle_message(RuntimeError("Test error"), session, {}, raise_exceptions=False)
+
+    session.send_log_message.assert_called_once()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- guard the low-level exception logging path when the session write stream is already closed
- add regression coverage for both `ClosedResourceError` and `BrokenResourceError` from `send_log_message()`

## Problem
When the server receives an exception from the stream during shutdown, `_handle_message()` tries to emit an internal error log notification through `session.send_log_message()`. If the session write stream has already been torn down, that best-effort log write can raise `ClosedResourceError` or `BrokenResourceError` and crash the enclosing task group.

## Fix
Treat exception logging in this shutdown path as best-effort. If the write stream is already gone, skip the log notification and continue handling the original shutdown flow.

## Validation
- `uv run pytest tests/server/test_lowlevel_exception_handling.py`
- `uv run ruff check src/mcp/server/lowlevel/server.py tests/server/test_lowlevel_exception_handling.py`
- `uv run ruff format --check src/mcp/server/lowlevel/server.py tests/server/test_lowlevel_exception_handling.py`
- `uv run pyright src/mcp/server/lowlevel/server.py tests/server/test_lowlevel_exception_handling.py`
