### PR TITLE
fix: validate_scope treats None registered scopes as no restrictions

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -71,11 +71,14 @@ class OAuthClientMetadata(BaseModel):
         if requested_scope is None:
             return None
         requested_scopes = requested_scope.split(" ")
-        allowed_scopes = [] if self.scope is None else self.scope.split(" ")
+        if self.scope is None:
+            # No registered scopes means no restrictions
+            return requested_scopes
+        allowed_scopes = self.scope.split(" ")
         for scope in requested_scopes:
-            if scope not in allowed_scopes:  # pragma: no branch
+            if scope not in allowed_scopes:
                 raise InvalidScopeError(f"Client was not registered with scope {scope}")
-        return requested_scopes  # pragma: no cover
+        return requested_scopes
 
     def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
         if redirect_uri is not None:

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,6 +1,8 @@
 """Tests for OAuth 2.0 shared code."""
 
-from mcp.shared.auth import OAuthMetadata
+import pytest
+
+from mcp.shared.auth import InvalidScopeError, OAuthClientMetadata, OAuthMetadata
 
 
 def test_oauth():
@@ -58,3 +60,39 @@ def test_oauth_with_jarm():
             "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
         }
     )
+
+
+class TestValidateScope:
+    """Tests for OAuthClientMetadata.validate_scope."""
+
+    def _make_client(self, scope: str | None = None) -> OAuthClientMetadata:
+        return OAuthClientMetadata.model_validate({"redirect_uris": ["https://example.com/callback"], "scope": scope})
+
+    def test_none_requested_scope_returns_none(self):
+        client = self._make_client(scope="read write")
+        assert client.validate_scope(None) is None
+
+    def test_none_registered_scope_allows_any_requested_scope(self):
+        client = self._make_client(scope=None)
+        result = client.validate_scope("read write admin")
+        assert result == ["read", "write", "admin"]
+
+    def test_registered_scope_allows_matching_requested_scope(self):
+        client = self._make_client(scope="read write")
+        result = client.validate_scope("read")
+        assert result == ["read"]
+
+    def test_registered_scope_allows_all_matching_scopes(self):
+        client = self._make_client(scope="read write")
+        result = client.validate_scope("read write")
+        assert result == ["read", "write"]
+
+    def test_registered_scope_rejects_unregistered_scope(self):
+        client = self._make_client(scope="read write")
+        with pytest.raises(InvalidScopeError, match="Client was not registered with scope admin"):
+            client.validate_scope("read admin")
+
+    def test_empty_registered_scope_rejects_any_requested_scope(self):
+        client = self._make_client(scope="")
+        with pytest.raises(InvalidScopeError):
+            client.validate_scope("read")


### PR DESCRIPTION
## Summary
- `OAuthClientMetadata.validate_scope()` incorrectly treated `self.scope = None` (no scopes registered) as an empty allowed list, rejecting all requested scopes with `InvalidScopeError`
- Now `None` is correctly treated as "no restrictions", allowing any requested scope through

Closes #2216

## Changes
- **Modified**: `src/mcp/shared/auth.py` — early return when `self.scope is None` instead of converting to empty list
- **Modified**: `tests/shared/test_auth.py` — added 6 unit tests for `validate_scope` covering None/matching/rejection/empty cases

## Test plan
- [x] All 9 shared auth tests pass (3 existing + 6 new)
- [x] All 42 auth integration tests pass (including `test_authorize_invalid_scope`)
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `pyright` passes with 0 errors