### PR TITLE
docs: explain FastMCP request IDs for cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1138,27 +1138,6 @@ The request context accessible via `ctx.request_context` contains request-specif
 - `ctx.request_context.request` - The original MCP request object for advanced processing
 - `ctx.request_context.request_id` - Unique identifier for this request
 
-Inside a FastMCP tool, the current request ID is available as `ctx.request_id`
-or `ctx.request_context.request_id`. This is the same JSON-RPC request ID that
-would be used in a `notifications/cancelled` message.
-
-Use `notifications/cancelled` for cancelling normal in-flight requests such as
-`tools/call`. For task-based work, use `tasks/cancel` instead.
-
-```python
-@mcp.tool()
-async def slow_tool(ctx: Context) -> str:
-    current_request_id = ctx.request_id
-    return f"handling request {current_request_id}"
-```
-
-If you are using the SDK's high-level client helpers such as
-`client.call_tool()` or `client.session.call_tool()`, the SDK manages request
-IDs for you and does not currently expose them directly. If you need explicit
-client-driven cancellation, prefer a task-based workflow (`tasks/cancel`) or a
-lower-level integration where you control request/notification correlation
-yourself.
-
 ```python
 # Example with typed lifespan context
 @dataclass

--- a/README.v2.md
+++ b/README.v2.md
@@ -1134,6 +1134,27 @@ The request context accessible via `ctx.request_context` contains request-specif
 - `ctx.request_context.request` - The original MCP request object for advanced processing
 - `ctx.request_context.request_id` - Unique identifier for this request
 
+Inside a FastMCP tool, the current request ID is available as `ctx.request_id`
+or `ctx.request_context.request_id`. This is the same JSON-RPC request ID that
+would be used in a `notifications/cancelled` message.
+
+Use `notifications/cancelled` for cancelling normal in-flight requests such as
+`tools/call`. For task-based work, use `tasks/cancel` instead.
+
+```python
+@mcp.tool()
+async def slow_tool(ctx: Context) -> str:
+    current_request_id = ctx.request_id
+    return f"handling request {current_request_id}"
+```
+
+If you are using the SDK's high-level client helpers such as
+`client.call_tool()` or `client.session.call_tool()`, the SDK manages request
+IDs for you and does not currently expose them directly. If you need explicit
+client-driven cancellation, prefer a task-based workflow (`tasks/cancel`) or a
+lower-level integration where you control request/notification correlation
+yourself.
+
 ```python
 # Example with typed lifespan context
 @dataclass


### PR DESCRIPTION
Closes #1410

Summary:
- document that `ctx.request_id` and `ctx.request_context.request_id` expose the current FastMCP request ID inside a tool
- clarify that `notifications/cancelled` uses that same JSON-RPC request ID for normal in-flight requests such as `tools/call`
- note the current limitation that high-level client helpers do not expose request IDs directly, and point readers toward task-based cancellation for explicit client-side control

Testing:
- `python3 -m uv run pytest tests/shared/test_session.py -k test_request_cancellation`
