### PR TITLE
Add warning log for unknown/expired session IDs

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -272,6 +272,10 @@ class StreamableHTTPSessionManager:
             # Unknown or expired session ID - return 404 per MCP spec
             # TODO: Align error code once spec clarifies
             # See: https://github.com/modelcontextprotocol/python-sdk/issues/1821
+            logger.warning(
+                "Rejected request with unknown or expired session ID: %s",
+                request_mcp_session_id,
+            )
             error_response = JSONRPCError(
                 jsonrpc="2.0",
                 id=None,

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -1,6 +1,7 @@
 """Tests for StreamableHTTPSessionManager."""
 
 import json
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -269,7 +270,7 @@ async def test_stateless_requests_memory_cleanup():
 
 
 @pytest.mark.anyio
-async def test_unknown_session_id_returns_404():
+async def test_unknown_session_id_returns_404(caplog: pytest.LogCaptureFixture):
     """Test that requests with unknown session IDs return HTTP 404 per MCP spec."""
     app = Server("test-unknown-session")
     manager = StreamableHTTPSessionManager(app=app)
@@ -299,7 +300,14 @@ async def test_unknown_session_id_returns_404():
         async def mock_receive():
             return {"type": "http.request", "body": b"{}", "more_body": False}  # pragma: no cover
 
-        await manager.handle_request(scope, mock_receive, mock_send)
+        with caplog.at_level(logging.WARNING, logger="mcp.server.streamable_http_manager"):
+            await manager.handle_request(scope, mock_receive, mock_send)
+
+        # Verify warning was logged for the unknown session ID
+        assert any(
+            "non-existent-session-id" in record.message and record.levelno == logging.WARNING
+            for record in caplog.records
+        ), "Should log a warning for unknown session ID"
 
         # Find the response start message
         response_start = next(


### PR DESCRIPTION
## Summary

- Adds `logger.warning()` in the `else` branch of `_handle_stateful_request()` when a request is rejected due to an unknown or expired session ID
- Adds test assertion verifying the warning is logged with the session ID

The other two branches already log at debug/info level, but this branch silently returned 404. This makes it difficult to diagnose connection failures caused by stale session IDs (e.g. after server restarts).

## Test plan

- [x] Existing test `test_unknown_session_id_returns_404` updated and passing
- [x] Verified warning includes the session ID string for traceability

Closes #2204