### PR TITLE
fix: add warning log when session ID is unknown or expired

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -272,6 +272,10 @@ class StreamableHTTPSessionManager:
             # Unknown or expired session ID - return 404 per MCP spec
             # TODO: Align error code once spec clarifies
             # See: https://github.com/modelcontextprotocol/python-sdk/issues/1821
+            logger.warning(
+                "Rejected request with unknown or expired session ID: %s",
+                session_id,
+            )
             error_response = JSONRPCError(
                 jsonrpc="2.0",
                 id=None,


### PR DESCRIPTION
## Summary

Adds a `logger.warning()` call in the `else` branch of `StreamableHTTPSessionManager._handle_stateful_request()` when a request arrives with an unknown or expired session ID.

## Problem

The other two branches in this method already log:
- `logger.debug("Session already exists for session ID ...")`
- `logger.info("Created new transport for session ...")`

But the `else` branch (unknown/expired session) returns a 404 silently, making it difficult to diagnose why connections are failing — especially after server restarts when clients send stale `mcp-session-id` headers.

## Change

Added `logger.warning()` with the rejected session ID to help operators identify stale session issues.

Closes #2204