### PR TITLE
fix: remove MIME type validation from MCPServer Resource

### DIFF
--- a/src/mcp/server/mcpserver/resources/base.py
+++ b/src/mcp/server/mcpserver/resources/base.py
@@ -23,11 +23,7 @@ class Resource(BaseModel, abc.ABC):
     name: str | None = Field(description="Name of the resource", default=None)
     title: str | None = Field(description="Human-readable title of the resource", default=None)
     description: str | None = Field(description="Description of the resource", default=None)
-    mime_type: str = Field(
-        default="text/plain",
-        description="MIME type of the resource content",
-        pattern=r"^[a-zA-Z0-9]+/[a-zA-Z0-9\-+.]+(;\s*[a-zA-Z0-9\-_.]+=[a-zA-Z0-9\-_.]+)*$",
-    )
+    mime_type: str = Field(default="text/plain", description="MIME type of the resource content")
     icons: list[Icon] | None = Field(default=None, description="Optional list of icons for this resource")
     annotations: Annotations | None = Field(default=None, description="Optional annotations for the resource")
     meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for this resource")

--- a/tests/server/mcpserver/resources/test_resources.py
+++ b/tests/server/mcpserver/resources/test_resources.py
@@ -91,6 +91,14 @@ class TestResourceValidation:
         )
         assert resource.mime_type == "application/json"
 
+        # RFC 2045 quoted parameter value (gh-1756)
+        resource = FunctionResource(
+            uri="resource://test",
+            fn=dummy_func,
+            mime_type='text/plain; charset="utf-8"',
+        )
+        assert resource.mime_type == 'text/plain; charset="utf-8"'
+
     @pytest.mark.anyio
     async def test_resource_read_abstract(self):
         """Test that Resource.read() is abstract."""


### PR DESCRIPTION
Removes the MIME type validation regex from `MCPServer.Resource.mime_type`.

Closes #1756. Supersedes #1819 and #2067.

## Motivation and Context

The `pattern=` constraint on `Resource.mime_type` was the **only MIME type validation anywhere in the MCP ecosystem**, and it rejected valid RFC 2045 MIME types — most notably quoted parameter values like `text/plain; charset="utf-8"`.

#1755 partially fixed this by extending the regex to allow unquoted parameters, but the fundamental problem is that no other SDK validates this field at all, and the spec doesn't ask them to:

| Where | Definition | Validation |
|---|---|---|
| [Spec schema — `Resource.mimeType`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/8811faecc24bf93b680282ee7bf5bbc3f99ecdfc/schema/2025-11-25/schema.ts#L822) | `mimeType?: string` | None |
| [TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk/blob/4a7cdf4f2b20b7bac71885e8414315f7bb6c66be/packages/core/src/types/types.ts#L859) | `z.optional(z.string())` | None |
| [Go SDK](https://github.com/modelcontextprotocol/go-sdk/blob/16d990b0416f63ca4948a5d8ba8f54ac6114b5a9/mcp/protocol.go#L1102) | `MIMEType string` | None |
| [C# SDK](https://github.com/modelcontextprotocol/csharp-sdk/blob/89fcf3f8b7db80bb7de6fcf7c8091b362fb18f84/src/ModelContextProtocol.Core/Protocol/Resource.cs#L65) | `string? MimeType` | None |
| [Python SDK — protocol types](https://github.com/modelcontextprotocol/python-sdk/blob/baa48571a3b4e6ed2cfaa804f22d3501200c181c/src/mcp/types/_types.py#L641) | `mime_type: str \| None = None` | None |
| [Python SDK — `ResourceTemplate`](https://github.com/modelcontextprotocol/python-sdk/blob/baa48571a3b4e6ed2cfaa804f22d3501200c181c/src/mcp/server/mcpserver/resources/templates.py#L30) | `Field(default="text/plain")` | None |
| Python SDK — `Resource` (before this PR) | `Field(pattern=r"^[a-zA-Z0-9]+/...")` | ❌ Regex |

The inconsistency with `ResourceTemplate` in the same module is the clearest signal — if templated resources don't need validation, concrete ones don't either.

## How Has This Been Tested?

- Extended existing `test_resource_mime_type` with a quoted-parameter case that the old regex rejected
- All resource tests pass (61 tests across `tests/server/mcpserver/resources/` + `tests/issues/test_1754_*` + `tests/issues/test_152_*`)
- 100% branch coverage on `base.py`

## Breaking Changes

None. Strictly more permissive.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Two prior PRs attempted this:
- #1819 added an `email.message`-based RFC 2045 validator (40+ lines) — right problem, wrong direction (more validation, not less); also predates the `fastmcp` → `mcpserver` rename
- #2067 added a minimal `"/" in value` check — reasonable, but still diverges from `ResourceTemplate` and the other SDKs

This PR just deletes the pattern: `+1/-5` source diff.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>