### PR TITLE
fix: make local coverage runs reliable

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Run pytest with coverage
         shell: bash
         run: |
+          uv run --frozen --no-sync coverage erase
           uv run --frozen --no-sync coverage run -m pytest -n auto
           uv run --frozen --no-sync coverage combine
           uv run --frozen --no-sync coverage report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,19 @@ This document contains critical information about working with this codebase. Fo
    - Bug fixes require regression tests
    - IMPORTANT: The `tests/client/test_client.py` is the most well designed test file. Follow its patterns.
    - IMPORTANT: Be minimal, and focus on E2E tests: Use the `mcp.client.Client` whenever possible.
-   - IMPORTANT: Before pushing, verify 100% branch coverage on changed files by running
-     `uv run --frozen pytest -x` (coverage is configured in `pyproject.toml` with `fail_under = 100`
-     and `branch = true`). If any branch is uncovered, add a test for it before pushing.
+   - Coverage: CI requires 100% (`fail_under = 100`, `branch = true`).
+     - Full check: `./scripts/test` (~20s, matches CI exactly)
+     - Targeted check while iterating:
+
+       ```bash
+       uv run --frozen coverage erase
+       uv run --frozen coverage run -m pytest tests/path/test_foo.py
+       uv run --frozen coverage combine
+       uv run --frozen coverage report --include='src/mcp/path/foo.py' --fail-under=0
+       ```
+
+       Partial runs can't hit 100% (coverage tracks `tests/` too), so `--fail-under=0`
+       and `--include` scope the report to what you actually changed.
    - Avoid `anyio.sleep()` with a fixed duration to wait for async operations. Instead:
      - Use `anyio.Event` — set it in the callback/handler, `await event.wait()` in the test
      - For stream messages, use `await stream.receive()` instead of `sleep()` + `receive_nowait()`

--- a/scripts/test
+++ b/scripts/test
@@ -2,6 +2,7 @@
 
 set -ex
 
+uv run --frozen coverage erase
 uv run --frozen coverage run -m pytest -n auto $@
 uv run --frozen coverage combine
 uv run --frozen coverage report

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -5,7 +5,6 @@
 # pyright: reportUnknownArgumentType=false
 # pyright: reportUnknownMemberType=false
 
-import sys
 from pathlib import Path
 
 import pytest
@@ -65,12 +64,17 @@ async def test_direct_call_tool_result_return():
 
 
 @pytest.mark.anyio
-async def test_desktop(monkeypatch: pytest.MonkeyPatch):
+async def test_desktop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Test the desktop server"""
-    # Mock desktop directory listing
-    mock_files = [Path("/fake/path/file1.txt"), Path("/fake/path/file2.txt")]
-    monkeypatch.setattr(Path, "iterdir", lambda self: mock_files)  # type: ignore[reportUnknownArgumentType]
-    monkeypatch.setattr(Path, "home", lambda: Path("/fake/home"))
+    # Build a real Desktop directory under tmp_path rather than patching
+    # Path.iterdir — a class-level patch breaks jsonschema_specifications'
+    # import-time schema discovery when this test happens to be the first
+    # tool call in an xdist worker.
+    desktop = tmp_path / "Desktop"
+    desktop.mkdir()
+    (desktop / "file1.txt").touch()
+    (desktop / "file2.txt").touch()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     from examples.mcpserver.desktop import mcp
 
@@ -85,15 +89,8 @@ async def test_desktop(monkeypatch: pytest.MonkeyPatch):
         content = result.contents[0]
         assert isinstance(content, TextResourceContents)
         assert isinstance(content.text, str)
-        if sys.platform == "win32":  # pragma: no cover
-            file_1 = "/fake/path/file1.txt".replace("/", "\\\\")  # might be a bug
-            file_2 = "/fake/path/file2.txt".replace("/", "\\\\")  # might be a bug
-            assert file_1 in content.text
-            assert file_2 in content.text
-            # might be a bug, but the test is passing
-        else:  # pragma: lax no cover
-            assert "/fake/path/file1.txt" in content.text
-            assert "/fake/path/file2.txt" in content.text
+        assert "file1.txt" in content.text
+        assert "file2.txt" in content.text
 
 
 # TODO(v2): Change back to README.md when v2 is released


### PR DESCRIPTION
Running `./scripts/test` locally was unreliable — stale state, a flaky test, and incorrect docs combined to make it fail often enough that local coverage checks were untrustworthy.

## Motivation and Context

Three distinct issues were compounding:

**1. `scripts/test` didn't erase before running.** `concurrency=['multiprocessing']` in `pyproject.toml` implicitly enables `parallel=True`, so each run produces ~70 `.coverage.*` files. If a previous run aborted before `coverage combine` (flaky test + `set -e`), those stale files contaminated the next run. CI never saw this because each job starts in a fresh container.

**2. `CLAUDE.md` said to verify coverage with `pytest -x`.** That command doesn't collect coverage — `pytest-cov` isn't installed and coverage isn't wired into `addopts`. The instruction silently did nothing, so coverage issues only surfaced on CI.

**3. `test_desktop` flaked under `-n auto`.** It monkeypatched `Path.iterdir` at the class level. When the test landed on an xdist worker that hadn't yet imported `jsonschema`, the lazy import in `_validate_tool_result` triggered `jsonschema_specifications`' schema discovery — which walks a directory with `iterdir()` and got the fake paths back. Flaky because it depended on whether another test in the same worker had already triggered the import.

## How Has This Been Tested?

- `./scripts/test` run 3× back-to-back: 100% each time (previously flaked ~25% on re-runs due to the `test_desktop` + stale-file interaction)
- `test_desktop` verified to pass with a cold `jsonschema` import
- Targeted-check recipe from CLAUDE.md verified against a single module

## Breaking Changes

None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling — n/a
- [x] I have added or updated documentation as needed

## Additional context

Also added `coverage erase` to `.github/workflows/shared.yml` — a no-op on CI (fresh container), but keeps the command sequence identical to `scripts/test` so it's safe to copy-paste locally.

The `test_desktop` fix also drops the Windows/POSIX path-separator special-casing — with real files under `tmp_path`, `str(f)` uses the platform's native separator naturally, so a substring match on the bare filename works everywhere.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>