### PR TITLE
fix: make pywin32 imports soft to support server-only Windows installs

### DIFF
--- a/src/mcp/os/win32/utilities.py
+++ b/src/mcp/os/win32/utilities.py
@@ -17,10 +17,18 @@ logger = logging.getLogger("client.stdio.win32")
 
 # Windows-specific imports for Job Objects
 if sys.platform == "win32":
-    import pywintypes
-    import win32api
-    import win32con
-    import win32job
+    try:
+        import pywintypes
+        import win32api
+        import win32con
+        import win32job
+    except ImportError:
+        # pywin32 is not installed — degrade gracefully.
+        # All downstream code null-checks these modules before use.
+        pywintypes = None
+        win32api = None
+        win32con = None
+        win32job = None
 else:
     # Type stubs for non-Windows platforms
     win32api = None


### PR DESCRIPTION
## Problem

`pywin32>=311` is a Windows dependency used exclusively for Job Object support in `mcp.client.stdio`. However, because `mcp/__init__.py` eagerly imports `from .client.stdio import StdioServerParameters, stdio_client`, the pywin32 modules in `mcp/os/win32/utilities.py` are loaded unconditionally on Windows — even for server-only users who never use the stdio client.

This causes two issues:

1. **Installation failures**: The pywin32 wheel contains Windows DLLs that antivirus software (e.g., Windows Defender) locks during extraction, causing `uv` cache cleanup to fail with OS error 32 (file in use). This blocks server-only deployments entirely.

2. **Unnecessary dependency**: Pure MCP servers should not require pywin32 at all, since Job Objects are only relevant for client-side subprocess management.

This blocks downstream projects like [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) on Windows (tracked in [homeassistant-ai/ha-mcp#672](https://github.com/homeassistant-ai/ha-mcp/issues/672)).

## Solution

Wrap the pywin32 imports in `src/mcp/os/win32/utilities.py` with `try/except ImportError`, falling back to `None` when the package is not installed.

All downstream functions that use these modules — `_create_job_object()`, `_maybe_assign_process_to_job()`, and `terminate_windows_process_tree()` — already null-check them before use, so the graceful degradation path is fully covered with no behavior change for users who have pywin32 installed.

## Change

```diff
 if sys.platform == "win32":
-    import pywintypes
-    import win32api
-    import win32con
-    import win32job
+    try:
+        import pywintypes
+        import win32api
+        import win32con
+        import win32job
+    except ImportError:
+        pywintypes = None
+        win32api = None
+        win32con = None
+        win32job = None
```

Fixes #2233