### PR TITLE
fix: preserve stdin/stdout file descriptors after server exits

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -17,6 +17,7 @@ Example:
     ```
 """
 
+import os
 import sys
 from contextlib import asynccontextmanager
 from io import TextIOWrapper
@@ -38,10 +39,16 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # standard process handles. Encoding of stdin/stdout as text streams on
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
+    # Use os.dup() to create copies of file descriptors to prevent closing
+    # the original sys.stdin/sys.stdout when the wrappers are closed.
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8"))
+        stdin_fd = os.dup(sys.stdin.fileno())
+        stdin_bin = os.fdopen(stdin_fd, "rb", closefd=True)
+        stdin = anyio.wrap_file(TextIOWrapper(stdin_bin, encoding="utf-8"))
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout_fd = os.dup(sys.stdout.fileno())
+        stdout_bin = os.fdopen(stdout_fd, "wb", closefd=True)
+        stdout = anyio.wrap_file(TextIOWrapper(stdout_bin, encoding="utf-8"))
 
     read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]
     read_stream_writer: MemoryObjectSendStream[SessionMessage | Exception]


### PR DESCRIPTION
## Description

Using os.dup() to create copies of file descriptors prevents closing the original sys.stdin/sys.stdout when the TextIOWrapper is closed.

## Fixes

Fixes https://github.com/modelcontextprotocol/python-sdk/issues/1933

## Changes

- Use os.dup() to create duplicate file descriptors for stdin/stdout
- Use os.fdopen() with closefd=True to manage the duplicated fd
- This prevents ValueError: I/O operation on closed file after the server exits

## Testing

The fix can be tested by running:
```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("Demo")
mcp.run(transport="stdio")
print("?")
```

After exiting the server with Ctrl+D, the print should work without errors.