### PR TITLE
Gracefully terminate active sessions during StreamableHTTP shutdown

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -766,8 +766,16 @@ class StreamableHTTPServerTransport:
         Once terminated, all requests with this session ID will receive 404 Not Found.
         """
 
+        if self._terminated:
+            return
         self._terminated = True
         logger.info(f"Terminating session: {self.mcp_session_id}")
+
+        # Close all SSE stream writers so that active EventSourceResponse
+        # coroutines complete gracefully instead of being cancelled mid-stream.
+        for writer in list(self._sse_stream_writers.values()):
+            writer.close()
+        self._sse_stream_writers.clear()
 
         # We need a copy of the keys to avoid modification during iteration
         request_stream_keys = list(self._request_streams.keys())

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -130,6 +130,17 @@ class StreamableHTTPSessionManager:
                 yield  # Let the application run
             finally:
                 logger.info("StreamableHTTP session manager shutting down")
+                # Gracefully terminate all active sessions before cancelling
+                # tasks so that EventSourceResponse coroutines can complete
+                # and Uvicorn does not log ASGI-incomplete-response errors.
+                for transport in list(self._server_instances.values()):
+                    try:
+                        await transport.terminate()
+                    except Exception:
+                        logger.debug(
+                            "Error terminating transport during shutdown",
+                            exc_info=True,
+                        )
                 # Cancel task group to stop all spawned tasks
                 tg.cancel_scope.cancel()
                 self._task_group = None

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -413,3 +413,51 @@ def test_session_idle_timeout_rejects_non_positive():
 def test_session_idle_timeout_rejects_stateless():
     with pytest.raises(RuntimeError, match="not supported in stateless"):
         StreamableHTTPSessionManager(app=Server("test"), session_idle_timeout=30, stateless=True)
+
+
+@pytest.mark.anyio
+async def test_terminate_closes_sse_stream_writers():
+    """Test that terminate() closes all active SSE stream writers."""
+    transport = StreamableHTTPServerTransport(mcp_session_id="test-sse-close")
+
+    # Create memory object streams to simulate active SSE writers
+    send1, recv1 = anyio.create_memory_object_stream[dict[str, str]]()
+    send2, recv2 = anyio.create_memory_object_stream[dict[str, str]]()
+
+    # Inject fake SSE writers into the transport
+    transport._sse_stream_writers["req-1"] = send1
+    transport._sse_stream_writers["req-2"] = send2
+
+    await transport.terminate()
+
+    # Writers should be closed (sending raises ClosedResourceError)
+    with pytest.raises(anyio.ClosedResourceError):
+        await send1.send({"data": "test"})
+    with pytest.raises(anyio.ClosedResourceError):
+        await send2.send({"data": "test"})
+
+    # Dict should be cleared
+    assert len(transport._sse_stream_writers) == 0
+
+    # Clean up receive streams
+    recv1.close()
+    recv2.close()
+
+
+@pytest.mark.anyio
+async def test_manager_shutdown_handles_terminate_exception(caplog: pytest.LogCaptureFixture):
+    """Test that manager shutdown continues even if transport.terminate() raises."""
+    app = Server("test-shutdown-error")
+    manager = StreamableHTTPSessionManager(app=app)
+
+    with caplog.at_level(logging.DEBUG):
+        async with manager.run():
+            # Inject a mock transport that raises on terminate
+            mock_transport = AsyncMock(spec=StreamableHTTPServerTransport)
+            mock_transport.terminate = AsyncMock(side_effect=RuntimeError("terminate failed"))
+            mock_transport.idle_scope = None
+            manager._server_instances["bad-session"] = mock_transport
+
+    # Manager should have shut down cleanly despite the exception
+    assert len(manager._server_instances) == 0
+    assert "Error terminating transport during shutdown" in caplog.text


### PR DESCRIPTION
Fixes #2150

## Problem

When shutting down a StreamableHTTP server while clients have active streaming connections, Uvicorn logs:

```
ERROR: ASGI callable returned without completing response.
```

This happens because `StreamableHTTPSessionManager.run()` cancels its task group on shutdown without first terminating active sessions. The `EventSourceResponse` coroutines are killed mid-stream before they can complete their HTTP responses.

There are two compounding issues:

1. `run()` never calls `terminate()` on active transports before cancelling the task group — it just clears the dict.
2. `terminate()` itself doesn't close `_sse_stream_writers`. It closes `_request_streams`, but the SSE writers that keep `EventSourceResponse` alive are stored separately and never touched during termination.

## Fix

**`streamable_http_manager.py`** — In `run()`'s `finally` block, iterate over all active transports and call `terminate()` on each *before* cancelling the task group.

**`streamable_http.py`** — In `terminate()`:
- Close all `_sse_stream_writers` so active `EventSourceResponse` instances complete gracefully.
- Add an early-return guard for idempotency, since `terminate()` may now be called from both the manager shutdown path and the per-session cleanup path.