### PR TITLE
fix: include "none" in token_endpoint_auth_methods_supported metadata

### DIFF
--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -165,7 +165,7 @@ def build_metadata(
         response_types_supported=["code"],
         response_modes_supported=None,
         grant_types_supported=["authorization_code", "refresh_token"],
-        token_endpoint_auth_methods_supported=["client_secret_post", "client_secret_basic"],
+        token_endpoint_auth_methods_supported=["client_secret_post", "client_secret_basic", "none"],
         token_endpoint_auth_signing_alg_values_supported=None,
         service_documentation=service_documentation_url,
         ui_locales_supported=None,
@@ -182,7 +182,7 @@ def build_metadata(
     # Add revocation endpoint if supported
     if revocation_options.enabled:  # pragma: no branch
         metadata.revocation_endpoint = AnyHttpUrl(str(issuer_url).rstrip("/") + REVOCATION_PATH)
-        metadata.revocation_endpoint_auth_methods_supported = ["client_secret_post", "client_secret_basic"]
+        metadata.revocation_endpoint_auth_methods_supported = ["client_secret_post", "client_secret_basic", "none"]
 
     return metadata
 

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1245,10 +1245,10 @@ def test_build_metadata(
             "registration_endpoint": Is(registration_endpoint),
             "scopes_supported": ["read", "write", "admin"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
-            "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic", "none"],
             "service_documentation": Is(service_documentation_url),
             "revocation_endpoint": Is(revocation_endpoint),
-            "revocation_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            "revocation_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic", "none"],
             "code_challenge_methods_supported": ["S256"],
         }
     )

--- a/tests/server/fastmcp/auth/test_auth_integration.py
+++ b/tests/server/fastmcp/auth/test_auth_integration.py
@@ -320,7 +320,11 @@ class TestAuthEndpoints:
         assert metadata["revocation_endpoint"] == "https://auth.example.com/revoke"
         assert metadata["response_types_supported"] == ["code"]
         assert metadata["code_challenge_methods_supported"] == ["S256"]
-        assert metadata["token_endpoint_auth_methods_supported"] == ["client_secret_post", "client_secret_basic"]
+        assert metadata["token_endpoint_auth_methods_supported"] == [
+            "client_secret_post",
+            "client_secret_basic",
+            "none",
+        ]
         assert metadata["grant_types_supported"] == [
             "authorization_code",
             "refresh_token",


### PR DESCRIPTION
## Summary

`build_metadata()` in `mcp/server/auth/routes.py` hardcodes `token_endpoint_auth_methods_supported` to `["client_secret_post", "client_secret_basic"]`, omitting `"none"`. This breaks public client OAuth flows used by MCP clients like Claude Code and Cursor.

### Spec References

- **MCP Authorization Spec ([2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization))**: "Authorization servers MUST implement OAuth 2.1 with appropriate security measures for both confidential and **public clients**." Best practices: "We strongly recommend that local clients implement OAuth 2.1 as a **public client**."
- **RFC 7591 [Section 2](https://datatracker.ietf.org/doc/html/rfc7591#section-2)**: `token_endpoint_auth_method: "none"` — "The client is a public client as defined in OAuth 2.0, Section 2.1, and does not have a client secret."
- **RFC 8414 [Section 2](https://datatracker.ietf.org/doc/html/rfc8414#section-2)**: `token_endpoint_auth_methods_supported` uses values from RFC 7591, which includes `"none"`.
- **[Official MCP example server](https://github.com/modelcontextprotocol/example-remote-server/blob/main/src/index.ts)**: Uses `token_endpoint_auth_methods_supported: ['none']` — the Python SDK is the outlier.

### The Problem

The registration handler (`register.py:54-60`) already supports public clients — it skips `client_secret` generation when `token_endpoint_auth_method: "none"`. But the metadata doesn't advertise this capability, so clients assume a secret is always required and fail during token exchange.

**Changes:**
- Add `"none"` to `token_endpoint_auth_methods_supported` in `build_metadata()`
- Add `"none"` to `revocation_endpoint_auth_methods_supported` for consistency
- Update test assertions

Fixes #2260

## Test plan

- [x] `uv run pytest tests/client/test_auth.py::test_build_metadata` — 2 passed, 1 xfailed
- [x] `uv run pytest tests/server/fastmcp/auth/test_auth_integration.py` — 40 passed
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — already formatted
- [ ] Manual verification: MCP server metadata now advertises `"none"`, allowing Claude Code to complete public client OAuth flow