### PR TITLE
fix: return 405 for GET/DELETE in stateless streamable-http mode

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -152,6 +152,21 @@ class StreamableHTTPSessionManager:
 
     async def _handle_stateless_request(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Process request in stateless mode - creating a new transport for each request."""
+        # In stateless mode only POST is meaningful.  GET would open a
+        # session-less SSE stream that idles until the platform kills it,
+        # and DELETE has no session to terminate.  Return 405 per spec.
+        request = Request(scope, receive)
+        if request.method != "POST":
+            from starlette.responses import Response
+
+            response = Response(
+                content="Method Not Allowed",
+                status_code=405,
+                headers={"Allow": "POST"},
+            )
+            await response(scope, receive, send)
+            return
+
         logger.debug("Stateless mode: Creating new transport for this request")
         # No session ID needed in stateless mode
         http_transport = StreamableHTTPServerTransport(

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -413,3 +413,59 @@ def test_session_idle_timeout_rejects_non_positive():
 def test_session_idle_timeout_rejects_stateless():
     with pytest.raises(RuntimeError, match="not supported in stateless"):
         StreamableHTTPSessionManager(app=Server("test"), session_idle_timeout=30, stateless=True)
+
+
+@pytest.mark.anyio
+async def test_stateless_get_returns_405():
+    """GET /mcp must return 405 in stateless mode (no SSE stream to open)."""
+    app = Server("test-stateless-get")
+    manager = StreamableHTTPSessionManager(app=app, stateless=True)
+
+    async with manager.run():
+        sent_messages: list[Message] = []
+
+        async def mock_send(message: Message):
+            sent_messages.append(message)
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/mcp",
+            "headers": [(b"accept", b"text/event-stream")],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await manager.handle_request(scope, mock_receive, mock_send)
+
+        assert sent_messages[0]["type"] == "http.response.start"
+        assert sent_messages[0]["status"] == 405
+
+
+@pytest.mark.anyio
+async def test_stateless_delete_returns_405():
+    """DELETE /mcp must return 405 in stateless mode (no session to terminate)."""
+    app = Server("test-stateless-delete")
+    manager = StreamableHTTPSessionManager(app=app, stateless=True)
+
+    async with manager.run():
+        sent_messages: list[Message] = []
+
+        async def mock_send(message: Message):
+            sent_messages.append(message)
+
+        scope = {
+            "type": "http",
+            "method": "DELETE",
+            "path": "/mcp",
+            "headers": [],
+        }
+
+        async def mock_receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await manager.handle_request(scope, mock_receive, mock_send)
+
+        assert sent_messages[0]["type"] == "http.response.start"
+        assert sent_messages[0]["status"] == 405


### PR DESCRIPTION
## Problem

When `stateless=True`, `StreamableHTTPSessionManager._handle_stateless_request()` delegates all HTTP methods (GET, POST, DELETE) to a per-request `StreamableHTTPServerTransport`. GET opens an SSE stream that has no session context and will never receive server-initiated messages. The stream idles until the platform kills it (e.g. Cloud Run 120s timeout), then clients like `mcp-remote` auto-reconnect, creating an infinite loop of billed CPU time.

The TypeScript SDK correctly returns 405 for GET and DELETE in stateless mode (see `src/server/streamableHttp.ts` stateless example).

## Impact

Any MCP server deployed on serverless platforms (Cloud Run, Lambda, Azure Container Apps) with `stateless=True` is affected. Each idle SSE reconnection cycle bills ~120s of CPU. A single forgotten client session can consume **180,000+ CPU-seconds/month** (exceeding Cloud Run's entire free tier).

## Fix

In `_handle_stateless_request()`, validate that the method is POST before creating the transport. Return 405 with `Allow: POST` header for GET and DELETE, matching the TypeScript SDK behavior and the MCP spec.

## Spec reference

MCP Streamable HTTP transport (2025-03-26):
- "The client **MAY** issue an HTTP GET" (optional, not required)
- "The server **MUST** return HTTP 405 Method Not Allowed if an SSE stream is not offered at the endpoint"
- Stateless servers have no session → no notifications → no SSE stream to offer

## Tests

Added two tests in `tests/server/test_streamable_http_manager.py`:
- `test_stateless_get_returns_405`
- `test_stateless_delete_returns_405`