### PR TITLE
Fix stdio_client BrokenResourceError race condition during shutdown

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -158,7 +158,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
 
                         session_message = SessionMessage(message)
                         await read_stream_writer.send(session_message)
-        except anyio.ClosedResourceError:  # pragma: lax no cover
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):  # pragma: lax no cover
             await anyio.lowlevel.checkpoint()
 
     async def stdin_writer():
@@ -174,7 +174,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                             errors=server.encoding_error_handler,
                         )
                     )
-        except anyio.ClosedResourceError:  # pragma: no cover
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):  # pragma: no cover
             await anyio.lowlevel.checkpoint()
 
     async with anyio.create_task_group() as tg, process:

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -509,6 +509,44 @@ class TestChildProcessCleanup:
 
 
 @pytest.mark.anyio
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
+async def test_stdio_client_no_broken_resource_error_on_shutdown():
+    """Test that exiting stdio_client without consuming the read stream does not
+    raise BrokenResourceError.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/1960.
+    The race condition occurs when stdout_reader is blocked on send() into a
+    zero-buffer memory stream and the finally block closes the receiving end,
+    causing BrokenResourceError instead of ClosedResourceError.
+    """
+    # Server sends a JSON-RPC message and then sleeps, keeping stdout open.
+    # The client exits without consuming the read stream, triggering the race.
+    server_script = textwrap.dedent(
+        """
+        import sys
+        import time
+
+        sys.stdout.write('{"jsonrpc":"2.0","id":1,"result":{}}\\n')
+        sys.stdout.flush()
+        time.sleep(5.0)
+        """
+    )
+
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-c", server_script],
+    )
+
+    # This should exit cleanly without raising an ExceptionGroup
+    # containing BrokenResourceError.
+    with anyio.fail_after(10.0):
+        async with stdio_client(server_params) as (_read_stream, _write_stream):
+            # Give stdout_reader time to read the message and block on send()
+            await anyio.sleep(0.3)
+            # Exit without consuming read_stream - this triggers the race
+
+
+@pytest.mark.anyio
 async def test_stdio_client_graceful_stdin_exit():
     """Test that a process exits gracefully when stdin is closed,
     without needing SIGTERM or SIGKILL.


### PR DESCRIPTION
## Summary

Fixes #1960. Supersedes #2219 (which was closed).

During `stdio_client` shutdown, the `finally` block closes `read_stream` (the receiving end of a zero-buffer memory channel) while `stdout_reader` may still be blocked on `send()`. When the receiving end closes underneath a pending `send()`, anyio raises `BrokenResourceError` — not `ClosedResourceError`. The existing `except` clause only caught `ClosedResourceError`, so `BrokenResourceError` escaped into an `ExceptionGroup`.

The fix catches `BrokenResourceError` alongside `ClosedResourceError` in both `stdout_reader` and `stdin_writer`. This is the minimal, correct change: `ClosedResourceError` means "you called send on a handle you already closed", while `BrokenResourceError` means "the other end was closed" — both are expected during shutdown and should be handled identically.

## Test plan

- Added regression test `test_stdio_client_no_broken_resource_error_on_shutdown` that reproduces the exact scenario: server sends a JSON-RPC message, client exits without consuming the read stream
- All 12 existing `tests/client/test_stdio.py` tests pass