### PR TITLE
fix: preserve existing refresh_token when server omits it in refresh response

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -458,6 +458,17 @@ class OAuthClientProvider(httpx.Auth):
             content = await response.aread()
             token_response = OAuthToken.model_validate_json(content)
 
+            # Per RFC 6749 Section 6, the server MAY issue a new refresh token.
+            # If the response omits it, preserve the existing one.
+            if (
+                not token_response.refresh_token
+                and self.context.current_tokens
+                and self.context.current_tokens.refresh_token
+            ):
+                token_response = token_response.model_copy(
+                    update={"refresh_token": self.context.current_tokens.refresh_token}
+                )
+
             self.context.current_tokens = token_response
             self.context.update_token_expiry(token_response)
             await self.context.storage.set_tokens(token_response)


### PR DESCRIPTION
Per RFC 6749 Section 6, the authorization server MAY issue a new refresh token in the refresh response. If omitted, the client must preserve the existing one.

This fix prevents token refresh failures after the first refresh when using OAuth providers that don't return refresh tokens in responses (e.g., Google, Auth0 without rotation, Okta in persistent token mode).

Fixes #2270