### PR TITLE
fix(auth): preserve existing refresh_token when server omits it

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -458,6 +458,11 @@ class OAuthClientProvider(httpx.Auth):
             content = await response.aread()
             token_response = OAuthToken.model_validate_json(content)
 
+            # Per RFC 6749 Section 6, the server may not return a new refresh_token.
+            # If the server omits it, preserve the existing refresh_token.
+            if not token_response.refresh_token and self.context.current_tokens:
+                token_response.refresh_token = self.context.current_tokens.refresh_token
+
             self.context.current_tokens = token_response
             self.context.update_token_expiry(token_response)
             await self.context.storage.set_tokens(token_response)


### PR DESCRIPTION
Per RFC 6749 Section 6, issuing a new refresh token in the refresh response is optional. When the authorization server does not return a new refresh_token, the previously stored refresh_token is now preserved instead of being discarded.

Fixes: #2270