### PR TITLE
Fix: preserve existing refresh_token when server omits it in refresh response

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -458,6 +458,17 @@ class OAuthClientProvider(httpx.Auth):
             content = await response.aread()
             token_response = OAuthToken.model_validate_json(content)
 
+            # Per RFC 6749 Section 6, the server MAY issue a new refresh token.
+            # If the response omits it, preserve the existing one.
+            if (
+                not token_response.refresh_token
+                and self.context.current_tokens
+                and self.context.current_tokens.refresh_token
+            ):
+                token_response = token_response.model_copy(
+                    update={"refresh_token": self.context.current_tokens.refresh_token}
+                )
+
             self.context.current_tokens = token_response
             self.context.update_token_expiry(token_response)
             await self.context.storage.set_tokens(token_response)


### PR DESCRIPTION
Fixes #2270

Per RFC 6749 Section 6, the server MAY issue a new refresh token. If the response omits it, preserve the existing one.

Many OAuth providers (Google, Auth0, Okta) omit refresh_token from refresh responses by default. The current behavior causes `can_refresh_token()` to return False after the first refresh, forcing full re-authentication.