### PR TITLE
fix: move logging configuration from MCPServer.__init__ to run()

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -194,9 +194,6 @@ class MCPServer(Generic[LifespanResultT]):
             self._token_verifier = ProviderTokenVerifier(auth_server_provider)
         self._custom_starlette_routes: list[Route] = []
 
-        # Configure logging
-        configure_logging(self.settings.log_level)
-
     @property
     def name(self) -> str:
         return self._lowlevel_server.name
@@ -278,6 +275,8 @@ class MCPServer(Generic[LifespanResultT]):
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
             **kwargs: Transport-specific options (see overloads for details)
         """
+        configure_logging(self.settings.log_level)
+
         TRANSPORTS = Literal["stdio", "sse", "streamable-http"]
         if transport not in TRANSPORTS.__args__:  # type: ignore  # pragma: no cover
             raise ValueError(f"Unknown transport: {transport}")

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1481,3 +1481,17 @@ async def test_report_progress_passes_related_request_id():
         message="halfway",
         related_request_id="req-abc-123",
     )
+
+
+def test_init_does_not_configure_logging():
+    """MCPServer.__init__ must not call logging.basicConfig or add handlers.
+
+    Libraries should never configure the root logger — that is the
+    application's responsibility.  Logging should only be configured
+    when the server is run as a standalone process via ``run()``.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/1656
+    """
+    with patch("mcp.server.mcpserver.server.configure_logging") as mock_configure:
+        MCPServer("test")
+        mock_configure.assert_not_called()


### PR DESCRIPTION
## Problem

`MCPServer.__init__()` calls `configure_logging()` which invokes `logging.basicConfig()` — configuring the **root logger** with handlers and a level on every instantiation. Per [Python's logging documentation](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library):

> It is strongly advised that you do not add any handlers other than NullHandler to your library's loggers.

Any application that imports and instantiates `MCPServer` gets its logging configuration silently overwritten.

## Fix

Move the single `configure_logging(self.settings.log_level)` call from `__init__` to `run()`. This is the actual application entrypoint — the method users call when they want to start the server as a standalone process.

- `MCPServer("test")` (library usage) — zero logging side effects
- `mcp.run()` (standalone entrypoint) — configures logging before starting

## Changes

- `src/mcp/server/mcpserver/server.py` — moved 1 call (3 lines removed, 2 added)
- `tests/server/mcpserver/test_server.py` — regression test verifying `__init__` does not call `configure_logging`

Full test suite passes with 100% coverage.

Closes #1656