### PR TITLE
feat: add subject and claims fields to AccessToken

### DIFF
--- a/src/mcp/server/auth/provider.py
+++ b/src/mcp/server/auth/provider.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Generic, Literal, Protocol, TypeVar
+from typing import Any, Generic, Literal, Protocol, TypeVar
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from pydantic import AnyUrl, BaseModel
@@ -40,6 +40,8 @@ class AccessToken(BaseModel):
     scopes: list[str]
     expires_at: int | None = None
     resource: str | None = None  # RFC 8707 resource indicator
+    subject: str | None = None  # JWT sub claim — identifies the end-user
+    claims: dict[str, Any] | None = None  # arbitrary JWT claims from the token
 
 
 RegistrationErrorCode = Literal[

--- a/src/mcp/server/mcpserver/context.py
+++ b/src/mcp/server/mcpserver/context.py
@@ -219,6 +219,18 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
         return self.request_context.meta.get("client_id") if self.request_context.meta else None  # pragma: no cover
 
     @property
+    def subject(self) -> str | None:
+        """Get the authenticated user's subject (JWT sub claim) if available.
+
+        This returns the subject claim from the OAuth access token, identifying
+        the end-user on whose behalf the request is made.
+        """
+        from mcp.server.auth.middleware.auth_context import get_access_token
+
+        token = get_access_token()
+        return token.subject if token else None
+
+    @property
     def request_id(self) -> str:
         """Get the unique ID for this request."""
         return str(self.request_context.request_id)

--- a/tests/server/auth/middleware/test_auth_context.py
+++ b/tests/server/auth/middleware/test_auth_context.py
@@ -41,6 +41,7 @@ def valid_access_token() -> AccessToken:
         client_id="test_client",
         scopes=["read", "write"],
         expires_at=int(time.time()) + 3600,  # 1 hour from now
+        subject="user_123",
     )
 
 
@@ -81,6 +82,27 @@ async def test_auth_context_middleware_with_authenticated_user(valid_access_toke
     # Verify context is reset after middleware
     assert auth_context_var.get() is None
     assert get_access_token() is None
+
+
+@pytest.mark.anyio
+async def test_auth_context_middleware_subject_preserved(valid_access_token: AccessToken):
+    """Test that subject field on AccessToken is available via get_access_token()."""
+    app = MockApp()
+    middleware = AuthContextMiddleware(app)
+
+    user = AuthenticatedUser(valid_access_token)
+    scope: Scope = {"type": "http", "user": user}
+
+    async def receive() -> Message:  # pragma: no cover
+        return {"type": "http.request"}
+
+    async def send(message: Message) -> None:  # pragma: no cover
+        pass
+
+    await middleware(scope, receive, send)
+
+    assert app.access_token_during_call is not None
+    assert app.access_token_during_call.subject == "user_123"
 
 
 @pytest.mark.anyio

--- a/tests/server/auth/middleware/test_bearer_auth.py
+++ b/tests/server/auth/middleware/test_bearer_auth.py
@@ -77,6 +77,7 @@ def valid_access_token() -> AccessToken:
         client_id="test_client",
         scopes=["read", "write"],
         expires_at=int(time.time()) + 3600,  # 1 hour from now
+        subject="user_123",
     )
 
 


### PR DESCRIPTION
## Summary

Closes #1038

Adds two optional fields to `AccessToken` to enable servers to identify the end-user behind an access token (not just the OAuth client application):

- `subject: str | None = None` — the JWT standard `sub` claim, identifying the end-user
- `claims: dict[str, Any] | None = None` — arbitrary JWT claims for carrying additional token data

Also exposes `ctx.subject` on the `Context` class in the MCPServer via `get_access_token()` from the auth middleware context var, so tool/resource handlers can access the authenticated user's identity without reaching into the middleware layer directly.

## Changes

- `src/mcp/server/auth/provider.py`: Added `Any` import, `subject` and `claims` fields to `AccessToken`
- `src/mcp/server/mcpserver/context.py`: Added `Context.subject` property
- `tests/server/auth/middleware/test_auth_context.py`: Added `subject` to fixture + new test verifying subject flows through middleware
- `tests/server/auth/middleware/test_bearer_auth.py`: Added `subject` to token fixtures

## Test plan

- [x] All 19 existing middleware tests pass
- [x] New `test_auth_context_middleware_subject_preserved` test verifies subject is available via `get_access_token()` during request
- [x] Both new fields are optional with `None` default — fully backwards compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)