### PR TITLE
client: store server_info on ClientSession after initialization

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -132,6 +132,7 @@ class ClientSession(
         self._message_handler = message_handler or _default_message_handler
         self._tool_output_schemas: dict[str, dict[str, Any] | None] = {}
         self._server_capabilities: types.ServerCapabilities | None = None
+        self._server_info: types.Implementation | None = None
         self._experimental_features: ExperimentalClientFeatures | None = None
 
         # Experimental: Task handlers (use defaults if not provided)
@@ -186,6 +187,7 @@ class ClientSession(
             raise RuntimeError(f"Unsupported protocol version from the server: {result.protocol_version}")
 
         self._server_capabilities = result.capabilities
+        self._server_info = result.server_info
 
         await self.send_notification(types.InitializedNotification())
 
@@ -197,6 +199,13 @@ class ClientSession(
         Returns None if the session has not been initialized yet.
         """
         return self._server_capabilities
+
+    def get_server_info(self) -> types.Implementation | None:
+        """Return the server info received during initialization.
+
+        Returns None if the session has not been initialized yet.
+        """
+        return self._server_info
 
     @property
     def experimental(self) -> ExperimentalClientFeatures:

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -608,6 +608,64 @@ async def test_get_server_capabilities():
 
 
 @pytest.mark.anyio
+async def test_get_server_info():
+    """Test that get_server_info returns None before init and server info after"""
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+
+    expected_server_info = Implementation(name="my-test-server", version="2.5.0")
+
+    async def mock_server():
+        session_message = await client_to_server_receive.receive()
+        jsonrpc_request = session_message.message
+        assert isinstance(jsonrpc_request, JSONRPCRequest)
+        request = client_request_adapter.validate_python(
+            jsonrpc_request.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )
+        assert isinstance(request, InitializeRequest)
+
+        result = InitializeResult(
+            protocol_version=LATEST_PROTOCOL_VERSION,
+            capabilities=ServerCapabilities(),
+            server_info=expected_server_info,
+        )
+
+        async with server_to_client_send:
+            await server_to_client_send.send(
+                SessionMessage(
+                    JSONRPCResponse(
+                        jsonrpc="2.0",
+                        id=jsonrpc_request.id,
+                        result=result.model_dump(by_alias=True, mode="json", exclude_none=True),
+                    )
+                )
+            )
+            await client_to_server_receive.receive()
+
+    async with (
+        ClientSession(
+            server_to_client_receive,
+            client_to_server_send,
+        ) as session,
+        anyio.create_task_group() as tg,
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        assert session.get_server_info() is None
+
+        tg.start_soon(mock_server)
+        await session.initialize()
+
+        server_info = session.get_server_info()
+        assert server_info is not None
+        assert server_info == expected_server_info
+        assert server_info.name == "my-test-server"
+        assert server_info.version == "2.5.0"
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(argnames="meta", argvalues=[None, {"toolMeta": "value"}])
 async def test_client_tool_call_with_meta(meta: RequestParamsMeta | None):
     """Test that client tool call requests can include metadata"""


### PR DESCRIPTION
## Problem

When a `ClientSession` completes the MCP initialize handshake, the server returns `serverInfo` (name, version) inside `InitializeResult`. This data was returned from `initialize()` but not retained on the session object — callers had no way to inspect which server they were connected to without capturing it at call time.

Fixes #1018

## Solution

Add a `_server_info: types.Implementation | None` attribute to `ClientSession`, populated during `initialize()` from `result.server_info`. Expose it via a `get_server_info()` method, mirroring the existing `get_server_capabilities()` pattern:

- Returns `None` before initialization
- Returns the `Implementation` (name + version) after a successful handshake

## Example

```python
session = await exit_stack.enter_async_context(ClientSession(read, write))
await session.initialize()

server_info = session.get_server_info()
print(server_info.name)     # e.g. "my-mcp-server"
print(server_info.version)  # e.g. "1.0.0"
```

## Changes

- `src/mcp/client/session.py`: added `_server_info` field in `__init__`, assigned in `initialize()`, exposed via `get_server_info()`
- `tests/client/test_session.py`: added `test_get_server_info` verifying pre-init returns `None` and post-init returns the correct `Implementation`