### PR TITLE
fix: remove scope registration check from authorize handler

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -797,6 +797,23 @@ server = Server("my-server")
 server.experimental.enable_tasks(on_get_task=custom_get_task)
 ```
 
+### Server auth: `InvalidScopeError` removed, `validate_scope` no longer enforces
+
+`OAuthClientMetadata.validate_scope()` no longer rejects scopes outside the client's registered set — it now only parses the scope string. The previous check blocked the MCP spec's step-up authorization flow, where a client must be able to request scopes beyond its initial registration in response to a `WWW-Authenticate: insufficient_scope` challenge. See [TypeScript SDK #983](https://github.com/modelcontextprotocol/typescript-sdk/pull/983) for the equivalent change.
+
+`InvalidScopeError` (from `mcp.shared.auth`) has been removed — the SDK no longer raises it.
+
+If your server needs to reject scopes, enforce policy inside `OAuthAuthorizationServerProvider.authorize()`:
+
+```python
+from mcp.server.auth.provider import AuthorizeError
+
+async def authorize(self, client, params):
+    if params.scopes and "admin" in params.scopes and not client_is_trusted(client):
+        raise AuthorizeError(error="invalid_scope", error_description="admin scope requires approval")
+    ...
+```
+
 ## Deprecations
 
 <!-- Add deprecations below -->

--- a/src/mcp/server/auth/handlers/authorize.py
+++ b/src/mcp/server/auth/handlers/authorize.py
@@ -17,7 +17,7 @@ from mcp.server.auth.provider import (
     OAuthAuthorizationServerProvider,
     construct_redirect_uri,
 )
-from mcp.shared.auth import InvalidRedirectUriError, InvalidScopeError
+from mcp.shared.auth import InvalidRedirectUriError
 
 logger = logging.getLogger(__name__)
 
@@ -185,15 +185,7 @@ class AuthorizationHandler:
                     error_description=validation_error.message,
                 )
 
-            # Validate scope - for scope errors, we can redirect
-            try:
-                scopes = client.validate_scope(auth_request.scope)
-            except InvalidScopeError as validation_error:
-                # For scope errors, redirect with error parameters
-                return await error_response(
-                    error="invalid_scope",
-                    error_description=validation_error.message,
-                )
+            scopes = client.validate_scope(auth_request.scope)
 
             # Setup authorization parameters
             auth_params = AuthorizationParams(

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -22,11 +22,6 @@ class OAuthToken(BaseModel):
         return v  # pragma: no cover
 
 
-class InvalidScopeError(Exception):
-    def __init__(self, message: str):
-        self.message = message
-
-
 class InvalidRedirectUriError(Exception):
     def __init__(self, message: str):
         self.message = message
@@ -68,14 +63,15 @@ class OAuthClientMetadata(BaseModel):
     software_version: str | None = None
 
     def validate_scope(self, requested_scope: str | None) -> list[str] | None:
+        """Parse the requested scope string into a list.
+
+        Scope policy enforcement is the provider's responsibility: raise
+        ``AuthorizeError(error="invalid_scope", ...)`` from
+        ``OAuthAuthorizationServerProvider.authorize()`` to reject.
+        """
         if requested_scope is None:
             return None
-        requested_scopes = requested_scope.split(" ")
-        allowed_scopes = [] if self.scope is None else self.scope.split(" ")
-        for scope in requested_scopes:
-            if scope not in allowed_scopes:  # pragma: no branch
-                raise InvalidScopeError(f"Client was not registered with scope {scope}")
-        return requested_scopes  # pragma: no cover
+        return requested_scope.split(" ")
 
     def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
         if redirect_uri is not None:

--- a/tests/server/mcpserver/auth/test_auth_integration.py
+++ b/tests/server/mcpserver/auth/test_auth_integration.py
@@ -1607,37 +1607,3 @@ class TestAuthorizeEndpointErrors:
         # State should be preserved
         assert "state" in query_params
         assert query_params["state"][0] == "test_state"
-
-    @pytest.mark.anyio
-    async def test_authorize_invalid_scope(
-        self, test_client: httpx.AsyncClient, registered_client: dict[str, Any], pkce_challenge: dict[str, str]
-    ):
-        """Test authorization endpoint with invalid scope.
-
-        Invalid scope should redirect with invalid_scope error.
-        """
-
-        response = await test_client.get(
-            "/authorize",
-            params={
-                "response_type": "code",
-                "client_id": registered_client["client_id"],
-                "redirect_uri": "https://client.example.com/callback",
-                "code_challenge": pkce_challenge["code_challenge"],
-                "code_challenge_method": "S256",
-                "scope": "invalid_scope_that_does_not_exist",
-                "state": "test_state",
-            },
-        )
-
-        # Should redirect with error parameters
-        assert response.status_code == 302
-        redirect_url = response.headers["location"]
-        parsed_url = urlparse(redirect_url)
-        query_params = parse_qs(parsed_url.query)
-
-        assert "error" in query_params
-        assert query_params["error"][0] == "invalid_scope"
-        # State should be preserved
-        assert "state" in query_params
-        assert query_params["state"][0] == "test_state"

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,6 +1,6 @@
 """Tests for OAuth 2.0 shared code."""
 
-from mcp.shared.auth import OAuthMetadata
+from mcp.shared.auth import OAuthClientMetadata, OAuthMetadata
 
 
 def test_oauth():
@@ -58,3 +58,13 @@ def test_oauth_with_jarm():
             "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
         }
     )
+
+
+def test_validate_scope_none_returns_none():
+    client = OAuthClientMetadata.model_validate({"redirect_uris": ["https://example.com/cb"]})
+    assert client.validate_scope(None) is None
+
+
+def test_validate_scope_splits_requested():
+    client = OAuthClientMetadata.model_validate({"redirect_uris": ["https://example.com/cb"]})
+    assert client.validate_scope("read write admin") == ["read", "write", "admin"]


### PR DESCRIPTION
Supersedes #2220 and #2224. Fixes #2216.

## Motivation and Context

`OAuthClientMetadata.validate_scope()` rejected any requested scope not in the client's registered `scope` field. When `scope` was `None` (no registration restriction), this converted to an empty allow-list and rejected *everything* — the bug reported in #2216. Both #2220 and #2224 fix that narrow case.

But the check itself breaks the MCP spec's [step-up authorization flow](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#scope-step-up). The Python client already implements step-up ([`client/auth/oauth2.py`](src/mcp/client/auth/oauth2.py)): on `403 insufficient_scope` it re-authorizes with the expanded scopes from `WWW-Authenticate`. The server then rejects those scopes because they weren't in the original registration, so step-up against a Python MCP server is currently broken.

[RFC 7591 §2](https://datatracker.ietf.org/doc/html/rfc7591#section-2) defines registered scope as values the client *"can use"* — there's no language restricting requests to that set. The TypeScript SDK removed the equivalent check in [typescript-sdk#983](https://github.com/modelcontextprotocol/typescript-sdk/pull/983) for the same reason.

Scope policy enforcement belongs in `OAuthAuthorizationServerProvider.authorize()`, which can already raise `AuthorizeError(error="invalid_scope", ...)` — the handler already catches this.

## How Has This Been Tested?

- `./scripts/test` — full suite passes with 100% branch coverage
- `test_authorize_invalid_scope` removed (tested the behavior being removed, same as typescript-sdk#983)
- New unit tests cover both branches of the simplified `validate_scope`

## Breaking Changes

- `mcp.shared.auth.InvalidScopeError` removed (only raised from the deleted code path)
- `OAuthClientMetadata.validate_scope()` no longer raises — it only parses
- Servers relying on the SDK to reject scopes should move enforcement into `provider.authorize()` (example in `docs/migration.md`)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Thanks to @nik1097 for the original report, and to @shivama205 (#2224) and @lavish0000 (#2220) for the initial fixes that surfaced the broader issue.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>