### PR TITLE
Mark SSE transport as deprecated in favor of Streamable HTTP

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import Any
@@ -39,6 +40,12 @@ async def sse_client(
 ):
     """Client transport for SSE.
 
+    .. deprecated::
+        sse_client is deprecated. Prefer to use
+        :func:`streamablehttp_client` where possible instead.
+        Note that because some servers still use SSE, clients may need
+        to support both transports during the migration period.
+
     `sse_read_timeout` determines how long (in seconds) the client will wait for a new
     event before disconnecting. All other HTTP operations are controlled by `timeout`.
 
@@ -51,6 +58,13 @@ async def sse_client(
         auth: Optional HTTPX authentication handler.
         on_session_created: Optional callback invoked with the session ID when received.
     """
+    warnings.warn(
+        "sse_client is deprecated. Prefer to use streamablehttp_client where possible "
+        "instead. Note that because some servers still use SSE, clients may need to "
+        "support both transports during the migration period.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]
     read_stream_writer: MemoryObjectSendStream[SessionMessage | Exception]
 

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -6,6 +6,7 @@ import base64
 import inspect
 import json
 import re
+import warnings
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any, Generic, Literal, TypeVar, overload
@@ -286,6 +287,11 @@ class MCPServer(Generic[LifespanResultT]):
             case "stdio":
                 anyio.run(self.run_stdio_async)
             case "sse":  # pragma: no cover
+                warnings.warn(
+                    'transport="sse" is deprecated. Use transport="streamable-http" instead.',
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 anyio.run(lambda: self.run_sse_async(**kwargs))
             case "streamable-http":  # pragma: no cover
                 anyio.run(lambda: self.run_streamable_http_async(**kwargs))
@@ -854,7 +860,17 @@ class MCPServer(Generic[LifespanResultT]):
         message_path: str = "/messages/",
         transport_security: TransportSecuritySettings | None = None,
     ) -> None:
-        """Run the server using SSE transport."""
+        """Run the server using SSE transport.
+
+        .. deprecated::
+            SSE transport is deprecated. Prefer to use
+            :meth:`run_streamable_http_async` instead.
+        """
+        warnings.warn(
+            "run_sse_async is deprecated. Use run_streamable_http_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         import uvicorn
 
         starlette_app = self.sse_app(
@@ -915,7 +931,17 @@ class MCPServer(Generic[LifespanResultT]):
         transport_security: TransportSecuritySettings | None = None,
         host: str = "127.0.0.1",
     ) -> Starlette:
-        """Return an instance of the SSE server app."""
+        """Return an instance of the SSE server app.
+
+        .. deprecated::
+            SSE transport is deprecated. Prefer to use
+            :meth:`streamable_http_app` instead.
+        """
+        warnings.warn(
+            "sse_app is deprecated. Use streamable_http_app instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # Auto-enable DNS rebinding protection for localhost (IPv4 and IPv6)
         if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
             transport_security = TransportSecuritySettings(

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -1,4 +1,10 @@
-"""SSE Server Transport Module
+"""SSE Server Transport Module (Deprecated)
+
+.. deprecated::
+    The HTTP+SSE transport was replaced by Streamable HTTP in the
+    `2025-03-26 <https://modelcontextprotocol.io/specification/2025-03-26/changelog>`_
+    protocol revision. Use :class:`mcp.server.streamable_http.StreamableHTTPServerTransport`
+    instead. SSE is retained for backwards compatibility with older clients.
 
 This module implements a Server-Sent Events (SSE) transport layer for MCP servers.
 
@@ -37,6 +43,7 @@ See SseServerTransport class documentation for more details.
 """
 
 import logging
+import warnings
 from contextlib import asynccontextmanager
 from typing import Any
 from urllib.parse import quote
@@ -61,7 +68,15 @@ logger = logging.getLogger(__name__)
 
 
 class SseServerTransport:
-    """SSE server transport for MCP. This class provides two ASGI applications,
+    """SSE server transport for MCP.
+
+    .. deprecated::
+        ``SseServerTransport`` is deprecated. Prefer to use
+        :class:`~mcp.server.streamable_http.StreamableHTTPServerTransport`
+        where possible instead. Note that because some clients still use SSE,
+        servers may need to support both transports during the migration period.
+
+    This class provides two ASGI applications,
     suitable for use with a framework like Starlette and a server like Hypercorn:
 
         1. connect_sse() is an ASGI application which receives incoming GET requests,
@@ -98,6 +113,15 @@ class SseServerTransport:
         """
 
         super().__init__()
+
+        warnings.warn(
+            "SseServerTransport is deprecated. Prefer to use "
+            "StreamableHTTPServerTransport where possible instead. Note that because "
+            "some clients still use SSE, servers may need to support both transports "
+            "during the migration period.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         # Validate that endpoint is a relative path and not a full URL
         if "://" in endpoint or endpoint.startswith("//") or "?" in endpoint or "#" in endpoint:


### PR DESCRIPTION
## Summary

- Adds `warnings.warn(..., DeprecationWarning, stacklevel=2)` runtime warnings and `.. deprecated::` docstring markers to all SSE transport entry points
- Aligns the Python SDK with the TypeScript SDK, which already marks `SSEClientTransport` as `@deprecated`
- Follows the wording from the TypeScript SDK: acknowledges that some servers/clients still use SSE during the migration period

### Files changed

- **`src/mcp/client/sse.py`** — `sse_client()`: deprecation warning + docstring
- **`src/mcp/server/sse.py`** — `SseServerTransport` class: deprecation warning in `__init__`, module docstring, and class docstring
- **`src/mcp/server/mcpserver/server.py`** — `run(transport="sse")`, `run_sse_async()`, and `sse_app()`: deprecation warnings + docstrings

### Context

The HTTP+SSE transport was replaced by Streamable HTTP in protocol revision [2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26/changelog). The spec now refers to it as the ["deprecated HTTP+SSE transport"](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#backwards-compatibility).

Closes #2278

## Test plan

- [ ] Verify `DeprecationWarning` is emitted when calling `sse_client()`
- [ ] Verify `DeprecationWarning` is emitted when instantiating `SseServerTransport`
- [ ] Verify `DeprecationWarning` is emitted when calling `MCPServer.run(transport="sse")`
- [ ] Verify `DeprecationWarning` is emitted when calling `run_sse_async()` and `sse_app()`
- [ ] Existing SSE tests continue to pass (warnings do not break functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)