### PR TITLE
feat: Add protocol_version parameter to ClientSession

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -121,6 +121,7 @@ class ClientSession(
         *,
         sampling_capabilities: types.SamplingCapability | None = None,
         experimental_task_handlers: ExperimentalTaskHandlers | None = None,
+        protocol_version: str | None = None,
     ) -> None:
         super().__init__(read_stream, write_stream, read_timeout_seconds=read_timeout_seconds)
         self._client_info = client_info or DEFAULT_CLIENT_INFO
@@ -136,6 +137,9 @@ class ClientSession(
 
         # Experimental: Task handlers (use defaults if not provided)
         self._task_handlers = experimental_task_handlers or ExperimentalTaskHandlers()
+        
+        # Protocol version (defaults to LATEST_PROTOCOL_VERSION)
+        self._protocol_version = protocol_version or types.LATEST_PROTOCOL_VERSION
 
     @property
     def _receive_request_adapter(self) -> TypeAdapter[types.ServerRequest]:
@@ -168,7 +172,7 @@ class ClientSession(
         result = await self.send_request(
             types.InitializeRequest(
                 params=types.InitializeRequestParams(
-                    protocol_version=types.LATEST_PROTOCOL_VERSION,
+                    protocol_version=self._protocol_version,
                     capabilities=types.ClientCapabilities(
                         sampling=sampling,
                         elicitation=elicitation,

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -137,7 +137,7 @@ class ClientSession(
 
         # Experimental: Task handlers (use defaults if not provided)
         self._task_handlers = experimental_task_handlers or ExperimentalTaskHandlers()
-        
+
         # Protocol version (defaults to LATEST_PROTOCOL_VERSION)
         self._protocol_version = protocol_version or types.LATEST_PROTOCOL_VERSION
 


### PR DESCRIPTION
## Summary

Add optional `protocol_version` parameter to `ClientSession.__init__()` to allow callers to override the default `LATEST_PROTOCOL_VERSION` when connecting to servers that require a specific protocol version.

## Changes

- Added `protocol_version: str | None = None` parameter to `ClientSession.__init__()`
- Store protocol version in `self._protocol_version` (defaults to `LATEST_PROTOCOL_VERSION`)
- Use `self._protocol_version` in `initialize()` instead of hardcoded constant

## Backwards Compatibility

This is a non-breaking change. Existing callers will continue to use `LATEST_PROTOCOL_VERSION` as the default. Callers that need a specific version can pass it explicitly.

## Example Usage

```python
# Connect to server requiring specific protocol version
async with ClientSession(read_stream, write_stream, protocol_version=2025-06-18) as session:
    await session.initialize()
```

Fixes #2307