### PR TITLE
docs: Add troubleshooting guide for 421 Invalid Host Header error

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,71 @@
+# Troubleshooting
+
+This guide helps you resolve common issues when using the MCP Python SDK.
+
+## 421 Invalid Host Header (DNS Rebinding Protection)
+
+A recent update introduced [DNS rebinding protection](./transports.md#dns-rebinding-protection) to the MCP Python SDK. While this improves security, it may cause existing setups to fail with a **421 Misdirected Request / Invalid Host Header** error if the host header doesn't match the allowed list (common when using proxies, gateways, or custom domains).
+
+### Solutions
+
+Depending on your security requirements, you can resolve this in two ways:
+
+#### Option 1: Explicitly Allow Specific Hosts (Recommended)
+
+Use this approach if you are running in production or through a gateway. You can wildcard the ports using `*`.
+
+```python
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+
+mcp = FastMCP(
+    "MyServer",
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        # Add your specific gateway or domain here
+        allowed_hosts=["localhost:*", "127.0.0.1:*", "your-gateway-host:*"],
+        allowed_origins=["http://localhost:*", "http://your-gateway-host:*"],
+    )
+)
+```
+
+#### Option 2: Disable DNS Rebinding Protection
+
+Use this approach for local development or if you are managing security at a different layer of your infrastructure.
+
+```python
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+
+mcp = FastMCP(
+    "MyServer",
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=False,
+    )
+)
+```
+
+### Reverse Proxy Configuration
+
+If you are using a reverse proxy (like Nginx or Caddy), ensure your proxy is passing the correct `Host` header to the MCP server.
+
+**Nginx example:**
+```nginx
+location / {
+    proxy_pass http://localhost:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+}
+```
+
+**Caddy example:**
+```caddy
+reverse_proxy localhost:8000 {
+    header_up Host {upstream_hostport}
+}
+```
+
+## See Also
+
+- [Transport Security](./transports.md#dns-rebinding-protection)
+- [FastMCP Server Documentation](./servers.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,6 +50,7 @@ mcp = FastMCP(
 If you are using a reverse proxy (like Nginx or Caddy), ensure your proxy is passing the correct `Host` header to the MCP server.
 
 **Nginx example:**
+
 ```nginx
 location / {
     proxy_pass http://localhost:8000;
@@ -59,6 +60,7 @@ location / {
 ```
 
 **Caddy example:**
+
 ```caddy
 reverse_proxy localhost:8000 {
     header_up Host {upstream_hostport}

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from collections.abc import Callable
 from contextlib import asynccontextmanager
 from typing import Any
@@ -37,7 +38,11 @@ async def sse_client(
     auth: httpx.Auth | None = None,
     on_session_created: Callable[[str], None] | None = None,
 ):
-    """Client transport for SSE.
+    """Client transport for SSE (Deprecated).
+
+    .. deprecated::
+        The HTTP+SSE transport is deprecated. Use `streamable_http_client` with
+        `StreamableHTTPTransport` instead for connecting to MCP servers.
 
     `sse_read_timeout` determines how long (in seconds) the client will wait for a new
     event before disconnecting. All other HTTP operations are controlled by `timeout`.
@@ -154,4 +159,10 @@ async def sse_client(
                 tg.start_soon(post_writer, endpoint_url)
 
                 yield read_stream, write_stream
-                tg.cancel_scope.cancel()
+    tg.cancel_scope.cancel()
+
+    warnings.warn(
+        "sse_client is deprecated. Use streamable_http_client with StreamableHTTPTransport instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -860,6 +860,7 @@ class MCPServer(Generic[LifespanResultT]):
             The HTTP+SSE transport is deprecated. Use `run_streamable_http_async` instead.
         """
         import warnings
+
         warnings.warn(
             "run_sse_async is deprecated. Use run_streamable_http_async instead.",
             DeprecationWarning,
@@ -932,6 +933,7 @@ class MCPServer(Generic[LifespanResultT]):
             The HTTP+SSE transport is deprecated. Use `streamable_http_app` instead.
         """
         import warnings
+
         warnings.warn(
             "sse_app is deprecated. Use streamable_http_app instead.",
             DeprecationWarning,

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -854,7 +854,18 @@ class MCPServer(Generic[LifespanResultT]):
         message_path: str = "/messages/",
         transport_security: TransportSecuritySettings | None = None,
     ) -> None:
-        """Run the server using SSE transport."""
+        """Run the server using SSE transport (Deprecated).
+
+        .. deprecated::
+            The HTTP+SSE transport is deprecated. Use `run_streamable_http_async` instead.
+        """
+        import warnings
+        warnings.warn(
+            "run_sse_async is deprecated. Use run_streamable_http_async instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         import uvicorn
 
         starlette_app = self.sse_app(
@@ -915,7 +926,17 @@ class MCPServer(Generic[LifespanResultT]):
         transport_security: TransportSecuritySettings | None = None,
         host: str = "127.0.0.1",
     ) -> Starlette:
-        """Return an instance of the SSE server app."""
+        """Return an instance of the SSE server app (Deprecated).
+
+        .. deprecated::
+            The HTTP+SSE transport is deprecated. Use `streamable_http_app` instead.
+        """
+        import warnings
+        warnings.warn(
+            "sse_app is deprecated. Use streamable_http_app instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # Auto-enable DNS rebinding protection for localhost (IPv4 and IPv6)
         if transport_security is None and host in ("127.0.0.1", "localhost", "::1"):
             transport_security = TransportSecuritySettings(

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -1,4 +1,7 @@
-"""SSE Server Transport Module
+"""SSE Server Transport Module (Deprecated)
+
+.. deprecated::
+    The HTTP+SSE transport is deprecated. Use `StreamableHTTPTransport` instead.
 
 This module implements a Server-Sent Events (SSE) transport layer for MCP servers.
 
@@ -37,6 +40,7 @@ See SseServerTransport class documentation for more details.
 """
 
 import logging
+import warnings
 from contextlib import asynccontextmanager
 from typing import Any
 from urllib.parse import quote
@@ -61,7 +65,13 @@ logger = logging.getLogger(__name__)
 
 
 class SseServerTransport:
-    """SSE server transport for MCP. This class provides two ASGI applications,
+    """SSE server transport for MCP (Deprecated).
+
+    .. deprecated::
+        The HTTP+SSE transport is deprecated. Use `StreamableHTTPTransport` instead
+        for new MCP server implementations.
+
+    This class provides two ASGI applications,
     suitable for use with a framework like Starlette and a server like Hypercorn:
 
         1. connect_sse() is an ASGI application which receives incoming GET requests,
@@ -78,6 +88,9 @@ class SseServerTransport:
     def __init__(self, endpoint: str, security_settings: TransportSecuritySettings | None = None) -> None:
         """Creates a new SSE server transport, which will direct the client to POST
         messages to the relative path given.
+
+        .. deprecated::
+            The HTTP+SSE transport is deprecated. Use `StreamableHTTPTransport` instead.
 
         Args:
             endpoint: A relative path where messages should be posted
@@ -98,6 +111,12 @@ class SseServerTransport:
         """
 
         super().__init__()
+
+        warnings.warn(
+            "SseServerTransport is deprecated. Use StreamableHTTPTransport instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         # Validate that endpoint is a relative path and not a full URL
         if "://" in endpoint or endpoint.startswith("//") or "?" in endpoint or "#" in endpoint:


### PR DESCRIPTION
Adds a troubleshooting guide to help users resolve DNS rebinding protection errors that can occur when using proxies, gateways, or custom domains.

## Changes

- Created `docs/troubleshooting.md` with comprehensive troubleshooting guide
- Includes explanation of DNS rebinding protection
- Provides two solution options:\n  1. Explicitly allow specific hosts (recommended for production)\n  2. Disable DNS rebinding protection (for local development)
- Added reverse proxy configuration examples for Nginx and Caddy

Fixes #1798