### PR TITLE
fix: widen errlog type to accept subprocess.DEVNULL

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -102,7 +102,7 @@ class StdioServerParameters(BaseModel):
 
 
 @asynccontextmanager
-async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stderr):
+async def stdio_client(server: StdioServerParameters, errlog: TextIO | int = sys.stderr):
     """Client transport for stdio: this will connect to a server by spawning a
     process and communicating with it over stdin/stdout.
     """
@@ -230,7 +230,7 @@ async def _create_platform_compatible_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO = sys.stderr,
+    errlog: TextIO | int = sys.stderr,
     cwd: Path | str | None = None,
 ):
     """Creates a subprocess in a platform-compatible way.

--- a/src/mcp/os/win32/utilities.py
+++ b/src/mcp/os/win32/utilities.py
@@ -138,7 +138,7 @@ async def create_windows_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO | None = sys.stderr,
+    errlog: TextIO | int | None = sys.stderr,
     cwd: Path | str | None = None,
 ) -> Process | FallbackProcess:
     """Creates a subprocess in a Windows-compatible way with Job Object support.
@@ -155,7 +155,7 @@ async def create_windows_process(
         command (str): The executable to run
         args (list[str]): List of command line arguments
         env (dict[str, str] | None): Environment variables
-        errlog (TextIO | None): Where to send stderr output (defaults to sys.stderr)
+        errlog (TextIO | int | None): Where to send stderr output (defaults to sys.stderr)
         cwd (Path | str | None): Working directory for the subprocess
 
     Returns:
@@ -196,7 +196,7 @@ async def _create_windows_fallback_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO | None = sys.stderr,
+    errlog: TextIO | int | None = sys.stderr,
     cwd: Path | str | None = None,
 ) -> FallbackProcess:
     """Create a subprocess using subprocess.Popen as a fallback when anyio fails.


### PR DESCRIPTION
Closes #1806

## Summary

Widens the `errlog` parameter type in `stdio_client` and the internal process creation helpers from `TextIO` to `TextIO | int`. This allows passing `subprocess.DEVNULL` (which is `int` value `-3`) to suppress stderr output from MCP server subprocesses.

## Motivation

Users who want to suppress stderr output from their MCP server subprocesses currently can't pass `subprocess.DEVNULL` because the type hint restricts to `TextIO`. Both `subprocess.Popen` and `anyio.open_process` already accept `int` values for their `stderr` parameter, so widening the type is safe and aligns with the underlying APIs.

## Changes

- `stdio_client()`: `errlog: TextIO` → `errlog: TextIO | int`
- `_create_platform_compatible_process()`: `errlog: TextIO` → `errlog: TextIO | int`
- `create_windows_process()`: `errlog: TextIO | None` → `errlog: TextIO | int | None`
- `_create_windows_fallback_process()`: `errlog: TextIO | None` → `errlog: TextIO | int | None`

## Test plan

- Pyright passes with 0 errors on `src/mcp/client/stdio.py`
- Ruff passes with no issues
- `subprocess.DEVNULL` is now accepted without type errors