### PR TITLE
fix: handle unbound response_or_error in send_request timeout

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -270,6 +270,7 @@ class BaseSession(
             # request read timeout takes precedence over session read timeout
             timeout = request_read_timeout_seconds or self._session_read_timeout_seconds
 
+            response_or_error: JSONRPCResponse | JSONRPCError | None = None
             try:
                 with anyio.fail_after(timeout):
                     response_or_error = await response_stream_reader.receive()
@@ -277,6 +278,15 @@ class BaseSession(
                 class_name = request.__class__.__name__
                 message = f"Timed out while waiting for response to {class_name}. Waited {timeout} seconds."
                 raise MCPError(code=REQUEST_TIMEOUT, message=message)
+
+            if response_or_error is None:
+                raise MCPError(
+                    code=REQUEST_TIMEOUT,
+                    message=(
+                        f"Response not received for {request.__class__.__name__}. "
+                        "This may indicate a race condition in the cancel scope."
+                    ),
+                )
 
             if isinstance(response_or_error, JSONRPCError):
                 raise MCPError.from_jsonrpc_error(response_or_error)


### PR DESCRIPTION
Closes #1717

## Summary

Fixes an intermittent `UnboundLocalError` in `send_request()` where `response_or_error` could be accessed without being assigned.

The root cause is a documented race condition in anyio's `fail_after` cancel scope ([agronholm/anyio#589](https://github.com/agronholm/anyio/issues/589)): when the timeout deadline is hit at the exact moment `receive()` is executing, the cancellation exception can be suppressed without raising `TimeoutError`, causing execution to continue past the `try/except` block with `response_or_error` never assigned.

## Fix

- Initialize `response_or_error` to `None` before the inner `try` block
- Add an explicit `None` check after the `try/except`, raising `MCPError` with `REQUEST_TIMEOUT` code and a descriptive message if the variable was never assigned

This is a minimal, defensive fix — it converts an opaque `UnboundLocalError` into a proper `MCPError` with a clear message indicating the cancel scope race condition.

## Test plan

- Existing test suite passes (193 passed, 1 pre-existing Windows-only subprocess timeout failure unrelated to this change)
- Ruff lint and format checks pass
- The fix is purely defensive — it only changes behavior in the edge case where `response_or_error` would otherwise be unbound