### PR TITLE
fix: preserve client_metadata.scope if already set

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -571,12 +571,13 @@ class OAuthClientProvider(httpx.Auth):
                         else:
                             logger.debug(f"OAuth metadata discovery failed: {url}")
 
-                    # Step 3: Apply scope selection strategy
-                    self.context.client_metadata.scope = get_client_metadata_scopes(
-                        extract_scope_from_www_auth(response),
-                        self.context.protected_resource_metadata,
-                        self.context.oauth_metadata,
-                    )
+                    # Step 3: Apply scope selection strategy (only if not already set)
+                    if self.context.client_metadata.scope is None:
+                        self.context.client_metadata.scope = get_client_metadata_scopes(
+                            extract_scope_from_www_auth(response),
+                            self.context.protected_resource_metadata,
+                            self.context.oauth_metadata,
+                        )
 
                     # Step 4: Register client or use URL-based client ID (CIMD)
                     if not self.context.client_info:


### PR DESCRIPTION
## Summary

Don't override `client_metadata.scope` if it was explicitly set by the client.

## Problem

As reported in #2317, the scope selection strategy in `async_auth_flow` unconditionally overwrites any scope that was explicitly set by the client. This prevents clients from:
- Requesting fewer permissions than available
- Working with servers that reject requests for unauthorized scopes (e.g., SalesForce)

## Solution

Made the scope assignment conditional:

```python
# Step 3: Apply scope selection strategy (only if not already set)
if self.context.client_metadata.scope is None:
    self.context.client_metadata.scope = get_client_metadata_scopes(...)
```

This preserves the existing behavior when no scope is set, while respecting explicit scope configuration.

## Testing

- Existing tests continue to pass (scope is None by default)
- Clients that explicitly set `client_metadata.scope` will now have that value preserved

Fixes #2317