### PR TITLE
fix: improve log clarity for stateless mode session termination

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -767,7 +767,10 @@ class StreamableHTTPServerTransport:
         """
 
         self._terminated = True
-        logger.info(f"Terminating session: {self.mcp_session_id}")
+        if self.mcp_session_id:
+            logger.info(f"Terminating session: {self.mcp_session_id}")
+        else:
+            logger.debug("Stateless request completed, cleaning up transport")
 
         # We need a copy of the keys to avoid modification during iteration
         request_stream_keys = list(self._request_streams.keys())


### PR DESCRIPTION
## Summary
In stateless HTTP mode, every request logs `INFO: Terminating session: None`.
This is correct behavior but confusing to users who assume their connection
is failing or being dropped.

## Changes
- Downgrade stateless cleanup to DEBUG (routine, not noteworthy)  
- Use clearer wording: 'Stateless request completed, cleaning up transport'
- Keep existing INFO-level log for actual session terminations

Fixes #2329