### PR TITLE
ci: skip claude.yml when comment is '@claude review'

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !startsWith(github.event.comment.body, '@claude review')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))


### PR DESCRIPTION
Excludes `@claude review` comments from triggering this workflow.

## Motivation and Context
Comments starting with `@claude review` are handled by the hosted code-review webhook, which creates a dedicated "Claude Code Review" check run. When this GitHub Action also fires on the same comment, both systems respond — the GHA run then fails on fork PRs because it tries to fetch the fork branch from origin, leaving a red ❌ on the PR alongside the actual (successful) review.

## How Has This Been Tested?
Observed the double-trigger on typescript-sdk PR #1003: `@claude review` fired both the hosted webhook (check run started correctly) and the equivalent claude.yml workflow (failed with `git fetch origin <fork-branch>`). Same workflow file here.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Only the `issue_comment` event is excluded since that's the only event type the hosted webhook listens to. `@claude review` in a PR review comment or issue body still triggers this workflow as before.

Mirror of modelcontextprotocol/typescript-sdk#1737.