### PR TITLE
Expose optional stdin/stdout on MCPServer stdio entrypoints

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -238,7 +238,13 @@ class MCPServer(Generic[LifespanResultT]):
         return self._lowlevel_server.session_manager  # pragma: no cover
 
     @overload
-    def run(self, transport: Literal["stdio"] = ...) -> None: ...
+    def run(
+        self,
+        transport: Literal["stdio"] = ...,
+        *,
+        stdin: anyio.AsyncFile[str] | None = ...,
+        stdout: anyio.AsyncFile[str] | None = ...,
+    ) -> None: ...
 
     @overload
     def run(
@@ -270,12 +276,19 @@ class MCPServer(Generic[LifespanResultT]):
     def run(
         self,
         transport: Literal["stdio", "sse", "streamable-http"] = "stdio",
+        *,
+        stdin: anyio.AsyncFile[str] | None = None,
+        stdout: anyio.AsyncFile[str] | None = None,
         **kwargs: Any,
     ) -> None:
         """Run the MCP server. Note this is a synchronous function.
 
         Args:
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
+            stdin: Optional async text stream for MCP input (stdio transport only).
+                When omitted, uses process stdin. See :func:`mcp.server.stdio.stdio_server`.
+            stdout: Optional async text stream for MCP output (stdio transport only).
+                When omitted, uses process stdout.
             **kwargs: Transport-specific options (see overloads for details)
         """
         TRANSPORTS = Literal["stdio", "sse", "streamable-http"]
@@ -284,7 +297,7 @@ class MCPServer(Generic[LifespanResultT]):
 
         match transport:
             case "stdio":
-                anyio.run(self.run_stdio_async)
+                anyio.run(lambda: self.run_stdio_async(stdin=stdin, stdout=stdout))
             case "sse":  # pragma: no cover
                 anyio.run(lambda: self.run_sse_async(**kwargs))
             case "streamable-http":  # pragma: no cover
@@ -836,9 +849,25 @@ class MCPServer(Generic[LifespanResultT]):
 
         return decorator  # pragma: no cover
 
-    async def run_stdio_async(self) -> None:
-        """Run the server using stdio transport."""
-        async with stdio_server() as (read_stream, write_stream):
+    async def run_stdio_async(
+        self,
+        *,
+        stdin: anyio.AsyncFile[str] | None = None,
+        stdout: anyio.AsyncFile[str] | None = None,
+    ) -> None:
+        """Run the server using stdio transport.
+
+        Args:
+            stdin: Async text stream to read JSON-RPC lines from. When ``None``,
+                uses the process stdin (see :func:`mcp.server.stdio.stdio_server`).
+            stdout: Async text stream to write JSON-RPC lines to. When ``None``,
+                uses the process stdout.
+
+        Custom streams are useful when the process ``sys.stdout`` / ``sys.stdin``
+        must be redirected (for example so logging or subprocess output does not
+        corrupt the MCP JSON-RPC stream on fd 1).
+        """
+        async with stdio_server(stdin=stdin, stdout=stdout) as (read_stream, write_stream):
             await self._lowlevel_server.run(
                 read_stream,
                 write_stream,

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -276,19 +276,12 @@ class MCPServer(Generic[LifespanResultT]):
     def run(
         self,
         transport: Literal["stdio", "sse", "streamable-http"] = "stdio",
-        *,
-        stdin: anyio.AsyncFile[str] | None = None,
-        stdout: anyio.AsyncFile[str] | None = None,
         **kwargs: Any,
     ) -> None:
         """Run the MCP server. Note this is a synchronous function.
 
         Args:
             transport: Transport protocol to use ("stdio", "sse", or "streamable-http")
-            stdin: Optional async text stream for MCP input (stdio transport only).
-                When omitted, uses process stdin. See :func:`mcp.server.stdio.stdio_server`.
-            stdout: Optional async text stream for MCP output (stdio transport only).
-                When omitted, uses process stdout.
             **kwargs: Transport-specific options (see overloads for details)
         """
         TRANSPORTS = Literal["stdio", "sse", "streamable-http"]
@@ -297,7 +290,7 @@ class MCPServer(Generic[LifespanResultT]):
 
         match transport:
             case "stdio":
-                anyio.run(lambda: self.run_stdio_async(stdin=stdin, stdout=stdout))
+                anyio.run(lambda: self.run_stdio_async(**kwargs))
             case "sse":  # pragma: no cover
                 anyio.run(lambda: self.run_sse_async(**kwargs))
             case "streamable-http":  # pragma: no cover

--- a/tests/server/mcpserver/test_run_stdio_custom_streams.py
+++ b/tests/server/mcpserver/test_run_stdio_custom_streams.py
@@ -1,0 +1,44 @@
+"""MCPServer.run_stdio_async forwards optional stdin/stdout to stdio_server."""
+
+from __future__ import annotations
+
+import io
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import anyio
+import pytest
+
+from mcp.server.mcpserver import MCPServer
+
+
+@pytest.mark.anyio
+async def test_run_stdio_async_passes_streams_to_stdio_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def spy_stdio_server(stdin=None, stdout=None):
+        captured["stdin"] = stdin
+        captured["stdout"] = stdout
+        read_stream = AsyncMock()
+        write_stream = AsyncMock()
+        yield read_stream, write_stream
+
+    async def noop_run(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("mcp.server.mcpserver.server.stdio_server", spy_stdio_server)
+
+    server = MCPServer("test-stdio-spy")
+    monkeypatch.setattr(server._lowlevel_server, "run", noop_run)
+    monkeypatch.setattr(server._lowlevel_server, "create_initialization_options", lambda: object())
+
+    sin = io.StringIO()
+    sout = io.StringIO()
+    await server.run_stdio_async(
+        stdin=anyio.AsyncFile(sin),
+        stdout=anyio.AsyncFile(sout),
+    )
+
+    assert captured["stdin"] is not None
+    assert captured["stdout"] is not None

--- a/tests/server/mcpserver/test_run_stdio_custom_streams.py
+++ b/tests/server/mcpserver/test_run_stdio_custom_streams.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import io
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock
 
 import anyio
@@ -17,14 +19,17 @@ async def test_run_stdio_async_passes_streams_to_stdio_server(monkeypatch: pytes
     captured: dict[str, object] = {}
 
     @asynccontextmanager
-    async def spy_stdio_server(stdin=None, stdout=None):
+    async def spy_stdio_server(
+        stdin: anyio.AsyncFile[str] | None = None,
+        stdout: anyio.AsyncFile[str] | None = None,
+    ) -> AsyncIterator[tuple[AsyncMock, AsyncMock]]:
         captured["stdin"] = stdin
         captured["stdout"] = stdout
         read_stream = AsyncMock()
         write_stream = AsyncMock()
         yield read_stream, write_stream
 
-    async def noop_run(*_args, **_kwargs):
+    async def noop_run(*_args: Any, **_kwargs: Any) -> None:
         return None
 
     monkeypatch.setattr("mcp.server.mcpserver.server.stdio_server", spy_stdio_server)


### PR DESCRIPTION
### Summary

`mcp.server.stdio.stdio_server` already supports optional `stdin` and `stdout`. This PR threads those parameters through **`MCPServer.run_stdio_async`** and the **`stdio`** branch of **`MCPServer.run`**, so applications can use the public API instead of calling `stdio_server` manually and depending on internal wiring.

### Motivation

MCP over stdio is JSON-RPC on a dedicated pair of streams. In real processes, fd 1 is also used for logging, `print()`, subprocesses, and native code. Any extra bytes on the protocol stream corrupt JSON-RPC and break clients.

A common pattern is to duplicate the real stdout fd for MCP-only I/O and redirect fd 1 (and often `sys.stdout`) to stderr so other output stays off the wire. That requires passing custom `stdin`/`stdout` into the same code path the server uses for stdio. **`stdio_server` already accepts them**; this exposes the same capability on **`MCPServer`**.

### Testing

Adds `tests/server/mcpserver/test_run_stdio_custom_streams.py`, which asserts custom streams are forwarded to `stdio_server` (with `stdio_server` and low-level `run` stubbed).

### Example consumer

Downstream servers https://github.com/jumpstarter-dev/jumpstarter/pull/383 need this to keep logs and tooling output off the MCP stream while staying on supported APIs.
We have a lot of logging originating from gRPC and other libraries that we want to keep out of the channel, and we are using async io.
