### PR TITLE
fix(server): return -32602 for resource not found (SEP-2164)

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -489,7 +489,7 @@ Positional calls (`await ctx.info("hello")`) are unaffected.
 
 ### `ResourceManager.get_resource()` and `ResourceTemplate.create_resource()` raise typed exceptions
 
-`ResourceManager.get_resource()` now raises `ResourceNotFoundError` (instead of `ValueError`) when no resource or template matches the URI. `ResourceTemplate.create_resource()` now raises `ResourceError` (instead of `ValueError`) when the template function fails. Neither subclasses `ValueError`, so callers catching `ValueError` should switch to `ResourceNotFoundError` / `ResourceError` (both importable from `mcp.server.mcpserver`). `MCPServer.read_resource()` continues to raise `ResourceError` and is unaffected.
+`ResourceManager.get_resource()` now raises `ResourceNotFoundError` (instead of `ValueError`) when no resource or template matches the URI. `ResourceTemplate.create_resource()` now raises `ResourceError` (instead of `ValueError`) when the template function fails. Neither subclasses `ValueError`, so callers catching `ValueError` should switch to `ResourceNotFoundError` / `ResourceError` (both importable from `mcp.server.mcpserver.exceptions`). `MCPServer.read_resource()` continues to raise `ResourceError` and is unaffected.
 
 ### Replace `RootModel` by union types with `TypeAdapter` validation
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -487,6 +487,10 @@ await ctx.log(level="info", data="hello")
 
 Positional calls (`await ctx.info("hello")`) are unaffected.
 
+### `ResourceManager.get_resource()` and `ResourceTemplate.create_resource()` raise typed exceptions
+
+`ResourceManager.get_resource()` now raises `ResourceNotFoundError` (instead of `ValueError`) when no resource or template matches the URI. `ResourceTemplate.create_resource()` now raises `ResourceError` (instead of `ValueError`) when the template function fails. Neither subclasses `ValueError`, so callers catching `ValueError` should switch to `ResourceNotFoundError` / `ResourceError` (both importable from `mcp.server.mcpserver`). `MCPServer.read_resource()` continues to raise `ResourceError` and is unaffected.
+
 ### Replace `RootModel` by union types with `TypeAdapter` validation
 
 The following union types are no longer `RootModel` subclasses:

--- a/src/mcp/server/mcpserver/__init__.py
+++ b/src/mcp/server/mcpserver/__init__.py
@@ -3,8 +3,7 @@
 from mcp.types import Icon
 
 from .context import Context
-from .exceptions import ResourceError, ResourceNotFoundError
 from .server import MCPServer
 from .utilities.types import Audio, Image
 
-__all__ = ["MCPServer", "Context", "Image", "Audio", "Icon", "ResourceError", "ResourceNotFoundError"]
+__all__ = ["MCPServer", "Context", "Image", "Audio", "Icon"]

--- a/src/mcp/server/mcpserver/__init__.py
+++ b/src/mcp/server/mcpserver/__init__.py
@@ -3,7 +3,8 @@
 from mcp.types import Icon
 
 from .context import Context
+from .exceptions import ResourceError, ResourceNotFoundError
 from .server import MCPServer
 from .utilities.types import Audio, Image
 
-__all__ = ["MCPServer", "Context", "Image", "Audio", "Icon"]
+__all__ = ["MCPServer", "Context", "Image", "Audio", "Icon", "ResourceError", "ResourceNotFoundError"]

--- a/src/mcp/server/mcpserver/context.py
+++ b/src/mcp/server/mcpserver/context.py
@@ -113,6 +113,10 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
 
         Returns:
             The resource content as either text or bytes
+
+        Raises:
+            ResourceNotFoundError: If no resource or template matches the URI.
+            ResourceError: If template creation or resource reading fails.
         """
         assert self._mcp_server is not None, "Context is not available outside of a request"
         return await self._mcp_server.read_resource(uri, self)

--- a/src/mcp/server/mcpserver/exceptions.py
+++ b/src/mcp/server/mcpserver/exceptions.py
@@ -14,7 +14,12 @@ class ResourceError(MCPServerError):
 
 
 class ResourceNotFoundError(ResourceError):
-    """Resource does not exist."""
+    """Resource does not exist.
+
+    Raise this from a resource template handler to signal that the requested
+    instance does not exist; clients receive ``-32602`` (invalid params) per
+    SEP-2164.
+    """
 
 
 class ToolError(MCPServerError):

--- a/src/mcp/server/mcpserver/exceptions.py
+++ b/src/mcp/server/mcpserver/exceptions.py
@@ -13,6 +13,10 @@ class ResourceError(MCPServerError):
     """Error in resource operations."""
 
 
+class ResourceNotFoundError(ResourceError):
+    """Resource does not exist."""
+
+
 class ToolError(MCPServerError):
     """Error in tool operations."""
 

--- a/src/mcp/server/mcpserver/resources/resource_manager.py
+++ b/src/mcp/server/mcpserver/resources/resource_manager.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import AnyUrl
 
+from mcp.server.mcpserver.exceptions import ResourceNotFoundError
 from mcp.server.mcpserver.resources.base import Resource
 from mcp.server.mcpserver.resources.templates import ResourceTemplate
 from mcp.server.mcpserver.utilities.logging import get_logger
@@ -90,12 +91,9 @@ class ResourceManager:
         # Then check templates
         for template in self._templates.values():
             if params := template.matches(uri_str):
-                try:
-                    return await template.create_resource(uri_str, params, context=context)
-                except Exception as e:  # pragma: no cover
-                    raise ValueError(f"Error creating resource from template: {e}")
+                return await template.create_resource(uri_str, params, context=context)
 
-        raise ValueError(f"Unknown resource: {uri}")
+        raise ResourceNotFoundError(f"Unknown resource: {uri}")
 
     def list_resources(self) -> list[Resource]:
         """List all registered resources."""

--- a/src/mcp/server/mcpserver/resources/resource_manager.py
+++ b/src/mcp/server/mcpserver/resources/resource_manager.py
@@ -80,7 +80,12 @@ class ResourceManager:
         return template
 
     async def get_resource(self, uri: AnyUrl | str, context: Context[LifespanContextT, RequestT]) -> Resource:
-        """Get resource by URI, checking concrete resources first, then templates."""
+        """Get resource by URI, checking concrete resources first, then templates.
+
+        Raises:
+            ResourceNotFoundError: If no resource or template matches the URI.
+            ResourceError: If a matching template fails to create the resource.
+        """
         uri_str = str(uri)
         logger.debug("Getting resource", extra={"uri": uri_str})
 

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -15,8 +15,11 @@ from mcp.server.mcpserver.exceptions import ResourceError
 from mcp.server.mcpserver.resources.types import FunctionResource, Resource
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter, inject_context
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+from mcp.server.mcpserver.utilities.logging import get_logger
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.types import Annotations, Icon
+
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from mcp.server.context import LifespanContextT, RequestT
@@ -133,4 +136,5 @@ class ResourceTemplate(BaseModel):
         except ResourceError:
             raise
         except Exception as e:
-            raise ResourceError(f"Error creating resource from template: {e}")
+            logger.exception("Error creating resource from template")
+            raise ResourceError(f"Error creating resource from template: {e}") from e

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -11,6 +11,7 @@ from urllib.parse import unquote
 import anyio.to_thread
 from pydantic import BaseModel, Field, validate_call
 
+from mcp.server.mcpserver.exceptions import ResourceError
 from mcp.server.mcpserver.resources.types import FunctionResource, Resource
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter, inject_context
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
@@ -106,7 +107,7 @@ class ResourceTemplate(BaseModel):
         """Create a resource from the template with the given parameters.
 
         Raises:
-            ValueError: If creating the resource fails.
+            ResourceError: If creating the resource fails.
         """
         try:
             # Add context to params if needed
@@ -130,4 +131,4 @@ class ResourceTemplate(BaseModel):
                 fn=lambda: result,  # Capture result in closure
             )
         except Exception as e:
-            raise ValueError(f"Error creating resource from template: {e}")
+            raise ResourceError(f"Error creating resource from template: {e}")

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -130,5 +130,7 @@ class ResourceTemplate(BaseModel):
                 meta=self.meta,
                 fn=lambda: result,  # Capture result in closure
             )
+        except ResourceError:
+            raise
         except Exception as e:
             raise ResourceError(f"Error creating resource from template: {e}")

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -31,7 +31,7 @@ from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.lowlevel.server import LifespanResultT, Server
 from mcp.server.lowlevel.server import lifespan as default_lifespan
 from mcp.server.mcpserver.context import Context
-from mcp.server.mcpserver.exceptions import ResourceError
+from mcp.server.mcpserver.exceptions import ResourceError, ResourceNotFoundError
 from mcp.server.mcpserver.prompts import Prompt, PromptManager
 from mcp.server.mcpserver.resources import FunctionResource, Resource, ResourceManager
 from mcp.server.mcpserver.tools import Tool, ToolManager
@@ -44,6 +44,7 @@ from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import MCPError
 from mcp.types import (
+    INVALID_PARAMS,
     Annotations,
     BlobResourceContents,
     CallToolRequestParams,
@@ -341,7 +342,10 @@ class MCPServer(Generic[LifespanResultT]):
         self, ctx: ServerRequestContext[LifespanResultT], params: ReadResourceRequestParams
     ) -> ReadResourceResult:
         context = Context(request_context=ctx, mcp_server=self)
-        results = await self.read_resource(params.uri, context)
+        try:
+            results = await self.read_resource(params.uri, context)
+        except ResourceNotFoundError as err:
+            raise MCPError(code=INVALID_PARAMS, message=str(err), data={"uri": str(params.uri)})
         contents: list[TextResourceContents | BlobResourceContents] = []
         for item in results:
             if isinstance(item.content, bytes):
@@ -448,7 +452,7 @@ class MCPServer(Generic[LifespanResultT]):
         try:
             resource = await self._resource_manager.get_resource(uri, context)
         except ValueError:
-            raise ResourceError(f"Unknown resource: {uri}")
+            raise ResourceNotFoundError(f"Unknown resource: {uri}")
 
         try:
             content = await resource.read()

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -449,7 +449,12 @@ class MCPServer(Generic[LifespanResultT]):
     async def read_resource(
         self, uri: AnyUrl | str, context: Context[LifespanResultT, Any] | None = None
     ) -> Iterable[ReadResourceContents]:
-        """Read a resource by URI."""
+        """Read a resource by URI.
+
+        Raises:
+            ResourceNotFoundError: If no resource or template matches the URI.
+            ResourceError: If template creation or resource reading fails.
+        """
         if context is None:
             context = Context(mcp_server=self)
         resource = await self._resource_manager.get_resource(uri, context)

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -44,6 +44,7 @@ from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import MCPError
 from mcp.types import (
+    INTERNAL_ERROR,
     INVALID_PARAMS,
     Annotations,
     BlobResourceContents,
@@ -346,6 +347,8 @@ class MCPServer(Generic[LifespanResultT]):
             results = await self.read_resource(params.uri, context)
         except ResourceNotFoundError as err:
             raise MCPError(code=INVALID_PARAMS, message=str(err), data={"uri": str(params.uri)})
+        except ResourceError as err:
+            raise MCPError(code=INTERNAL_ERROR, message=str(err), data={"uri": str(params.uri)})
         contents: list[TextResourceContents | BlobResourceContents] = []
         for item in results:
             if isinstance(item.content, bytes):
@@ -449,10 +452,7 @@ class MCPServer(Generic[LifespanResultT]):
         """Read a resource by URI."""
         if context is None:
             context = Context(mcp_server=self)
-        try:
-            resource = await self._resource_manager.get_resource(uri, context)
-        except ValueError:
-            raise ResourceNotFoundError(f"Unknown resource: {uri}")
+        resource = await self._resource_manager.get_resource(uri, context)
 
         try:
             content = await resource.read()

--- a/tests/server/mcpserver/resources/test_resource_manager.py
+++ b/tests/server/mcpserver/resources/test_resource_manager.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import AnyUrl
 
 from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ResourceNotFoundError
 from mcp.server.mcpserver.resources import FileResource, FunctionResource, ResourceManager, ResourceTemplate
 
 
@@ -101,7 +102,7 @@ async def test_get_resource_from_template():
 async def test_get_unknown_resource():
     """Test getting a non-existent resource."""
     manager = ResourceManager()
-    with pytest.raises(ValueError, match="Unknown resource"):
+    with pytest.raises(ResourceNotFoundError, match="Unknown resource"):
         await manager.get_resource(AnyUrl("unknown://test"), Context())
 
 

--- a/tests/server/mcpserver/resources/test_resource_template.py
+++ b/tests/server/mcpserver/resources/test_resource_template.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import BaseModel
 
 from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ResourceError
 from mcp.server.mcpserver.resources import FunctionResource, ResourceTemplate
 from mcp.types import Annotations
 
@@ -87,7 +88,7 @@ class TestResourceTemplate:
             name="fail",
         )
 
-        with pytest.raises(ValueError, match="Error creating resource from template"):
+        with pytest.raises(ResourceError, match="Error creating resource from template"):
             await template.create_resource("fail://test", {"x": "test"}, Context())
 
     @pytest.mark.anyio

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -20,6 +20,7 @@ from mcp.server.mcpserver.utilities.types import Audio, Image
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import MCPError
 from mcp.types import (
+    INVALID_PARAMS,
     AudioContent,
     BlobResourceContents,
     Completion,
@@ -727,12 +728,15 @@ class TestServerResources:
             assert result.contents[0].text == "Hello, world!"
 
     async def test_read_unknown_resource(self):
-        """Test that reading an unknown resource raises MCPError."""
+        """Test that reading an unknown resource returns -32602 with uri in data (SEP-2164)."""
         mcp = MCPServer()
 
         async with Client(mcp) as client:
-            with pytest.raises(MCPError, match="Unknown resource: unknown://missing"):
+            with pytest.raises(MCPError, match="Unknown resource: unknown://missing") as exc_info:
                 await client.read_resource("unknown://missing")
+
+            assert exc_info.value.error.code == INVALID_PARAMS
+            assert exc_info.value.error.data == {"uri": "unknown://missing"}
 
     async def test_read_resource_error(self):
         """Test that resource read errors are properly wrapped in MCPError."""

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -20,6 +20,7 @@ from mcp.server.mcpserver.utilities.types import Audio, Image
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import MCPError
 from mcp.types import (
+    INTERNAL_ERROR,
     INVALID_PARAMS,
     AudioContent,
     BlobResourceContents,
@@ -749,6 +750,21 @@ class TestServerResources:
         async with Client(mcp) as client:
             with pytest.raises(MCPError, match="Error reading resource resource://failing"):
                 await client.read_resource("resource://failing")
+
+    async def test_read_resource_template_error(self):
+        """Template-creation failure must surface as INTERNAL_ERROR, not INVALID_PARAMS (not-found)."""
+        mcp = MCPServer()
+
+        @mcp.resource("resource://item/{item_id}")
+        def get_item(item_id: str) -> str:
+            raise RuntimeError("backend unavailable")
+
+        async with Client(mcp) as client:
+            with pytest.raises(MCPError, match="Error creating resource from template") as exc_info:
+                await client.read_resource("resource://item/42")
+
+            assert exc_info.value.error.code == INTERNAL_ERROR
+            assert exc_info.value.error.code != INVALID_PARAMS
 
     async def test_binary_resource(self):
         mcp = MCPServer()

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -751,36 +751,6 @@ class TestServerResources:
             with pytest.raises(MCPError, match="Error reading resource resource://failing"):
                 await client.read_resource("resource://failing")
 
-    async def test_read_resource_template_error(self):
-        """Template-creation failure must surface as INTERNAL_ERROR, not INVALID_PARAMS (not-found)."""
-        mcp = MCPServer()
-
-        @mcp.resource("resource://item/{item_id}")
-        def get_item(item_id: str) -> str:
-            raise RuntimeError("backend unavailable")
-
-        async with Client(mcp) as client:
-            with pytest.raises(MCPError, match="Error creating resource from template") as exc_info:
-                await client.read_resource("resource://item/42")
-
-            assert exc_info.value.error.code == INTERNAL_ERROR
-            assert exc_info.value.error.code != INVALID_PARAMS
-
-    async def test_read_resource_template_not_found(self):
-        """A template handler raising ResourceNotFoundError must surface as INVALID_PARAMS per SEP-2164."""
-        mcp = MCPServer()
-
-        @mcp.resource("resource://users/{user_id}")
-        def get_user(user_id: str) -> str:
-            raise ResourceNotFoundError(f"no user {user_id}")
-
-        async with Client(mcp) as client:
-            with pytest.raises(MCPError, match="no user 999") as exc_info:
-                await client.read_resource("resource://users/999")
-
-            assert exc_info.value.error.code == INVALID_PARAMS
-            assert exc_info.value.error.data == {"uri": "resource://users/999"}
-
     async def test_binary_resource(self):
         mcp = MCPServer()
 
@@ -1551,3 +1521,35 @@ async def test_report_progress_passes_related_request_id():
         message="halfway",
         related_request_id="req-abc-123",
     )
+
+
+async def test_read_resource_template_error():
+    """Template-creation failure must surface as INTERNAL_ERROR, not INVALID_PARAMS (not-found)."""
+    mcp = MCPServer()
+
+    @mcp.resource("resource://item/{item_id}")
+    def get_item(item_id: str) -> str:
+        raise RuntimeError("backend unavailable")
+
+    async with Client(mcp) as client:
+        with pytest.raises(MCPError, match="Error creating resource from template") as exc_info:
+            await client.read_resource("resource://item/42")
+
+        assert exc_info.value.error.code == INTERNAL_ERROR
+        assert exc_info.value.error.code != INVALID_PARAMS
+
+
+async def test_read_resource_template_not_found():
+    """A template handler raising ResourceNotFoundError must surface as INVALID_PARAMS per SEP-2164."""
+    mcp = MCPServer()
+
+    @mcp.resource("resource://users/{user_id}")
+    def get_user(user_id: str) -> str:
+        raise ResourceNotFoundError(f"no user {user_id}")
+
+    async with Client(mcp) as client:
+        with pytest.raises(MCPError, match="no user 999") as exc_info:
+            await client.read_resource("resource://users/999")
+
+        assert exc_info.value.error.code == INVALID_PARAMS
+        assert exc_info.value.error.data == {"uri": "resource://users/999"}

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -12,8 +12,8 @@ from starlette.routing import Mount, Route
 from mcp.client import Client
 from mcp.server.context import ServerRequestContext
 from mcp.server.experimental.request_context import Experimental
-from mcp.server.mcpserver import Context, MCPServer, ResourceNotFoundError
-from mcp.server.mcpserver.exceptions import ToolError
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.exceptions import ResourceNotFoundError, ToolError
 from mcp.server.mcpserver.prompts.base import Message, UserMessage
 from mcp.server.mcpserver.resources import FileResource, FunctionResource
 from mcp.server.mcpserver.utilities.types import Audio, Image

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -12,7 +12,7 @@ from starlette.routing import Mount, Route
 from mcp.client import Client
 from mcp.server.context import ServerRequestContext
 from mcp.server.experimental.request_context import Experimental
-from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver import Context, MCPServer, ResourceNotFoundError
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.prompts.base import Message, UserMessage
 from mcp.server.mcpserver.resources import FileResource, FunctionResource
@@ -765,6 +765,21 @@ class TestServerResources:
 
             assert exc_info.value.error.code == INTERNAL_ERROR
             assert exc_info.value.error.code != INVALID_PARAMS
+
+    async def test_read_resource_template_not_found(self):
+        """A template handler raising ResourceNotFoundError must surface as INVALID_PARAMS per SEP-2164."""
+        mcp = MCPServer()
+
+        @mcp.resource("resource://users/{user_id}")
+        def get_user(user_id: str) -> str:
+            raise ResourceNotFoundError(f"no user {user_id}")
+
+        async with Client(mcp) as client:
+            with pytest.raises(MCPError, match="no user 999") as exc_info:
+                await client.read_resource("resource://users/999")
+
+            assert exc_info.value.error.code == INVALID_PARAMS
+            assert exc_info.value.error.data == {"uri": "resource://users/999"}
 
     async def test_binary_resource(self):
         mcp = MCPServer()


### PR DESCRIPTION
## Summary

Implements [SEP-2164](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2164) — standardizes the resource-not-found error code to `-32602` (Invalid Params).

## Problem

The Python SDK currently returns error code `0` for resource-not-found, making it impossible for clients to reliably distinguish this from other errors. The spec now requires `-32602` with the URI in the `data` field.

## Changes

- Add `ResourceNotFoundError(ResourceError)` subclass in `mcpserver/exceptions.py`
- `MCPServer.read_resource()` now raises `ResourceNotFoundError` (instead of generic `ResourceError`) when the resource doesn't exist
- `_handle_read_resource()` catches `ResourceNotFoundError` and converts it to `MCPError(code=INVALID_PARAMS, ..., data={"uri": ...})`

The subclass approach keeps backward compatibility — existing code catching `ResourceError` continues to work unchanged.

## Wire format (before → after)

```diff
 {
   "jsonrpc": "2.0",
   "id": 2,
   "error": {
-    "code": 0,
+    "code": -32602,
     "message": "Unknown resource: file:///nonexistent.txt",
-    "data": null
+    "data": {"uri": "file:///nonexistent.txt"}
   }
 }
```

Spec: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2164