### PR TITLE
feat: add MCP_HIDE_INPUT_IN_ERRORS env var to redact payloads from validation errors

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,10 +1,14 @@
 from typing import Any, Literal
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator
+
+from mcp.types.jsonrpc import HIDE_INPUT_IN_ERRORS
 
 
 class OAuthToken(BaseModel):
     """See https://datatracker.ietf.org/doc/html/rfc6749#section-5.1"""
+
+    model_config = ConfigDict(hide_input_in_errors=HIDE_INPUT_IN_ERRORS)
 
     access_token: str
     token_type: Literal["Bearer"] = "Bearer"
@@ -36,6 +40,8 @@ class OAuthClientMetadata(BaseModel):
     """RFC 7591 OAuth 2.0 Dynamic Client Registration Metadata.
     See https://datatracker.ietf.org/doc/html/rfc7591#section-2
     """
+
+    model_config = ConfigDict(hide_input_in_errors=HIDE_INPUT_IN_ERRORS)
 
     redirect_uris: list[AnyUrl] | None = Field(..., min_length=1)
     # supported auth methods for the token endpoint
@@ -105,6 +111,8 @@ class OAuthMetadata(BaseModel):
     See https://datatracker.ietf.org/doc/html/rfc8414#section-2
     """
 
+    model_config = ConfigDict(hide_input_in_errors=HIDE_INPUT_IN_ERRORS)
+
     issuer: AnyHttpUrl
     authorization_endpoint: AnyHttpUrl
     token_endpoint: AnyHttpUrl
@@ -133,6 +141,8 @@ class ProtectedResourceMetadata(BaseModel):
     """RFC 9728 OAuth 2.0 Protected Resource Metadata.
     See https://datatracker.ietf.org/doc/html/rfc9728#section-2
     """
+
+    model_config = ConfigDict(hide_input_in_errors=HIDE_INPUT_IN_ERRORS)
 
     resource: AnyHttpUrl
     authorization_servers: list[AnyHttpUrl] = Field(..., min_length=1)

--- a/src/mcp/types/jsonrpc.py
+++ b/src/mcp/types/jsonrpc.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+import os
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+HIDE_INPUT_IN_ERRORS = os.environ.get("MCP_HIDE_INPUT_IN_ERRORS", "").lower() in ("1", "true")
+"""When True, pydantic ValidationError reprs omit the ``input_value`` field.
+
+Set the ``MCP_HIDE_INPUT_IN_ERRORS`` environment variable to ``1`` or ``true`` before
+importing the SDK to prevent raw request/response payloads from appearing in logs
+when JSON parsing or validation fails. The error type and location are still shown.
+"""
 
 RequestId = Annotated[int, Field(strict=True)] | str
 """The ID of a JSON-RPC request."""
@@ -80,4 +89,6 @@ class JSONRPCError(BaseModel):
 
 
 JSONRPCMessage = JSONRPCRequest | JSONRPCNotification | JSONRPCResponse | JSONRPCError
-jsonrpc_message_adapter: TypeAdapter[JSONRPCMessage] = TypeAdapter(JSONRPCMessage)
+jsonrpc_message_adapter: TypeAdapter[JSONRPCMessage] = TypeAdapter(
+    JSONRPCMessage, config=ConfigDict(hide_input_in_errors=HIDE_INPUT_IN_ERRORS)
+)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,9 @@
+import subprocess
+import sys
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from mcp.types import (
     LATEST_PROTOCOL_VERSION,
@@ -360,3 +363,51 @@ def test_list_tools_result_preserves_json_schema_2020_12_fields():
     assert tool.input_schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
     assert "$defs" in tool.input_schema
     assert tool.input_schema["additionalProperties"] is False
+
+
+def test_validation_error_shows_input_by_default():
+    """By default, ValidationError repr includes input_value (pydantic's default behavior)."""
+    with pytest.raises(ValidationError) as exc_info:
+        jsonrpc_message_adapter.validate_json('{"result":{"content":"SECRET-PAYLOAD')
+    assert "input_value" in repr(exc_info.value)
+    assert "SECRET-PAYLOAD" in repr(exc_info.value)
+
+
+_HIDE_INPUT_CHECK_SCRIPT = """
+import pydantic
+from mcp.types import jsonrpc_message_adapter
+from mcp.shared.auth import OAuthToken, OAuthMetadata, ProtectedResourceMetadata, OAuthClientMetadata
+
+def check(fn, name):
+    try:
+        fn()
+    except pydantic.ValidationError as e:
+        err = repr(e)
+        assert "input_value" not in err, f"{name}: input_value leaked: {err!r}"
+        assert "SECRET" not in err, f"{name}: payload leaked: {err!r}"
+        # still useful: error type/location present
+        assert "json_invalid" in err or "validation error" in err
+    else:
+        raise AssertionError(f"{name}: expected ValidationError")
+
+check(lambda: jsonrpc_message_adapter.validate_json('{"result":"SECRET'), "jsonrpc_message_adapter")
+check(lambda: OAuthToken.model_validate_json('{"access_token":"SECRET'), "OAuthToken")
+check(lambda: OAuthMetadata.model_validate_json('{"issuer":"SECRET'), "OAuthMetadata")
+check(lambda: ProtectedResourceMetadata.model_validate_json('{"resource":"SECRET'), "ProtectedResourceMetadata")
+check(lambda: OAuthClientMetadata.model_validate_json('{"redirect_uris":"SECRET'), "OAuthClientMetadata")
+print("OK")
+"""
+
+
+@pytest.mark.parametrize("env_value", ["1", "true", "True", "TRUE"])
+def test_hide_input_in_errors_env_var(env_value: str):
+    """When MCP_HIDE_INPUT_IN_ERRORS is set, ValidationError repr omits input_value."""
+    result = subprocess.run(
+        [sys.executable, "-c", _HIDE_INPUT_CHECK_SCRIPT],
+        env={"MCP_HIDE_INPUT_IN_ERRORS": env_value},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert result.stdout.strip() == "OK"


### PR DESCRIPTION
Adds an opt-in `MCP_HIDE_INPUT_IN_ERRORS` environment variable that suppresses the `input_value` field in pydantic `ValidationError` reprs for models that parse untrusted external data.

## Motivation and Context

Pydantic's `ValidationError.__repr__` includes the raw `input_value` by default. When the SDK calls `model_validate_json()` on untrusted input and validation fails, any `logger.exception(...)` at the call site dumps the entire payload into logs.

Example from a production deployment — a truncated SSE message caused the client to log 55KB of tool result content:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for JSONRPCMessage
  Invalid JSON: EOF while parsing a string at line 1 column 55456
  [type=json_invalid, input_value='{"result":{"content":[{"...<55KB of payload>...', input_type=str]
```

This pattern exists at several call sites:
- `client/streamable_http.py` — SSE and JSON response parsing → `logger.exception("Error parsing SSE message")`
- `client/sse.py`, `client/stdio.py`, `client/websocket.py` — same pattern for `jsonrpc_message_adapter.validate_json()`
- `client/auth/oauth2.py` — `OAuthToken.model_validate_json()` → `logger.exception("Invalid refresh response")` (can leak token payloads)
- `client/auth/utils.py`, `server/auth/handlers/register.py` — OAuth metadata and client registration parsing

Setting `MCP_HIDE_INPUT_IN_ERRORS=1` before importing the SDK applies pydantic's `hide_input_in_errors=True` config so errors still show the type and location (e.g. `EOF while parsing a string at line 1 column 55456`) but omit the raw payload.

## How Has This Been Tested?

- `test_validation_error_shows_input_by_default` — verifies current behavior unchanged (input shown by default)
- `test_hide_input_in_errors_env_var` — subprocess test verifying `input_value` is absent from errors for `jsonrpc_message_adapter`, `OAuthToken`, `OAuthMetadata`, `ProtectedResourceMetadata`, and `OAuthClientMetadata` when the env var is set (parametrized over `1`/`true`/`True`/`TRUE`)

Subprocess is used because the env var is read at import time — `monkeypatch.setenv` would have no effect on the already-constructed `TypeAdapter`.

## Breaking Changes

None. The default behavior is unchanged; the env var is opt-in.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Why env var instead of a `configure()` function?** The `jsonrpc_message_adapter` is a module-level `TypeAdapter` that's directly imported (`from mcp.types import jsonrpc_message_adapter`) in several transports. A runtime `configure()` that rebuilds the adapter would leave those direct imports holding stale references. Checking the env var at import time avoids this entirely with zero runtime cost.

**Why config on the `TypeAdapter` and not the union's member models?** Verified that setting `hide_input_in_errors=True` on `JSONRPCRequest`/`JSONRPCResponse`/etc. does **not** propagate to top-level JSON parse errors raised by the `TypeAdapter` — the config must be on the adapter itself. The OAuth models are validated directly via `Model.model_validate_json()`, so they get `model_config` individually.

**Why not `SecretStr`?** `SecretStr` only masks field values after successful parsing. The motivating error is a JSON parse failure (`EOF while parsing`) — validation fails before any field types run, so `SecretStr` never executes. The leaked data is also `JSONRPCResponse.result: dict[str, Any]` (arbitrary tool output), not a nameable secret field.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>