### PR TITLE
fix: return METHOD_NOT_FOUND (-32601) for unknown methods instead of INVALID_PARAMS (-32602)

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -145,6 +145,17 @@ class ClientSession(
     def _receive_notification_adapter(self) -> TypeAdapter[types.ServerNotification]:
         return types.server_notification_adapter
 
+    @property
+    def _known_request_methods(self) -> frozenset[str]:
+        import typing
+        return frozenset(
+            str(t.model_fields["method"].default)
+            for t in typing.get_args(types.ServerRequest)
+            if hasattr(t, "model_fields")
+            and "method" in t.model_fields
+            and t.model_fields["method"].default not in (None, ...)
+        )
+
     async def initialize(self) -> types.InitializeResult:
         sampling = (
             (self._sampling_capabilities or types.SamplingCapability())

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -105,6 +105,17 @@ class ServerSession(
         return types.client_notification_adapter
 
     @property
+    def _known_request_methods(self) -> frozenset[str]:
+        import typing
+        return frozenset(
+            str(t.model_fields["method"].default)
+            for t in typing.get_args(types.ClientRequest)
+            if hasattr(t, "model_fields")
+            and "method" in t.model_fields
+            and t.model_fields["method"].default not in (None, ...)
+        )
+
+    @property
     def client_params(self) -> types.InitializeRequestParams | None:
         return self._client_params
 

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import typing
 from collections.abc import Callable
 from contextlib import AsyncExitStack
 from types import TracebackType
@@ -17,6 +18,7 @@ from mcp.shared.response_router import ResponseRouter
 from mcp.types import (
     CONNECTION_CLOSED,
     INVALID_PARAMS,
+    METHOD_NOT_FOUND,
     REQUEST_TIMEOUT,
     CancelledNotification,
     ClientNotification,
@@ -327,6 +329,16 @@ class BaseSession(
         raise NotImplementedError
 
     @property
+    def _known_request_methods(self) -> frozenset[str]:
+        """Return the set of method names this session accepts.
+
+        Subclasses override this to return the correct set for their request
+        union type (ClientRequest for servers, ServerRequest for clients).
+        Used to distinguish METHOD_NOT_FOUND from INVALID_PARAMS errors.
+        """
+        raise NotImplementedError
+
+    @property
     def _receive_notification_adapter(self) -> TypeAdapter[ReceiveNotificationT]:
         raise NotImplementedError
 
@@ -360,10 +372,24 @@ class BaseSession(
                             # response instead of crashing the server
                             logging.warning("Failed to validate request", exc_info=True)
                             logging.debug(f"Message that failed validation: {message.message}")
+                            # Per JSON-RPC spec, return METHOD_NOT_FOUND (-32601) when
+                            # the method is not in the supported set, and INVALID_PARAMS
+                            # (-32602) when the method is known but parameters are invalid.
+                            method = getattr(message.message, "method", None)
+                            try:
+                                known = self._known_request_methods
+                            except NotImplementedError:
+                                known = frozenset()
+                            if method is not None and method not in known:
+                                error_code = METHOD_NOT_FOUND
+                                error_msg = "Method not found"
+                            else:
+                                error_code = INVALID_PARAMS
+                                error_msg = "Invalid request parameters"
                             error_response = JSONRPCError(
                                 jsonrpc="2.0",
                                 id=message.message.id,
-                                error=ErrorData(code=INVALID_PARAMS, message="Invalid request parameters", data=""),
+                                error=ErrorData(code=error_code, message=error_msg, data=""),
                             )
                             session_message = SessionMessage(message=error_response)
                             await self._write_stream.send(session_message)


### PR DESCRIPTION
## Problem

When a client sends a request with an unknown method (e.g. `tools/register`, `hack/inject`), the server returns `-32602 Invalid request parameters` instead of `-32601 Method not found`.

This happens because `pydantic`'s `ValidationError` is caught in `_receive_loop` before the dispatcher's method-not-found branch in `_handle_request` is reached. The catch-all `except Exception` block unconditionally returns `INVALID_PARAMS`.

Reported in #1561. Confirmed on SSE transport with the following reproduction:

```python
# POST tools/register to an SSE MCP server after initialize
# Response: {"error": {"code": -32602, "message": "Invalid request parameters"}}
# Expected: {"error": {"code": -32601, "message": "Method not found"}}
```

**Security relevance:** Security harnesses testing MCP-002 (Tool Registration via Call Injection) rely on the correct `-32601` rejection to distinguish "method unknown" from "params malformed". Returning `-32602` causes false negatives in injection detection.

## Solution

Add a `_known_request_methods` property to `BaseSession`, implemented by:
- `ServerSession` → extracts method literals from `ClientRequest` union
- `ClientSession` → extracts method literals from `ServerRequest` union

The `except` block in `_receive_loop` now checks whether the failing method is in the known set and selects the correct error code accordingly.

## Changes

- `src/mcp/shared/session.py`: add `import typing`, import `METHOD_NOT_FOUND`, add `_known_request_methods` property, fix except block
- `src/mcp/server/session.py`: implement `_known_request_methods` for `ClientRequest`
- `src/mcp/client/session.py`: implement `_known_request_methods` for `ServerRequest`

## Testing

```python
import typing
from mcp.types import ClientRequest

known = frozenset(
    str(t.model_fields["method"].default)
    for t in typing.get_args(ClientRequest)
    if hasattr(t, "model_fields")
    and "method" in t.model_fields
    and t.model_fields["method"].default not in (None, ...)
)

assert "tools/register" not in known  # → METHOD_NOT_FOUND
assert "tools/call" in known           # → INVALID_PARAMS (bad params)
assert "hack/inject" not in known      # → METHOD_NOT_FOUND
```