### PR TITLE
Return METHOD_NOT_FOUND for invalid request methods

### DIFF
--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -29,7 +29,7 @@ be instantiated directly by users of the MCP framework.
 """
 
 from enum import Enum
-from typing import Any, TypeVar, overload
+from typing import Any, TypeVar, get_args, overload
 
 import anyio
 import anyio.lowlevel
@@ -61,6 +61,12 @@ ServerSessionT = TypeVar("ServerSessionT", bound="ServerSession")
 
 ServerRequestResponder = (
     RequestResponder[types.ClientRequest, types.ServerResult] | types.ClientNotification | Exception
+)
+
+_KNOWN_CLIENT_REQUEST_METHODS = frozenset(
+    method
+    for request_type in get_args(types.ClientRequest)
+    if isinstance(method := request_type.model_fields["method"].default, str)
 )
 
 
@@ -103,6 +109,11 @@ class ServerSession(
     @property
     def _receive_notification_adapter(self) -> TypeAdapter[types.ClientNotification]:
         return types.client_notification_adapter
+
+    def _get_request_validation_error(self, request: types.JSONRPCRequest) -> types.ErrorData:
+        if request.method not in _KNOWN_CLIENT_REQUEST_METHODS:
+            return types.ErrorData(code=types.METHOD_NOT_FOUND, message="Method not found")
+        return super()._get_request_validation_error(request)
 
     @property
     def client_params(self) -> types.InitializeRequestParams | None:

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -330,6 +330,9 @@ class BaseSession(
     def _receive_notification_adapter(self) -> TypeAdapter[ReceiveNotificationT]:
         raise NotImplementedError
 
+    def _get_request_validation_error(self, request: JSONRPCRequest) -> ErrorData:
+        return ErrorData(code=INVALID_PARAMS, message="Invalid request parameters", data="")
+
     async def _receive_loop(self) -> None:
         async with self._read_stream, self._write_stream:
             try:
@@ -363,7 +366,7 @@ class BaseSession(
                             error_response = JSONRPCError(
                                 jsonrpc="2.0",
                                 id=message.message.id,
-                                error=ErrorData(code=INVALID_PARAMS, message="Invalid request parameters", data=""),
+                                error=self._get_request_validation_error(message.message),
                             )
                             session_message = SessionMessage(message=error_response)
                             await self._write_stream.send(session_message)

--- a/tests/issues/test_1561_invalid_method_names.py
+++ b/tests/issues/test_1561_invalid_method_names.py
@@ -1,0 +1,54 @@
+import anyio
+import pytest
+
+from mcp.server.models import InitializationOptions
+from mcp.server.session import ServerSession
+from mcp.shared.message import SessionMessage
+from mcp.types import INVALID_PARAMS, METHOD_NOT_FOUND, JSONRPCError, JSONRPCRequest, ServerCapabilities
+
+
+@pytest.mark.anyio
+async def test_invalid_method_names_return_method_not_found() -> None:
+    read_send_stream, read_receive_stream = anyio.create_memory_object_stream[SessionMessage | Exception](10)
+    write_send_stream, write_receive_stream = anyio.create_memory_object_stream[SessionMessage](10)
+
+    try:
+        async with ServerSession(
+            read_stream=read_receive_stream,
+            write_stream=write_send_stream,
+            init_options=InitializationOptions(
+                server_name="test_server",
+                server_version="1.0.0",
+                capabilities=ServerCapabilities(),
+            ),
+        ):
+            await read_send_stream.send(
+                SessionMessage(
+                    message=JSONRPCRequest(jsonrpc="2.0", id=1, method="invalid/method", params={})
+                )
+            )
+
+            invalid_method_response = (await write_receive_stream.receive()).message
+
+            assert isinstance(invalid_method_response, JSONRPCError)
+            assert invalid_method_response.id == 1
+            assert invalid_method_response.error.code == METHOD_NOT_FOUND
+            assert invalid_method_response.error.message == "Method not found"
+
+            await read_send_stream.send(
+                SessionMessage(
+                    message=JSONRPCRequest(jsonrpc="2.0", id=2, method="initialize")
+                )
+            )
+
+            malformed_known_method_response = (await write_receive_stream.receive()).message
+
+            assert isinstance(malformed_known_method_response, JSONRPCError)
+            assert malformed_known_method_response.id == 2
+            assert malformed_known_method_response.error.code == INVALID_PARAMS
+            assert malformed_known_method_response.error.message == "Invalid request parameters"
+    finally:  # pragma: lax no cover
+        await read_send_stream.aclose()
+        await write_send_stream.aclose()
+        await read_receive_stream.aclose()
+        await write_receive_stream.aclose()


### PR DESCRIPTION
Fixes #1561.

## Summary
- return `METHOD_NOT_FOUND` for unknown JSON-RPC request methods instead of collapsing them into the generic request-validation `INVALID_PARAMS` fallback
- keep `INVALID_PARAMS` for malformed known methods by only special-casing method names that are outside the typed client request union
- add a focused regression proving `invalid/method` returns `-32601` while malformed `initialize` still returns `-32602`

## Testing
- `PYTHONPATH=src python -m pytest -o addopts="" tests/issues/test_1561_invalid_method_names.py -q`
- `python -m ruff check src/mcp/shared/session.py src/mcp/server/session.py tests/issues/test_1561_invalid_method_names.py`
- `git diff --check`