### PR TITLE
Don't block the event loop on sync resource and prompt functions

### DIFF
--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
+import anyio.to_thread
 import pydantic_core
 from pydantic import BaseModel, Field, TypeAdapter, validate_call
 
@@ -155,10 +157,10 @@ class Prompt(BaseModel):
             # Add context to arguments if needed
             call_args = inject_context(self.fn, arguments or {}, context, self.context_kwarg)
 
-            # Call function and check if result is a coroutine
-            result = self.fn(**call_args)
-            if inspect.iscoroutine(result):
-                result = await result
+            if inspect.iscoroutinefunction(self.fn):
+                result = await self.fn(**call_args)
+            else:
+                result = await anyio.to_thread.run_sync(functools.partial(self.fn, **call_args))
 
             # Validate messages
             if not isinstance(result, list | tuple):

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
 import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
+import anyio.to_thread
 from pydantic import BaseModel, Field, validate_call
 
 from mcp.server.mcpserver.resources.types import FunctionResource, Resource
@@ -110,10 +112,10 @@ class ResourceTemplate(BaseModel):
             # Add context to params if needed
             params = inject_context(self.fn, params, context, self.context_kwarg)
 
-            # Call function and check if result is a coroutine
-            result = self.fn(**params)
-            if inspect.iscoroutine(result):
-                result = await result
+            if inspect.iscoroutinefunction(self.fn):
+                result = await self.fn(**params)
+            else:
+                result = await anyio.to_thread.run_sync(functools.partial(self.fn, **params))
 
             return FunctionResource(
                 uri=uri,  # type: ignore

--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -55,11 +55,10 @@ class FunctionResource(Resource):
     async def read(self) -> str | bytes:
         """Read the resource by calling the wrapped function."""
         try:
-            # Call the function first to see if it returns a coroutine
-            result = self.fn()
-            # If it's a coroutine, await it
-            if inspect.iscoroutine(result):
-                result = await result
+            if inspect.iscoroutinefunction(self.fn):
+                result = await self.fn()
+            else:
+                result = await anyio.to_thread.run_sync(self.fn)
 
             if isinstance(result, Resource):  # pragma: no cover
                 return await result.read()

--- a/tests/server/mcpserver/prompts/test_base.py
+++ b/tests/server/mcpserver/prompts/test_base.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Any
 
 import pytest
@@ -190,3 +191,21 @@ class TestRenderPrompt:
                 )
             )
         ]
+
+
+@pytest.mark.anyio
+async def test_sync_fn_runs_in_worker_thread():
+    """Sync prompt functions must run in a worker thread, not the event loop."""
+
+    main_thread = threading.get_ident()
+    fn_thread: list[int] = []
+
+    def blocking_fn() -> str:
+        fn_thread.append(threading.get_ident())
+        return "hello"
+
+    prompt = Prompt.from_function(blocking_fn)
+    messages = await prompt.render(None, Context())
+
+    assert messages == [UserMessage(content=TextContent(type="text", text="hello"))]
+    assert fn_thread[0] != main_thread

--- a/tests/server/mcpserver/resources/test_function_resources.py
+++ b/tests/server/mcpserver/resources/test_function_resources.py
@@ -1,5 +1,7 @@
 import threading
 
+import anyio
+import anyio.from_thread
 import pytest
 from pydantic import BaseModel
 
@@ -210,3 +212,33 @@ async def test_sync_fn_runs_in_worker_thread():
 
     assert result == "data"
     assert fn_thread[0] != main_thread
+
+
+@pytest.mark.anyio
+async def test_sync_fn_does_not_block_event_loop():
+    """A blocking sync resource function must not stall the event loop.
+
+    On regression (sync runs inline), anyio.from_thread.run_sync raises
+    RuntimeError because there is no worker-thread context, failing fast.
+    """
+    handler_entered = anyio.Event()
+    release = threading.Event()
+
+    def blocking_fn() -> str:
+        anyio.from_thread.run_sync(handler_entered.set)
+        release.wait()
+        return "done"
+
+    resource = FunctionResource(uri="resource://test", name="test", fn=blocking_fn)
+    result: list[str | bytes] = []
+
+    async def run() -> None:
+        result.append(await resource.read())
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(run)
+            await handler_entered.wait()
+            release.set()
+
+    assert result == ["done"]

--- a/tests/server/mcpserver/resources/test_function_resources.py
+++ b/tests/server/mcpserver/resources/test_function_resources.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 from pydantic import BaseModel
 
@@ -190,3 +192,21 @@ class TestFunctionResourceMetadata:
         )
 
         assert resource.meta is None
+
+
+@pytest.mark.anyio
+async def test_sync_fn_runs_in_worker_thread():
+    """Sync resource functions must run in a worker thread, not the event loop."""
+
+    main_thread = threading.get_ident()
+    fn_thread: list[int] = []
+
+    def blocking_fn() -> str:
+        fn_thread.append(threading.get_ident())
+        return "data"
+
+    resource = FunctionResource(uri="resource://test", name="test", fn=blocking_fn)
+    result = await resource.read()
+
+    assert result == "data"
+    assert fn_thread[0] != main_thread

--- a/tests/server/mcpserver/resources/test_resource_template.py
+++ b/tests/server/mcpserver/resources/test_resource_template.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from typing import Any
 
 import pytest
@@ -310,3 +311,22 @@ class TestResourceTemplateMetadata:
         assert resource.meta == metadata
         assert resource.meta["category"] == "inventory"
         assert resource.meta["cacheable"] is True
+
+
+@pytest.mark.anyio
+async def test_sync_fn_runs_in_worker_thread():
+    """Sync template functions must run in a worker thread, not the event loop."""
+
+    main_thread = threading.get_ident()
+    fn_thread: list[int] = []
+
+    def blocking_fn(name: str) -> str:
+        fn_thread.append(threading.get_ident())
+        return f"hello {name}"
+
+    template = ResourceTemplate.from_function(fn=blocking_fn, uri_template="test://{name}")
+    resource = await template.create_resource("test://world", {"name": "world"}, Context())
+
+    assert isinstance(resource, FunctionResource)
+    assert await resource.read() == "hello world"
+    assert fn_thread[0] != main_thread


### PR DESCRIPTION
Extends the #1909 fix to resources and prompts — sync `@mcp.resource` and `@mcp.prompt` handlers now run in worker threads instead of blocking the event loop.

## Motivation and Context

#1909 fixed tools by routing sync functions through `anyio.to_thread.run_sync`, but the same blocking pattern existed in three other places:

- `FunctionResource.read()`
- `ResourceTemplate.create_resource()`
- `Prompt.render()`

All three called `self.fn(...)` directly and checked `inspect.iscoroutine(result)` afterward. A blocking sync handler (file I/O, HTTP request, CPU-bound work) would freeze the entire event loop.

This applies the same fix: check `inspect.iscoroutinefunction(self.fn)` up front and dispatch sync functions to a worker thread.

Related: #1646, #1839

## How Has This Been Tested?

Added thread-identity regression tests for each of the three call sites. Each test captures `threading.get_ident()` inside a sync handler and asserts it differs from the event loop's thread.

Verified that `pydantic.validate_call` (which wraps the stored `self.fn` in templates and prompts) preserves async-ness — `inspect.iscoroutinefunction(validate_call(async_fn))` returns `True`, so the dispatch check works correctly on the wrapped function.

All 39 tests in the affected test files pass; pyright, ruff, and `strict-no-cover` are clean.

## Breaking Changes

None. Sync handlers that were previously starving the event loop now run concurrently.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

The previous implementation happened to support callable objects with async `__call__` (by checking `iscoroutine(result)` after calling). That edge case is not preserved here — matching the approach taken in #1909, which relies on `_is_async_callable` being evaluated at registration time for tools. Resources and prompts have no equivalent pre-computed field; if that edge case matters, it's worth a separate discussion.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>