### PR TITLE
Use shared `is_async_callable` instead of `inspect.iscoroutinefunction`

### DIFF
--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -13,6 +12,7 @@ from pydantic import BaseModel, Field, TypeAdapter, validate_call
 
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter, inject_context
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+from mcp.shared._callable_inspection import is_async_callable
 from mcp.types import ContentBlock, Icon, TextContent
 
 if TYPE_CHECKING:
@@ -157,8 +157,9 @@ class Prompt(BaseModel):
             # Add context to arguments if needed
             call_args = inject_context(self.fn, arguments or {}, context, self.context_kwarg)
 
-            if inspect.iscoroutinefunction(self.fn):
-                result = await self.fn(**call_args)
+            fn = self.fn
+            if is_async_callable(fn):
+                result = await fn(**call_args)
             else:
                 result = await anyio.to_thread.run_sync(functools.partial(self.fn, **call_args))
 

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -15,6 +14,7 @@ from pydantic import BaseModel, Field, validate_call
 from mcp.server.mcpserver.resources.types import FunctionResource, Resource
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter, inject_context
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+from mcp.shared._callable_inspection import is_async_callable
 from mcp.types import Annotations, Icon
 
 if TYPE_CHECKING:
@@ -112,8 +112,9 @@ class ResourceTemplate(BaseModel):
             # Add context to params if needed
             params = inject_context(self.fn, params, context, self.context_kwarg)
 
-            if inspect.iscoroutinefunction(self.fn):
-                result = await self.fn(**params)
+            fn = self.fn
+            if is_async_callable(fn):
+                result = await fn(**params)
             else:
                 result = await anyio.to_thread.run_sync(functools.partial(self.fn, **params))
 

--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -1,6 +1,7 @@
 """Concrete resource implementations."""
 
-import inspect
+from __future__ import annotations
+
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -14,6 +15,7 @@ import pydantic_core
 from pydantic import Field, ValidationInfo, validate_call
 
 from mcp.server.mcpserver.resources.base import Resource
+from mcp.shared._callable_inspection import is_async_callable
 from mcp.types import Annotations, Icon
 
 
@@ -55,8 +57,9 @@ class FunctionResource(Resource):
     async def read(self) -> str | bytes:
         """Read the resource by calling the wrapped function."""
         try:
-            if inspect.iscoroutinefunction(self.fn):
-                result = await self.fn()
+            fn = self.fn
+            if is_async_callable(fn):
+                result = await fn()
             else:
                 result = await anyio.to_thread.run_sync(self.fn)
 
@@ -83,7 +86,7 @@ class FunctionResource(Resource):
         icons: list[Icon] | None = None,
         annotations: Annotations | None = None,
         meta: dict[str, Any] | None = None,
-    ) -> "FunctionResource":
+    ) -> FunctionResource:
         """Create a FunctionResource from a function."""
         func_name = name or fn.__name__
         if func_name == "<lambda>":  # pragma: no cover

--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import functools
-import inspect
 from collections.abc import Callable
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -11,6 +9,7 @@ from pydantic import BaseModel, Field
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
 from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
+from mcp.shared._callable_inspection import is_async_callable
 from mcp.shared.exceptions import UrlElicitationRequiredError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
 from mcp.types import Icon, ToolAnnotations
@@ -63,7 +62,7 @@ class Tool(BaseModel):
             raise ValueError("You must provide a name for lambda functions")
 
         func_doc = description or fn.__doc__ or ""
-        is_async = _is_async_callable(fn)
+        is_async = is_async_callable(fn)
 
         if context_kwarg is None:  # pragma: no branch
             context_kwarg = find_context_parameter(fn)
@@ -118,12 +117,3 @@ class Tool(BaseModel):
             raise
         except Exception as e:
             raise ToolError(f"Error executing tool {self.name}: {e}") from e
-
-
-def _is_async_callable(obj: Any) -> bool:
-    while isinstance(obj, functools.partial):  # pragma: lax no cover
-        obj = obj.func
-
-    return inspect.iscoroutinefunction(obj) or (
-        callable(obj) and inspect.iscoroutinefunction(getattr(obj, "__call__", None))
-    )

--- a/src/mcp/shared/_callable_inspection.py
+++ b/src/mcp/shared/_callable_inspection.py
@@ -1,0 +1,32 @@
+"""Callable inspection utilities.
+
+Adapted from Starlette's `is_async_callable` implementation.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeGuard, TypeVar, overload
+
+T = TypeVar("T")
+
+AwaitableCallable = Callable[..., Awaitable[T]]
+
+
+@overload
+def is_async_callable(obj: AwaitableCallable[T]) -> TypeGuard[AwaitableCallable[T]]: ...
+
+
+@overload
+def is_async_callable(obj: Any) -> TypeGuard[AwaitableCallable[Any]]: ...
+
+
+def is_async_callable(obj: Any) -> Any:
+    while isinstance(obj, functools.partial):  # pragma: lax no cover
+        obj = obj.func
+
+    return inspect.iscoroutinefunction(obj) or (
+        callable(obj) and inspect.iscoroutinefunction(getattr(obj, "__call__", None))
+    )

--- a/src/mcp/shared/_callable_inspection.py
+++ b/src/mcp/shared/_callable_inspection.py
@@ -1,7 +1,7 @@
 """Callable inspection utilities.
 
 Adapted from Starlette's `is_async_callable` implementation.
-https://github.com/encode/starlette/blob/master/starlette/_utils.py
+https://github.com/encode/starlette/blob/main/starlette/_utils.py
 """
 
 from __future__ import annotations

--- a/src/mcp/shared/_callable_inspection.py
+++ b/src/mcp/shared/_callable_inspection.py
@@ -1,6 +1,7 @@
 """Callable inspection utilities.
 
 Adapted from Starlette's `is_async_callable` implementation.
+https://github.com/encode/starlette/blob/master/starlette/_utils.py
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`inspect.iscoroutinefunction` misses callable objects with an async `__call__` and `functools.partial`-wrapped coroutines. The `tools/base.py` module already had a local `_is_async_callable` helper that handles these cases, but the prompts, resources, and templates modules were using the raw `inspect.iscoroutinefunction`.

This PR extracts the helper into `mcp.shared._callable_inspection.is_async_callable` (adapted from Starlette's implementation) and replaces all `inspect.iscoroutinefunction` usage across the codebase.

## Test plan

- [x] All 333 mcpserver tests pass
- [x] pyright clean on all changed files
- [x] ruff lint + format clean