### PR TITLE
Fix #1933: Prevent closing real stdio when server exits

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -30,7 +30,10 @@ from mcp.shared.message import SessionMessage
 
 
 @asynccontextmanager
-async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.AsyncFile[str] | None = None):
+async def stdio_server(
+    stdin: anyio.AsyncFile[str] | None = None,
+    stdout: anyio.AsyncFile[str] | None = None,
+):
     """Server transport for stdio: this communicates with an MCP client by reading
     from the current process' stdin and writing to stdout.
     """
@@ -44,14 +47,18 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     if not stdin:
         stdin_fd = os.dup(sys.stdin.fileno())
         stdin_bin = os.fdopen(stdin_fd, "rb", closefd=True)
-        stdin = anyio.wrap_file(TextIOWrapper(stdin_bin, encoding="utf-8", errors="replace"))
-    
+        stdin = anyio.wrap_file(
+            TextIOWrapper(stdin_bin, encoding="utf-8", errors="replace")
+        )
+
     if not stdout:
         stdout_fd = os.dup(sys.stdout.fileno())
         stdout_bin = os.fdopen(stdout_fd, "wb", closefd=True)
         stdout = anyio.wrap_file(TextIOWrapper(stdout_bin, encoding="utf-8"))
 
-    read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
+    read_stream_writer, read_stream = create_context_streams[
+        SessionMessage | Exception
+    ](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)
 
     async def stdin_reader():
@@ -59,7 +66,9 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
             async with read_stream_writer:
                 async for line in stdin:
                     try:
-                        message = types.jsonrpc_message_adapter.validate_json(line, by_name=False)
+                        message = types.jsonrpc_message_adapter.validate_json(
+                            line, by_name=False
+                        )
                     except Exception as exc:
                         await read_stream_writer.send(exc)
                         continue
@@ -73,7 +82,9 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
         try:
             async with write_stream_reader:
                 async for session_message in write_stream_reader:
-                    json = session_message.message.model_dump_json(by_alias=True, exclude_unset=True)
+                    json = session_message.message.model_dump_json(
+                        by_alias=True, exclude_unset=True
+                    )
                     await stdout.write(json + "\n")
                     await stdout.flush()
         except anyio.ClosedResourceError:  # pragma: no cover

--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -1,22 +1,22 @@
 """Stdio Server Transport Module
 
 This module provides functionality for creating an stdio-based transport layer
-that can be used to communicate with an MCP client through standard input/output
-streams.
+that can be used to communicate with an MCP client through standard input/output streams.
 
 Example:
-    ```python
-    async def run_server():
-        async with stdio_server() as (read_stream, write_stream):
-            # read_stream contains incoming JSONRPCMessages from stdin
-            # write_stream allows sending JSONRPCMessages to stdout
-            server = await create_my_server()
-            await server.run(read_stream, write_stream, init_options)
+```python
+async def run_server():
+    async with stdio_server() as (read_stream, write_stream):
+        # read_stream contains incoming JSONRPCMessages from stdin
+        # write_stream allows sending JSONRPCMessages to stdout
+        server = await create_my_server()
+        await server.run(read_stream, write_stream, init_options)
 
-    anyio.run(run_server)
-    ```
+anyio.run(run_server)
+```
 """
 
+import os
 import sys
 from contextlib import asynccontextmanager
 from io import TextIOWrapper
@@ -38,10 +38,18 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # standard process handles. Encoding of stdin/stdout as text streams on
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
+    #
+    # Fix #1933: Use os.dup() to avoid closing the original stdin/stdout
+    # when the wrapper is closed, preventing "I/O operation on closed file" errors.
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
+        stdin_fd = os.dup(sys.stdin.fileno())
+        stdin_bin = os.fdopen(stdin_fd, "rb", closefd=True)
+        stdin = anyio.wrap_file(TextIOWrapper(stdin_bin, encoding="utf-8", errors="replace"))
+    
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout_fd = os.dup(sys.stdout.fileno())
+        stdout_bin = os.fdopen(stdout_fd, "wb", closefd=True)
+        stdout = anyio.wrap_file(TextIOWrapper(stdout_bin, encoding="utf-8"))
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)


### PR DESCRIPTION
Fixes #1933

## Problem
When using `transport="stdio"`, the server closes `sys.stdin.buffer` and `sys.stdout.buffer` when exiting, causing subsequent stdio operations to fail with:
```
ValueError: I/O operation on closed file.
```

## Root Cause
The `stdio_server()` function wraps `sys.stdin.buffer` and `sys.stdout.buffer` directly. When these wrappers are closed (when the context manager exits), they also close the original system streams.

## Solution
Use `os.dup()` to create duplicate file descriptors before wrapping:
- Duplicate `sys.stdin.fileno()` and `sys.stdout.fileno()`
- Open new file handles from the duplicated descriptors
- Wrap these duplicated handles instead of the originals

This ensures the original stdin/stdout remain open when the wrapper streams are closed.

## Testing
Tested with the reproduction case from the issue:
```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("Demo")
mcp.run(transport="stdio")
print("?")  # This now works without error
```

Pressing Ctrl+D to exit the server no longer causes "I/O operation on closed file" error.

---
*This fix implements the proposed solution from the original issue.*
