### PR TITLE
Fix infinite retry loop in _handle_reconnection

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -421,9 +421,9 @@ class StreamableHTTPTransport:
                         await event_source.response.aclose()
                         return
 
-                # Stream ended again without response - reconnect again (reset attempt counter)
+                # Stream ended again without response - reconnect again
                 logger.info("SSE stream disconnected, reconnecting...")
-                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, 0)
+                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, attempt + 1)
         except Exception as e:  # pragma: no cover
             logger.debug(f"Reconnection failed: {e}")
             # Try to reconnect again if we still have an event ID

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -423,7 +423,10 @@ class StreamableHTTPTransport:
 
                 # Stream ended again without response - reconnect again
                 logger.info("SSE stream disconnected, reconnecting...")
-                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, attempt + 1)
+                # Reset attempt counter if server made progress (sent new events),
+                # otherwise count as a failed attempt
+                next_attempt = 0 if reconnect_last_event_id != last_event_id else attempt + 1
+                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, next_attempt)
         except Exception as e:  # pragma: no cover
             logger.debug(f"Reconnection failed: {e}")
             # Try to reconnect again if we still have an event ID


### PR DESCRIPTION
## Summary

- Fixes `_handle_reconnection` resetting the `attempt` counter to `0` when an SSE stream ends without a complete response, which made `MAX_RECONNECTION_ATTEMPTS` ineffective and caused infinite retries
- Changes line 426 to pass `attempt + 1` instead of `0` so total reconnection attempts are tracked across recursions

## Root Cause

When a reconnection succeeds at the HTTP level (200 OK) but the SSE stream drops before delivering a complete `JSONRPCResponse`, the method recursed with `attempt=0`. Only the exception path (connection failure) incremented the counter. A server that accepts connections but drops streams caused the client to retry forever at 1-second intervals.

## Test plan

- [ ] Existing tests pass (no behavioral change for streams that complete normally or fail at the connection level)
- [ ] With the reproducer from #2393, the client now gives up after `MAX_RECONNECTION_ATTEMPTS` (2) instead of looping indefinitely

Fixes #2393