### PR TITLE
fix: prevent infinite retry loop in StreamableHTTP client reconnection

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -421,9 +421,9 @@ class StreamableHTTPTransport:
                         await event_source.response.aclose()
                         return
 
-                # Stream ended again without response - reconnect again (reset attempt counter)
+                # Stream ended again without response - reconnect again
                 logger.info("SSE stream disconnected, reconnecting...")
-                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, 0)
+                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, attempt + 1)
         except Exception as e:  # pragma: no cover
             logger.debug(f"Reconnection failed: {e}")
             # Try to reconnect again if we still have an event ID

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -423,7 +423,13 @@ class StreamableHTTPTransport:
 
                 # Stream ended again without response - reconnect again
                 logger.info("SSE stream disconnected, reconnecting...")
-                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, attempt + 1)
+                # Reset attempt counter only if the stream delivered new events
+                # (i.e. made forward progress). If no new events arrived, the
+                # server is connecting then dropping immediately — count that
+                # towards the retry budget to avoid infinite loops (#2393).
+                made_progress = reconnect_last_event_id != last_event_id
+                next_attempt = 0 if made_progress else attempt + 1
+                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, next_attempt)
         except Exception as e:  # pragma: no cover
             logger.debug(f"Reconnection failed: {e}")
             # Try to reconnect again if we still have an event ID

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -14,7 +14,7 @@ from collections.abc import AsyncIterator, Generator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
 import anyio
@@ -29,7 +29,14 @@ from starlette.routing import Mount
 
 from mcp import MCPError, types
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import StreamableHTTPTransport, streamable_http_client
+from mcp.client.streamable_http import (
+    MAX_RECONNECTION_ATTEMPTS,
+    StreamableHTTPTransport,
+    streamable_http_client,
+)
+from mcp.client.streamable_http import (
+    RequestContext as ClientRequestContext,
+)
 from mcp.server import Server, ServerRequestContext
 from mcp.server.streamable_http import (
     MCP_PROTOCOL_VERSION_HEADER,
@@ -2318,3 +2325,73 @@ async def test_streamable_http_client_preserves_custom_with_mcp_headers(
 
                 assert "content-type" in headers_data
                 assert headers_data["content-type"] == "application/json"
+
+
+@pytest.mark.anyio
+async def test_handle_reconnection_does_not_retry_infinitely():
+    """Reconnection must count TOTAL attempts, not reset on each successful connect.
+
+    Regression test for #2393: when a stream connects successfully but drops
+    before delivering a response, the attempt counter was reset to 0 on the
+    recursive call, allowing an infinite retry loop.
+
+    This test simulates a stream that connects, yields one non-completing SSE
+    event, then ends — repeatedly. With MAX_RECONNECTION_ATTEMPTS the loop
+    must terminate.
+    """
+    transport = StreamableHTTPTransport(url="http://localhost:8000/mcp")
+    transport.session_id = "test-session"
+
+    # Track how many times aconnect_sse is called
+    connect_count = 0
+
+    @asynccontextmanager
+    async def fake_aconnect_sse(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        """Simulate a stream that connects OK, yields one event, then ends."""
+        nonlocal connect_count
+        connect_count += 1
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+
+        # Yield a single non-completing notification SSE event, then end the stream
+        # (simulating a server that drops the connection after partial delivery)
+        async def aiter_sse() -> AsyncIterator[ServerSentEvent]:
+            yield ServerSentEvent(
+                event="message",
+                data='{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"tok","progress":1,"total":10}}',
+                id=f"evt-{connect_count}",
+                retry=None,
+            )
+
+        event_source = MagicMock()
+        event_source.response = mock_response
+        event_source.aiter_sse = aiter_sse
+        yield event_source
+
+    # Build a minimal RequestContext for _handle_reconnection
+    write_stream, read_stream = create_context_streams[SessionMessage | Exception](32)
+
+    async with write_stream, read_stream:
+        request_message = JSONRPCRequest(jsonrpc="2.0", id="req-1", method="tools/call", params={})
+        session_message = SessionMessage(request_message)
+        ctx = ClientRequestContext(
+            client=MagicMock(),
+            session_id="test-session",
+            session_message=session_message,
+            metadata=None,
+            read_stream_writer=write_stream,
+        )
+
+        with patch("mcp.client.streamable_http.aconnect_sse", fake_aconnect_sse):
+            # Use a short sleep override so the test doesn't wait on reconnection delays
+            with patch("mcp.client.streamable_http.DEFAULT_RECONNECTION_DELAY_MS", 0):
+                await transport._handle_reconnection(ctx, last_event_id="evt-0", retry_interval_ms=0)
+
+    # The method should have connected at most MAX_RECONNECTION_ATTEMPTS times
+    # (one for the initial call at attempt=0, then up to MAX-1 more)
+    assert connect_count <= MAX_RECONNECTION_ATTEMPTS, (
+        f"Expected at most {MAX_RECONNECTION_ATTEMPTS} reconnection attempts, "
+        f"but aconnect_sse was called {connect_count} times — "
+        f"the attempt counter is not being incremented across reconnections"
+    )

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2329,15 +2329,16 @@ async def test_streamable_http_client_preserves_custom_with_mcp_headers(
 
 @pytest.mark.anyio
 async def test_handle_reconnection_does_not_retry_infinitely():
-    """Reconnection must count TOTAL attempts, not reset on each successful connect.
+    """Reconnection must give up when no forward progress is made.
 
     Regression test for #2393: when a stream connects successfully but drops
     before delivering a response, the attempt counter was reset to 0 on the
     recursive call, allowing an infinite retry loop.
 
     This test simulates a stream that connects, yields one non-completing SSE
-    event, then ends — repeatedly. With MAX_RECONNECTION_ATTEMPTS the loop
-    must terminate.
+    event with the SAME event ID each time (no new data), then ends —
+    repeatedly. Without forward progress the loop must terminate within
+    MAX_RECONNECTION_ATTEMPTS.
     """
     transport = StreamableHTTPTransport(url="http://localhost:8000/mcp")
     transport.session_id = "test-session"
@@ -2354,13 +2355,15 @@ async def test_handle_reconnection_does_not_retry_infinitely():
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
 
-        # Yield a single non-completing notification SSE event, then end the stream
-        # (simulating a server that drops the connection after partial delivery)
+        # Yield a single non-completing notification SSE event with the SAME
+        # event ID every time, then end the stream.  Because the ID never
+        # changes, the transport sees no forward progress and should count
+        # each reconnection towards the retry budget.
         async def aiter_sse() -> AsyncIterator[ServerSentEvent]:
             yield ServerSentEvent(
                 event="message",
                 data='{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"tok","progress":1,"total":10}}',
-                id=f"evt-{connect_count}",
+                id="evt-static",
                 retry=None,
             )
 


### PR DESCRIPTION
## Summary

Fix `_handle_reconnection()` infinite retry loop when a server repeatedly drops connections after partially delivering SSE events (#2393).

**Approach:** Track whether each reconnection made *forward progress* (received new SSE events with a different `last_event_id`). If progress was made, reset the attempt counter — the server is legitimately checkpointing work across disconnections. If no progress was made (same or no new event IDs), increment the counter toward `MAX_RECONNECTION_ATTEMPTS` to prevent infinite loops.

This preserves the existing multi-reconnection behavior tested by `test_streamable_http_multiple_reconnections` while preventing the infinite loop in #2393.

Fixes #2393

## Details

The bug is on [this line](https://github.com/modelcontextprotocol/python-sdk/blob/d5b91551e9e7748f29ed5f07deaae5e40acf90a3/src/mcp/client/streamable_http.py#L426): when the SSE stream ends normally (iterator exhausted, no exception), `_handle_reconnection` calls itself recursively with `attempt=0`. This means every connection that drops before delivering a response/error resets the counter, and `MAX_RECONNECTION_ATTEMPTS` is never reached.

The fix compares `reconnect_last_event_id` against the incoming `last_event_id`:
- **Different** → new events were delivered → reset counter (legitimate checkpoint-and-reconnect)
- **Same** → no new data → increment counter → eventually give up

## Test plan

- [x] New test `test_handle_reconnection_does_not_retry_infinitely` uses a static event ID (no progress) and verifies termination within `MAX_RECONNECTION_ATTEMPTS`
- [x] Existing `test_streamable_http_multiple_reconnections` continues to pass — it delivers new event IDs on each reconnection (progress), so the counter resets as expected
- [x] Conformance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)