### PR TITLE
fix: prefix auth routes with issuer_url base path for gateway deployments

### DIFF
--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -80,13 +80,18 @@ def create_auth_routes(
     )
     client_authenticator = ClientAuthenticator(provider)
 
+    # Extract the base path from the issuer URL so that auth routes are
+    # registered under the same prefix. This is necessary when the server
+    # sits behind a gateway with a custom base path (e.g., /custom/path).
+    issuer_path = urlparse(str(issuer_url)).path.rstrip("/")
+
     # Create routes
     # Allow CORS requests for endpoints meant to be hit by the OAuth client
     # (with the client secret). This is intended to support things like MCP Inspector,
     # where the client runs in a web browser.
     routes = [
         Route(
-            "/.well-known/oauth-authorization-server",
+            issuer_path + "/.well-known/oauth-authorization-server",
             endpoint=cors_middleware(
                 MetadataHandler(metadata).handle,
                 ["GET", "OPTIONS"],
@@ -94,14 +99,14 @@ def create_auth_routes(
             methods=["GET", "OPTIONS"],
         ),
         Route(
-            AUTHORIZATION_PATH,
+            issuer_path + AUTHORIZATION_PATH,
             # do not allow CORS for authorization endpoint;
             # clients should just redirect to this
             endpoint=AuthorizationHandler(provider).handle,
             methods=["GET", "POST"],
         ),
         Route(
-            TOKEN_PATH,
+            issuer_path + TOKEN_PATH,
             endpoint=cors_middleware(
                 TokenHandler(provider, client_authenticator).handle,
                 ["POST", "OPTIONS"],
@@ -117,7 +122,7 @@ def create_auth_routes(
         )
         routes.append(
             Route(
-                REGISTRATION_PATH,
+                issuer_path + REGISTRATION_PATH,
                 endpoint=cors_middleware(
                     registration_handler.handle,
                     ["POST", "OPTIONS"],
@@ -130,7 +135,7 @@ def create_auth_routes(
         revocation_handler = RevocationHandler(provider, client_authenticator)
         routes.append(
             Route(
-                REVOCATION_PATH,
+                issuer_path + REVOCATION_PATH,
                 endpoint=cors_middleware(
                     revocation_handler.handle,
                     ["POST", "OPTIONS"],

--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -106,7 +106,10 @@ def create_auth_routes(
     # responses produced by inner layers (such as a 413) still carry CORS headers.
     routes = [
         Route(
-            issuer_path + "/.well-known/oauth-authorization-server",
+            # RFC 8414 3.1: the well-known suffix goes between the authority and
+            # the issuer's path component, not after it — "/custom/path/.well-known/..."
+            # is not a valid well-known URI per RFC 8615 3.
+            "/.well-known/oauth-authorization-server" + issuer_path,
             endpoint=cors_middleware(
                 MetadataHandler(metadata).handle,
                 ["GET", "OPTIONS"],

--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -85,13 +85,18 @@ def create_auth_routes(
     )
     client_authenticator = ClientAuthenticator(provider)
 
+    # Extract the base path from the issuer URL so that auth routes are
+    # registered under the same prefix. This is necessary when the server
+    # sits behind a gateway with a custom base path (e.g., /custom/path).
+    issuer_path = urlparse(str(issuer_url)).path.rstrip("/")
+
     # Create routes
     # Allow CORS requests for endpoints meant to be hit by the OAuth client
     # (with the client secret). This is intended to support things like MCP Inspector,
     # where the client runs in a web browser.
     routes = [
         Route(
-            "/.well-known/oauth-authorization-server",
+            issuer_path + "/.well-known/oauth-authorization-server",
             endpoint=cors_middleware(
                 MetadataHandler(metadata).handle,
                 ["GET", "OPTIONS"],
@@ -99,14 +104,14 @@ def create_auth_routes(
             methods=["GET", "OPTIONS"],
         ),
         Route(
-            AUTHORIZATION_PATH,
+            issuer_path + AUTHORIZATION_PATH,
             # do not allow CORS for authorization endpoint;
             # clients should just redirect to this
             endpoint=AuthorizationHandler(provider).handle,
             methods=["GET", "POST"],
         ),
         Route(
-            TOKEN_PATH,
+            issuer_path + TOKEN_PATH,
             endpoint=cors_middleware(
                 TokenHandler(
                     provider, client_authenticator, identity_assertion_enabled=identity_assertion_enabled
@@ -124,7 +129,7 @@ def create_auth_routes(
         )
         routes.append(
             Route(
-                REGISTRATION_PATH,
+                issuer_path + REGISTRATION_PATH,
                 endpoint=cors_middleware(
                     registration_handler.handle,
                     ["POST", "OPTIONS"],
@@ -137,7 +142,7 @@ def create_auth_routes(
         revocation_handler = RevocationHandler(provider, client_authenticator)
         routes.append(
             Route(
-                REVOCATION_PATH,
+                issuer_path + REVOCATION_PATH,
                 endpoint=cors_middleware(
                     revocation_handler.handle,
                     ["POST", "OPTIONS"],

--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -94,6 +94,11 @@ def create_auth_routes(
     client_authenticator = ClientAuthenticator(provider)
     token_handler = TokenHandler(provider, client_authenticator, identity_assertion_enabled=identity_assertion_enabled)
 
+    # Extract the base path from the issuer URL so that auth routes are
+    # registered under the same prefix. This is necessary when the server
+    # sits behind a gateway with a custom base path (e.g., /custom/path).
+    issuer_path = urlparse(str(issuer_url)).path.rstrip("/")
+
     # Create routes
     # Allow CORS requests for endpoints meant to be hit by the OAuth client
     # (with the client secret). This is intended to support things like MCP Inspector,
@@ -101,7 +106,7 @@ def create_auth_routes(
     # responses produced by inner layers (such as a 413) still carry CORS headers.
     routes = [
         Route(
-            "/.well-known/oauth-authorization-server",
+            issuer_path + "/.well-known/oauth-authorization-server",
             endpoint=cors_middleware(
                 MetadataHandler(metadata).handle,
                 ["GET", "OPTIONS"],
@@ -109,14 +114,14 @@ def create_auth_routes(
             methods=["GET", "OPTIONS"],
         ),
         Route(
-            AUTHORIZATION_PATH,
+            issuer_path + AUTHORIZATION_PATH,
             # do not allow CORS for authorization endpoint;
             # clients should just redirect to this
             endpoint=_body_limited(request_response(AuthorizationHandler(provider).handle)),
             methods=["GET", "POST"],
         ),
         Route(
-            TOKEN_PATH,
+            issuer_path + TOKEN_PATH,
             endpoint=_cors(_body_limited(request_response(token_handler.handle)), ["POST", "OPTIONS"]),
             methods=["POST", "OPTIONS"],
         ),
@@ -129,7 +134,7 @@ def create_auth_routes(
         )
         routes.append(
             Route(
-                REGISTRATION_PATH,
+                issuer_path + REGISTRATION_PATH,
                 endpoint=_cors(_body_limited(request_response(registration_handler.handle)), ["POST", "OPTIONS"]),
                 methods=["POST", "OPTIONS"],
             )
@@ -139,7 +144,7 @@ def create_auth_routes(
         revocation_handler = RevocationHandler(provider, client_authenticator)
         routes.append(
             Route(
-                REVOCATION_PATH,
+                issuer_path + REVOCATION_PATH,
                 endpoint=_cors(_body_limited(request_response(revocation_handler.handle)), ["POST", "OPTIONS"]),
                 methods=["POST", "OPTIONS"],
             )

--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -96,7 +96,10 @@ def create_auth_routes(
     # where the client runs in a web browser.
     routes = [
         Route(
-            issuer_path + "/.well-known/oauth-authorization-server",
+            # RFC 8414 3.1: the well-known suffix goes between the authority and
+            # the issuer's path component, not after it — "/custom/path/.well-known/..."
+            # is not a valid well-known URI per RFC 8615 3.
+            "/.well-known/oauth-authorization-server" + issuer_path,
             endpoint=cors_middleware(
                 MetadataHandler(metadata).handle,
                 ["GET", "OPTIONS"],

--- a/tests/server/auth/test_routes.py
+++ b/tests/server/auth/test_routes.py
@@ -1,7 +1,9 @@
 import pytest
 from pydantic import AnyHttpUrl
 
-from mcp.server.auth.routes import validate_issuer_url
+from mcp.server.auth.routes import create_auth_routes, validate_issuer_url
+from mcp.server.auth.settings import ClientRegistrationOptions, RevocationOptions
+from tests.server.mcpserver.auth.test_auth_integration import MockOAuthProvider
 
 
 def test_validate_issuer_url_https_allowed():
@@ -45,3 +47,52 @@ def test_validate_issuer_url_fragment_rejected():
 def test_validate_issuer_url_query_rejected():
     with pytest.raises(ValueError, match="query"):
         validate_issuer_url(AnyHttpUrl("https://example.com/path?q=1"))
+
+
+def test_create_auth_routes_default_paths():
+    """Auth routes are registered at root when issuer_url has no path."""
+    provider = MockOAuthProvider()
+    routes = create_auth_routes(
+        provider,
+        issuer_url=AnyHttpUrl("https://example.com"),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        revocation_options=RevocationOptions(enabled=True),
+    )
+    paths = [route.path for route in routes]
+    assert "/.well-known/oauth-authorization-server" in paths
+    assert "/authorize" in paths
+    assert "/token" in paths
+    assert "/register" in paths
+    assert "/revoke" in paths
+
+
+def test_create_auth_routes_custom_base_path():
+    """Auth routes are prefixed with the issuer_url path for gateway deployments."""
+    provider = MockOAuthProvider()
+    routes = create_auth_routes(
+        provider,
+        issuer_url=AnyHttpUrl("https://example.com/custom/path"),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        revocation_options=RevocationOptions(enabled=True),
+    )
+    paths = [route.path for route in routes]
+    assert "/custom/path/.well-known/oauth-authorization-server" in paths
+    assert "/custom/path/authorize" in paths
+    assert "/custom/path/token" in paths
+    assert "/custom/path/register" in paths
+    assert "/custom/path/revoke" in paths
+
+
+def test_create_auth_routes_trailing_slash_stripped():
+    """Trailing slash on issuer_url path is stripped to avoid double slashes."""
+    provider = MockOAuthProvider()
+    routes = create_auth_routes(
+        provider,
+        issuer_url=AnyHttpUrl("https://example.com/base/"),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        revocation_options=RevocationOptions(enabled=True),
+    )
+    paths = [route.path for route in routes]
+    assert "/base/.well-known/oauth-authorization-server" in paths
+    assert "/base/authorize" in paths
+    assert "/base/token" in paths

--- a/tests/server/auth/test_routes.py
+++ b/tests/server/auth/test_routes.py
@@ -91,7 +91,11 @@ def test_create_auth_routes_default_paths():
 
 
 def test_create_auth_routes_custom_base_path():
-    """Auth routes are prefixed with the issuer_url path for gateway deployments."""
+    """Auth routes are prefixed with the issuer_url path for gateway deployments.
+
+    Per RFC 8414 3.1 / RFC 8615 3, the well-known discovery URI is rooted at the
+    domain and inserted *before* the issuer's path component, not after it.
+    """
     provider = MockOAuthProvider()
     routes = create_auth_routes(
         provider,
@@ -100,7 +104,7 @@ def test_create_auth_routes_custom_base_path():
         revocation_options=RevocationOptions(enabled=True),
     )
     paths = [route.path for route in routes]
-    assert "/custom/path/.well-known/oauth-authorization-server" in paths
+    assert "/.well-known/oauth-authorization-server/custom/path" in paths
     assert "/custom/path/authorize" in paths
     assert "/custom/path/token" in paths
     assert "/custom/path/register" in paths
@@ -117,6 +121,6 @@ def test_create_auth_routes_trailing_slash_stripped():
         revocation_options=RevocationOptions(enabled=True),
     )
     paths = [route.path for route in routes]
-    assert "/base/.well-known/oauth-authorization-server" in paths
+    assert "/.well-known/oauth-authorization-server/base" in paths
     assert "/base/authorize" in paths
     assert "/base/token" in paths

--- a/tests/server/auth/test_routes.py
+++ b/tests/server/auth/test_routes.py
@@ -1,8 +1,9 @@
 import pytest
 from pydantic import AnyHttpUrl
 
-from mcp.server.auth.routes import build_metadata, validate_issuer_url
+from mcp.server.auth.routes import build_metadata, create_auth_routes, validate_issuer_url
 from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions, RevocationOptions
+from tests.server.mcpserver.auth.test_auth_integration import MockOAuthProvider
 
 
 def test_validate_issuer_url_https_allowed():
@@ -70,3 +71,52 @@ def test_build_metadata_serves_issuer_without_trailing_slash():
     assert served["issuer"] == "https://as.example.com"
     assert served["authorization_endpoint"] == "https://as.example.com/authorize"
     assert served["token_endpoint"] == "https://as.example.com/token"
+
+
+def test_create_auth_routes_default_paths():
+    """Auth routes are registered at root when issuer_url has no path."""
+    provider = MockOAuthProvider()
+    routes = create_auth_routes(
+        provider,
+        issuer_url=AnyHttpUrl("https://example.com"),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        revocation_options=RevocationOptions(enabled=True),
+    )
+    paths = [route.path for route in routes]
+    assert "/.well-known/oauth-authorization-server" in paths
+    assert "/authorize" in paths
+    assert "/token" in paths
+    assert "/register" in paths
+    assert "/revoke" in paths
+
+
+def test_create_auth_routes_custom_base_path():
+    """Auth routes are prefixed with the issuer_url path for gateway deployments."""
+    provider = MockOAuthProvider()
+    routes = create_auth_routes(
+        provider,
+        issuer_url=AnyHttpUrl("https://example.com/custom/path"),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        revocation_options=RevocationOptions(enabled=True),
+    )
+    paths = [route.path for route in routes]
+    assert "/custom/path/.well-known/oauth-authorization-server" in paths
+    assert "/custom/path/authorize" in paths
+    assert "/custom/path/token" in paths
+    assert "/custom/path/register" in paths
+    assert "/custom/path/revoke" in paths
+
+
+def test_create_auth_routes_trailing_slash_stripped():
+    """Trailing slash on issuer_url path is stripped to avoid double slashes."""
+    provider = MockOAuthProvider()
+    routes = create_auth_routes(
+        provider,
+        issuer_url=AnyHttpUrl("https://example.com/base/"),
+        client_registration_options=ClientRegistrationOptions(enabled=True),
+        revocation_options=RevocationOptions(enabled=True),
+    )
+    paths = [route.path for route in routes]
+    assert "/base/.well-known/oauth-authorization-server" in paths
+    assert "/base/authorize" in paths
+    assert "/base/token" in paths


### PR DESCRIPTION
## Summary

Fixes #1335 — When an MCP server is deployed behind a gateway with a custom base path (e.g., `https://gateway/custom/path/mcp`), the OAuth auth routes (`.well-known`, `/authorize`, `/token`, `/register`, `/revoke`) are hardcoded at root, making them unreachable through the gateway.

**Root cause:** `create_auth_routes()` registers routes at fixed root paths (`/.well-known/oauth-authorization-server`, `/authorize`, etc.) regardless of the `issuer_url` path. Meanwhile, `build_metadata()` correctly builds metadata URLs using `issuer_url` + path, creating a mismatch.

**Fix:** Extract the path component from `issuer_url` and prefix it to all auth route registrations. This aligns the actual route paths with the metadata URLs already built by `build_metadata()`.

```python
# issuer_url = "https://example.com/custom/path"
# Before: routes at /authorize, /token, etc. (unreachable behind gateway)
# After:  routes at /custom/path/authorize, /custom/path/token, etc.
```

Backward compatible: when `issuer_url` has no path (or just `/`), `issuer_path` is empty and routes stay at root.

## Changes
- `src/mcp/server/auth/routes.py`: Extract `issuer_path` from `issuer_url` and prefix all route paths
- `tests/server/auth/test_routes.py`: Add 3 tests for default paths, custom base path, and trailing slash handling

## Test plan
- [x] All 12 `test_routes.py` tests pass (9 existing + 3 new)
- [x] All 4 `test_error_handling.py` tests pass (no regression)
- [x] All 42 `test_auth_integration.py` tests pass (no regression)
- [x] Ruff format + lint clean