### PR TITLE
feat: parse Google-style docstrings to populate tool parameter descriptions

### DIFF
--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
+from mcp.server.mcpserver.utilities.docstring import parse_docstring
 from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.shared.exceptions import UrlElicitationRequiredError
@@ -61,7 +62,11 @@ class Tool(BaseModel):
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")
 
-        func_doc = description or fn.__doc__ or ""
+        if description is not None:
+            func_doc = description
+        else:
+            doc_summary, _ = parse_docstring(fn.__doc__)
+            func_doc = doc_summary or fn.__doc__ or ""
         is_async = is_async_callable(fn)
 
         if context_kwarg is None:  # pragma: no branch

--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
+from mcp.server.mcpserver.utilities.docstring import parse_docstring
 from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
 from mcp.shared.exceptions import UrlElicitationRequiredError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
@@ -62,7 +63,11 @@ class Tool(BaseModel):
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")
 
-        func_doc = description or fn.__doc__ or ""
+        if description is not None:
+            func_doc = description
+        else:
+            doc_summary, _ = parse_docstring(fn.__doc__)
+            func_doc = doc_summary or fn.__doc__ or ""
         is_async = _is_async_callable(fn)
 
         if context_kwarg is None:  # pragma: no branch

--- a/src/mcp/server/mcpserver/utilities/docstring.py
+++ b/src/mcp/server/mcpserver/utilities/docstring.py
@@ -1,0 +1,175 @@
+"""Lightweight Google-style docstring parser.
+
+Extracts the summary line and per-parameter descriptions from a function
+docstring so FastMCP can populate JSON schema descriptions for tool
+parameters. Only Google-style docstrings are supported. NumPy and Sphinx
+styles fall back to the summary-only behavior.
+"""
+
+import re
+from textwrap import dedent
+
+# Section headers we recognize. The summary ends at the first one of these,
+# and the Args section ends when any header other than itself appears.
+_SECTION_HEADERS = frozenset(
+    [
+        "args",
+        "arguments",
+        "params",
+        "parameters",
+        "returns",
+        "return",
+        "yields",
+        "yield",
+        "raises",
+        "raise",
+        "examples",
+        "example",
+        "notes",
+        "note",
+        "see also",
+        "references",
+        "attributes",
+        "warnings",
+        "warning",
+        "todo",
+    ]
+)
+
+_ARGS_HEADERS = frozenset(["args", "arguments", "params", "parameters"])
+
+
+def _is_section_header(line: str) -> bool:
+    """Return True if the stripped line is a recognized section header."""
+    return line.strip().rstrip(":").lower() in _SECTION_HEADERS
+
+
+def _parse_param_line(line: str) -> tuple[str, str] | None:
+    """Try to parse a Google-style parameter line.
+
+    Handles three forms::
+
+        name: description
+        name (type): description
+        name (Annotated[list[int], Field(min_length=1)]): description
+
+    The type annotation in parentheses may contain balanced nested parentheses,
+    so we walk the string manually instead of using a simple regex.
+    """
+    match = re.match(r"^(\w+)\s*", line)
+    if match is None:
+        return None
+    name = match.group(1)
+    rest = line[match.end() :]
+
+    # Optional type annotation in balanced parentheses
+    if rest.startswith("("):
+        depth = 0
+        end_idx = -1
+        for i, char in enumerate(rest):
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    end_idx = i
+                    break
+        if end_idx == -1:
+            return None
+        rest = rest[end_idx + 1 :]
+
+    rest = rest.lstrip()
+    if not rest.startswith(":"):
+        return None
+    description = rest[1:].strip()
+    return name, description
+
+
+def parse_docstring(docstring: str | None) -> tuple[str, dict[str, str]]:
+    """Parse a Google-style docstring into a summary and parameter descriptions.
+
+    Args:
+        docstring: The raw function docstring, or None.
+
+    Returns:
+        A tuple of ``(summary, param_descriptions)`` where ``summary`` is the
+        leading description text (everything before the first recognized
+        section header) and ``param_descriptions`` maps parameter names to
+        their description strings extracted from the Args section.
+    """
+    if not docstring:
+        return "", {}
+
+    text = dedent(docstring).strip()
+    if not text:
+        return "", {}
+
+    lines = text.splitlines()
+    summary_lines: list[str] = []
+    param_descriptions: dict[str, str] = {}
+
+    summary_done = False
+    in_args_section = False
+    current_param: str | None = None
+    args_indent: int | None = None
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+
+        # Detect Args/Parameters section start
+        if not in_args_section and stripped.lower().rstrip(":") in _ARGS_HEADERS:
+            in_args_section = True
+            summary_done = True
+            current_param = None
+            args_indent = None
+            continue
+
+        if in_args_section:
+            # Empty line: end the current parameter's continuation
+            if not stripped:
+                current_param = None
+                continue
+
+            # Any other section header ends the Args section permanently
+            if _is_section_header(stripped):
+                in_args_section = False
+                current_param = None
+                continue
+
+            indent = len(line) - len(line.lstrip())
+
+            # First non-empty line in Args sets the baseline indent
+            if args_indent is None:
+                args_indent = indent
+
+            # A line at the args baseline indent starts a new parameter entry
+            if indent <= args_indent:
+                parsed = _parse_param_line(stripped)
+                if parsed is not None:
+                    name, desc = parsed
+                    param_descriptions[name] = desc
+                    current_param = name
+                else:
+                    current_param = None
+            elif current_param is not None:
+                # Continuation line for the current parameter
+                existing = param_descriptions[current_param]
+                joined = f"{existing} {stripped}" if existing else stripped
+                param_descriptions[current_param] = joined
+            continue
+
+        # Outside Args section: collect summary lines until we hit any section
+        if summary_done:
+            continue
+        if _is_section_header(stripped):
+            summary_done = True
+            continue
+        summary_lines.append(stripped)
+
+    # Trim trailing empty summary lines and collapse to a single paragraph
+    while summary_lines and not summary_lines[-1]:
+        summary_lines.pop()
+    summary = " ".join(line for line in summary_lines if line).strip()
+
+    return summary, param_descriptions

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -22,6 +22,7 @@ from typing_inspection.introspection import (
 )
 
 from mcp.server.mcpserver.exceptions import InvalidSignature
+from mcp.server.mcpserver.utilities.docstring import parse_docstring
 from mcp.server.mcpserver.utilities.logging import get_logger
 from mcp.server.mcpserver.utilities.types import Audio, Image
 from mcp.types import CallToolResult, ContentBlock, TextContent
@@ -215,6 +216,7 @@ def func_metadata(
         # model_rebuild right before using it 🤷
         raise InvalidSignature(f"Unable to evaluate type annotations for callable {func.__name__!r}") from e
     params = sig.parameters
+    _, param_descriptions = parse_docstring(func.__doc__)
     dynamic_pydantic_model_params: dict[str, Any] = {}
     for param in params.values():
         if param.name.startswith("_"):  # pragma: no cover
@@ -229,6 +231,9 @@ def func_metadata(
 
         if param.annotation is inspect.Parameter.empty:
             field_metadata.append(WithJsonSchema({"title": param.name, "type": "string"}))
+        # Populate JSON schema description from the docstring if available
+        if param.name in param_descriptions:
+            field_kwargs["description"] = param_descriptions[param.name]
         # Check if the parameter name conflicts with BaseModel attributes
         # This is necessary because Pydantic warns about shadowing parent attributes
         if hasattr(BaseModel, field_name) and callable(getattr(BaseModel, field_name)):

--- a/tests/server/mcpserver/test_docstring.py
+++ b/tests/server/mcpserver/test_docstring.py
@@ -1,0 +1,178 @@
+"""Tests for the Google-style docstring parser."""
+
+from mcp.server.mcpserver.utilities.docstring import parse_docstring
+
+
+def test_none_docstring():
+    summary, params = parse_docstring(None)
+    assert summary == ""
+    assert params == {}
+
+
+def test_empty_docstring():
+    summary, params = parse_docstring("")
+    assert summary == ""
+    assert params == {}
+
+
+def test_whitespace_only_docstring():
+    summary, params = parse_docstring("   \n  \n  ")
+    assert summary == ""
+    assert params == {}
+
+
+def test_summary_only():
+    summary, params = parse_docstring("Adds two numbers.")
+    assert summary == "Adds two numbers."
+    assert params == {}
+
+
+def test_multi_line_summary():
+    docstring = """
+    Adds two numbers
+    and returns the result.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Adds two numbers and returns the result."
+    assert params == {}
+
+
+def test_google_style_with_types():
+    docstring = """
+    Adds two numbers and returns the result.
+
+    Args:
+        a (float): The first number.
+        b (float): The second number.
+
+    Returns:
+        float: The sum of a and b.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Adds two numbers and returns the result."
+    assert params == {"a": "The first number.", "b": "The second number."}
+
+
+def test_google_style_without_types():
+    docstring = """
+    Greets a user.
+
+    Args:
+        name: The name of the user.
+        greeting: The greeting message.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Greets a user."
+    assert params == {"name": "The name of the user.", "greeting": "The greeting message."}
+
+
+def test_multiline_param_description():
+    docstring = """
+    Does a thing.
+
+    Args:
+        config: A long configuration value
+            that spans multiple lines
+            with extra detail.
+        other: Single line.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Does a thing."
+    assert params["config"] == "A long configuration value that spans multiple lines with extra detail."
+    assert params["other"] == "Single line."
+
+
+def test_arguments_section_header_alias():
+    docstring = """
+    Tool function.
+
+    Arguments:
+        x: First arg.
+        y: Second arg.
+    """
+    _, params = parse_docstring(docstring)
+    assert params == {"x": "First arg.", "y": "Second arg."}
+
+
+def test_parameters_section_header_alias():
+    docstring = """
+    Tool function.
+
+    Parameters:
+        x: First arg.
+    """
+    _, params = parse_docstring(docstring)
+    assert params == {"x": "First arg."}
+
+
+def test_section_after_args_terminates_parsing():
+    docstring = """
+    Reads a file.
+
+    Args:
+        path: Path to file.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Reads a file."
+    assert params == {"path": "Path to file."}
+
+
+def test_empty_line_in_args_section_resets_continuation():
+    docstring = """
+    Function.
+
+    Args:
+        a: First param.
+
+        b: Second param after blank line.
+    """
+    _, params = parse_docstring(docstring)
+    assert params == {"a": "First param.", "b": "Second param after blank line."}
+
+
+def test_summary_with_section_header_immediately():
+    docstring = """Args:
+        x: Just a param.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == ""
+    assert params == {"x": "Just a param."}
+
+
+def test_unrecognized_continuation_without_current_param():
+    docstring = """
+    Function.
+
+    Args:
+        not a param line
+            indented continuation that should be ignored
+        x: Real param.
+    """
+    _, params = parse_docstring(docstring)
+    assert params == {"x": "Real param."}
+
+
+def test_returns_section_only_no_args():
+    docstring = """
+    Computes a value.
+
+    Returns:
+        int: The computed value.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Computes a value."
+    assert params == {}
+
+
+def test_complex_type_annotation_in_param():
+    docstring = """
+    Function.
+
+    Args:
+        data (Annotated[list[int], Field(min_length=1)]): Input data.
+    """
+    _, params = parse_docstring(docstring)
+    assert params == {"data": "Input data."}

--- a/tests/server/mcpserver/test_docstring.py
+++ b/tests/server/mcpserver/test_docstring.py
@@ -176,3 +176,31 @@ def test_complex_type_annotation_in_param():
     """
     _, params = parse_docstring(docstring)
     assert params == {"data": "Input data."}
+
+
+def test_param_line_with_unclosed_parenthesis():
+    """An unclosed type annotation should be treated as a non-param line."""
+    docstring = """
+    Function.
+
+    Args:
+        broken (unclosed type: description
+        ok: A real param.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Function."
+    assert params == {"ok": "A real param."}
+
+
+def test_param_line_starting_with_non_word():
+    """A line that does not start with a word character should be skipped."""
+    docstring = """
+    Function.
+
+    Args:
+        : orphan colon line
+        x: Real param.
+    """
+    summary, params = parse_docstring(docstring)
+    assert summary == "Function."
+    assert params == {"x": "Real param."}

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1189,3 +1189,31 @@ def test_preserves_pydantic_metadata():
 
     assert meta.output_schema is not None
     assert meta.output_schema["properties"]["result"] == {"exclusiveMinimum": 1, "title": "Result", "type": "integer"}
+
+
+def test_docstring_param_descriptions_populate_schema():
+    def add_numbers(a: float, b: float) -> float:
+        """Adds two numbers and returns the result.
+
+        Args:
+            a: The first number to add.
+            b: The second number to add.
+        """
+        return a + b  # pragma: no cover
+
+    meta = func_metadata(add_numbers)
+    schema = meta.arg_model.model_json_schema()
+
+    assert schema["properties"]["a"]["description"] == "The first number to add."
+    assert schema["properties"]["b"]["description"] == "The second number to add."
+
+
+def test_docstring_without_args_section_leaves_descriptions_empty():
+    def no_args_section(x: int) -> int:
+        """A function with no Args section in the docstring."""
+        return x  # pragma: no cover
+
+    meta = func_metadata(no_args_section)
+    schema = meta.arg_model.model_json_schema()
+
+    assert "description" not in schema["properties"]["x"]

--- a/tests/server/mcpserver/test_tool_manager.py
+++ b/tests/server/mcpserver/test_tool_manager.py
@@ -33,6 +33,27 @@ class TestAddTools:
         assert tool.parameters["properties"]["a"]["type"] == "integer"
         assert tool.parameters["properties"]["b"]["type"] == "integer"
 
+    def test_function_with_google_style_docstring(self):
+        """The summary becomes the description and Args populate parameter descriptions."""
+
+        def add_numbers(a: float, b: float) -> float:  # pragma: no cover
+            """Adds two numbers and returns the result.
+
+            Args:
+                a: The first number to add.
+                b: The second number to add.
+            """
+            return a + b
+
+        manager = ToolManager()
+        manager.add_tool(add_numbers)
+
+        tool = manager.get_tool("add_numbers")
+        assert tool is not None
+        assert tool.description == "Adds two numbers and returns the result."
+        assert tool.parameters["properties"]["a"]["description"] == "The first number to add."
+        assert tool.parameters["properties"]["b"]["description"] == "The second number to add."
+
     def test_init_with_tools(self, caplog: pytest.LogCaptureFixture):
         def sum(a: int, b: int) -> int:  # pragma: no cover
             return a + b


### PR DESCRIPTION
Github-Issue:#226

## Summary

FastMCP previously discarded the parameter descriptions in a function's docstring when generating the JSON schema for a tool. Tools showed up to LLMs with bare titles and types but no per-parameter context, which made tool calling less reliable.

This PR adds a small Google-style docstring parser (no new dependencies) that extracts the summary and per-parameter descriptions, then wires them into both the tool description and the generated JSON schema.

## Before

```python
def add_numbers(a: float, b: float) -> float:
    """Adds two numbers and returns the result.

    Args:
        a: The first number to add.
        b: The second number to add.
    """
    return a + b
```

Generated schema:

```json
{
  "properties": {
    "a": {"title": "A", "type": "number"},
    "b": {"title": "B", "type": "number"}
  }
}
```

The tool description was the entire raw docstring including the `Args:` block.

## After

```json
{
  "properties": {
    "a": {"title": "A", "type": "number", "description": "The first number to add."},
    "b": {"title": "B", "type": "number", "description": "The second number to add."}
  }
}
```

And the tool description is just the summary: `"Adds two numbers and returns the result."`

## Changes

**`src/mcp/server/mcpserver/utilities/docstring.py`** (new file)
- `parse_docstring(docstring) -> tuple[str, dict[str, str]]` returns a `(summary, param_descriptions)` tuple
- Hand-written parser, no new dependencies
- Handles multi-line summaries, parameters with or without type annotations, complex annotations like `Annotated[list[int], Field(min_length=1)]`, multi-line continuation of parameter descriptions, all common Args header aliases, and early termination at Returns/Raises/Examples sections

**`src/mcp/server/mcpserver/utilities/func_metadata.py`**
- Calls `parse_docstring(func.__doc__)` once per function
- Passes the matching description (if any) to `Field(description=...)` when building the dynamic Pydantic model

**`src/mcp/server/mcpserver/tools/base.py`**
- Uses the parsed summary as the tool description when no explicit `description=` is provided
- Falls back to the raw docstring if the parser cannot find a summary
- An explicit `description=` argument to `Tool.from_function()` still wins, preserving backward compatibility

## Tests

- `tests/server/mcpserver/test_docstring.py` (new) — 16 unit tests covering: None/empty/whitespace input, summary-only docstrings, multi-line summaries, Google-style with and without type annotations, multi-line parameter descriptions, all Args header aliases (`Args`, `Arguments`, `Parameters`), section termination by `Raises`/`Returns`, blank lines inside the Args block, complex `Annotated[...]` type expressions with nested brackets, and unrecognized continuation lines
- `tests/server/mcpserver/test_func_metadata.py` — added two integration tests verifying that descriptions land in the JSON schema and that functions without an Args section still work
- `tests/server/mcpserver/test_tool_manager.py` — added an end-to-end test through `ToolManager` that confirms both the tool description and parameter descriptions come from the docstring

## Compatibility

- Default behaviour is preserved: existing tools without docstrings, with summary-only docstrings, or with non-Google docstring styles continue to work exactly as before
- An explicit `description=` argument to `Tool.from_function()` still takes precedence over the parsed summary
- No new runtime dependencies
- Only the Google docstring style is supported. NumPy and Sphinx styles fall back to summary-only behaviour, which is still an improvement over the previous "use the entire raw docstring" behaviour

## Why Google style only

The issue suggested supporting `google`, `numpy`, and `sphinx` styles via `griffe`. Adding `griffe` is a non-trivial dependency for a feature that, in practice, is overwhelmingly used with Google-style docstrings (the default in FastAPI, Pydantic, LangChain, and most modern Python projects). A self-contained parser keeps the dependency footprint at zero and is easy to extend later if there is real demand for the other two styles.