### PR TITLE
fix(auth): coerce empty-string optional URL fields to None in OAuthClientMetadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,9 @@
 
 - Framework: `uv run --frozen pytest`
 - Async testing: use anyio, not asyncio
-- Do not use `Test` prefixed classes, use functions
+- Do not use `Test` prefixed classes — write plain top-level `test_*` functions.
+  Legacy files still contain `Test*` classes; do NOT follow that pattern for new
+  tests even when adding to such a file.
 - IMPORTANT: Tests should be fast and deterministic. Prefer in-memory async execution;
   reach for threads only when necessary, and subprocesses only as a last resort.
 - For end-to-end behavior, an in-memory `Client(server)` is usually the

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -67,6 +67,24 @@ class OAuthClientMetadata(BaseModel):
     software_id: str | None = None
     software_version: str | None = None
 
+    @field_validator(
+        "client_uri",
+        "logo_uri",
+        "tos_uri",
+        "policy_uri",
+        "jwks_uri",
+        mode="before",
+    )
+    @classmethod
+    def _empty_string_optional_url_to_none(cls, v: object) -> object:
+        # RFC 7591 §2 marks these URL fields OPTIONAL. Some authorization servers
+        # echo omitted metadata back as "" instead of dropping the keys, which
+        # AnyHttpUrl would otherwise reject — throwing away an otherwise valid
+        # registration response. Treat "" as absent.
+        if v == "":
+            return None
+        return v
+
     def validate_scope(self, requested_scope: str | None) -> list[str] | None:
         if requested_scope is None:
             return None

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, quote, unquote, urlparse
 import httpx
 import pytest
 from inline_snapshot import Is, snapshot
-from pydantic import AnyHttpUrl, AnyUrl
+from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
 from mcp.client.auth import OAuthClientProvider, PKCEParameters
 from mcp.client.auth.exceptions import OAuthFlowError
@@ -983,6 +983,79 @@ class TestRegistrationResponse:
         assert mock_response._aread_called
         # Verify the error message includes the response text
         assert "Registration failed: 400" in str(exc_info.value)
+
+
+class TestOAuthClientMetadataEmptyUrlCoercion:
+    """RFC 7591 §2 marks client_uri/logo_uri/tos_uri/policy_uri/jwks_uri as OPTIONAL.
+    Some authorization servers echo the client's omitted metadata back as ""
+    instead of dropping the keys; without coercion, AnyHttpUrl rejects "" and
+    the whole registration response is thrown away even though the server
+    returned a valid client_id."""
+
+    @pytest.mark.parametrize(
+        "empty_field",
+        ["client_uri", "logo_uri", "tos_uri", "policy_uri", "jwks_uri"],
+    )
+    def test_optional_url_empty_string_coerced_to_none(self, empty_field: str):
+        data = {
+            "redirect_uris": ["https://example.com/callback"],
+            empty_field: "",
+        }
+        metadata = OAuthClientMetadata.model_validate(data)
+        assert getattr(metadata, empty_field) is None
+
+    def test_all_optional_urls_empty_together(self):
+        data = {
+            "redirect_uris": ["https://example.com/callback"],
+            "client_uri": "",
+            "logo_uri": "",
+            "tos_uri": "",
+            "policy_uri": "",
+            "jwks_uri": "",
+        }
+        metadata = OAuthClientMetadata.model_validate(data)
+        assert metadata.client_uri is None
+        assert metadata.logo_uri is None
+        assert metadata.tos_uri is None
+        assert metadata.policy_uri is None
+        assert metadata.jwks_uri is None
+
+    def test_valid_url_passes_through_unchanged(self):
+        data = {
+            "redirect_uris": ["https://example.com/callback"],
+            "client_uri": "https://udemy.com/",
+        }
+        metadata = OAuthClientMetadata.model_validate(data)
+        assert str(metadata.client_uri) == "https://udemy.com/"
+
+    def test_information_full_inherits_coercion(self):
+        """OAuthClientInformationFull subclasses OAuthClientMetadata, so the
+        same coercion applies to DCR responses parsed via the full model."""
+        data = {
+            "client_id": "abc123",
+            "redirect_uris": ["https://example.com/callback"],
+            "client_uri": "",
+            "logo_uri": "",
+            "tos_uri": "",
+            "policy_uri": "",
+            "jwks_uri": "",
+        }
+        info = OAuthClientInformationFull.model_validate(data)
+        assert info.client_id == "abc123"
+        assert info.client_uri is None
+        assert info.logo_uri is None
+        assert info.tos_uri is None
+        assert info.policy_uri is None
+        assert info.jwks_uri is None
+
+    def test_invalid_non_empty_url_still_rejected(self):
+        """Coercion must only touch empty strings — garbage URLs still raise."""
+        data = {
+            "redirect_uris": ["https://example.com/callback"],
+            "client_uri": "not a url",
+        }
+        with pytest.raises(ValidationError):
+            OAuthClientMetadata.model_validate(data)
 
 
 class TestCreateClientRegistrationRequest:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, quote, unquote, urlparse
 import httpx
 import pytest
 from inline_snapshot import Is, snapshot
-from pydantic import AnyHttpUrl, AnyUrl, ValidationError
+from pydantic import AnyHttpUrl, AnyUrl
 
 from mcp.client.auth import OAuthClientProvider, PKCEParameters
 from mcp.client.auth.exceptions import OAuthFlowError
@@ -983,79 +983,6 @@ class TestRegistrationResponse:
         assert mock_response._aread_called
         # Verify the error message includes the response text
         assert "Registration failed: 400" in str(exc_info.value)
-
-
-class TestOAuthClientMetadataEmptyUrlCoercion:
-    """RFC 7591 §2 marks client_uri/logo_uri/tos_uri/policy_uri/jwks_uri as OPTIONAL.
-    Some authorization servers echo the client's omitted metadata back as ""
-    instead of dropping the keys; without coercion, AnyHttpUrl rejects "" and
-    the whole registration response is thrown away even though the server
-    returned a valid client_id."""
-
-    @pytest.mark.parametrize(
-        "empty_field",
-        ["client_uri", "logo_uri", "tos_uri", "policy_uri", "jwks_uri"],
-    )
-    def test_optional_url_empty_string_coerced_to_none(self, empty_field: str):
-        data = {
-            "redirect_uris": ["https://example.com/callback"],
-            empty_field: "",
-        }
-        metadata = OAuthClientMetadata.model_validate(data)
-        assert getattr(metadata, empty_field) is None
-
-    def test_all_optional_urls_empty_together(self):
-        data = {
-            "redirect_uris": ["https://example.com/callback"],
-            "client_uri": "",
-            "logo_uri": "",
-            "tos_uri": "",
-            "policy_uri": "",
-            "jwks_uri": "",
-        }
-        metadata = OAuthClientMetadata.model_validate(data)
-        assert metadata.client_uri is None
-        assert metadata.logo_uri is None
-        assert metadata.tos_uri is None
-        assert metadata.policy_uri is None
-        assert metadata.jwks_uri is None
-
-    def test_valid_url_passes_through_unchanged(self):
-        data = {
-            "redirect_uris": ["https://example.com/callback"],
-            "client_uri": "https://udemy.com/",
-        }
-        metadata = OAuthClientMetadata.model_validate(data)
-        assert str(metadata.client_uri) == "https://udemy.com/"
-
-    def test_information_full_inherits_coercion(self):
-        """OAuthClientInformationFull subclasses OAuthClientMetadata, so the
-        same coercion applies to DCR responses parsed via the full model."""
-        data = {
-            "client_id": "abc123",
-            "redirect_uris": ["https://example.com/callback"],
-            "client_uri": "",
-            "logo_uri": "",
-            "tos_uri": "",
-            "policy_uri": "",
-            "jwks_uri": "",
-        }
-        info = OAuthClientInformationFull.model_validate(data)
-        assert info.client_id == "abc123"
-        assert info.client_uri is None
-        assert info.logo_uri is None
-        assert info.tos_uri is None
-        assert info.policy_uri is None
-        assert info.jwks_uri is None
-
-    def test_invalid_non_empty_url_still_rejected(self):
-        """Coercion must only touch empty strings — garbage URLs still raise."""
-        data = {
-            "redirect_uris": ["https://example.com/callback"],
-            "client_uri": "not a url",
-        }
-        with pytest.raises(ValidationError):
-            OAuthClientMetadata.model_validate(data)
 
 
 class TestCreateClientRegistrationRequest:

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,6 +1,9 @@
 """Tests for OAuth 2.0 shared code."""
 
-from mcp.shared.auth import OAuthMetadata
+import pytest
+from pydantic import ValidationError
+
+from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
 
 
 def test_oauth():
@@ -58,3 +61,80 @@ def test_oauth_with_jarm():
             "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
         }
     )
+
+
+# RFC 7591 §2 marks client_uri/logo_uri/tos_uri/policy_uri/jwks_uri as OPTIONAL.
+# Some authorization servers echo the client's omitted metadata back as ""
+# instead of dropping the keys; without coercion, AnyHttpUrl rejects "" and
+# the whole registration response is thrown away even though the server
+# returned a valid client_id.
+
+
+@pytest.mark.parametrize(
+    "empty_field",
+    ["client_uri", "logo_uri", "tos_uri", "policy_uri", "jwks_uri"],
+)
+def test_optional_url_empty_string_coerced_to_none(empty_field: str):
+    data = {
+        "redirect_uris": ["https://example.com/callback"],
+        empty_field: "",
+    }
+    metadata = OAuthClientMetadata.model_validate(data)
+    assert getattr(metadata, empty_field) is None
+
+
+def test_all_optional_urls_empty_together():
+    data = {
+        "redirect_uris": ["https://example.com/callback"],
+        "client_uri": "",
+        "logo_uri": "",
+        "tos_uri": "",
+        "policy_uri": "",
+        "jwks_uri": "",
+    }
+    metadata = OAuthClientMetadata.model_validate(data)
+    assert metadata.client_uri is None
+    assert metadata.logo_uri is None
+    assert metadata.tos_uri is None
+    assert metadata.policy_uri is None
+    assert metadata.jwks_uri is None
+
+
+def test_valid_url_passes_through_unchanged():
+    data = {
+        "redirect_uris": ["https://example.com/callback"],
+        "client_uri": "https://udemy.com/",
+    }
+    metadata = OAuthClientMetadata.model_validate(data)
+    assert str(metadata.client_uri) == "https://udemy.com/"
+
+
+def test_information_full_inherits_coercion():
+    """OAuthClientInformationFull subclasses OAuthClientMetadata, so the
+    same coercion applies to DCR responses parsed via the full model."""
+    data = {
+        "client_id": "abc123",
+        "redirect_uris": ["https://example.com/callback"],
+        "client_uri": "",
+        "logo_uri": "",
+        "tos_uri": "",
+        "policy_uri": "",
+        "jwks_uri": "",
+    }
+    info = OAuthClientInformationFull.model_validate(data)
+    assert info.client_id == "abc123"
+    assert info.client_uri is None
+    assert info.logo_uri is None
+    assert info.tos_uri is None
+    assert info.policy_uri is None
+    assert info.jwks_uri is None
+
+
+def test_invalid_non_empty_url_still_rejected():
+    """Coercion must only touch empty strings — garbage URLs still raise."""
+    data = {
+        "redirect_uris": ["https://example.com/callback"],
+        "client_uri": "not a url",
+    }
+    with pytest.raises(ValidationError):
+        OAuthClientMetadata.model_validate(data)


### PR DESCRIPTION
Coerce `""` to `None` for the five OPTIONAL URL fields on `OAuthClientMetadata` so that DCR responses from servers that echo omitted metadata as empty strings parse successfully.

## Motivation and Context

RFC 7591 §2 marks `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`, and `jwks_uri` as OPTIONAL. Some authorization servers in the wild (observed: Udemy, deepsense.ai, Apify, windsor.ai, firecrawl, and others) echo the client's omitted metadata back as `""` instead of dropping the keys:

```json
{"client_id": "abc123", "client_uri": "", "logo_uri": "", "tos_uri": "", "policy_uri": "", ...}
```

`AnyHttpUrl` rejects `""`, so `handle_registration_response` raises `ValidationError` and callers discard an otherwise valid registration — the server returned 201 with a real `client_id`.

The servers are technically non-compliant (an empty string is not a valid URL), but the only reasonable interpretation of `""` for an OPTIONAL field is "absent". This applies Postel's law at the deserialization boundary, matching the existing `normalize_token_type` validator on `OAuthToken` in the same file. Because `OAuthClientInformationFull` inherits from `OAuthClientMetadata`, the coercion applies to parsed DCR responses as well.

## How Has This Been Tested?

New `TestOAuthClientMetadataEmptyUrlCoercion` covers per-field coercion (parametrized over all five fields), all-fields-together, valid-URL passthrough, inheritance through `OAuthClientInformationFull` (the DCR-response model), and a negative case confirming non-empty invalid URLs still raise.

## Breaking Changes

None. This only widens accepted input — previously-rejected `""` values now succeed as `None`. Valid URLs, `None`, and omitted keys are unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

RFC 7591 §2: https://datatracker.ietf.org/doc/html/rfc7591#section-2

v1.x backport: #2405

