### PR TITLE
docs: add CLI reference table for mcp dev/run/install flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@
     - [Development Mode](#development-mode)
     - [Claude Desktop Integration](#claude-desktop-integration)
     - [Direct Execution](#direct-execution)
-    - [CLI Reference](#cli-reference)
     - [Streamable HTTP Transport](#streamable-http-transport)
       - [CORS Configuration for Browser-Based Clients](#cors-configuration-for-browser-based-clients)
     - [Mounting to an Existing ASGI Server](#mounting-to-an-existing-asgi-server)
@@ -1241,43 +1240,6 @@ uv run mcp run servers/direct_execution.py
 ```
 
 Note that `uv run mcp run` or `uv run mcp dev` only supports server using FastMCP and not the low-level server variant.
-
-### CLI Reference
-
-A complete reference for all `mcp` CLI commands and their flags.
-
-#### `mcp dev <file_spec>`
-
-Run an MCP server with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) for interactive testing and debugging.
-
-| Flag | Short | Type | Description |
-|------|-------|------|-------------|
-| `--with-editable` | `-e` | `PATH` | Directory containing `pyproject.toml` to install in editable mode |
-| `--with` | | `TEXT` | Additional packages to install (repeatable) |
-
-#### `mcp run <file_spec>`
-
-Run an MCP server directly. The server can be specified as a module (`server.py`) or with an explicit object path (`server.py:app`).
-
-| Flag | Short | Type | Description |
-|------|-------|------|-------------|
-| `--transport` | `-t` | `stdio\|sse` | Transport protocol to use (default: `stdio`) |
-
-#### `mcp install <file_spec>`
-
-Install an MCP server in the Claude Desktop app. Environment variables are preserved once set and only updated when new values are explicitly provided.
-
-| Flag | Short | Type | Description |
-|------|-------|------|-------------|
-| `--name` | `-n` | `TEXT` | Custom name for the server (defaults to file name) |
-| `--with-editable` | `-e` | `PATH` | Directory containing `pyproject.toml` to install in editable mode |
-| `--with` | | `TEXT` | Additional packages to install (repeatable) |
-| `--env-var` | `-v` | `KEY=VALUE` | Environment variables in `KEY=VALUE` format (repeatable) |
-| `--env-file` | `-f` | `PATH` | Load environment variables from a `.env` file |
-
-#### `mcp version`
-
-Print the installed MCP SDK version.
 
 ### Streamable HTTP Transport
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
     - [Development Mode](#development-mode)
     - [Claude Desktop Integration](#claude-desktop-integration)
     - [Direct Execution](#direct-execution)
+    - [CLI Reference](#cli-reference)
     - [Streamable HTTP Transport](#streamable-http-transport)
       - [CORS Configuration for Browser-Based Clients](#cors-configuration-for-browser-based-clients)
     - [Mounting to an Existing ASGI Server](#mounting-to-an-existing-asgi-server)
@@ -1240,6 +1241,43 @@ uv run mcp run servers/direct_execution.py
 ```
 
 Note that `uv run mcp run` or `uv run mcp dev` only supports server using FastMCP and not the low-level server variant.
+
+### CLI Reference
+
+A complete reference for all `mcp` CLI commands and their flags.
+
+#### `mcp dev <file_spec>`
+
+Run an MCP server with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) for interactive testing and debugging.
+
+| Flag | Short | Type | Description |
+|------|-------|------|-------------|
+| `--with-editable` | `-e` | `PATH` | Directory containing `pyproject.toml` to install in editable mode |
+| `--with` | | `TEXT` | Additional packages to install (repeatable) |
+
+#### `mcp run <file_spec>`
+
+Run an MCP server directly. The server can be specified as a module (`server.py`) or with an explicit object path (`server.py:app`).
+
+| Flag | Short | Type | Description |
+|------|-------|------|-------------|
+| `--transport` | `-t` | `stdio\|sse` | Transport protocol to use (default: `stdio`) |
+
+#### `mcp install <file_spec>`
+
+Install an MCP server in the Claude Desktop app. Environment variables are preserved once set and only updated when new values are explicitly provided.
+
+| Flag | Short | Type | Description |
+|------|-------|------|-------------|
+| `--name` | `-n` | `TEXT` | Custom name for the server (defaults to file name) |
+| `--with-editable` | `-e` | `PATH` | Directory containing `pyproject.toml` to install in editable mode |
+| `--with` | | `TEXT` | Additional packages to install (repeatable) |
+| `--env-var` | `-v` | `KEY=VALUE` | Environment variables in `KEY=VALUE` format (repeatable) |
+| `--env-file` | `-f` | `PATH` | Load environment variables from a `.env` file |
+
+#### `mcp version`
+
+Print the installed MCP SDK version.
 
 ### Streamable HTTP Transport
 

--- a/README.v2.md
+++ b/README.v2.md
@@ -54,6 +54,7 @@
     - [Development Mode](#development-mode)
     - [Claude Desktop Integration](#claude-desktop-integration)
     - [Direct Execution](#direct-execution)
+    - [CLI Reference](#cli-reference)
     - [Streamable HTTP Transport](#streamable-http-transport)
       - [CORS Configuration for Browser-Based Clients](#cors-configuration-for-browser-based-clients)
     - [Mounting to an Existing ASGI Server](#mounting-to-an-existing-asgi-server)
@@ -1231,6 +1232,43 @@ uv run mcp run servers/direct_execution.py
 ```
 
 Note that `uv run mcp run` or `uv run mcp dev` only supports server using MCPServer and not the low-level server variant.
+
+### CLI Reference
+
+A complete reference for all `mcp` CLI commands and their flags.
+
+#### `mcp dev <file_spec>`
+
+Run an MCP server with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) for interactive testing and debugging.
+
+| Flag | Short | Type | Description |
+| -------------------- | ----- | ------ | ----------------------------------------------------------------- |
+| `--with-editable` | `-e` | `PATH` | Directory containing `pyproject.toml` to install in editable mode |
+| `--with` | | `TEXT` | Additional packages to install (repeatable) |
+
+#### `mcp run <file_spec>`
+
+Run an MCP server directly. The server can be specified as a module (`server.py`) or with an explicit object path (`server.py:app`).
+
+| Flag | Short | Type | Description |
+| --------------- | ----- | ------------- | -------------------------------------------- |
+| `--transport` | `-t` | `stdio\|sse` | Transport protocol to use (default: `stdio`) |
+
+#### `mcp install <file_spec>`
+
+Install an MCP server in the Claude Desktop app. Environment variables are preserved once set and only updated when new values are explicitly provided.
+
+| Flag | Short | Type | Description |
+| -------------------- | ----- | ----------- | ----------------------------------------------------------------- |
+| `--name` | `-n` | `TEXT` | Custom name for the server (defaults to file name) |
+| `--with-editable` | `-e` | `PATH` | Directory containing `pyproject.toml` to install in editable mode |
+| `--with` | | `TEXT` | Additional packages to install (repeatable) |
+| `--env-var` | `-v` | `KEY=VALUE` | Environment variables in `KEY=VALUE` format (repeatable) |
+| `--env-file` | `-f` | `PATH` | Load environment variables from a `.env` file |
+
+#### `mcp version`
+
+Print the installed MCP SDK version.
 
 ### Streamable HTTP Transport
 


### PR DESCRIPTION
The `-t, --transport` flag and all other `mcp` CLI flags were undocumented                                                                 
  in the README. Users and LLMs connecting to MCP servers had no reference                                                                 
  for available options without reading the source code.                                                                                     
                                                                                                                                             
  Added a `### CLI Reference` subsection under `## Running Your Server`                                                                      
  with complete flag tables for `mcp dev`, `mcp run`, `mcp install`, and                                                                     
  `mcp version`. Flags sourced directly from `src/mcp/cli/cli.py`.                                                                           
                                                                                                                                             
  ## Motivation and Context                                                                                                                  
  Users trying to connect external clients (e.g. Cursor, Claude Desktop) to                                                                  
  a locally-running MCP server need to know which transport to specify. The                                                                  
  `-t, --transport` flag for `mcp run` was only discoverable by reading the                                                                  
  source — it was absent from the README entirely. This adds a single                                                                        
  reference table so users don't have to grep the code.                                                                                      
                                                                                                                                             
  ## How Has This Been Tested?                                                                                                               
  Documentation-only change. Verified flag names and types against                                                                           
  `src/mcp/cli/cli.py` directly. No code paths changed.                                                                                      
                                                                 
  ## Breaking Changes                                                                                                                        
  None.                                                            
                                                                                                                                             
  ## Types of changes                                              
  - [x] Documentation update                                                                                                                 
                                                                 
  ## Checklist                                         
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines                                                                                    
  - [x] New and existing tests pass locally
  - [x] I have added or updated documentation as needed 