### PR TITLE
fix: allow integer file descriptors for errlog in stdio_client

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -102,9 +102,15 @@ class StdioServerParameters(BaseModel):
 
 
 @asynccontextmanager
-async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stderr):
+async def stdio_client(server: StdioServerParameters, errlog: TextIO | int = sys.stderr):
     """Client transport for stdio: this will connect to a server by spawning a
     process and communicating with it over stdin/stdout.
+
+    Args:
+        server: Parameters for the server process to spawn.
+        errlog: Where to send stderr output from the server process. Accepts a
+            text stream (e.g. ``sys.stderr``) or an integer file descriptor,
+            including ``subprocess.DEVNULL`` to discard stderr entirely.
     """
     read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]
     read_stream_writer: MemoryObjectSendStream[SessionMessage | Exception]
@@ -230,7 +236,7 @@ async def _create_platform_compatible_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO = sys.stderr,
+    errlog: TextIO | int = sys.stderr,
     cwd: Path | str | None = None,
 ):
     """Creates a subprocess in a platform-compatible way.

--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -112,9 +112,15 @@ class StdioServerParameters(BaseModel):
 
 @asynccontextmanager
 async def stdio_client(
-    server: StdioServerParameters, errlog: TextIO = sys.stderr
+    server: StdioServerParameters, errlog: TextIO | int = sys.stderr
 ) -> AsyncGenerator[TransportStreams, None]:
     """Spawns an MCP server subprocess and connects to it over stdin/stdout.
+
+    Args:
+        server: Parameters for the server process to spawn.
+        errlog: Where to send the server's stderr. Accepts a text stream
+            (e.g. ``sys.stderr``) or an integer file descriptor, including
+            ``subprocess.DEVNULL`` to discard stderr entirely.
 
     Raises:
         OSError: If the server process cannot be spawned.
@@ -329,7 +335,7 @@ async def _create_platform_compatible_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO = sys.stderr,
+    errlog: TextIO | int = sys.stderr,
     cwd: Path | str | None = None,
 ) -> ServerProcess:
     """Spawns the server in its own kill scope.

--- a/src/mcp/os/win32/utilities.py
+++ b/src/mcp/os/win32/utilities.py
@@ -138,7 +138,7 @@ async def create_windows_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO | None = sys.stderr,
+    errlog: TextIO | int | None = sys.stderr,
     cwd: Path | str | None = None,
 ) -> Process | FallbackProcess:
     """Creates a subprocess in a Windows-compatible way with Job Object support.
@@ -155,7 +155,9 @@ async def create_windows_process(
         command (str): The executable to run
         args (list[str]): List of command line arguments
         env (dict[str, str] | None): Environment variables
-        errlog (TextIO | None): Where to send stderr output (defaults to sys.stderr)
+        errlog (TextIO | int | None): Where to send stderr output. Accepts a text
+            stream, an integer file descriptor (e.g. ``subprocess.DEVNULL``), or
+            ``None`` (defaults to sys.stderr)
         cwd (Path | str | None): Working directory for the subprocess
 
     Returns:
@@ -196,7 +198,7 @@ async def _create_windows_fallback_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO | None = sys.stderr,
+    errlog: TextIO | int | None = sys.stderr,
     cwd: Path | str | None = None,
 ) -> FallbackProcess:
     """Create a subprocess using subprocess.Popen as a fallback when anyio fails.

--- a/src/mcp/os/win32/utilities.py
+++ b/src/mcp/os/win32/utilities.py
@@ -137,7 +137,7 @@ async def create_windows_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO | None = sys.stderr,
+    errlog: TextIO | int | None = sys.stderr,
     cwd: Path | str | None = None,
 ) -> Process | FallbackProcess:
     """Creates a subprocess with Job Object support for tree termination.
@@ -148,6 +148,9 @@ async def create_windows_process(
     process is then assigned to a Job Object so its children can be terminated
     with it; children spawned before the assignment completes are not captured
     (see the inline note below).
+
+    errlog accepts a text stream (e.g. ``sys.stderr``), an integer file
+    descriptor (e.g. ``subprocess.DEVNULL``), or ``None``.
 
     Returns:
         Process | FallbackProcess: The spawned process with async stdin/stdout streams.
@@ -177,7 +180,7 @@ async def _create_windows_fallback_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO | None = sys.stderr,
+    errlog: TextIO | int | None = sys.stderr,
     cwd: Path | str | None = None,
 ) -> FallbackProcess:
     """Spawns via subprocess.Popen and wraps it in FallbackProcess."""


### PR DESCRIPTION
Fixes #1806                                                                                                                        
                                                                  
  `stdio_client()` typed `errlog` as `TextIO`, preventing callers from passing                                                       
  integer file descriptors such as `subprocess.DEVNULL`. The underlying subprocess
  calls (`anyio.open_process` and `subprocess.Popen`) already accept integers for                                                    
  `stderr` — this was a type-annotation gap, not a runtime limitation.                                                               
                                                                                                                                     
  ## Motivation and Context                                                                                                          
                                                                                                                                     
  Users running CLI tools or embedding MCP servers in larger applications often                                                      
  want to suppress server stderr entirely. `subprocess.DEVNULL` is the standard
  Python way to do this, but passing it to `stdio_client()` raised a type error                                                      
  because `errlog` was annotated as `TextIO` only.                                                                                   
                                                                                                                                     
  ## How Has This Been Tested?                                                                                                       
                                                                                                                                     
  Type annotation change only — no runtime behaviour changes. The underlying                                                         
  `anyio.open_process` and `subprocess.Popen` calls already accept `int` for
  `stderr`. All existing tests continue to pass.                                                                                     
                                                                                                                                     
  ## Breaking Changes                                     
                                                                                                                                     
  None. Existing callers using `TextIO` (e.g. `sys.stderr`) are unaffected.                                                          
                                                          
  ## Types of changes                                                                                                                
  - [x] Bug fix (non-breaking change which fixes an issue)        
                                                                                                                                     
  ## Checklist                                                      
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)                                                         
  - [x] My code follows the repository's style guidelines                                                                            
  - [x] New and existing tests pass locally               
  - [x] I have added or updated documentation as needed   