### PR TITLE
fix: handle cancellation race in RequestResponder.respond()

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -130,7 +130,9 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
         """
         if not self._entered:  # pragma: no cover
             raise RuntimeError("RequestResponder must be used as a context manager")
-        assert not self._completed, "Request already responded to"
+        # Guard against race: if cancel() already set _completed, skip silently.
+        if self._completed:
+            return
 
         if not self.cancelled:  # pragma: no branch
             self._completed = True


### PR DESCRIPTION
## Fix: Cancellation Race in `RequestResponder.respond()`

When a `CancelledNotification` arrives after the handler completes but before
`respond()` is called, `cancel()` sets `_completed=True` and sends an error response.
The subsequent `respond()` call would hit `AssertionError: Request already responded to`.

### The Fix

Replace the `assert not self._completed` guard with a silent early-return:

```python
# Before:
assert not self._completed, "Request already responded to"

# After:
# Guard against race: if cancel() already set _completed, skip silently.
if self._completed:
    return
```

This is safe because `cancel()` already sent an error response (`"Request cancelled"`),
so skipping the duplicate response is correct behavior.

### Why This Is The Right Fix

- `cancel()` is called on a different task (the cancellation notification handler)
- Between handler completion and `respond()`, there is no async checkpoint
- `CancelledError` cannot be raised in that gap
- `BrokenResourceError`/`ClosedResourceError` are already handled in `server.py`
- This race requires handling at the source of `_completed`

Fixes #2416

---

_Submitted via TTClaw bounty hunter._