### PR TITLE
Create specific ToolNotFoundError for easier handling than ToolError in multi-tenant environments

### DIFF
--- a/src/mcp/server/mcpserver/exceptions.py
+++ b/src/mcp/server/mcpserver/exceptions.py
@@ -17,5 +17,9 @@ class ToolError(MCPServerError):
     """Error in tool operations."""
 
 
+class ToolNotFoundError(ToolError):
+    """Tool not found."""
+
+
 class InvalidSignature(Exception):
     """Invalid signature for use with MCPServer."""

--- a/src/mcp/server/mcpserver/tools/tool_manager.py
+++ b/src/mcp/server/mcpserver/tools/tool_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from mcp.server.mcpserver.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolNotFoundError
 from mcp.server.mcpserver.tools.base import Tool
 from mcp.server.mcpserver.utilities.logging import get_logger
 from mcp.types import Icon, ToolAnnotations
@@ -74,7 +74,7 @@ class ToolManager:
     def remove_tool(self, name: str) -> None:
         """Remove a tool by name."""
         if name not in self._tools:
-            raise ToolError(f"Unknown tool: {name}")
+            raise ToolNotFoundError(f"Unknown tool: {name}")
         del self._tools[name]
 
     async def call_tool(
@@ -87,6 +87,6 @@ class ToolManager:
         """Call a tool by name with arguments."""
         tool = self.get_tool(name)
         if not tool:
-            raise ToolError(f"Unknown tool: {name}")
+            raise ToolNotFoundError(f"Unknown tool: {name}")
 
         return await tool.run(arguments, context, convert_result=convert_result)

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -13,7 +13,7 @@ from mcp.client import Client
 from mcp.server.context import ServerRequestContext
 from mcp.server.experimental.request_context import Experimental
 from mcp.server.mcpserver import Context, MCPServer
-from mcp.server.mcpserver.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError, ToolNotFoundError
 from mcp.server.mcpserver.prompts.base import Message, UserMessage
 from mcp.server.mcpserver.resources import FileResource, FunctionResource
 from mcp.server.mcpserver.utilities.types import Audio, Image
@@ -634,6 +634,13 @@ class TestServerTools:
         mcp = MCPServer()
 
         with pytest.raises(ToolError, match="Unknown tool: nonexistent"):
+            mcp.remove_tool("nonexistent")
+
+    async def test_remove_nonexistent_tool_raises_tool_not_found_error(self):
+        """Test that removing a non-existent tool raises ToolNotFoundError."""
+        mcp = MCPServer()
+
+        with pytest.raises(ToolNotFoundError, match="Unknown tool: nonexistent"):
             mcp.remove_tool("nonexistent")
 
     async def test_remove_tool_and_list(self):

--- a/tests/server/mcpserver/test_tool_manager.py
+++ b/tests/server/mcpserver/test_tool_manager.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from mcp.server.context import LifespanContextT, RequestT
 from mcp.server.mcpserver import Context, MCPServer
-from mcp.server.mcpserver.exceptions import ToolError
+from mcp.server.mcpserver.exceptions import ToolError, ToolNotFoundError
 from mcp.server.mcpserver.tools import Tool, ToolManager
 from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata
 from mcp.types import TextContent, ToolAnnotations
@@ -820,6 +820,13 @@ class TestRemoveTools:
         with pytest.raises(ToolError, match="Unknown tool: nonexistent"):
             manager.remove_tool("nonexistent")
 
+    def test_remove_nonexistent_tool_raises_tool_not_found_error(self):
+        """Test removing a non-existent tool raises ToolError."""
+        manager = ToolManager()
+
+        with pytest.raises(ToolNotFoundError, match="Unknown tool: nonexistent"):
+            manager.remove_tool("nonexistent")
+
     def test_remove_tool_from_multiple_tools(self):
         """Test removing one tool when multiple tools exist."""
 
@@ -877,6 +884,10 @@ class TestRemoveTools:
         with pytest.raises(ToolError, match="Unknown tool: greet"):
             await manager.call_tool("greet", {"name": "World"}, Context())
 
+        # Verify calling removed tool raises ToolNotFoundError
+        with pytest.raises(ToolNotFoundError, match="Unknown tool: greet"):
+            await manager.call_tool("greet", {"name": "World"}, Context())
+
     def test_remove_tool_case_sensitive(self):
         """Test that tool removal is case-sensitive."""
 
@@ -892,6 +903,10 @@ class TestRemoveTools:
 
         # Try to remove with different case - should raise ToolError
         with pytest.raises(ToolError, match="Unknown tool: Test_Func"):
+            manager.remove_tool("Test_Func")
+
+        # Try to remove with different case - should raise ToolNotFoundError
+        with pytest.raises(ToolNotFoundError, match="Unknown tool: Test_Func"):
             manager.remove_tool("Test_Func")
 
         # Verify original tool still exists


### PR DESCRIPTION
## Summary

Create a new error type `ToolNotFoundError` that is a more specific version of the generic `ToolError`.

closes #2422

## Motivation and Context

We are running a remote MCP server and we are seeing errors like:
```
mcp.server.fastmcp.exceptions.ToolError: Unknown tool: <unknown-tool-name>
```
I'm unsure why our users are trying to call our remote MCP server with the name of a tool that we don't manage. Regardless, we would like to handle these errors separately from a generic `ToolError`. For instance:
- `ToolNotFoundError`: user error that shouldn't alert us.
- `ToolError`: an error that could indicate an actual issue with our system that we should alert on and fix.

## How Has This Been Tested?

I added unit tests and successfully ran all tests locally.

## Breaking Changes

There are no breaking changes in this PR. SDK users can still catch these as `ToolError` as they have done before.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed