### PR TITLE
Fix validate_scope rejecting scopes when client scope is None

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -71,11 +71,12 @@ class OAuthClientMetadata(BaseModel):
         if requested_scope is None:
             return None
         requested_scopes = requested_scope.split(" ")
-        allowed_scopes = [] if self.scope is None else self.scope.split(" ")
-        for scope in requested_scopes:
-            if scope not in allowed_scopes:  # pragma: no branch
-                raise InvalidScopeError(f"Client was not registered with scope {scope}")
-        return requested_scopes  # pragma: no cover
+        if self.scope is not None:
+            allowed_scopes = self.scope.split(" ")
+            for scope in requested_scopes:
+                if scope not in allowed_scopes:
+                    raise InvalidScopeError(f"Client was not registered with scope {scope}")
+        return requested_scopes
 
     def validate_redirect_uri(self, redirect_uri: AnyUrl | None) -> AnyUrl:
         if redirect_uri is not None:

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -58,3 +58,53 @@ def test_oauth_with_jarm():
             "token_endpoint_auth_methods_supported": ["client_secret_basic", "client_secret_post"],
         }
     )
+
+
+def test_validate_scope_none_client_scope_allows_any_requested_scope():
+    """When client.scope is None, any requested scope should be allowed."""
+    from mcp.shared.auth import OAuthClientMetadata
+
+    client = OAuthClientMetadata(
+        redirect_uris=["https://example.com/callback"],
+        scope=None,
+    )
+    result = client.validate_scope("read write admin")
+    assert result == ["read", "write", "admin"]
+
+
+def test_validate_scope_with_client_scope_rejects_unregistered():
+    """When client.scope is set, unregistered scopes should be rejected."""
+    import pytest
+
+    from mcp.shared.auth import InvalidScopeError, OAuthClientMetadata
+
+    client = OAuthClientMetadata(
+        redirect_uris=["https://example.com/callback"],
+        scope="read write",
+    )
+    with pytest.raises(InvalidScopeError):
+        client.validate_scope("admin")
+
+
+def test_validate_scope_with_client_scope_allows_registered():
+    """When client.scope is set, registered scopes should be allowed."""
+    from mcp.shared.auth import OAuthClientMetadata
+
+    client = OAuthClientMetadata(
+        redirect_uris=["https://example.com/callback"],
+        scope="read write",
+    )
+    result = client.validate_scope("read")
+    assert result == ["read"]
+
+
+def test_validate_scope_none_requested_returns_none():
+    """When requested_scope is None, should return None."""
+    from mcp.shared.auth import OAuthClientMetadata
+
+    client = OAuthClientMetadata(
+        redirect_uris=["https://example.com/callback"],
+        scope=None,
+    )
+    result = client.validate_scope(None)
+    assert result is None


### PR DESCRIPTION
## Summary

Fixes #2216

`OAuthClientMetadata.validate_scope()` incorrectly treats `self.scope = None` as an empty allowlist (`[]`), causing all requested scopes to be rejected with `InvalidScopeError`. Per OAuth 2.0 semantics, `None` means the client was registered without scope restrictions, so any requested scope should be permitted.

**Before:** `allowed_scopes = [] if self.scope is None else self.scope.split(" ")` -- any requested scope fails the `in` check against `[]`.

**After:** Skip the allowlist check entirely when `self.scope is None`, only validate against registered scopes when they are explicitly set.

## Test plan

- Added test: `None` client scope allows any requested scope
- Added test: set client scope correctly rejects unregistered scopes
- Added test: set client scope correctly allows registered scopes
- Added test: `None` requested scope returns `None` regardless of client scope
- All existing tests continue to pass