### PR TITLE
Fix SSE timeout hang by propagating transport exceptions to pending r…

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -428,6 +428,21 @@ class BaseSession(
                 async for message in self._read_stream:
                     if isinstance(message, Exception):
                         await self._handle_incoming(message)
+                        
+                        # Fix #1401: Propagate exception to all pending requests
+                        # This prevents waiters from hanging when the transport fails
+                        error_data = (
+                            message.to_error_data() 
+                            if isinstance(message, MCPError) 
+                            else ErrorData(code=0, message=str(message))
+                        )
+                        jsonrpc_error = JSONRPCError(jsonrpc="2.0", id=None, error=error_data) # id=None because it applies to all
+                        
+                        # We must send an error to every individual waiter
+                        for req_id, stream in list(self._response_streams.items()):
+                            # Send a response with the correct ID
+                            await stream.send(JSONRPCError(jsonrpc="2.0", id=req_id, error=error_data))
+                        
                         continue
 
                     await _handle_session_message(message)

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -439,9 +439,13 @@ class BaseSession(
 
                         # We must send an error to every individual waiter
                         for req_id, stream in list(self._response_streams.items()):
-                            # Send a response with the correct ID
-                            await stream.send(JSONRPCError(jsonrpc="2.0", id=req_id, error=error_data))
-
+                            try:
+                                # Send a response with the correct ID
+                                await stream.send(JSONRPCError(jsonrpc="2.0", id=req_id, error=error_data))
+                            finally:
+                                # Ensure we clean up the stream so finally block doesn't double-handle
+                                self._response_streams.pop(req_id, None)
+                                await stream.aclose()
                         continue
 
                     await _handle_session_message(message)

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -432,17 +432,16 @@ class BaseSession(
                         # Fix #1401: Propagate exception to all pending requests
                         # This prevents waiters from hanging when the transport fails
                         error_data = (
-                            message.to_error_data() 
-                            if isinstance(message, MCPError) 
+                            message.to_error_data()
+                            if isinstance(message, MCPError)
                             else ErrorData(code=0, message=str(message))
                         )
-                        jsonrpc_error = JSONRPCError(jsonrpc="2.0", id=None, error=error_data) # id=None because it applies to all
-                        
+
                         # We must send an error to every individual waiter
                         for req_id, stream in list(self._response_streams.items()):
                             # Send a response with the correct ID
                             await stream.send(JSONRPCError(jsonrpc="2.0", id=req_id, error=error_data))
-                        
+
                         continue
 
                     await _handle_session_message(message)


### PR DESCRIPTION
Fixed SSE timeout hang in BaseSession._receive_loop. This fix propagates transport-level exceptions (like SSE read timeouts) to all pending request streams, ensuring RPC calls don't hang if the underlying connection fails. This specifically addresses issue #1401.