### PR TITLE
fix: catch PydanticUserError when generating output schema (pydantic 2.13 compat)

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, cast, get_args, get_origin, get_type_hints
 import anyio
 import anyio.to_thread
 import pydantic_core
-from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, create_model
+from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, WithJsonSchema, create_model
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaWarningKind
 from typing_extensions import is_typeddict
@@ -402,9 +402,16 @@ def _try_create_model_and_schema(
         # Use StrictJsonSchema to raise exceptions instead of warnings
         try:
             schema = model.model_json_schema(schema_generator=StrictJsonSchema)
-        except (TypeError, ValueError, pydantic_core.SchemaError, pydantic_core.ValidationError) as e:
+        except (
+            PydanticUserError,
+            TypeError,
+            ValueError,
+            pydantic_core.SchemaError,
+            pydantic_core.ValidationError,
+        ) as e:
             # These are expected errors when a type can't be converted to a Pydantic schema
-            # TypeError: When Pydantic can't handle the type
+            # PydanticUserError: When Pydantic can't handle the type (e.g. PydanticInvalidForJsonSchema);
+            #   subclasses TypeError on pydantic <2.13 and RuntimeError on pydantic >=2.13
             # ValueError: When there are issues with the type definition (including our custom warnings)
             # SchemaError: When Pydantic can't build a schema
             # ValidationError: When validation fails


### PR DESCRIPTION
Pydantic 2.13.0 changed `PydanticUserError`'s base class from `TypeError` to `RuntimeError` (pydantic/pydantic#12579). `_try_create_model_and_schema` was relying on `except TypeError` to catch `PydanticInvalidForJsonSchema` when a return type contains a field that can't be represented in JSON Schema (e.g. `Callable`). On pydantic 2.13.0 that exception now escapes, so registering such a tool crashes instead of falling back to unstructured output.

This adds `PydanticUserError` to the except tuple so the fallback works on all supported pydantic versions.

## Motivation and Context

Without this, on pydantic 2.13.0:

```python
class Config:
    name: str
    callback: Callable[[Any], Any] = lambda x: x

@server.tool()
def get_config() -> Config:  # raises PydanticInvalidForJsonSchema at decorator time
    ...
```

Previously this logged a message and continued with `output_schema=None`.

## How Has This Been Tested?

Covered by the existing `test_structured_output_unserializable_type_error`, which fails on pydantic 2.13.0 without this change and passes with it. Verified locally on the locked pydantic version; CI will exercise both `lowest-direct` and the locked version.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

`PydanticUserError` is the parent of both `PydanticInvalidForJsonSchema` and `PydanticSchemaGenerationError` and has existed since pydantic 2.0, so catching it is correct regardless of which built-in exception it subclasses in a given pydantic release. `TypeError` is kept in the tuple to avoid changing behaviour for any other code path that might raise a plain `TypeError` here.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
