### PR TITLE
[v1.x] fix: catch PydanticUserError when generating output schema (pydantic 2.13 compat)

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -10,6 +10,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PydanticUserError,
     RootModel,
     WithJsonSchema,
     create_model,
@@ -411,9 +412,16 @@ def _try_create_model_and_schema(
         # Use StrictJsonSchema to raise exceptions instead of warnings
         try:
             schema = model.model_json_schema(schema_generator=StrictJsonSchema)
-        except (TypeError, ValueError, pydantic_core.SchemaError, pydantic_core.ValidationError) as e:
+        except (
+            PydanticUserError,
+            TypeError,
+            ValueError,
+            pydantic_core.SchemaError,
+            pydantic_core.ValidationError,
+        ) as e:
             # These are expected errors when a type can't be converted to a Pydantic schema
-            # TypeError: When Pydantic can't handle the type
+            # PydanticUserError: When Pydantic can't handle the type (e.g. PydanticInvalidForJsonSchema);
+            #   subclasses TypeError on pydantic <2.13 and RuntimeError on pydantic >=2.13
             # ValueError: When there are issues with the type definition (including our custom warnings)
             # SchemaError: When Pydantic can't build a schema
             # ValidationError: When validation fails


### PR DESCRIPTION
Backport of #2434 to `v1.x`.

Pydantic 2.13.0 changed `PydanticUserError`'s base class from `TypeError` to `RuntimeError` (pydantic/pydantic#12579). `_try_create_model_and_schema` was relying on `except TypeError` to catch `PydanticInvalidForJsonSchema` when a return type contains a field that can't be represented in JSON Schema (e.g. `Callable`). On pydantic 2.13.0 that exception now escapes, so registering such a tool crashes instead of falling back to unstructured output.

This adds `PydanticUserError` to the except tuple so the fallback works on all supported pydantic versions.

## How Has This Been Tested?

Covered by the existing `test_structured_output_unserializable_type_error`, which fails on pydantic 2.13.0 without this change. The `highest` resolution leg of the v1.x CI matrix exercises pydantic 2.13.0 directly.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
