### PR TITLE
fix: consume response body on unexpected content type to prevent client hang

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -295,6 +295,7 @@ class StreamableHTTPTransport:
                 elif content_type.startswith("text/event-stream"):
                     await self._handle_sse_response(response, ctx, is_initialization)
                 else:
+                    await response.aread()  # consume body to prevent stream hang
                     logger.error(f"Unexpected content type: {content_type}")
                     error_data = ErrorData(code=INVALID_REQUEST, message=f"Unexpected content type: {content_type}")
                     error_msg = SessionMessage(JSONRPCError(jsonrpc="2.0", id=message.id, error=error_data))

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2336,4 +2336,3 @@ async def test_unexpected_content_type_does_not_hang():
         async with ClientSession(read_stream, write_stream) as session:
             with pytest.raises(MCPError, match="Unexpected content type"):
                 await session.initialize()
-

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2318,3 +2318,22 @@ async def test_streamable_http_client_preserves_custom_with_mcp_headers(
 
                 assert "content-type" in headers_data
                 assert headers_data["content-type"] == "application/json"
+
+
+@pytest.mark.anyio
+async def test_unexpected_content_type_does_not_hang():
+    """Test that client raises MCPError instead of hanging when server returns unexpected content type."""
+
+    def return_plain_text(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/plain"}, content=b"this is not json")
+
+    mock_client = httpx.AsyncClient(transport=httpx.MockTransport(return_plain_text))
+
+    async with streamable_http_client("http://test/mcp", http_client=mock_client) as (
+        read_stream,
+        write_stream,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            with pytest.raises(MCPError, match="Unexpected content type"):
+                await session.initialize()
+

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2334,5 +2334,5 @@ async def test_unexpected_content_type_does_not_hang():
         write_stream,
     ):
         async with ClientSession(read_stream, write_stream) as session:
-            with pytest.raises(MCPError, match="Unexpected content type"):
+            with pytest.raises(MCPError, match="Unexpected content type"):  # pragma: no branch
                 await session.initialize()


### PR DESCRIPTION
## Summary

Fixes #2432

When an MCP server returns an unexpected `Content-Type` (e.g. `text/plain` instead of `application/json` or `text/event-stream`), `session.initialize()` hangs indefinitely because the response body is never consumed, causing the httpx streaming context to block on exit.

**The fix:** Call `await response.aread()` to consume the response body before sending the error message through the read stream. This allows the streaming context to close cleanly and the error to propagate to the caller.

## Changes

- `src/mcp/client/streamable_http.py`: Added `await response.aread()` in the unexpected content-type branch to drain the response body
- `tests/shared/test_streamable_http.py`: Added test using httpx MockTransport to verify the client raises `MCPError` instead of hanging

## Test plan

- [x] New test `test_unexpected_content_type_does_not_hang` passes locally
- [ ] Verify existing streamable HTTP tests still pass