### PR TITLE
fix: update context logging type hints to allow any JSON-serializable data

### DIFF
--- a/src/mcp/server/mcpserver/context.py
+++ b/src/mcp/server/mcpserver/context.py
@@ -187,7 +187,7 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
     async def log(
         self,
         level: Literal["debug", "info", "warning", "error"],
-        message: str,
+        message: Any,
         *,
         logger_name: str | None = None,
         extra: dict[str, Any] | None = None,
@@ -196,7 +196,7 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
 
         Args:
             level: Log level (debug, info, warning, error)
-            message: Log message
+            message: Log message. Any JSON-serializable type is allowed per the MCP spec.
             logger_name: Optional logger name
             extra: Optional dictionary with additional structured data to include
         """
@@ -261,20 +261,20 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
             await self._request_context.close_standalone_sse_stream()
 
     # Convenience methods for common log levels
-    async def debug(self, message: str, *, logger_name: str | None = None, extra: dict[str, Any] | None = None) -> None:
-        """Send a debug log message."""
+    async def debug(self, message: Any, *, logger_name: str | None = None, extra: dict[str, Any] | None = None) -> None:
+        """Send a debug log message. Any JSON-serializable type is allowed for message."""
         await self.log("debug", message, logger_name=logger_name, extra=extra)
 
-    async def info(self, message: str, *, logger_name: str | None = None, extra: dict[str, Any] | None = None) -> None:
-        """Send an info log message."""
+    async def info(self, message: Any, *, logger_name: str | None = None, extra: dict[str, Any] | None = None) -> None:
+        """Send an info log message. Any JSON-serializable type is allowed for message."""
         await self.log("info", message, logger_name=logger_name, extra=extra)
 
     async def warning(
-        self, message: str, *, logger_name: str | None = None, extra: dict[str, Any] | None = None
+        self, message: Any, *, logger_name: str | None = None, extra: dict[str, Any] | None = None
     ) -> None:
-        """Send a warning log message."""
+        """Send a warning log message. Any JSON-serializable type is allowed for message."""
         await self.log("warning", message, logger_name=logger_name, extra=extra)
 
-    async def error(self, message: str, *, logger_name: str | None = None, extra: dict[str, Any] | None = None) -> None:
-        """Send an error log message."""
+    async def error(self, message: Any, *, logger_name: str | None = None, extra: dict[str, Any] | None = None) -> None:
+        """Send an error log message. Any JSON-serializable type is allowed for message."""
         await self.log("error", message, logger_name=logger_name, extra=extra)


### PR DESCRIPTION
The issue here comes down to a frustrating type mismatch: the MCP spec clearly states that log message data can be any JSON-serializable type, but the convenience wrappers for `ctx.info()`, `ctx.warning()`, etc., were strictly enforcing `message: str`. So whenever a dev tried to log a simple Python dictionary or list, the type checker would throw a fit.

I traced it down and the good news is the underlying `send_log_message` method already handles `Any` properly without trying to blindly stringify things. The bug was entirely superficial.

So I went in and updated the surface-level type hints to bring the API back into alignment with the spec. 

Specifically, this updates `message: str` to `message: Any` across:
- `ctx.log()`
- `ctx.info()`
- `ctx.debug()`
- `ctx.warning()`
- `ctx.error()`

**Validation:**
I ran the full `pytest` suite against `mcpserver/test_server.py` and `client/test_logging_callback.py` — all 90 tests ran cleanly with no regressions to the existing logging behavior.

(Side note: I didn't have to touch any serialization logic, since the transport layer already handles the `Any` payload exactly as it should).

Let me know if there's anything else you'd like me to tweak before we merge this in! Fixes #397.
