### PR TITLE
feat(auth): add subject field to AccessToken

### DIFF
--- a/src/mcp/server/auth/provider.py
+++ b/src/mcp/server/auth/provider.py
@@ -40,6 +40,7 @@ class AccessToken(BaseModel):
     scopes: list[str]
     expires_at: int | None = None
     resource: str | None = None  # RFC 8707 resource indicator
+    subject: str | None = None  # Subject identifier (typically the "sub" JWT claim / user ID)
 
 
 RegistrationErrorCode = Literal[

--- a/tests/server/auth/middleware/test_auth_context.py
+++ b/tests/server/auth/middleware/test_auth_context.py
@@ -117,3 +117,23 @@ async def test_auth_context_middleware_with_no_user():
     # Verify context is still empty after middleware
     assert auth_context_var.get() is None
     assert get_access_token() is None
+
+
+def test_access_token_subject_field():
+    """Test that AccessToken supports the optional subject field."""
+    # Without subject (backward compatible)
+    token_no_sub = AccessToken(
+        token="token1",
+        client_id="client1",
+        scopes=["read"],
+    )
+    assert token_no_sub.subject is None
+
+    # With subject
+    token_with_sub = AccessToken(
+        token="token2",
+        client_id="client2",
+        scopes=["read", "write"],
+        subject="user-123",
+    )
+    assert token_with_sub.subject == "user-123"


### PR DESCRIPTION
## Summary

Add an optional `subject` field to `AccessToken` for storing the JWT `sub` claim (user ID).

## Motivation

Currently, token verifiers that decode JWTs have no standard way to pass through the subject/user identity. Consumers must re-decode the JWT to retrieve `sub`, duplicating work.

With this change:

```python
class MyTokenVerifier:
    async def verify_token(self, token: str) -> AccessToken | None:
        claims = decode_and_validate_jwt(token)
        return AccessToken(
            token=token,
            client_id=claims["client_id"],
            scopes=claims["scope"].split(),
            subject=claims["sub"],
        )
```

Then downstream code can access the user ID directly:

```python
from mcp.server.auth.middleware.auth_context import get_access_token
user_id = get_access_token().subject
```

## Changes

- Added `subject: str | None = None` to `AccessToken` in `provider.py`
- Added test for backward compatibility (no subject) and with subject

Backward compatible - field defaults to `None`.

Fixes #1038