### PR TITLE
[v1.x] fix(stdio): handle BrokenResourceError in stdout_reader race (#1960)

### DIFF
--- a/src/mcp/client/stdio/__init__.py
+++ b/src/mcp/client/stdio/__init__.py
@@ -155,12 +155,22 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                             message = types.JSONRPCMessage.model_validate_json(line)
                         except Exception as exc:  # pragma: no cover
                             logger.exception("Failed to parse JSONRPC message from server")
-                            await read_stream_writer.send(exc)
+                            try:
+                                await read_stream_writer.send(exc)
+                            except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                                # Context is closing; exit gracefully (issue #1960).
+                                return
                             continue
 
                         session_message = SessionMessage(message)
-                        await read_stream_writer.send(session_message)
-        except anyio.ClosedResourceError:  # pragma: no cover
+                        try:
+                            await read_stream_writer.send(session_message)
+                        except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                            # Context is closing; exit gracefully (issue #1960).
+                            # Happens when the caller exits the stdio_client context
+                            # while the subprocess is still writing to stdout.
+                            return
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):  # pragma: no cover
             await anyio.lowlevel.checkpoint()
 
     async def stdin_writer():

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -34,6 +34,45 @@ async def test_stdio_context_manager_exiting():
 
 
 @pytest.mark.anyio
+async def test_stdio_client_exits_cleanly_while_server_still_writing():
+    """Regression test for #1960.
+
+    Exiting the ``stdio_client`` context while the subprocess is still writing to
+    stdout used to surface ``anyio.BrokenResourceError`` through the task group
+    (as an ``ExceptionGroup``). The ``finally`` block closes
+    ``read_stream_writer`` while the background ``stdout_reader`` task is
+    mid-``send``.
+
+    The fix makes ``stdout_reader`` catch both ``ClosedResourceError`` and
+    ``BrokenResourceError`` and return cleanly, so exiting the context is a
+    no-op no matter what the subprocess is doing.
+    """
+    # A server that emits a large burst of valid JSON-RPC notifications without
+    # ever reading stdin. When we exit the context below, the subprocess is
+    # still in the middle of that burst, which is the exact shape of the race.
+    noisy_script = textwrap.dedent(
+        """
+        import sys
+        for i in range(1000):
+            sys.stdout.write(
+                '{"jsonrpc":"2.0","method":"notifications/message",'
+                '"params":{"level":"info","data":"line ' + str(i) + '"}}\\n'
+            )
+            sys.stdout.flush()
+        """
+    )
+
+    server_params = StdioServerParameters(command=sys.executable, args=["-c", noisy_script])
+
+    # The ``async with`` must complete without an ``ExceptionGroup`` /
+    # ``BrokenResourceError`` propagating. ``anyio.fail_after`` prevents a
+    # regression from hanging CI.
+    with anyio.fail_after(5.0):
+        async with stdio_client(server_params) as (_, _):
+            pass
+
+
+@pytest.mark.anyio
 @pytest.mark.skipif(tee is None, reason="could not find tee command")
 async def test_stdio_client():
     assert tee is not None


### PR DESCRIPTION
## Summary

Fixes #1960. The `stdio_client` in `mcp/client/stdio/__init__.py` has a race
condition: `read_stream_writer.aclose()` in the `finally` block can close the
stream while the background `stdout_reader` task is mid-`send`, which raises
`anyio.BrokenResourceError` and propagates through the task group as an
`ExceptionGroup`, failing the caller.

## Root cause

The two `read_stream_writer.send(...)` sites inside `stdout_reader` were not
guarded against `BrokenResourceError`. The outer `except` only caught
`ClosedResourceError`, which is the sibling class raised on **already-closed**
streams; `BrokenResourceError` is raised when the receiver is closed **during**
an in-flight `send`, which is the exact shape of this shutdown race.

## Fix

- Wrap each `read_stream_writer.send(...)` in `try`/`except` catching both
  `ClosedResourceError` and `BrokenResourceError`, then `return` cleanly.
- Widen the outer `except` to the same union for defense in depth.
- No API changes.

## Alternative considered

Issue #1960 suggests `tg.cancel_scope.cancel()` before the stream closes in
`finally`. That works but changes shutdown ordering (cancels user-defined
notification handlers, etc.). The chosen fix is narrower: it treats the
shutdown race as a graceful exit from `stdout_reader` specifically, without
altering the task group lifecycle.

## Reproduction

Any stdio MCP server that emits log-channel notifications alongside tool
responses will exhibit this when driven by a downstream wrapper (e.g.,
`mcp2cli`) that opens a fresh `stdio_client` per invocation. The task group
exits quickly, the subprocess is still flushing output, and the race is
triggered.

## Verification

Drove `jules-mcp-server` (an MCP server that emits `notifications/message`
log frames during init) through `mcp2cli` with a `list-schedules` tool call.

Before this patch:
```
ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File ".../mcp/client/stdio/__init__.py", line 162, in stdout_reader
    |     await read_stream_writer.send(session_message)
    |   File ".../anyio/streams/memory.py", line 220, in send_nowait
    |     raise BrokenResourceError
    | anyio.BrokenResourceError
```

After this patch:
```
{"count": 0, "schedules": []}
EXIT:0
```

Closes #1960.