### PR TITLE
fix(stdio_client): tolerate invalid UTF-8 from child stdout

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -151,7 +151,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                     for line in lines:
                         try:
                             message = types.jsonrpc_message_adapter.validate_json(line, by_name=False)
-                        except Exception as exc:  # pragma: no cover
+                        except Exception as exc:
                             logger.exception("Failed to parse JSONRPC message from server")
                             await read_stream_writer.send(exc)
                             continue

--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -92,7 +92,7 @@ class StdioServerParameters(BaseModel):
     Defaults to utf-8.
     """
 
-    encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
+    encoding_error_handler: Literal["strict", "ignore", "replace"] = "replace"
     """
     The text encoding error handler.
 
@@ -158,7 +158,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
 
                         session_message = SessionMessage(message)
                         await read_stream_writer.send(session_message)
-        except anyio.ClosedResourceError:  # pragma: lax no cover
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError, ConnectionResetError):  # pragma: lax no cover
             await anyio.lowlevel.checkpoint()
 
     async def stdin_writer():
@@ -174,7 +174,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                             errors=server.encoding_error_handler,
                         )
                     )
-        except anyio.ClosedResourceError:  # pragma: no cover
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError, ConnectionResetError):  # pragma: no cover
             await anyio.lowlevel.checkpoint()
 
     async with anyio.create_task_group() as tg, process:

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -4,6 +4,7 @@ import sys
 import textwrap
 import time
 from contextlib import AsyncExitStack, suppress
+from pathlib import Path
 
 import anyio
 import anyio.abc
@@ -68,6 +69,42 @@ async def test_stdio_client():
         assert len(read_messages) == 2
         assert read_messages[0] == JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")
         assert read_messages[1] == JSONRPCResponse(jsonrpc="2.0", id=2, result={})
+
+
+@pytest.mark.anyio
+async def test_stdio_client_invalid_utf8_from_server_does_not_crash(tmp_path: Path):
+    """A buggy child server should surface malformed UTF-8 as an in-stream error.
+
+    The client should continue reading subsequent valid JSON-RPC lines instead of
+    crashing the whole transport task group during decoding.
+    """
+    script = tmp_path / "bad_stdout_server.py"
+    valid = JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            import sys
+            import time
+
+            sys.stdout.buffer.write(b"\\xff\\xfe\\n")
+            sys.stdout.buffer.write({valid.model_dump_json(by_alias=True, exclude_none=True)!r}.encode() + b"\\n")
+            sys.stdout.buffer.flush()
+            time.sleep(0.2)
+            """
+        )
+    )
+
+    server_params = StdioServerParameters(command=sys.executable, args=[str(script)])
+
+    with anyio.fail_after(5):
+        async with stdio_client(server_params) as (read_stream, write_stream):
+            await write_stream.aclose()
+            first = await read_stream.receive()
+            assert isinstance(first, Exception)
+
+            second = await read_stream.receive()
+            assert isinstance(second, SessionMessage)
+            assert second.message == valid
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #2454

## Summary

`stdio_client()` currently decodes child stdout with `encoding_error_handler="strict"`, so a malformed UTF-8 line can raise during `TextReceiveStream(...)` iteration and crash the transport task group.

This PR makes the client follow the same strategy that `stdio_server()` already uses after #2302:

- decode with `errors="replace"`
- let malformed lines fail JSON validation
- surface those failures as in-stream exceptions instead of killing the transport

It also treats abrupt child shutdowns (`BrokenResourceError` / `ConnectionResetError`) as normal shutdown-time conditions in the background stdio tasks.

## Motivation and Context

PR #2302 fixed the server side so invalid UTF-8 on stdin becomes a parse error instead of a transport crash. The client side still behaved asymmetrically: a buggy or non-compliant child process could kill the Python client with a single malformed stdout line even if the next line was valid JSON-RPC.

That makes the client less robust than the server for the same class of malformed stdio input.

## How Has This Been Tested?

Added a focused regression test in `tests/client/test_stdio.py` that spawns a child process which writes:

1. one malformed UTF-8 line (`b"\xff\xfe\n"`)
2. one valid JSON-RPC line

Without this patch, the transport fails before the valid line is delivered.

With this patch:
- the first item from the read stream is an `Exception`
- the second item is the valid `SessionMessage`

Local verification:
- `uv run --frozen pytest tests/client/test_stdio.py`
- `uv run --frozen ruff check src/mcp/client/stdio.py tests/client/test_stdio.py`
- `uv run --frozen pyright src/mcp/client/stdio.py`

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
