### PR TITLE
feat: PeerMixin, BaseContext, Connection, server Context

### DIFF
--- a/src/mcp/server/_typed_request.py
+++ b/src/mcp/server/_typed_request.py
@@ -1,13 +1,14 @@
-"""Shape-2 typed ``send_request`` for server-to-client requests.
+"""Typed ``send_request`` for server-to-client requests.
 
 `TypedServerRequestMixin` provides a typed `send_request(req) -> Result` over
 the host's raw `Outbound.send_raw_request`. Spec server-to-client request types
 have their result type inferred via per-type overloads; custom requests pass
 ``result_type=`` explicitly.
 
-A `HasResult[R]` protocol (one generic signature, mapping declared on the
-request type) is the cleaner long-term shape — see FOLLOWUPS.md. This per-spec
-overload set is used for now to avoid touching `mcp.types`.
+If the spec's request set grows substantially, consider declaring the result
+mapping on the request types themselves (a ``__mcp_result__`` ClassVar read via
+a structural protocol) so this overload ladder doesn't need maintaining
+per-host-class.
 """
 
 from typing import Any, TypeVar, overload

--- a/src/mcp/server/_typed_request.py
+++ b/src/mcp/server/_typed_request.py
@@ -1,0 +1,85 @@
+"""Shape-2 typed ``send_request`` for server-to-client requests.
+
+`TypedServerRequestMixin` provides a typed `send_request(req) -> Result` over
+the host's raw `Outbound.send_raw_request`. Spec server-to-client request types
+have their result type inferred via per-type overloads; custom requests pass
+``result_type=`` explicitly.
+
+A `HasResult[R]` protocol (one generic signature, mapping declared on the
+request type) is the cleaner long-term shape — see FOLLOWUPS.md. This per-spec
+overload set is used for now to avoid touching `mcp.types`.
+"""
+
+from typing import Any, TypeVar, overload
+
+from pydantic import BaseModel
+
+from mcp.shared.dispatcher import CallOptions, Outbound
+from mcp.shared.peer import dump_params
+from mcp.types import (
+    CreateMessageRequest,
+    CreateMessageResult,
+    ElicitRequest,
+    ElicitResult,
+    EmptyResult,
+    ListRootsRequest,
+    ListRootsResult,
+    PingRequest,
+    Request,
+)
+
+__all__ = ["TypedServerRequestMixin"]
+
+ResultT = TypeVar("ResultT", bound=BaseModel)
+
+_RESULT_FOR: dict[type[Request[Any, Any]], type[BaseModel]] = {
+    CreateMessageRequest: CreateMessageResult,
+    ElicitRequest: ElicitResult,
+    ListRootsRequest: ListRootsResult,
+    PingRequest: EmptyResult,
+}
+
+
+class TypedServerRequestMixin:
+    """Typed ``send_request`` for the server-to-client request set.
+
+    Mixed into `Connection` and the server `Context`. Each method constrains
+    ``self`` to `Outbound` so any host with ``send_raw_request`` works.
+    """
+
+    @overload
+    async def send_request(
+        self: Outbound, req: CreateMessageRequest, *, opts: CallOptions | None = None
+    ) -> CreateMessageResult: ...
+    @overload
+    async def send_request(self: Outbound, req: ElicitRequest, *, opts: CallOptions | None = None) -> ElicitResult: ...
+    @overload
+    async def send_request(
+        self: Outbound, req: ListRootsRequest, *, opts: CallOptions | None = None
+    ) -> ListRootsResult: ...
+    @overload
+    async def send_request(self: Outbound, req: PingRequest, *, opts: CallOptions | None = None) -> EmptyResult: ...
+    @overload
+    async def send_request(
+        self: Outbound, req: Request[Any, Any], *, result_type: type[ResultT], opts: CallOptions | None = None
+    ) -> ResultT: ...
+    async def send_request(
+        self: Outbound,
+        req: Request[Any, Any],
+        *,
+        result_type: type[BaseModel] | None = None,
+        opts: CallOptions | None = None,
+    ) -> BaseModel:
+        """Send a typed server-to-client request and return its typed result.
+
+        For spec request types the result type is inferred. For custom requests
+        pass ``result_type=`` explicitly.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: No back-channel for server-initiated requests.
+            KeyError: ``result_type`` omitted for a non-spec request type.
+        """
+        raw = await self.send_raw_request(req.method, dump_params(req.params), opts)
+        cls = result_type if result_type is not None else _RESULT_FOR[type(req)]
+        return cls.model_validate(raw)

--- a/src/mcp/server/connection.py
+++ b/src/mcp/server/connection.py
@@ -53,7 +53,7 @@ class Connection(TypedServerRequestMixin):
         self.protocol_version: str | None = None
         self.initialized: anyio.Event = anyio.Event()
         # TODO: make this generic (Connection[StateT]) once connection_lifespan
-        # wiring lands in ServerRunner — see FOLLOWUPS.md.
+        # wiring lands in ServerRunner.
         self.state: Any = None
 
     async def send_raw_request(
@@ -124,7 +124,7 @@ class Connection(TypedServerRequestMixin):
         Returns ``False`` if ``initialize`` hasn't completed yet.
         """
         # TODO: redesign — mirrors v1 ServerSession.check_client_capability
-        # verbatim for parity. See FOLLOWUPS.md.
+        # verbatim for parity.
         if self.client_capabilities is None:
             return False
         have = self.client_capabilities

--- a/src/mcp/server/connection.py
+++ b/src/mcp/server/connection.py
@@ -1,0 +1,146 @@
+"""`Connection` — per-client connection state and the standalone outbound channel.
+
+Always present on `Context` (never ``None``), even in stateless deployments.
+Holds peer info populated at ``initialize`` time, the per-connection lifespan
+output, and an `Outbound` for the standalone stream (the SSE GET stream in
+streamable HTTP, or the single duplex stream in stdio).
+
+`notify` is best-effort: it never raises. If there's no standalone channel
+(stateless HTTP) or the stream has been dropped, the notification is
+debug-logged and silently discarded — server-initiated notifications are
+inherently advisory. `send_raw_request` *does* raise `NoBackChannelError` when
+there's no channel; `ping` is the only spec-sanctioned standalone request.
+"""
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import anyio
+
+from mcp.server._typed_request import TypedServerRequestMixin
+from mcp.shared.dispatcher import CallOptions, Outbound
+from mcp.shared.exceptions import NoBackChannelError
+from mcp.shared.peer import Meta, dump_params
+from mcp.types import ClientCapabilities, Implementation, LoggingLevel
+
+__all__ = ["Connection"]
+
+logger = logging.getLogger(__name__)
+
+
+def _notification_params(payload: dict[str, Any] | None, meta: Meta | None) -> dict[str, Any] | None:
+    if not meta:
+        return payload
+    out = dict(payload or {})
+    out["_meta"] = meta
+    return out
+
+
+class Connection(TypedServerRequestMixin):
+    """Per-client connection state and standalone-stream `Outbound`.
+
+    Constructed by `ServerRunner` once per connection. The peer-info fields are
+    ``None`` until ``initialize`` completes; ``initialized`` is set then.
+    """
+
+    def __init__(self, outbound: Outbound, *, has_standalone_channel: bool) -> None:
+        self._outbound = outbound
+        self.has_standalone_channel = has_standalone_channel
+
+        self.client_info: Implementation | None = None
+        self.client_capabilities: ClientCapabilities | None = None
+        self.protocol_version: str | None = None
+        self.initialized: anyio.Event = anyio.Event()
+        # TODO: make this generic (Connection[StateT]) once connection_lifespan
+        # wiring lands in ServerRunner — see FOLLOWUPS.md.
+        self.state: Any = None
+
+    async def send_raw_request(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None,
+        opts: CallOptions | None = None,
+    ) -> dict[str, Any]:
+        """Send a raw request on the standalone stream.
+
+        Low-level `Outbound` channel. Prefer the typed ``send_request`` (from
+        `TypedServerRequestMixin`) or the convenience methods below; use this
+        directly only for off-spec messages.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: ``has_standalone_channel`` is ``False``.
+        """
+        if not self.has_standalone_channel:
+            raise NoBackChannelError(method)
+        return await self._outbound.send_raw_request(method, params, opts)
+
+    async def notify(self, method: str, params: Mapping[str, Any] | None) -> None:
+        """Send a best-effort notification on the standalone stream.
+
+        Never raises. If there's no standalone channel or the stream is broken,
+        the notification is dropped and debug-logged.
+        """
+        if not self.has_standalone_channel:
+            logger.debug("dropped %s: no standalone channel", method)
+            return
+        try:
+            await self._outbound.notify(method, params)
+        except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+            logger.debug("dropped %s: standalone stream closed", method)
+
+    async def ping(self, *, meta: Meta | None = None, opts: CallOptions | None = None) -> None:
+        """Send a ``ping`` request on the standalone stream.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: ``has_standalone_channel`` is ``False``.
+        """
+        await self.send_raw_request("ping", dump_params(None, meta), opts)
+
+    async def log(self, level: LoggingLevel, data: Any, logger: str | None = None, *, meta: Meta | None = None) -> None:
+        """Send a ``notifications/message`` log entry on the standalone stream. Best-effort."""
+        params: dict[str, Any] = {"level": level, "data": data}
+        if logger is not None:
+            params["logger"] = logger
+        await self.notify("notifications/message", _notification_params(params, meta))
+
+    async def send_tool_list_changed(self, *, meta: Meta | None = None) -> None:
+        await self.notify("notifications/tools/list_changed", _notification_params(None, meta))
+
+    async def send_prompt_list_changed(self, *, meta: Meta | None = None) -> None:
+        await self.notify("notifications/prompts/list_changed", _notification_params(None, meta))
+
+    async def send_resource_list_changed(self, *, meta: Meta | None = None) -> None:
+        await self.notify("notifications/resources/list_changed", _notification_params(None, meta))
+
+    async def send_resource_updated(self, uri: str, *, meta: Meta | None = None) -> None:
+        await self.notify("notifications/resources/updated", _notification_params({"uri": uri}, meta))
+
+    def check_capability(self, capability: ClientCapabilities) -> bool:
+        """Return whether the connected client declared the given capability.
+
+        Returns ``False`` if ``initialize`` hasn't completed yet.
+        """
+        # TODO: redesign — mirrors v1 ServerSession.check_client_capability
+        # verbatim for parity. See FOLLOWUPS.md.
+        if self.client_capabilities is None:
+            return False
+        have = self.client_capabilities
+        if capability.roots is not None:
+            if have.roots is None:
+                return False
+            if capability.roots.list_changed and not have.roots.list_changed:
+                return False
+        if capability.sampling is not None and have.sampling is None:
+            return False
+        if capability.elicitation is not None and have.elicitation is None:
+            return False
+        if capability.experimental is not None:
+            if have.experimental is None:
+                return False
+            for k in capability.experimental:
+                if k not in have.experimental:
+                    return False
+        return True

--- a/src/mcp/server/context.py
+++ b/src/mcp/server/context.py
@@ -30,8 +30,8 @@ class ServerRequestContext(RequestContext[ServerSession], Generic[LifespanContex
     close_standalone_sse_stream: CloseSSEStreamCallback | None = None
 
 
-LifespanT = TypeVar("LifespanT", default=Any)
-TransportT = TypeVar("TransportT", bound=TransportContext, default=TransportContext)
+LifespanT = TypeVar("LifespanT", default=Any, covariant=True)
+TransportT = TypeVar("TransportT", bound=TransportContext, default=TransportContext, covariant=True)
 
 
 class Context(BaseContext[TransportT], PeerMixin, TypedServerRequestMixin, Generic[LifespanT, TransportT]):

--- a/src/mcp/server/context.py
+++ b/src/mcp/server/context.py
@@ -5,10 +5,17 @@ from typing import Any, Generic
 
 from typing_extensions import TypeVar
 
+from mcp.server._typed_request import TypedServerRequestMixin
+from mcp.server.connection import Connection
 from mcp.server.experimental.request_context import Experimental
 from mcp.server.session import ServerSession
 from mcp.shared._context import RequestContext
+from mcp.shared.context import BaseContext
+from mcp.shared.dispatcher import DispatchContext
 from mcp.shared.message import CloseSSEStreamCallback
+from mcp.shared.peer import Meta, PeerMixin
+from mcp.shared.transport_context import TransportContext
+from mcp.types import LoggingLevel, RequestParamsMeta
 
 LifespanContextT = TypeVar("LifespanContextT", default=dict[str, Any])
 RequestT = TypeVar("RequestT", default=Any)
@@ -21,3 +28,56 @@ class ServerRequestContext(RequestContext[ServerSession], Generic[LifespanContex
     request: RequestT | None = None
     close_sse_stream: CloseSSEStreamCallback | None = None
     close_standalone_sse_stream: CloseSSEStreamCallback | None = None
+
+
+LifespanT = TypeVar("LifespanT", default=Any)
+TransportT = TypeVar("TransportT", bound=TransportContext, default=TransportContext)
+
+
+class Context(BaseContext[TransportT], PeerMixin, TypedServerRequestMixin, Generic[LifespanT, TransportT]):
+    """Server-side per-request context.
+
+    Composes `BaseContext` (forwards to `DispatchContext`, satisfies `Outbound`),
+    `PeerMixin` (kwarg-style ``sample``/``elicit_*``/``list_roots``/``ping``),
+    and `TypedServerRequestMixin` (typed ``send_request(req) -> Result``). Adds
+    ``lifespan`` and ``connection``.
+
+    Constructed by `ServerRunner` (PR4) per inbound request and handed to the
+    user's handler.
+    """
+
+    def __init__(
+        self,
+        dctx: DispatchContext[TransportT],
+        *,
+        lifespan: LifespanT,
+        connection: Connection,
+        meta: RequestParamsMeta | None = None,
+    ) -> None:
+        super().__init__(dctx, meta=meta)
+        self._lifespan = lifespan
+        self._connection = connection
+
+    @property
+    def lifespan(self) -> LifespanT:
+        """The server-wide lifespan output (what `Server(..., lifespan=...)` yielded)."""
+        return self._lifespan
+
+    @property
+    def connection(self) -> Connection:
+        """The per-client `Connection` for this request's connection."""
+        return self._connection
+
+    async def log(self, level: LoggingLevel, data: Any, logger: str | None = None, *, meta: Meta | None = None) -> None:
+        """Send a request-scoped ``notifications/message`` log entry.
+
+        Uses this request's back-channel (so the entry rides the request's SSE
+        stream in streamable HTTP), not the standalone stream — use
+        ``ctx.connection.log(...)`` for that.
+        """
+        params: dict[str, Any] = {"level": level, "data": data}
+        if logger is not None:
+            params["logger"] = logger
+        if meta:
+            params["_meta"] = meta
+        await self.notify("notifications/message", params)

--- a/src/mcp/server/context.py
+++ b/src/mcp/server/context.py
@@ -42,8 +42,8 @@ class Context(BaseContext[TransportT], PeerMixin, TypedServerRequestMixin, Gener
     and `TypedServerRequestMixin` (typed ``send_request(req) -> Result``). Adds
     ``lifespan`` and ``connection``.
 
-    Constructed by `ServerRunner` (PR4) per inbound request and handed to the
-    user's handler.
+    Constructed by `ServerRunner` per inbound request and handed to the user's
+    handler.
     """
 
     def __init__(

--- a/src/mcp/shared/context.py
+++ b/src/mcp/shared/context.py
@@ -22,7 +22,7 @@ from mcp.types import RequestParamsMeta
 
 __all__ = ["BaseContext"]
 
-TransportT = TypeVar("TransportT", bound=TransportContext, default=TransportContext)
+TransportT = TypeVar("TransportT", bound=TransportContext, default=TransportContext, covariant=True)
 
 
 class BaseContext(Generic[TransportT]):

--- a/src/mcp/shared/context.py
+++ b/src/mcp/shared/context.py
@@ -1,7 +1,7 @@
 """`BaseContext` — the user-facing per-request context.
 
 Composition over a `DispatchContext`: forwards the transport metadata, the
-back-channel (`send_request`/`notify`), progress reporting, and the cancel
+back-channel (`send_raw_request`/`notify`), progress reporting, and the cancel
 event. Adds `meta` (the inbound request's `_meta` field).
 
 Satisfies `Outbound`, so `PeerMixin` works on it (the server-side `Context`
@@ -56,7 +56,7 @@ class BaseContext(Generic[TransportT]):
         """The inbound request's ``_meta`` field, if present."""
         return self._meta
 
-    async def send_request(
+    async def send_raw_request(
         self,
         method: str,
         params: Mapping[str, Any] | None,
@@ -68,7 +68,7 @@ class BaseContext(Generic[TransportT]):
             MCPError: The peer responded with an error.
             NoBackChannelError: ``can_send_request`` is ``False``.
         """
-        return await self._dctx.send_request(method, params, opts)
+        return await self._dctx.send_raw_request(method, params, opts)
 
     async def notify(self, method: str, params: Mapping[str, Any] | None) -> None:
         """Send a notification to the peer on the back-channel."""

--- a/src/mcp/shared/context.py
+++ b/src/mcp/shared/context.py
@@ -28,8 +28,8 @@ TransportT = TypeVar("TransportT", bound=TransportContext, default=TransportCont
 class BaseContext(Generic[TransportT]):
     """Per-request context wrapping a `DispatchContext`.
 
-    `ServerRunner` (PR4) constructs one per inbound request and passes it to
-    the user's handler.
+    `ServerRunner` constructs one per inbound request and passes it to the
+    user's handler.
     """
 
     def __init__(self, dctx: DispatchContext[TransportT], meta: RequestParamsMeta | None = None) -> None:

--- a/src/mcp/shared/context.py
+++ b/src/mcp/shared/context.py
@@ -1,0 +1,82 @@
+"""`BaseContext` — the user-facing per-request context.
+
+Composition over a `DispatchContext`: forwards the transport metadata, the
+back-channel (`send_request`/`notify`), progress reporting, and the cancel
+event. Adds `meta` (the inbound request's `_meta` field).
+
+Satisfies `Outbound`, so `PeerMixin` works on it (the server-side `Context`
+mixes that in directly). Shared between client and server: the server's
+`Context` extends this with `lifespan`/`connection`; `ClientContext` is just an
+alias.
+"""
+
+from collections.abc import Mapping
+from typing import Any, Generic
+
+import anyio
+from typing_extensions import TypeVar
+
+from mcp.shared.dispatcher import CallOptions, DispatchContext
+from mcp.shared.transport_context import TransportContext
+from mcp.types import RequestParamsMeta
+
+__all__ = ["BaseContext"]
+
+TransportT = TypeVar("TransportT", bound=TransportContext, default=TransportContext)
+
+
+class BaseContext(Generic[TransportT]):
+    """Per-request context wrapping a `DispatchContext`.
+
+    `ServerRunner` (PR4) constructs one per inbound request and passes it to
+    the user's handler.
+    """
+
+    def __init__(self, dctx: DispatchContext[TransportT], meta: RequestParamsMeta | None = None) -> None:
+        self._dctx = dctx
+        self._meta = meta
+
+    @property
+    def transport(self) -> TransportT:
+        """Transport-specific metadata for this inbound request."""
+        return self._dctx.transport
+
+    @property
+    def cancel_requested(self) -> anyio.Event:
+        """Set when the peer sends ``notifications/cancelled`` for this request."""
+        return self._dctx.cancel_requested
+
+    @property
+    def can_send_request(self) -> bool:
+        """Whether the back-channel can deliver server-initiated requests."""
+        return self._dctx.transport.can_send_request
+
+    @property
+    def meta(self) -> RequestParamsMeta | None:
+        """The inbound request's ``_meta`` field, if present."""
+        return self._meta
+
+    async def send_request(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None,
+        opts: CallOptions | None = None,
+    ) -> dict[str, Any]:
+        """Send a request to the peer on the back-channel.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: ``can_send_request`` is ``False``.
+        """
+        return await self._dctx.send_request(method, params, opts)
+
+    async def notify(self, method: str, params: Mapping[str, Any] | None) -> None:
+        """Send a notification to the peer on the back-channel."""
+        await self._dctx.notify(method, params)
+
+    async def report_progress(self, progress: float, total: float | None = None, message: str | None = None) -> None:
+        """Report progress for this request, if the peer supplied a progress token.
+
+        A no-op when no token was supplied.
+        """
+        await self._dctx.progress(progress, total, message)

--- a/src/mcp/shared/peer.py
+++ b/src/mcp/shared/peer.py
@@ -1,0 +1,194 @@
+"""Typed MCP request sugar over an `Outbound`.
+
+`PeerMixin` defines the server-to-client request methods (sampling, elicitation,
+roots, ping) once. Any class that satisfies `Outbound` (i.e. has `send_request`
+and `notify`) can mix it in and get the typed methods for free — `Context`,
+`Connection`, `Client`, or the bare `Peer` wrapper below.
+
+The mixin does no capability gating: it builds the params, calls
+``self.send_request(method, params)``, and parses the result into the typed
+model. Gating (and `NoBackChannelError`) is the host's `send_request`'s job.
+"""
+
+from collections.abc import Mapping
+from typing import Any, overload
+
+from pydantic import BaseModel
+
+from mcp.shared.dispatcher import CallOptions, Outbound
+from mcp.types import (
+    CreateMessageRequestParams,
+    CreateMessageResult,
+    CreateMessageResultWithTools,
+    ElicitRequestedSchema,
+    ElicitRequestFormParams,
+    ElicitRequestURLParams,
+    ElicitResult,
+    IncludeContext,
+    ListRootsResult,
+    ModelPreferences,
+    SamplingMessage,
+    Tool,
+    ToolChoice,
+)
+
+__all__ = ["Peer", "PeerMixin"]
+
+
+def _dump(model: BaseModel) -> dict[str, Any]:
+    return model.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+
+class PeerMixin:
+    """Typed server-to-client request methods.
+
+    Each method constrains ``self`` to `Outbound` so the mixin can be applied
+    to anything with ``send_request``/``notify`` — pyright checks the host
+    class structurally at the call site.
+    """
+
+    @overload
+    async def sample(
+        self: Outbound,
+        messages: list[SamplingMessage],
+        *,
+        max_tokens: int,
+        system_prompt: str | None = None,
+        include_context: IncludeContext | None = None,
+        temperature: float | None = None,
+        stop_sequences: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        model_preferences: ModelPreferences | None = None,
+        tools: None = None,
+        tool_choice: ToolChoice | None = None,
+        opts: CallOptions | None = None,
+    ) -> CreateMessageResult: ...
+    @overload
+    async def sample(
+        self: Outbound,
+        messages: list[SamplingMessage],
+        *,
+        max_tokens: int,
+        system_prompt: str | None = None,
+        include_context: IncludeContext | None = None,
+        temperature: float | None = None,
+        stop_sequences: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        model_preferences: ModelPreferences | None = None,
+        tools: list[Tool],
+        tool_choice: ToolChoice | None = None,
+        opts: CallOptions | None = None,
+    ) -> CreateMessageResultWithTools: ...
+    async def sample(
+        self: Outbound,
+        messages: list[SamplingMessage],
+        *,
+        max_tokens: int,
+        system_prompt: str | None = None,
+        include_context: IncludeContext | None = None,
+        temperature: float | None = None,
+        stop_sequences: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        model_preferences: ModelPreferences | None = None,
+        tools: list[Tool] | None = None,
+        tool_choice: ToolChoice | None = None,
+        opts: CallOptions | None = None,
+    ) -> CreateMessageResult | CreateMessageResultWithTools:
+        """Send a ``sampling/createMessage`` request to the peer.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: The host's transport context has no
+                back-channel for server-initiated requests.
+        """
+        params = CreateMessageRequestParams(
+            messages=messages,
+            system_prompt=system_prompt,
+            include_context=include_context,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stop_sequences=stop_sequences,
+            metadata=metadata,
+            model_preferences=model_preferences,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        result = await self.send_request("sampling/createMessage", _dump(params), opts)
+        if tools is not None:
+            return CreateMessageResultWithTools.model_validate(result)
+        return CreateMessageResult.model_validate(result)
+
+    async def elicit_form(
+        self: Outbound,
+        message: str,
+        requested_schema: ElicitRequestedSchema,
+        opts: CallOptions | None = None,
+    ) -> ElicitResult:
+        """Send a form-mode ``elicitation/create`` request.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: No back-channel for server-initiated requests.
+        """
+        params = ElicitRequestFormParams(message=message, requested_schema=requested_schema)
+        result = await self.send_request("elicitation/create", _dump(params), opts)
+        return ElicitResult.model_validate(result)
+
+    async def elicit_url(
+        self: Outbound,
+        message: str,
+        url: str,
+        elicitation_id: str,
+        opts: CallOptions | None = None,
+    ) -> ElicitResult:
+        """Send a URL-mode ``elicitation/create`` request.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: No back-channel for server-initiated requests.
+        """
+        params = ElicitRequestURLParams(message=message, url=url, elicitation_id=elicitation_id)
+        result = await self.send_request("elicitation/create", _dump(params), opts)
+        return ElicitResult.model_validate(result)
+
+    async def list_roots(self: Outbound, opts: CallOptions | None = None) -> ListRootsResult:
+        """Send a ``roots/list`` request.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: No back-channel for server-initiated requests.
+        """
+        result = await self.send_request("roots/list", None, opts)
+        return ListRootsResult.model_validate(result)
+
+    async def ping(self: Outbound, opts: CallOptions | None = None) -> None:
+        """Send a ``ping`` request and ignore the result.
+
+        Raises:
+            MCPError: The peer responded with an error.
+            NoBackChannelError: No back-channel for server-initiated requests.
+        """
+        await self.send_request("ping", None, opts)
+
+
+class Peer(PeerMixin):
+    """Standalone wrapper that gives any `Outbound` the `PeerMixin` sugar.
+
+    `Context` and `Connection` mix `PeerMixin` in directly; use `Peer` when
+    you have a bare dispatcher (or any `Outbound`) and want the typed methods
+    without writing your own host class.
+    """
+
+    def __init__(self, outbound: Outbound) -> None:
+        self._outbound = outbound
+
+    async def send_request(
+        self,
+        method: str,
+        params: Mapping[str, Any] | None,
+        opts: CallOptions | None = None,
+    ) -> dict[str, Any]:
+        return await self._outbound.send_request(method, params, opts)
+
+    async def notify(self, method: str, params: Mapping[str, Any] | None) -> None:
+        await self._outbound.notify(method, params)

--- a/src/mcp/shared/peer.py
+++ b/src/mcp/shared/peer.py
@@ -1,9 +1,9 @@
 """Typed MCP request sugar over an `Outbound`.
 
 `PeerMixin` defines the server-to-client request methods (sampling, elicitation,
-roots, ping) once. Any class that satisfies `Outbound` (i.e. has `send_raw_request`
-and `notify`) can mix it in and get the typed methods for free — `Context`,
-`Connection`, `Client`, or the bare `Peer` wrapper below.
+roots, ping) once. Any class that satisfies `Outbound` (i.e. has
+``send_raw_request`` and ``notify``) can mix it in and get the typed methods for
+free — `Context`, `Connection`, `Client`, or the bare `Peer` wrapper below.
 
 The mixin does no capability gating: it builds the params, calls
 ``self.send_raw_request(method, params)``, and parses the result into the typed
@@ -32,11 +32,24 @@ from mcp.types import (
     ToolChoice,
 )
 
-__all__ = ["Peer", "PeerMixin"]
+__all__ = ["Meta", "Peer", "PeerMixin", "dump_params"]
+
+Meta = dict[str, Any]
+"""Type alias for the ``_meta`` field carried on request/notification params."""
 
 
-def _dump(model: BaseModel) -> dict[str, Any]:
-    return model.model_dump(by_alias=True, mode="json", exclude_none=True)
+def dump_params(model: BaseModel | None, meta: Meta | None = None) -> dict[str, Any] | None:
+    """Serialize a params model to a wire dict, merging ``meta`` into ``_meta``.
+
+    Shared by `PeerMixin`, `Connection`, and `TypedServerRequestMixin` so every
+    typed convenience method gets the same `_meta` handling. ``meta`` keys take
+    precedence over any ``_meta`` already present on the model.
+    """
+    out = model.model_dump(by_alias=True, mode="json", exclude_none=True) if model is not None else None
+    if meta:
+        out = dict(out or {})
+        out["_meta"] = {**out.get("_meta", {}), **meta}
+    return out
 
 
 class PeerMixin:
@@ -61,6 +74,7 @@ class PeerMixin:
         model_preferences: ModelPreferences | None = None,
         tools: None = None,
         tool_choice: ToolChoice | None = None,
+        meta: Meta | None = None,
         opts: CallOptions | None = None,
     ) -> CreateMessageResult: ...
     @overload
@@ -77,6 +91,7 @@ class PeerMixin:
         model_preferences: ModelPreferences | None = None,
         tools: list[Tool],
         tool_choice: ToolChoice | None = None,
+        meta: Meta | None = None,
         opts: CallOptions | None = None,
     ) -> CreateMessageResultWithTools: ...
     async def sample(
@@ -92,6 +107,7 @@ class PeerMixin:
         model_preferences: ModelPreferences | None = None,
         tools: list[Tool] | None = None,
         tool_choice: ToolChoice | None = None,
+        meta: Meta | None = None,
         opts: CallOptions | None = None,
     ) -> CreateMessageResult | CreateMessageResultWithTools:
         """Send a ``sampling/createMessage`` request to the peer.
@@ -113,7 +129,7 @@ class PeerMixin:
             tools=tools,
             tool_choice=tool_choice,
         )
-        result = await self.send_raw_request("sampling/createMessage", _dump(params), opts)
+        result = await self.send_raw_request("sampling/createMessage", dump_params(params, meta), opts)
         if tools is not None:
             return CreateMessageResultWithTools.model_validate(result)
         return CreateMessageResult.model_validate(result)
@@ -122,6 +138,8 @@ class PeerMixin:
         self: Outbound,
         message: str,
         requested_schema: ElicitRequestedSchema,
+        *,
+        meta: Meta | None = None,
         opts: CallOptions | None = None,
     ) -> ElicitResult:
         """Send a form-mode ``elicitation/create`` request.
@@ -131,7 +149,7 @@ class PeerMixin:
             NoBackChannelError: No back-channel for server-initiated requests.
         """
         params = ElicitRequestFormParams(message=message, requested_schema=requested_schema)
-        result = await self.send_raw_request("elicitation/create", _dump(params), opts)
+        result = await self.send_raw_request("elicitation/create", dump_params(params, meta), opts)
         return ElicitResult.model_validate(result)
 
     async def elicit_url(
@@ -139,6 +157,8 @@ class PeerMixin:
         message: str,
         url: str,
         elicitation_id: str,
+        *,
+        meta: Meta | None = None,
         opts: CallOptions | None = None,
     ) -> ElicitResult:
         """Send a URL-mode ``elicitation/create`` request.
@@ -148,27 +168,29 @@ class PeerMixin:
             NoBackChannelError: No back-channel for server-initiated requests.
         """
         params = ElicitRequestURLParams(message=message, url=url, elicitation_id=elicitation_id)
-        result = await self.send_raw_request("elicitation/create", _dump(params), opts)
+        result = await self.send_raw_request("elicitation/create", dump_params(params, meta), opts)
         return ElicitResult.model_validate(result)
 
-    async def list_roots(self: Outbound, opts: CallOptions | None = None) -> ListRootsResult:
+    async def list_roots(
+        self: Outbound, *, meta: Meta | None = None, opts: CallOptions | None = None
+    ) -> ListRootsResult:
         """Send a ``roots/list`` request.
 
         Raises:
             MCPError: The peer responded with an error.
             NoBackChannelError: No back-channel for server-initiated requests.
         """
-        result = await self.send_raw_request("roots/list", None, opts)
+        result = await self.send_raw_request("roots/list", dump_params(None, meta), opts)
         return ListRootsResult.model_validate(result)
 
-    async def ping(self: Outbound, opts: CallOptions | None = None) -> None:
+    async def ping(self: Outbound, *, meta: Meta | None = None, opts: CallOptions | None = None) -> None:
         """Send a ``ping`` request and ignore the result.
 
         Raises:
             MCPError: The peer responded with an error.
             NoBackChannelError: No back-channel for server-initiated requests.
         """
-        await self.send_raw_request("ping", None, opts)
+        await self.send_raw_request("ping", dump_params(None, meta), opts)
 
 
 class Peer(PeerMixin):

--- a/src/mcp/shared/peer.py
+++ b/src/mcp/shared/peer.py
@@ -1,13 +1,13 @@
 """Typed MCP request sugar over an `Outbound`.
 
 `PeerMixin` defines the server-to-client request methods (sampling, elicitation,
-roots, ping) once. Any class that satisfies `Outbound` (i.e. has `send_request`
+roots, ping) once. Any class that satisfies `Outbound` (i.e. has `send_raw_request`
 and `notify`) can mix it in and get the typed methods for free — `Context`,
 `Connection`, `Client`, or the bare `Peer` wrapper below.
 
 The mixin does no capability gating: it builds the params, calls
-``self.send_request(method, params)``, and parses the result into the typed
-model. Gating (and `NoBackChannelError`) is the host's `send_request`'s job.
+``self.send_raw_request(method, params)``, and parses the result into the typed
+model. Gating (and `NoBackChannelError`) is the host's `send_raw_request`'s job.
 """
 
 from collections.abc import Mapping
@@ -43,7 +43,7 @@ class PeerMixin:
     """Typed server-to-client request methods.
 
     Each method constrains ``self`` to `Outbound` so the mixin can be applied
-    to anything with ``send_request``/``notify`` — pyright checks the host
+    to anything with ``send_raw_request``/``notify`` — pyright checks the host
     class structurally at the call site.
     """
 
@@ -113,7 +113,7 @@ class PeerMixin:
             tools=tools,
             tool_choice=tool_choice,
         )
-        result = await self.send_request("sampling/createMessage", _dump(params), opts)
+        result = await self.send_raw_request("sampling/createMessage", _dump(params), opts)
         if tools is not None:
             return CreateMessageResultWithTools.model_validate(result)
         return CreateMessageResult.model_validate(result)
@@ -131,7 +131,7 @@ class PeerMixin:
             NoBackChannelError: No back-channel for server-initiated requests.
         """
         params = ElicitRequestFormParams(message=message, requested_schema=requested_schema)
-        result = await self.send_request("elicitation/create", _dump(params), opts)
+        result = await self.send_raw_request("elicitation/create", _dump(params), opts)
         return ElicitResult.model_validate(result)
 
     async def elicit_url(
@@ -148,7 +148,7 @@ class PeerMixin:
             NoBackChannelError: No back-channel for server-initiated requests.
         """
         params = ElicitRequestURLParams(message=message, url=url, elicitation_id=elicitation_id)
-        result = await self.send_request("elicitation/create", _dump(params), opts)
+        result = await self.send_raw_request("elicitation/create", _dump(params), opts)
         return ElicitResult.model_validate(result)
 
     async def list_roots(self: Outbound, opts: CallOptions | None = None) -> ListRootsResult:
@@ -158,7 +158,7 @@ class PeerMixin:
             MCPError: The peer responded with an error.
             NoBackChannelError: No back-channel for server-initiated requests.
         """
-        result = await self.send_request("roots/list", None, opts)
+        result = await self.send_raw_request("roots/list", None, opts)
         return ListRootsResult.model_validate(result)
 
     async def ping(self: Outbound, opts: CallOptions | None = None) -> None:
@@ -168,7 +168,7 @@ class PeerMixin:
             MCPError: The peer responded with an error.
             NoBackChannelError: No back-channel for server-initiated requests.
         """
-        await self.send_request("ping", None, opts)
+        await self.send_raw_request("ping", None, opts)
 
 
 class Peer(PeerMixin):
@@ -182,13 +182,13 @@ class Peer(PeerMixin):
     def __init__(self, outbound: Outbound) -> None:
         self._outbound = outbound
 
-    async def send_request(
+    async def send_raw_request(
         self,
         method: str,
         params: Mapping[str, Any] | None,
         opts: CallOptions | None = None,
     ) -> dict[str, Any]:
-        return await self._outbound.send_request(method, params, opts)
+        return await self._outbound.send_raw_request(method, params, opts)
 
     async def notify(self, method: str, params: Mapping[str, Any] | None) -> None:
         await self._outbound.notify(method, params)

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -1,0 +1,184 @@
+"""Tests for `Connection`.
+
+`Connection` wraps an `Outbound` (the standalone stream). Its `notify` is
+best-effort (never raises); `send_raw_request` is gated on
+``has_standalone_channel``. Tested with a stub `Outbound` so we can assert wire
+shape and inject failures.
+"""
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import anyio
+import pytest
+
+from mcp.server.connection import Connection
+from mcp.shared.dispatcher import CallOptions
+from mcp.shared.exceptions import NoBackChannelError
+from mcp.types import (
+    ClientCapabilities,
+    ElicitationCapability,
+    EmptyResult,
+    ListRootsRequest,
+    ListRootsResult,
+    PingRequest,
+    RootsCapability,
+    SamplingCapability,
+)
+
+
+class StubOutbound:
+    def __init__(
+        self, *, result: dict[str, Any] | None = None, raise_on_send: type[BaseException] | None = None
+    ) -> None:
+        self.requests: list[tuple[str, Mapping[str, Any] | None]] = []
+        self.notifications: list[tuple[str, Mapping[str, Any] | None]] = []
+        self._result = result if result is not None else {}
+        self._raise_on_send = raise_on_send
+
+    async def send_raw_request(
+        self, method: str, params: Mapping[str, Any] | None, opts: CallOptions | None = None
+    ) -> dict[str, Any]:
+        self.requests.append((method, params))
+        return self._result
+
+    async def notify(self, method: str, params: Mapping[str, Any] | None) -> None:
+        if self._raise_on_send is not None:
+            raise self._raise_on_send()
+        self.notifications.append((method, params))
+
+
+@pytest.mark.anyio
+async def test_connection_notify_forwards_to_outbound():
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=True)
+    await conn.notify("notifications/message", {"level": "info", "data": "hi"})
+    assert out.notifications == [("notifications/message", {"level": "info", "data": "hi"})]
+
+
+@pytest.mark.anyio
+async def test_connection_notify_swallows_broken_stream_and_debug_logs(caplog: pytest.LogCaptureFixture):
+    caplog.set_level(logging.DEBUG, logger="mcp.server.connection")
+    out = StubOutbound(raise_on_send=anyio.BrokenResourceError)
+    conn = Connection(out, has_standalone_channel=True)
+    await conn.notify("notifications/message", {"data": "x"})  # must not raise
+    assert "stream closed" in caplog.text.lower()
+
+
+@pytest.mark.anyio
+async def test_connection_notify_drops_when_no_standalone_channel(caplog: pytest.LogCaptureFixture):
+    caplog.set_level(logging.DEBUG, logger="mcp.server.connection")
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=False)
+    await conn.notify("notifications/message", {"data": "x"})  # must not raise
+    assert out.notifications == []
+    assert "no standalone channel" in caplog.text.lower()
+
+
+@pytest.mark.anyio
+async def test_connection_send_raw_request_raises_nobackchannel_when_no_standalone_channel():
+    conn = Connection(StubOutbound(), has_standalone_channel=False)
+    with pytest.raises(NoBackChannelError):
+        await conn.send_raw_request("ping", None)
+
+
+@pytest.mark.anyio
+async def test_connection_send_raw_request_forwards_when_standalone_channel_present():
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=True)
+    result = await conn.send_raw_request("ping", None)
+    assert out.requests == [("ping", None)]
+    assert result == {}
+
+
+@pytest.mark.anyio
+async def test_connection_send_request_with_spec_type_infers_result_type():
+    out = StubOutbound(result={"roots": [{"uri": "file:///ws"}]})
+    conn = Connection(out, has_standalone_channel=True)
+    result = await conn.send_request(ListRootsRequest())
+    method, _ = out.requests[0]
+    assert method == "roots/list"
+    assert isinstance(result, ListRootsResult)
+    assert str(result.roots[0].uri) == "file:///ws"
+
+
+@pytest.mark.anyio
+async def test_connection_send_request_with_result_type_kwarg_validates_custom_type():
+    out = StubOutbound(result={})
+    conn = Connection(out, has_standalone_channel=True)
+    result = await conn.send_request(PingRequest(), result_type=EmptyResult)
+    assert isinstance(result, EmptyResult)
+
+
+@pytest.mark.anyio
+async def test_connection_ping_sends_ping_on_standalone():
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=True)
+    await conn.ping()
+    assert out.requests == [("ping", None)]
+
+
+@pytest.mark.anyio
+async def test_connection_log_sends_logging_message_notification():
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=True)
+    await conn.log("info", {"k": "v"}, logger="my.logger")
+    method, params = out.notifications[0]
+    assert method == "notifications/message"
+    assert params is not None
+    assert params["level"] == "info"
+    assert params["data"] == {"k": "v"}
+    assert params["logger"] == "my.logger"
+
+
+@pytest.mark.anyio
+async def test_connection_log_with_meta_includes_meta_in_params():
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=True)
+    await conn.log("info", "x", meta={"traceId": "abc"})
+    _, params = out.notifications[0]
+    assert params is not None
+    assert params["_meta"] == {"traceId": "abc"}
+
+
+@pytest.mark.anyio
+async def test_connection_list_changed_notifications_send_correct_methods():
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=True)
+    await conn.send_tool_list_changed()
+    await conn.send_prompt_list_changed()
+    await conn.send_resource_list_changed()
+    await conn.send_resource_updated("file:///workspace/a.txt")
+    methods = [m for m, _ in out.notifications]
+    assert methods == [
+        "notifications/tools/list_changed",
+        "notifications/prompts/list_changed",
+        "notifications/resources/list_changed",
+        "notifications/resources/updated",
+    ]
+    assert out.notifications[-1][1] == {"uri": "file:///workspace/a.txt"}
+
+
+@pytest.mark.anyio
+async def test_connection_send_tool_list_changed_with_meta_includes_meta_only_params():
+    out = StubOutbound()
+    conn = Connection(out, has_standalone_channel=True)
+    await conn.send_tool_list_changed(meta={"k": 1})
+    assert out.notifications == [("notifications/tools/list_changed", {"_meta": {"k": 1}})]
+
+
+def test_connection_check_capability_false_before_initialized():
+    conn = Connection(StubOutbound(), has_standalone_channel=True)
+    assert conn.check_capability(ClientCapabilities(sampling=SamplingCapability())) is False
+
+
+def test_connection_check_capability_true_when_client_declares_it():
+    conn = Connection(StubOutbound(), has_standalone_channel=True)
+    conn.client_capabilities = ClientCapabilities(
+        sampling=SamplingCapability(), roots=RootsCapability(list_changed=True)
+    )
+    conn.initialized.set()
+    assert conn.check_capability(ClientCapabilities(sampling=SamplingCapability())) is True
+    assert conn.check_capability(ClientCapabilities(roots=RootsCapability(list_changed=True))) is True
+    assert conn.check_capability(ClientCapabilities(elicitation=ElicitationCapability())) is False

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -173,6 +173,27 @@ def test_connection_check_capability_false_before_initialized():
     assert conn.check_capability(ClientCapabilities(sampling=SamplingCapability())) is False
 
 
+@pytest.mark.parametrize(
+    ("have", "want", "expected"),
+    [
+        (ClientCapabilities(roots=None), ClientCapabilities(roots=RootsCapability()), False),
+        (
+            ClientCapabilities(roots=RootsCapability(list_changed=False)),
+            ClientCapabilities(roots=RootsCapability(list_changed=True)),
+            False,
+        ),
+        (ClientCapabilities(sampling=None), ClientCapabilities(sampling=SamplingCapability()), False),
+        (ClientCapabilities(experimental=None), ClientCapabilities(experimental={"a": {}}), False),
+        (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"b": {}}), False),
+        (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"a": {}}), True),
+    ],
+)
+def test_check_capability_per_field_branches(have: ClientCapabilities, want: ClientCapabilities, expected: bool):
+    conn = Connection(StubOutbound(), has_standalone_channel=True)
+    conn.client_capabilities = have
+    assert conn.check_capability(want) is expected
+
+
 def test_connection_check_capability_true_when_client_declares_it():
     conn = Connection(StubOutbound(), has_standalone_channel=True)
     conn.client_capabilities = ClientCapabilities(

--- a/tests/server/test_server_context.py
+++ b/tests/server/test_server_context.py
@@ -1,0 +1,131 @@
+"""Tests for the server-side `Context`.
+
+`Context` composes `BaseContext` (forwarding to a `DispatchContext`) with
+`PeerMixin` (typed sample/elicit/roots/ping) plus `lifespan` and `connection`.
+End-to-end tested over `DirectDispatcher`.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import anyio
+import pytest
+
+from mcp.server.connection import Connection
+from mcp.server.context import Context
+from mcp.shared.dispatcher import DispatchContext
+from mcp.shared.transport_context import TransportContext
+from mcp.types import CreateMessageResult, ListRootsRequest, ListRootsResult, SamplingMessage, TextContent
+
+from ..shared.conftest import direct_pair
+from ..shared.test_dispatcher import Recorder, echo_handlers, running_pair
+
+DCtx = DispatchContext[TransportContext]
+
+
+@dataclass
+class _Lifespan:
+    name: str
+
+
+@pytest.mark.anyio
+async def test_context_exposes_lifespan_and_connection_and_forwards_base_context():
+    captured: list[Context[_Lifespan, TransportContext]] = []
+    conn = Connection.__new__(Connection)  # placeholder until running_pair gives us the dispatcher
+
+    async def server_on_request(dctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        ctx: Context[_Lifespan, TransportContext] = Context(dctx, lifespan=_Lifespan("app"), connection=conn)
+        captured.append(ctx)
+        return {}
+
+    async with running_pair(direct_pair, server_on_request=server_on_request) as (client, server, *_):
+        # Now we have the server dispatcher; build the real Connection bound to it.
+        conn.__init__(server, has_standalone_channel=True)
+        with anyio.fail_after(5):
+            await client.send_raw_request("t", None)
+    ctx = captured[0]
+    assert ctx.lifespan.name == "app"
+    assert ctx.connection is conn
+    assert ctx.transport.kind == "direct"
+    assert ctx.can_send_request is True
+
+
+@pytest.mark.anyio
+async def test_context_sample_round_trips_via_peer_mixin_on_base_context_outbound():
+    crec = Recorder()
+
+    async def client_on_request(dctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        crec.requests.append((method, params))
+        return {"role": "assistant", "content": {"type": "text", "text": "ok"}, "model": "m"}
+
+    results: list[CreateMessageResult] = []
+
+    async def server_on_request(dctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        ctx: Context[_Lifespan, TransportContext] = Context(
+            dctx, lifespan=_Lifespan("app"), connection=Connection(dctx, has_standalone_channel=True)
+        )
+        results.append(
+            await ctx.sample(
+                [SamplingMessage(role="user", content=TextContent(type="text", text="hi"))],
+                max_tokens=5,
+            )
+        )
+        return {}
+
+    async with running_pair(
+        direct_pair,
+        server_on_request=server_on_request,
+        client_on_request=client_on_request,
+    ) as (client, *_):
+        with anyio.fail_after(5):
+            await client.send_raw_request("tools/call", None)
+    assert crec.requests[0][0] == "sampling/createMessage"
+    assert isinstance(results[0], CreateMessageResult)
+
+
+@pytest.mark.anyio
+async def test_context_send_request_with_spec_type_infers_result_via_typed_mixin():
+    async def client_on_request(dctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        return {"roots": []}
+
+    results: list[ListRootsResult] = []
+
+    async def server_on_request(dctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        ctx: Context[_Lifespan, TransportContext] = Context(
+            dctx, lifespan=_Lifespan("app"), connection=Connection(dctx, has_standalone_channel=True)
+        )
+        results.append(await ctx.send_request(ListRootsRequest()))
+        return {}
+
+    async with running_pair(direct_pair, server_on_request=server_on_request, client_on_request=client_on_request) as (
+        client,
+        *_,
+    ):
+        with anyio.fail_after(5):
+            await client.send_raw_request("t", None)
+    assert isinstance(results[0], ListRootsResult)
+
+
+@pytest.mark.anyio
+async def test_context_log_sends_request_scoped_message_notification():
+    crec = Recorder()
+    _, c_notify = echo_handlers(crec)
+
+    async def server_on_request(dctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        ctx: Context[_Lifespan, TransportContext] = Context(
+            dctx, lifespan=_Lifespan("app"), connection=Connection(dctx, has_standalone_channel=True)
+        )
+        await ctx.log("debug", "hello")
+        return {}
+
+    async with running_pair(direct_pair, server_on_request=server_on_request, client_on_notify=c_notify) as (
+        client,
+        *_,
+    ):
+        with anyio.fail_after(5):
+            await client.send_raw_request("t", None)
+            await crec.notified.wait()
+    method, params = crec.notifications[0]
+    assert method == "notifications/message"
+    assert params is not None and params["level"] == "debug" and params["data"] == "hello"

--- a/tests/server/test_server_context.py
+++ b/tests/server/test_server_context.py
@@ -44,11 +44,11 @@ async def test_context_exposes_lifespan_and_connection_and_forwards_base_context
         conn.__init__(server, has_standalone_channel=True)
         with anyio.fail_after(5):
             await client.send_raw_request("t", None)
-    ctx = captured[0]
-    assert ctx.lifespan.name == "app"
-    assert ctx.connection is conn
-    assert ctx.transport.kind == "direct"
-    assert ctx.can_send_request is True
+        ctx = captured[0]
+        assert ctx.lifespan.name == "app"
+        assert ctx.connection is conn
+        assert ctx.transport.kind == "direct"
+        assert ctx.can_send_request is True
 
 
 @pytest.mark.anyio
@@ -80,8 +80,8 @@ async def test_context_sample_round_trips_via_peer_mixin_on_base_context_outboun
     ) as (client, *_):
         with anyio.fail_after(5):
             await client.send_raw_request("tools/call", None)
-    assert crec.requests[0][0] == "sampling/createMessage"
-    assert isinstance(results[0], CreateMessageResult)
+        assert crec.requests[0][0] == "sampling/createMessage"
+        assert isinstance(results[0], CreateMessageResult)
 
 
 @pytest.mark.anyio
@@ -104,7 +104,7 @@ async def test_context_send_request_with_spec_type_infers_result_via_typed_mixin
     ):
         with anyio.fail_after(5):
             await client.send_raw_request("t", None)
-    assert isinstance(results[0], ListRootsResult)
+        assert isinstance(results[0], ListRootsResult)
 
 
 @pytest.mark.anyio
@@ -126,9 +126,9 @@ async def test_context_log_sends_request_scoped_message_notification():
         with anyio.fail_after(5):
             await client.send_raw_request("t", None)
             await crec.notified.wait()
-    method, params = crec.notifications[0]
-    assert method == "notifications/message"
-    assert params is not None and params["level"] == "debug" and params["data"] == "hello"
+        method, params = crec.notifications[0]
+        assert method == "notifications/message"
+        assert params is not None and params["level"] == "debug" and params["data"] == "hello"
 
 
 @pytest.mark.anyio
@@ -150,7 +150,7 @@ async def test_context_log_includes_logger_and_meta_when_supplied():
         with anyio.fail_after(5):
             await client.send_raw_request("t", None)
             await crec.notified.wait()
-    _, params = crec.notifications[0]
-    assert params is not None
-    assert params["logger"] == "my.log"
-    assert params["_meta"] == {"traceId": "t"}
+        _, params = crec.notifications[0]
+        assert params is not None
+        assert params["logger"] == "my.log"
+        assert params["_meta"] == {"traceId": "t"}

--- a/tests/server/test_server_context.py
+++ b/tests/server/test_server_context.py
@@ -129,3 +129,28 @@ async def test_context_log_sends_request_scoped_message_notification():
     method, params = crec.notifications[0]
     assert method == "notifications/message"
     assert params is not None and params["level"] == "debug" and params["data"] == "hello"
+
+
+@pytest.mark.anyio
+async def test_context_log_includes_logger_and_meta_when_supplied():
+    crec = Recorder()
+    _, c_notify = echo_handlers(crec)
+
+    async def server_on_request(dctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        ctx: Context[_Lifespan, TransportContext] = Context(
+            dctx, lifespan=_Lifespan("app"), connection=Connection(dctx, has_standalone_channel=True)
+        )
+        await ctx.log("info", "x", logger="my.log", meta={"traceId": "t"})
+        return {}
+
+    async with running_pair(direct_pair, server_on_request=server_on_request, client_on_notify=c_notify) as (
+        client,
+        *_,
+    ):
+        with anyio.fail_after(5):
+            await client.send_raw_request("t", None)
+            await crec.notified.wait()
+    _, params = crec.notifications[0]
+    assert params is not None
+    assert params["logger"] == "my.log"
+    assert params["_meta"] == {"traceId": "t"}

--- a/tests/shared/test_context.py
+++ b/tests/shared/test_context.py
@@ -1,7 +1,7 @@
 """Tests for `BaseContext`.
 
 `BaseContext` is composition over a `DispatchContext` — it forwards
-``transport``/``cancel_requested``/``send_request``/``notify``/``progress``
+``transport``/``cancel_requested``/``send_raw_request``/``notify``/``progress``
 and adds ``meta``. It must satisfy `Outbound` so `PeerMixin` works on it.
 """
 
@@ -33,7 +33,7 @@ async def test_base_context_forwards_transport_and_cancel_requested():
 
     async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
         with anyio.fail_after(5):
-            await client.send_request("t", None)
+            await client.send_raw_request("t", None)
     bctx = captured[0]
     assert bctx.transport.kind == "direct"
     assert isinstance(bctx.cancel_requested, anyio.Event)
@@ -42,13 +42,13 @@ async def test_base_context_forwards_transport_and_cancel_requested():
 
 
 @pytest.mark.anyio
-async def test_base_context_send_request_and_notify_forward_to_dispatch_context():
+async def test_base_context_send_raw_request_and_notify_forward_to_dispatch_context():
     crec = Recorder()
     c_req, c_notify = echo_handlers(crec)
 
     async def server_on_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
         bctx = BaseContext(ctx)
-        sample = await bctx.send_request("sampling/createMessage", {"x": 1})
+        sample = await bctx.send_raw_request("sampling/createMessage", {"x": 1})
         await bctx.notify("notifications/message", {"level": "info"})
         return {"sample": sample}
 
@@ -59,7 +59,7 @@ async def test_base_context_send_request_and_notify_forward_to_dispatch_context(
         client_on_notify=c_notify,
     ) as (client, *_):
         with anyio.fail_after(5):
-            result = await client.send_request("tools/call", None)
+            result = await client.send_raw_request("tools/call", None)
             await crec.notified.wait()
     assert crec.requests == [("sampling/createMessage", {"x": 1})]
     assert crec.notifications == [("notifications/message", {"level": "info"})]
@@ -80,7 +80,7 @@ async def test_base_context_report_progress_invokes_caller_on_progress():
 
     async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
         with anyio.fail_after(5):
-            await client.send_request("t", None, {"on_progress": on_progress})
+            await client.send_raw_request("t", None, {"on_progress": on_progress})
     assert received == [(0.5, 1.0, "halfway")]
 
 
@@ -99,7 +99,7 @@ async def test_base_context_satisfies_outbound_so_peer_mixin_works():
         direct_pair, server_on_request=server_on_request, client_on_request=c_req, client_on_notify=c_notify
     ) as (client, *_):
         with anyio.fail_after(5):
-            await client.send_request("t", None)
+            await client.send_raw_request("t", None)
     assert crec.requests == [("ping", None)]
 
 
@@ -112,4 +112,4 @@ async def test_base_context_meta_holds_supplied_request_params_meta():
 
     async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
         with anyio.fail_after(5):
-            await client.send_request("t", None)
+            await client.send_raw_request("t", None)

--- a/tests/shared/test_context.py
+++ b/tests/shared/test_context.py
@@ -34,11 +34,11 @@ async def test_base_context_forwards_transport_and_cancel_requested():
     async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
         with anyio.fail_after(5):
             await client.send_raw_request("t", None)
-    bctx = captured[0]
-    assert bctx.transport.kind == "direct"
-    assert isinstance(bctx.cancel_requested, anyio.Event)
-    assert bctx.can_send_request is True
-    assert bctx.meta is None
+        bctx = captured[0]
+        assert bctx.transport.kind == "direct"
+        assert isinstance(bctx.cancel_requested, anyio.Event)
+        assert bctx.can_send_request is True
+        assert bctx.meta is None
 
 
 @pytest.mark.anyio
@@ -61,9 +61,9 @@ async def test_base_context_send_raw_request_and_notify_forward_to_dispatch_cont
         with anyio.fail_after(5):
             result = await client.send_raw_request("tools/call", None)
             await crec.notified.wait()
-    assert crec.requests == [("sampling/createMessage", {"x": 1})]
-    assert crec.notifications == [("notifications/message", {"level": "info"})]
-    assert result["sample"] == {"echoed": "sampling/createMessage", "params": {"x": 1}}
+        assert crec.requests == [("sampling/createMessage", {"x": 1})]
+        assert crec.notifications == [("notifications/message", {"level": "info"})]
+        assert result["sample"] == {"echoed": "sampling/createMessage", "params": {"x": 1}}
 
 
 @pytest.mark.anyio
@@ -81,7 +81,7 @@ async def test_base_context_report_progress_invokes_caller_on_progress():
     async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
         with anyio.fail_after(5):
             await client.send_raw_request("t", None, {"on_progress": on_progress})
-    assert received == [(0.5, 1.0, "halfway")]
+        assert received == [(0.5, 1.0, "halfway")]
 
 
 @pytest.mark.anyio
@@ -100,7 +100,7 @@ async def test_base_context_satisfies_outbound_so_peer_mixin_works():
     ) as (client, *_):
         with anyio.fail_after(5):
             await client.send_raw_request("t", None)
-    assert crec.requests == [("ping", None)]
+        assert crec.requests == [("ping", None)]
 
 
 @pytest.mark.anyio

--- a/tests/shared/test_context.py
+++ b/tests/shared/test_context.py
@@ -1,0 +1,115 @@
+"""Tests for `BaseContext`.
+
+`BaseContext` is composition over a `DispatchContext` — it forwards
+``transport``/``cancel_requested``/``send_request``/``notify``/``progress``
+and adds ``meta``. It must satisfy `Outbound` so `PeerMixin` works on it.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+import anyio
+import pytest
+
+from mcp.shared.context import BaseContext
+from mcp.shared.dispatcher import DispatchContext
+from mcp.shared.peer import Peer
+from mcp.shared.transport_context import TransportContext
+
+from .conftest import direct_pair
+from .test_dispatcher import Recorder, echo_handlers, running_pair
+
+DCtx = DispatchContext[TransportContext]
+
+
+@pytest.mark.anyio
+async def test_base_context_forwards_transport_and_cancel_requested():
+    captured: list[BaseContext[TransportContext]] = []
+
+    async def server_on_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        bctx = BaseContext(ctx)
+        captured.append(bctx)
+        return {}
+
+    async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
+        with anyio.fail_after(5):
+            await client.send_request("t", None)
+    bctx = captured[0]
+    assert bctx.transport.kind == "direct"
+    assert isinstance(bctx.cancel_requested, anyio.Event)
+    assert bctx.can_send_request is True
+    assert bctx.meta is None
+
+
+@pytest.mark.anyio
+async def test_base_context_send_request_and_notify_forward_to_dispatch_context():
+    crec = Recorder()
+    c_req, c_notify = echo_handlers(crec)
+
+    async def server_on_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        bctx = BaseContext(ctx)
+        sample = await bctx.send_request("sampling/createMessage", {"x": 1})
+        await bctx.notify("notifications/message", {"level": "info"})
+        return {"sample": sample}
+
+    async with running_pair(
+        direct_pair,
+        server_on_request=server_on_request,
+        client_on_request=c_req,
+        client_on_notify=c_notify,
+    ) as (client, *_):
+        with anyio.fail_after(5):
+            result = await client.send_request("tools/call", None)
+            await crec.notified.wait()
+    assert crec.requests == [("sampling/createMessage", {"x": 1})]
+    assert crec.notifications == [("notifications/message", {"level": "info"})]
+    assert result["sample"] == {"echoed": "sampling/createMessage", "params": {"x": 1}}
+
+
+@pytest.mark.anyio
+async def test_base_context_report_progress_invokes_caller_on_progress():
+    received: list[tuple[float, float | None, str | None]] = []
+
+    async def on_progress(progress: float, total: float | None, message: str | None) -> None:
+        received.append((progress, total, message))
+
+    async def server_on_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        bctx = BaseContext(ctx)
+        await bctx.report_progress(0.5, total=1.0, message="halfway")
+        return {}
+
+    async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
+        with anyio.fail_after(5):
+            await client.send_request("t", None, {"on_progress": on_progress})
+    assert received == [(0.5, 1.0, "halfway")]
+
+
+@pytest.mark.anyio
+async def test_base_context_satisfies_outbound_so_peer_mixin_works():
+    """Wrapping a BaseContext in Peer proves it satisfies Outbound structurally."""
+
+    async def server_on_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        bctx = BaseContext(ctx)
+        await Peer(bctx).ping()
+        return {}
+
+    crec = Recorder()
+    c_req, c_notify = echo_handlers(crec)
+    async with running_pair(
+        direct_pair, server_on_request=server_on_request, client_on_request=c_req, client_on_notify=c_notify
+    ) as (client, *_):
+        with anyio.fail_after(5):
+            await client.send_request("t", None)
+    assert crec.requests == [("ping", None)]
+
+
+@pytest.mark.anyio
+async def test_base_context_meta_holds_supplied_request_params_meta():
+    async def server_on_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        bctx = BaseContext(ctx, meta={"progressToken": "abc"})
+        assert bctx.meta is not None and bctx.meta.get("progressToken") == "abc"
+        return {}
+
+    async with running_pair(direct_pair, server_on_request=server_on_request) as (client, *_):
+        with anyio.fail_after(5):
+            await client.send_request("t", None)

--- a/tests/shared/test_peer.py
+++ b/tests/shared/test_peer.py
@@ -136,6 +136,23 @@ def test_dump_params_merges_meta_over_model_meta():
 
 
 @pytest.mark.anyio
+async def test_peer_notify_forwards_to_wrapped_outbound():
+    sent: list[tuple[str, Mapping[str, Any] | None]] = []
+
+    class _Out:
+        async def send_raw_request(
+            self, method: str, params: Mapping[str, Any] | None, opts: Any = None
+        ) -> dict[str, Any]:
+            raise NotImplementedError
+
+        async def notify(self, method: str, params: Mapping[str, Any] | None) -> None:
+            sent.append((method, params))
+
+    await Peer(_Out()).notify("n", {"x": 1})
+    assert sent == [("n", {"x": 1})]
+
+
+@pytest.mark.anyio
 async def test_peer_ping_sends_ping_and_returns_none():
     rec = _Recorder({})
     async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):

--- a/tests/shared/test_peer.py
+++ b/tests/shared/test_peer.py
@@ -1,0 +1,128 @@
+"""Tests for `PeerMixin` and `Peer`.
+
+Each PeerMixin method is tested by wrapping a `DirectDispatcher` in `Peer`,
+calling the typed method, and asserting (a) the right method+params went out
+and (b) the return value is the typed result model.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+import anyio
+import pytest
+
+from mcp.shared.dispatcher import DispatchContext
+from mcp.shared.peer import Peer
+from mcp.shared.transport_context import TransportContext
+from mcp.types import (
+    CreateMessageResult,
+    CreateMessageResultWithTools,
+    ElicitResult,
+    ListRootsResult,
+    SamplingMessage,
+    TextContent,
+    Tool,
+)
+
+from .conftest import direct_pair
+from .test_dispatcher import running_pair
+
+DCtx = DispatchContext[TransportContext]
+
+
+class _Recorder:
+    def __init__(self, result: dict[str, Any]) -> None:
+        self.result = result
+        self.seen: list[tuple[str, Mapping[str, Any] | None]] = []
+
+    async def on_request(self, ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        self.seen.append((method, params))
+        return self.result
+
+
+@pytest.mark.anyio
+async def test_peer_sample_sends_create_message_and_returns_typed_result():
+    rec = _Recorder({"role": "assistant", "content": {"type": "text", "text": "hi"}, "model": "m"})
+    async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):
+        peer = Peer(client)
+        with anyio.fail_after(5):
+            result = await peer.sample(
+                [SamplingMessage(role="user", content=TextContent(type="text", text="hello"))],
+                max_tokens=10,
+            )
+    method, params = rec.seen[0]
+    assert method == "sampling/createMessage"
+    assert params is not None and params["maxTokens"] == 10
+    assert isinstance(result, CreateMessageResult)
+    assert result.model == "m"
+
+
+@pytest.mark.anyio
+async def test_peer_sample_with_tools_returns_with_tools_result():
+    rec = _Recorder({"role": "assistant", "content": [{"type": "text", "text": "x"}], "model": "m"})
+    async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):
+        peer = Peer(client)
+        with anyio.fail_after(5):
+            result = await peer.sample(
+                [SamplingMessage(role="user", content=TextContent(type="text", text="q"))],
+                max_tokens=5,
+                tools=[Tool(name="t", input_schema={"type": "object"})],
+            )
+    method, params = rec.seen[0]
+    assert method == "sampling/createMessage"
+    assert params is not None and params["tools"][0]["name"] == "t"
+    assert isinstance(result, CreateMessageResultWithTools)
+
+
+@pytest.mark.anyio
+async def test_peer_elicit_form_sends_elicitation_create_with_form_params():
+    rec = _Recorder({"action": "accept", "content": {"name": "Max"}})
+    async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):
+        peer = Peer(client)
+        with anyio.fail_after(5):
+            result = await peer.elicit_form("Your name?", requested_schema={"type": "object", "properties": {}})
+    method, params = rec.seen[0]
+    assert method == "elicitation/create"
+    assert params is not None and params["mode"] == "form"
+    assert params["message"] == "Your name?"
+    assert isinstance(result, ElicitResult)
+
+
+@pytest.mark.anyio
+async def test_peer_elicit_url_sends_elicitation_create_with_url_params():
+    rec = _Recorder({"action": "accept"})
+    async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):
+        peer = Peer(client)
+        with anyio.fail_after(5):
+            result = await peer.elicit_url("Auth needed", url="https://example.com/auth", elicitation_id="e1")
+    method, params = rec.seen[0]
+    assert method == "elicitation/create"
+    assert params is not None and params["mode"] == "url"
+    assert params["url"] == "https://example.com/auth"
+    assert isinstance(result, ElicitResult)
+
+
+@pytest.mark.anyio
+async def test_peer_list_roots_sends_roots_list_and_returns_typed_result():
+    rec = _Recorder({"roots": [{"uri": "file:///workspace"}]})
+    async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):
+        peer = Peer(client)
+        with anyio.fail_after(5):
+            result = await peer.list_roots()
+    method, _ = rec.seen[0]
+    assert method == "roots/list"
+    assert isinstance(result, ListRootsResult)
+    assert len(result.roots) == 1
+    assert str(result.roots[0].uri) == "file:///workspace"
+
+
+@pytest.mark.anyio
+async def test_peer_ping_sends_ping_and_returns_none():
+    rec = _Recorder({})
+    async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):
+        peer = Peer(client)
+        with anyio.fail_after(5):
+            result = await peer.ping()
+    method, _ = rec.seen[0]
+    assert method == "ping"
+    assert result is None

--- a/tests/shared/test_peer.py
+++ b/tests/shared/test_peer.py
@@ -50,11 +50,11 @@ async def test_peer_sample_sends_create_message_and_returns_typed_result():
                 [SamplingMessage(role="user", content=TextContent(type="text", text="hello"))],
                 max_tokens=10,
             )
-    method, params = rec.seen[0]
-    assert method == "sampling/createMessage"
-    assert params is not None and params["maxTokens"] == 10
-    assert isinstance(result, CreateMessageResult)
-    assert result.model == "m"
+        method, params = rec.seen[0]
+        assert method == "sampling/createMessage"
+        assert params is not None and params["maxTokens"] == 10
+        assert isinstance(result, CreateMessageResult)
+        assert result.model == "m"
 
 
 @pytest.mark.anyio
@@ -68,10 +68,10 @@ async def test_peer_sample_with_tools_returns_with_tools_result():
                 max_tokens=5,
                 tools=[Tool(name="t", input_schema={"type": "object"})],
             )
-    method, params = rec.seen[0]
-    assert method == "sampling/createMessage"
-    assert params is not None and params["tools"][0]["name"] == "t"
-    assert isinstance(result, CreateMessageResultWithTools)
+        method, params = rec.seen[0]
+        assert method == "sampling/createMessage"
+        assert params is not None and params["tools"][0]["name"] == "t"
+        assert isinstance(result, CreateMessageResultWithTools)
 
 
 @pytest.mark.anyio
@@ -81,11 +81,11 @@ async def test_peer_elicit_form_sends_elicitation_create_with_form_params():
         peer = Peer(client)
         with anyio.fail_after(5):
             result = await peer.elicit_form("Your name?", requested_schema={"type": "object", "properties": {}})
-    method, params = rec.seen[0]
-    assert method == "elicitation/create"
-    assert params is not None and params["mode"] == "form"
-    assert params["message"] == "Your name?"
-    assert isinstance(result, ElicitResult)
+        method, params = rec.seen[0]
+        assert method == "elicitation/create"
+        assert params is not None and params["mode"] == "form"
+        assert params["message"] == "Your name?"
+        assert isinstance(result, ElicitResult)
 
 
 @pytest.mark.anyio
@@ -95,11 +95,11 @@ async def test_peer_elicit_url_sends_elicitation_create_with_url_params():
         peer = Peer(client)
         with anyio.fail_after(5):
             result = await peer.elicit_url("Auth needed", url="https://example.com/auth", elicitation_id="e1")
-    method, params = rec.seen[0]
-    assert method == "elicitation/create"
-    assert params is not None and params["mode"] == "url"
-    assert params["url"] == "https://example.com/auth"
-    assert isinstance(result, ElicitResult)
+        method, params = rec.seen[0]
+        assert method == "elicitation/create"
+        assert params is not None and params["mode"] == "url"
+        assert params["url"] == "https://example.com/auth"
+        assert isinstance(result, ElicitResult)
 
 
 @pytest.mark.anyio
@@ -109,11 +109,11 @@ async def test_peer_list_roots_sends_roots_list_and_returns_typed_result():
         peer = Peer(client)
         with anyio.fail_after(5):
             result = await peer.list_roots()
-    method, _ = rec.seen[0]
-    assert method == "roots/list"
-    assert isinstance(result, ListRootsResult)
-    assert len(result.roots) == 1
-    assert str(result.roots[0].uri) == "file:///workspace"
+        method, _ = rec.seen[0]
+        assert method == "roots/list"
+        assert isinstance(result, ListRootsResult)
+        assert len(result.roots) == 1
+        assert str(result.roots[0].uri) == "file:///workspace"
 
 
 @pytest.mark.anyio
@@ -123,9 +123,9 @@ async def test_peer_list_roots_with_meta_sends_meta_in_params():
         peer = Peer(client)
         with anyio.fail_after(5):
             await peer.list_roots(meta={"traceId": "t1"})
-    method, params = rec.seen[0]
-    assert method == "roots/list"
-    assert params == {"_meta": {"traceId": "t1"}}
+        method, params = rec.seen[0]
+        assert method == "roots/list"
+        assert params == {"_meta": {"traceId": "t1"}}
 
 
 def test_dump_params_merges_meta_over_model_meta():
@@ -159,6 +159,6 @@ async def test_peer_ping_sends_ping_and_returns_none():
         peer = Peer(client)
         with anyio.fail_after(5):
             result = await peer.ping()
-    method, _ = rec.seen[0]
-    assert method == "ping"
-    assert result is None
+        method, _ = rec.seen[0]
+        assert method == "ping"
+        assert result is None

--- a/tests/shared/test_peer.py
+++ b/tests/shared/test_peer.py
@@ -12,7 +12,7 @@ import anyio
 import pytest
 
 from mcp.shared.dispatcher import DispatchContext
-from mcp.shared.peer import Peer
+from mcp.shared.peer import Peer, dump_params
 from mcp.shared.transport_context import TransportContext
 from mcp.types import (
     CreateMessageResult,
@@ -114,6 +114,25 @@ async def test_peer_list_roots_sends_roots_list_and_returns_typed_result():
     assert isinstance(result, ListRootsResult)
     assert len(result.roots) == 1
     assert str(result.roots[0].uri) == "file:///workspace"
+
+
+@pytest.mark.anyio
+async def test_peer_list_roots_with_meta_sends_meta_in_params():
+    rec = _Recorder({"roots": []})
+    async with running_pair(direct_pair, server_on_request=rec.on_request) as (client, *_):
+        peer = Peer(client)
+        with anyio.fail_after(5):
+            await peer.list_roots(meta={"traceId": "t1"})
+    method, params = rec.seen[0]
+    assert method == "roots/list"
+    assert params == {"_meta": {"traceId": "t1"}}
+
+
+def test_dump_params_merges_meta_over_model_meta():
+    out = dump_params(None, None)
+    assert out is None
+    out = dump_params(None, {"k": 1})
+    assert out == {"_meta": {"k": 1}}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Design doc: https://gist.github.com/maxisbey/1e14e741d774acf52b80e69db292c5d7

Stacked on #2458. The MCP-type layer that sits above the dispatcher: typed request sugar, the per-request `Context`, and the per-connection `Connection`.

## Motivation and Context

`Outbound` (from #2452) is the raw `send_raw_request(method, params) -> dict` channel. This PR builds the typed surface on top:

- **`PeerMixin`** (`shared/peer.py`) — kwarg-style typed methods (`sample`, `elicit_form`, `elicit_url`, `list_roots`, `ping`) defined once. Each constrains `self: Outbound` so any class with `send_raw_request`/`notify` gets them. `Peer` is a standalone wrapper for bare dispatchers.
- **`BaseContext[TT]`** (`shared/context.py`) — composition over a `DispatchContext`. Forwards `transport`/`cancel_requested`/`send_raw_request`/`notify`/`report_progress`; adds `meta`. Satisfies `Outbound`.
- **`TypedServerRequestMixin`** (`server/_typed_request.py`) — typed `send_request(req) -> Result` with per-spec overloads (`CreateMessageRequest`/`ElicitRequest`/`ListRootsRequest`/`PingRequest`) plus a `result_type=` fallback for custom requests.
- **`Connection`** (`server/connection.py`) — per-client state and the standalone-stream `Outbound`. Best-effort `notify` (never raises); `send_raw_request` gated on `has_standalone_channel`; convenience notifications (`log`, `send_*_list_changed`, `send_resource_updated`). Mixes in `TypedServerRequestMixin`.
- **`Context[LifespanT, TT]`** (`server/context.py`, alongside v1's `ServerRequestContext`) — `BaseContext` + `PeerMixin` + `TypedServerRequestMixin` + `lifespan`/`connection`. What `ServerRunner` (next PR) hands to user handlers.

`dump_params(model, meta)` merges user-supplied `meta` into `_meta`; threaded through every convenience method.

## How Has This Been Tested?

`tests/shared/test_peer.py` (8), `tests/shared/test_context.py` (5), `tests/server/test_connection.py` (14), `tests/server/test_server_context.py` (4) — all over `DirectDispatcher`. 31 tests, 0.06s.

## Breaking Changes

None. New code only; v1's `ServerRequestContext`/`ClientRequestContext` are untouched.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Stack:
1. #2452 — Dispatcher Protocol + DirectDispatcher
2. #2458 — JSONRPCDispatcher
3. **(this PR)** PeerMixin / BaseContext / Connection / server Context
4. ServerRunner

The typed `send_request` is shape 2 (per-spec overloads) for now. A `HasResult[R]` protocol (`__mcp_result__` ClassVar on each Request type, one generic signature, O(1) maintenance) is the cleaner long-term shape and would also handle MRTR/Tasks via discriminated unions — tracked as a follow-up once `Client` (PR7) lands and the overload duplication becomes visible.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>