### PR TITLE
fix: skip JSON pre-parsing for str union annotations in pre_parse_json

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -148,7 +148,7 @@ class FuncMetadata(BaseModel):
                 continue
 
             field_info = key_to_field_info[data_key]
-            if isinstance(data_value, str) and field_info.annotation is not str:
+            if isinstance(data_value, str) and _should_pre_parse_json(field_info.annotation):
                 try:
                     pre_parsed = json.loads(data_value)
                 except json.JSONDecodeError:
@@ -414,6 +414,30 @@ def _try_create_model_and_schema(
         return model, schema, wrap_output
 
     return None, None, False
+
+
+
+_SIMPLE_TYPES: frozenset[type] = frozenset({str, int, float, bool, type(None)})
+
+
+def _should_pre_parse_json(annotation: Any) -> bool:
+    """Return True if the annotation may benefit from JSON pre-parsing.
+
+    For unions containing only simple scalar types (str, int, float, bool, None),
+    pre-parsing is skipped because json.loads would corrupt string values that
+    happen to look like JSON objects or arrays -- e.g. a UUID passed as a string
+    should stay a string even if the annotation is ``str | None``.
+
+    Complex unions like ``list[str] | None`` still need pre-parsing so that a
+    JSON-encoded list arriving as a string can be deserialized before Pydantic
+    validation.
+    """
+    if annotation is str:
+        return False
+    origin = get_origin(annotation)
+    if origin is not None and is_union_origin(origin):
+        return any(arg not in _SIMPLE_TYPES for arg in get_args(annotation))
+    return True
 
 
 _no_default = object()

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -416,7 +416,6 @@ def _try_create_model_and_schema(
     return None, None, False
 
 
-
 _SIMPLE_TYPES: frozenset[type] = frozenset({str, int, float, bool, type(None)})
 
 

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -551,6 +551,70 @@ async def test_str_annotation_runtime_validation():
     assert result == f"Handled payload of length {len(json_array_payload)}"
 
 
+
+def test_str_union_pre_parse_preserves_strings():
+    """Regression test for #1873: pre_parse_json must not JSON-parse strings
+    when the annotation is a union of simple types like str | None.
+
+    UUIDs and other string identifiers that start with digits were being
+    corrupted because json.loads would partially parse them as numbers.
+    """
+
+    def func_optional_str(value: str | None = None) -> str:  # pragma: no cover
+        return str(value)
+
+    meta = func_metadata(func_optional_str)
+
+    # A JSON object string must be preserved as-is for str | None
+    json_obj = '{"database": "postgres", "port": 5432}'
+    assert meta.pre_parse_json({"value": json_obj})["value"] == json_obj
+
+    # A JSON array string must be preserved as-is for str | None
+    json_array = '["item1", "item2"]'
+    assert meta.pre_parse_json({"value": json_array})["value"] == json_array
+
+    # Plain strings are unaffected
+    assert meta.pre_parse_json({"value": "hello"})["value"] == "hello"
+
+    # UUID-like strings must never be corrupted
+    uuid_val = "58aa9efd-faad-4901-89e8-99e807a1a2d6"
+    assert meta.pre_parse_json({"value": uuid_val})["value"] == uuid_val
+
+    # UUID with scientific-notation-like prefix must be preserved
+    uuid_sci = "3400e37e-b251-49d9-91b0-f8dd8602ff7e"
+    assert meta.pre_parse_json({"value": uuid_sci})["value"] == uuid_sci
+
+
+def test_complex_union_still_pre_parses():
+    """Ensure complex unions like list[str] | None still benefit from
+    JSON pre-parsing so that serialized lists are deserialized properly.
+    """
+
+    def func_optional_list(items: list[str] | None = None) -> str:  # pragma: no cover
+        return str(items)
+
+    meta = func_metadata(func_optional_list)
+    assert meta.pre_parse_json({"items": '["a", "b", "c"]'})["items"] == ["a", "b", "c"]
+
+
+@pytest.mark.anyio
+async def test_str_union_uuid_end_to_end():
+    """End-to-end test: a str | None parameter receives the exact UUID string."""
+
+    def update_task(task_id: str | None = None) -> str:  # pragma: no cover
+        return f"got {task_id}"
+
+    meta = func_metadata(update_task)
+    uuid_val = "58aa9efd-faad-4901-89e8-99e807a1a2d6"
+    result = await meta.call_fn_with_arg_validation(
+        update_task,
+        fn_is_async=False,
+        arguments_to_validate={"task_id": uuid_val},
+        arguments_to_pass_directly=None,
+    )
+    assert result == f"got {uuid_val}"
+
+
 # Tests for structured output functionality
 
 

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -551,7 +551,6 @@ async def test_str_annotation_runtime_validation():
     assert result == f"Handled payload of length {len(json_array_payload)}"
 
 
-
 def test_str_union_pre_parse_preserves_strings():
     """Regression test for #1873: pre_parse_json must not JSON-parse strings
     when the annotation is a union of simple types like str | None.
@@ -560,7 +559,7 @@ def test_str_union_pre_parse_preserves_strings():
     corrupted because json.loads would partially parse them as numbers.
     """
 
-    def func_optional_str(value: str | None = None) -> str:  # pragma: no cover
+    def func_optional_str(value: str | None = None) -> str:
         return str(value)
 
     meta = func_metadata(func_optional_str)
@@ -590,7 +589,7 @@ def test_complex_union_still_pre_parses():
     JSON pre-parsing so that serialized lists are deserialized properly.
     """
 
-    def func_optional_list(items: list[str] | None = None) -> str:  # pragma: no cover
+    def func_optional_list(items: list[str] | None = None) -> str:
         return str(items)
 
     meta = func_metadata(func_optional_list)
@@ -601,7 +600,7 @@ def test_complex_union_still_pre_parses():
 async def test_str_union_uuid_end_to_end():
     """End-to-end test: a str | None parameter receives the exact UUID string."""
 
-    def update_task(task_id: str | None = None) -> str:  # pragma: no cover
+    def update_task(task_id: str | None = None) -> str:
         return f"got {task_id}"
 
     meta = func_metadata(update_task)

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -559,7 +559,7 @@ def test_str_union_pre_parse_preserves_strings():
     corrupted because json.loads would partially parse them as numbers.
     """
 
-    def func_optional_str(value: str | None = None) -> str:
+    def func_optional_str(value: str | None = None) -> str:  # pragma: no cover
         return str(value)
 
     meta = func_metadata(func_optional_str)
@@ -589,7 +589,7 @@ def test_complex_union_still_pre_parses():
     JSON pre-parsing so that serialized lists are deserialized properly.
     """
 
-    def func_optional_list(items: list[str] | None = None) -> str:
+    def func_optional_list(items: list[str] | None = None) -> str:  # pragma: no cover
         return str(items)
 
     meta = func_metadata(func_optional_list)


### PR DESCRIPTION
## Summary

- `pre_parse_json()` uses `field_info.annotation is not str` to decide whether to attempt `json.loads()` on incoming string values. For union types like `str | None`, this identity check passes because `str | None` is not `str`, so string values get JSON-parsed when they should not be.
- This can corrupt string identifiers -- for example, UUIDs beginning with digits may be partially parsed as numbers or scientific notation, causing silent data loss before the tool function ever runs.
- Replaces the identity check with a `_should_pre_parse_json()` helper that inspects union annotations: unions of only simple scalar types (str, int, float, bool, NoneType) skip pre-parsing, while complex unions like `list[str] | None` still get pre-parsed.

Closes #1873

## Test plan

- [x] `test_str_union_pre_parse_preserves_strings` -- verifies JSON object strings, JSON array strings, plain strings, and UUID strings are all preserved as-is when annotation is `str | None`
- [x] `test_complex_union_still_pre_parses` -- verifies `list[str] | None` still deserializes a JSON-encoded list from a string
- [x] `test_str_union_uuid_end_to_end` -- end-to-end validation that a UUID passed to a `str | None` parameter arrives intact through `call_fn_with_arg_validation`
- [x] All existing tests continue to pass