### PR TITLE
[v1.x] fix: canonicalize root protected resource URIs

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal
+from urllib.parse import urlparse
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_serializer, field_validator
 
 
 class OAuthToken(BaseModel):
@@ -123,6 +124,20 @@ class OAuthClientInformationFull(OAuthClientMetadata):
     client_secret_expires_at: int | None = None
 
 
+def _serialize_canonical_server_uri(url: AnyHttpUrl) -> str:
+    """Serialize root server URIs without the implicit trailing slash.
+
+    RFC-defined canonical server URIs omit the synthetic "/" path that
+    ``AnyHttpUrl`` adds for host-only URLs. Preserve non-root paths exactly.
+    """
+
+    serialized = str(url)
+    parsed = urlparse(serialized)
+    if parsed.path == "/" and not parsed.params and not parsed.query and not parsed.fragment:
+        return serialized[:-1]
+    return serialized
+
+
 class OAuthMetadata(BaseModel):
     """
     RFC 8414 OAuth 2.0 Authorization Server Metadata.
@@ -175,3 +190,11 @@ class ProtectedResourceMetadata(BaseModel):
     dpop_signing_alg_values_supported: list[str] | None = None
     # dpop_bound_access_tokens_required default is False, but ommited here for clarity
     dpop_bound_access_tokens_required: bool | None = None
+
+    @field_serializer("resource", when_used="json")
+    def _serialize_resource(self, resource: AnyHttpUrl) -> str:
+        return _serialize_canonical_server_uri(resource)
+
+    @field_serializer("authorization_servers", when_used="json")
+    def _serialize_authorization_servers(self, authorization_servers: list[AnyHttpUrl]) -> list[str]:
+        return [_serialize_canonical_server_uri(url) for url in authorization_servers]

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -96,8 +96,8 @@ async def test_metadata_endpoint_without_path(root_resource_client: httpx.AsyncC
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "resource": "https://example.com/",
-            "authorization_servers": ["https://auth.example.com/"],
+            "resource": "https://example.com",
+            "authorization_servers": ["https://auth.example.com"],
             "scopes_supported": ["read"],
             "resource_name": "Root Resource",
             "bearer_methods_supported": ["header"],


### PR DESCRIPTION
## Summary

Fixes #1265.

`ProtectedResourceMetadata` was serializing host-only `resource` and `authorization_servers` values with Pydantic's implicit trailing `/`, so a response like:

```json
{"resource":"https://example.com/","authorization_servers":["https://auth.example.com/"]}
```

was emitted for root-level servers.

This change keeps route registration and path-bearing URLs unchanged, and only canonicalizes those host-only server URIs in the JSON response.

## Test plan

- `uv run --frozen pytest tests/server/auth/test_protected_resource.py -q`
- `uv run --frozen pytest tests/client/test_auth.py -q -k 'validate_resource_accepts_root_url_with_trailing_slash or protected_resource_metadata'`
- `uv run --frozen ruff check src/mcp/shared/auth.py tests/server/auth/test_protected_resource.py`
- `uv run --frozen pyright src/mcp/shared/auth.py`
