### PR TITLE
fix: [v1.x backport] skip output schema validation when tool returns isError=True

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -112,7 +112,7 @@ class FuncMetadata(BaseModel):
         the structured output.
         """
         if isinstance(result, CallToolResult):
-            if self.output_schema is not None:
+            if self.output_schema is not None and not result.isError:
                 assert self.output_model is not None, "Output model must be set if output schema is defined"
                 self.output_model.model_validate(result.structuredContent)
             return result

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -13,7 +13,7 @@ from dirty_equals import IsPartialDict
 from pydantic import BaseModel, Field
 
 from mcp.server.fastmcp.utilities.func_metadata import func_metadata
-from mcp.types import CallToolResult
+from mcp.types import CallToolResult, TextContent
 
 
 class SomeInputModelA(BaseModel):
@@ -876,6 +876,31 @@ def test_tool_call_result_annotated_is_structured_and_invalid():
 
     with pytest.raises(ValueError):
         meta.convert_result(func_returning_annotated_tool_call_result())
+
+
+def test_tool_call_result_annotated_is_error_skips_validation():
+    """Test that isError=True skips output schema validation.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2429
+    """
+
+    class DivideOutput(BaseModel):
+        result: float
+
+    def func_returning_error() -> Annotated[CallToolResult, DivideOutput]:
+        return CallToolResult(
+            content=[TextContent(type="text", text="Division by zero")],
+            isError=True,
+        )
+
+    meta = func_metadata(func_returning_error)
+    assert meta.output_schema is not None
+
+    result = meta.convert_result(func_returning_error())
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "Division by zero"
 
 
 def test_tool_call_result_in_optional_is_rejected():


### PR DESCRIPTION
Backport of #2466 to v1.x branch.

Skip output schema validation for error results in `convert_result()`.

## Motivation and Context
When a tool with an inferred `output_schema` returns `CallToolResult(isError=True)`, the SDK's `convert_result()` calls `model_validate(None)` unconditionally, raising a pydantic `ValidationError` that replaces the intended error message.

This was already fixed in the TypeScript SDK via modelcontextprotocol/typescript-sdk#655. This PR backports the equivalent fix to the Python SDK v1.x branch.

## How Has This Been Tested?
- Added regression test `test_tool_call_result_annotated_is_error_skips_validation` that creates a tool with an output schema, returns `CallToolResult(isError=True)` with unstructured error content, and verifies the result is returned unchanged without raising a validation error.
- All existing `test_func_metadata.py` tests pass.
- `ruff check` and `ruff format` clean.

## Breaking Changes
None. This only changes behavior for the error path — tools returning `isError=True` were previously broken, so no working code is affected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
One-line fix matching the TypeScript SDK approach:
```diff
-            if self.output_schema is not None:
+            if self.output_schema is not None and not result.isError:
```

Fixes #2429