### PR TITLE
feat(mcpserver): add Context.assert_within_roots for server-side roots enforcement

### DIFF
--- a/src/mcp/server/mcpserver/context.py
+++ b/src/mcp/server/mcpserver/context.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from pydantic import AnyUrl, BaseModel
 
@@ -116,6 +119,42 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
         """
         assert self._mcp_server is not None, "Context is not available outside of a request"
         return await self._mcp_server.read_resource(uri, self)
+
+    async def assert_within_roots(self, path: str | Path) -> None:
+        """Assert that a filesystem path is within the client's declared roots.
+
+        Provides server-side enforcement of the filesystem boundaries declared by
+        the client via the Roots capability. Call this at the start of any tool
+        that accepts a user-provided path, to prevent the tool from accessing
+        files outside the client's declared scope.
+
+        Args:
+            path: The filesystem path to validate. Accepts a string or Path.
+                Relative paths and symlinks are resolved before comparison.
+
+        Raises:
+            PermissionError: If the path is outside every declared root, or if
+                the client has declared no roots.
+
+        Example:
+            ```python
+            @server.tool()
+            async def read_file(path: str, ctx: Context) -> str:
+                await ctx.assert_within_roots(path)
+                with open(path) as f:
+                    return f.read()
+            ```
+        """
+        target = Path(path).resolve()
+
+        result = await self.request_context.session.list_roots()
+
+        for root in result.roots:
+            root_path = Path(url2pathname(urlparse(str(root.uri)).path)).resolve()
+            if target.is_relative_to(root_path):
+                return
+
+        raise PermissionError(f"Path {target} is not within any declared root")
 
     async def elicit(
         self,

--- a/tests/server/mcpserver/test_roots.py
+++ b/tests/server/mcpserver/test_roots.py
@@ -52,7 +52,7 @@ async def test_path_outside_roots_raises(tmp_path: Path):
     @server.tool("check")
     async def check(context: Context, path: str) -> bool:
         await context.assert_within_roots(path)
-        return True
+        return True  # pragma: no cover
 
     callback = _make_callback([Root(uri=FileUrl(f"file://{root_dir}"))])
 
@@ -74,7 +74,7 @@ async def test_no_roots_declared_raises(tmp_path: Path):
     @server.tool("check")
     async def check(context: Context, path: str) -> bool:
         await context.assert_within_roots(path)
-        return True
+        return True  # pragma: no cover
 
     callback = _make_callback([])
 
@@ -103,7 +103,7 @@ async def test_symlink_escaping_root_raises(tmp_path: Path):
     @server.tool("check")
     async def check(context: Context, path: str) -> bool:
         await context.assert_within_roots(path)
-        return True
+        return True  # pragma: no cover
 
     callback = _make_callback([Root(uri=FileUrl(f"file://{root_dir}"))])
 

--- a/tests/server/mcpserver/test_roots.py
+++ b/tests/server/mcpserver/test_roots.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+import pytest
+from pydantic import FileUrl
+
+from mcp import Client
+from mcp.client.session import ClientSession
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.shared._context import RequestContext
+from mcp.types import ListRootsResult, Root, TextContent
+
+
+def _make_callback(roots: list[Root]):
+    async def list_roots_callback(
+        context: RequestContext[ClientSession],
+    ) -> ListRootsResult:
+        return ListRootsResult(roots=roots)
+
+    return list_roots_callback
+
+
+@pytest.mark.anyio
+async def test_path_within_root_passes(tmp_path: Path):
+    """A path inside a declared root should not raise."""
+    inside = tmp_path / "file.txt"
+    inside.touch()
+
+    server = MCPServer("test")
+
+    @server.tool("check")
+    async def check(context: Context, path: str) -> bool:
+        await context.assert_within_roots(path)
+        return True
+
+    callback = _make_callback([Root(uri=FileUrl(f"file://{tmp_path}"))])
+
+    async with Client(server, list_roots_callback=callback) as client:
+        result = await client.call_tool("check", {"path": str(inside)})
+        assert result.is_error is False
+
+
+@pytest.mark.anyio
+async def test_path_outside_roots_raises(tmp_path: Path):
+    """A path outside every declared root should raise PermissionError."""
+    root_dir = tmp_path / "allowed"
+    root_dir.mkdir()
+    outside = tmp_path / "elsewhere.txt"
+    outside.touch()
+
+    server = MCPServer("test")
+
+    @server.tool("check")
+    async def check(context: Context, path: str) -> bool:
+        await context.assert_within_roots(path)
+        return True
+
+    callback = _make_callback([Root(uri=FileUrl(f"file://{root_dir}"))])
+
+    async with Client(server, list_roots_callback=callback) as client:
+        result = await client.call_tool("check", {"path": str(outside)})
+        assert result.is_error is True
+        assert isinstance(result.content[0], TextContent)
+        assert "not within any declared root" in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_no_roots_declared_raises(tmp_path: Path):
+    """An empty roots list should always raise."""
+    target = tmp_path / "file.txt"
+    target.touch()
+
+    server = MCPServer("test")
+
+    @server.tool("check")
+    async def check(context: Context, path: str) -> bool:
+        await context.assert_within_roots(path)
+        return True
+
+    callback = _make_callback([])
+
+    async with Client(server, list_roots_callback=callback) as client:
+        result = await client.call_tool("check", {"path": str(target)})
+        assert result.is_error is True
+        assert isinstance(result.content[0], TextContent)
+        assert "not within any declared root" in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_symlink_escaping_root_raises(tmp_path: Path):
+    """A symlink inside a root that points outside should raise (resolve follows links)."""
+    root_dir = tmp_path / "allowed"
+    root_dir.mkdir()
+    outside_dir = tmp_path / "forbidden"
+    outside_dir.mkdir()
+    outside_target = outside_dir / "secret.txt"
+    outside_target.touch()
+
+    link = root_dir / "escape"
+    link.symlink_to(outside_target)
+
+    server = MCPServer("test")
+
+    @server.tool("check")
+    async def check(context: Context, path: str) -> bool:
+        await context.assert_within_roots(path)
+        return True
+
+    callback = _make_callback([Root(uri=FileUrl(f"file://{root_dir}"))])
+
+    async with Client(server, list_roots_callback=callback) as client:
+        result = await client.call_tool("check", {"path": str(link)})
+        assert result.is_error is True
+
+
+@pytest.mark.anyio
+async def test_multiple_roots_any_match_passes(tmp_path: Path):
+    """A path inside any one of several declared roots should pass."""
+    root_a = tmp_path / "a"
+    root_a.mkdir()
+    root_b = tmp_path / "b"
+    root_b.mkdir()
+    target = root_b / "file.txt"
+    target.touch()
+
+    server = MCPServer("test")
+
+    @server.tool("check")
+    async def check(context: Context, path: str) -> bool:
+        await context.assert_within_roots(path)
+        return True
+
+    callback = _make_callback(
+        [
+            Root(uri=FileUrl(f"file://{root_a}")),
+            Root(uri=FileUrl(f"file://{root_b}")),
+        ]
+    )
+
+    async with Client(server, list_roots_callback=callback) as client:
+        result = await client.call_tool("check", {"path": str(target)})
+        assert result.is_error is False


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Closes #2453.

Adds `assert_within_roots(path)` as an async method on the `Context` class, so any FastMCP/MCPServer tool can enforce that a user-provided path stays within the filesystem boundaries the client declared via the Roots capability.

```python
@mcp.tool()
async def read_file(path: str, ctx: Context) -> str:
    await ctx.assert_within_roots(path)  # raises PermissionError if outside roots
    with open(path) as f:
        return f.read()
```

## Motivation and Context

<!-- Why is this change needed? What problem does it solve? -->

MCP clients can declare roots, but the SDK never enforces them server-side. Any tool can open any path regardless of what the client declared — the check is left entirely to the tool author. This is a real security gap for filesystem-exposing servers and easy to forget.

The reference `@modelcontextprotocol/server-filesystem` has enforcement baked in, but anyone building a custom FastMCP/MCPServer doesn't get that for free.

**On the API design — responding to feedback on #2425:** an earlier attempt at this was closed with the feedback that the proposed API (a `@within_roots_check` decorator in a separate utility module) was "not easy to use." This PR takes a different approach based on that feedback:

- No decorator, no magic — the check is an explicit line at the top of the tool body
- Method lives on `Context` alongside `ctx.report_progress`, `ctx.read_resource`, `ctx.elicit`, so it's discoverable by anyone already writing tools that take a `Context`
- Single call site, clear failure mode — raises `PermissionError` with the offending path, no configuration, no opt-in

**Behavior:**

- Resolves the target path with `pathlib.Path.resolve()` — symlinks and relative segments are normalized before comparison
- Iterates declared roots via `self.request_context.session.list_roots()` and accepts the path if it falls within any of them
- Raises `PermissionError` if the path is outside every declared root, **or** if no roots are declared (fail-closed)
- Uses `urllib.request.url2pathname` to convert `file://` URIs — works on both POSIX and Windows

## How Has This Been Tested?

<!-- Have you tested this in a real application? Which scenarios were tested? -->

Five new tests in `tests/server/mcpserver/test_roots.py`, exercising the real client/server path (no mocks on `list_roots`):

- Path inside a declared root passes
- Path outside all declared roots raises
- Empty roots list raises
- Symlink inside a root pointing outside raises (validates `.resolve()` behavior)
- Path inside any one of multiple declared roots passes

All five pass locally. Full suite (`pytest tests/`) is also green — 1166 passed, 98 skipped, 1 xfailed (existing state, unchanged by this PR).

## Breaking Changes

<!-- Will users need to update their code or configurations? -->

None. This is a purely additive change — a new method on an existing class. Existing tools are unaffected; the check is opt-in per tool.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed (docstring on the new method with usage example)

## Additional context

<!-- Add any other context, implementation notes, or design decisions -->

The docstring on `assert_within_roots` includes a full usage example that matches the patterns already used in `report_progress`, `read_resource`, etc., so the method is self-documenting for anyone using hover tooltips or generated API docs.