### PR TITLE
fix: disable CRLF translation in stdio_server on Windows

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -39,9 +39,9 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
+        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace", newline=""))
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8", newline=""))
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -64,6 +64,32 @@ async def test_stdio_server():
 
 
 @pytest.mark.anyio
+async def test_stdio_server_uses_lf_newlines(monkeypatch: pytest.MonkeyPatch):
+    """stdio_server() must not emit CRLF on Windows (newline='' disables translation)."""
+
+    class UnclosableBuffer(io.BytesIO):
+        """BytesIO that ignores close() so we can read its value after the wrapper closes it."""
+
+        def close(self) -> None:
+            pass  # prevent TextIOWrapper from closing our buffer
+
+    raw_stdout = UnclosableBuffer()
+    monkeypatch.setattr(sys, "stdin", TextIOWrapper(io.BytesIO(b""), encoding="utf-8"))
+    monkeypatch.setattr(sys, "stdout", TextIOWrapper(raw_stdout, encoding="utf-8"))
+
+    with anyio.fail_after(5):
+        async with stdio_server() as (read_stream, write_stream):
+            await read_stream.aclose()
+            async with write_stream:
+                session_message = SessionMessage(JSONRPCRequest(jsonrpc="2.0", id=1, method="ping"))
+                await write_stream.send(session_message)
+
+    raw_bytes = raw_stdout.getvalue()
+    assert raw_bytes.endswith(b"\n"), "output must end with LF"
+    assert b"\r\n" not in raw_bytes, "output must not contain CRLF"
+
+
+@pytest.mark.anyio
 async def test_stdio_server_invalid_utf8(monkeypatch: pytest.MonkeyPatch):
     """Non-UTF-8 bytes on stdin must not crash the server.
 


### PR DESCRIPTION
## Summary

On Windows, `TextIOWrapper` with the default `newline=None` translates `\n` → `\r\n` on write. This means every JSON-RPC message emitted by `stdio_server()` gets `\r\n` line endings, violating the NDJSON wire format.

The fix is to pass `newline=""` to both `TextIOWrapper` calls in `stdio_server()`, which disables the platform-dependent line-ending translation while keeping the stream in text mode.

## Changes

- `src/mcp/server/stdio.py`: add `newline=""` to both `TextIOWrapper` constructors (stdin and stdout)
- `tests/server/test_stdio.py`: add `test_stdio_server_uses_lf_newlines` to assert the output contains only LF, not CRLF

Fixes #2433