### PR TITLE
Filter MCPServer capabilities by registered primitives

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -169,6 +169,7 @@ class Server(Generic[LifespanResultT]):
             Awaitable[types.EmptyResult],
         ]
         | None = None,
+        capability_filter: Callable[[types.ServerCapabilities], types.ServerCapabilities] | None = None,
         on_ping: Callable[
             [ServerRequestContext[LifespanResultT], types.RequestParams | None],
             Awaitable[types.EmptyResult],
@@ -192,6 +193,7 @@ class Server(Generic[LifespanResultT]):
         self.instructions = instructions
         self.website_url = website_url
         self.icons = icons
+        self._capability_filter = capability_filter
         self.lifespan = lifespan
         self._request_handlers: dict[str, Callable[[ServerRequestContext[LifespanResultT], Any], Awaitable[Any]]] = {}
         self._notification_handlers: dict[
@@ -325,6 +327,8 @@ class Server(Generic[LifespanResultT]):
         )
         if self._experimental_handlers:
             self._experimental_handlers.update_capabilities(capabilities)
+        if self._capability_filter:
+            capabilities = self._capability_filter(capabilities)
         return capabilities
 
     @property

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -182,6 +182,7 @@ class MCPServer(Generic[LifespanResultT]):
             on_list_resource_templates=self._handle_list_resource_templates,
             on_list_prompts=self._handle_list_prompts,
             on_get_prompt=self._handle_get_prompt,
+            capability_filter=self._filter_capabilities,
             # TODO(Marcelo): It seems there's a type mismatch between the lifespan type from an MCPServer and Server.
             # We need to create a Lifespan type that is a generic on the server type, like Starlette does.
             lifespan=(lifespan_wrapper(self, self.settings.lifespan) if self.settings.lifespan else default_lifespan),  # type: ignore
@@ -205,6 +206,16 @@ class MCPServer(Generic[LifespanResultT]):
 
         # Configure logging
         configure_logging(self.settings.log_level)
+
+    def _filter_capabilities(self, capabilities: Any) -> Any:
+        """Hide MCPServer capabilities for primitives that have not been registered."""
+        if not self._tool_manager.list_tools():
+            capabilities.tools = None
+        if not self._prompt_manager.list_prompts():
+            capabilities.prompts = None
+        if not self._resource_manager.list_resources() and not self._resource_manager.list_templates():
+            capabilities.resources = None
+        return capabilities
 
     @property
     def name(self) -> str:

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -74,6 +74,54 @@ class TestServer:
         mcp_no_deps = MCPServer("test")
         assert mcp_no_deps.dependencies == []
 
+    async def test_init_without_primitives_omits_prompt_resource_and_tool_capabilities(self):
+        mcp = MCPServer("empty")
+
+        async with Client(mcp) as client:
+            capabilities = client.initialize_result.capabilities
+            assert capabilities.tools is None
+            assert capabilities.resources is None
+            assert capabilities.prompts is None
+
+    async def test_init_with_tool_only_announces_only_tool_capability(self):
+        mcp = MCPServer("tool-only")
+
+        @mcp.tool()
+        def echo(text: str) -> str:
+            return text
+
+        async with Client(mcp) as client:
+            capabilities = client.initialize_result.capabilities
+            assert capabilities.tools is not None
+            assert capabilities.resources is None
+            assert capabilities.prompts is None
+
+    async def test_init_with_prompt_only_announces_only_prompt_capability(self):
+        mcp = MCPServer("prompt-only")
+
+        @mcp.prompt()
+        def greet(name: str) -> str:
+            return f"Hello {name}"
+
+        async with Client(mcp) as client:
+            capabilities = client.initialize_result.capabilities
+            assert capabilities.prompts is not None
+            assert capabilities.tools is None
+            assert capabilities.resources is None
+
+    async def test_init_with_resource_template_announces_resource_capability(self):
+        mcp = MCPServer("template-only")
+
+        @mcp.resource("resource://{city}/weather")
+        def weather(city: str) -> str:
+            return f"Weather for {city}"
+
+        async with Client(mcp) as client:
+            capabilities = client.initialize_result.capabilities
+            assert capabilities.resources is not None
+            assert capabilities.tools is None
+            assert capabilities.prompts is None
+
     async def test_sse_app_returns_starlette_app(self):
         """Test that sse_app returns a Starlette application with correct routes."""
         mcp = MCPServer("test")


### PR DESCRIPTION
## Summary
- stop `MCPServer` from advertising prompt, resource, and tool capabilities when nothing has been registered for that primitive
- keep the low-level `Server` behavior unchanged by making the filtering opt-in
- add coverage for empty, tool-only, prompt-only, and resource-template-only MCPServer initialization

## Testing
- `python3 -m py_compile src/mcp/server/lowlevel/server.py src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py`
- `pytest tests/server/mcpserver/test_server.py -k capability` *(not run locally: `pytest` is not installed in this environment)*
