### PR TITLE
fix: auto-send notifications/cancelled on anyio task cancellation

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -23,6 +23,7 @@ from mcp.types import (
     INVALID_PARAMS,
     REQUEST_TIMEOUT,
     CancelledNotification,
+    CancelledNotificationParams,
     ClientNotification,
     ClientRequest,
     ClientResult,
@@ -269,6 +270,7 @@ class BaseSession(
             # Store the callback for this request
             self._progress_callbacks[request_id] = progress_callback
 
+        request_sent = False
         try:
             target = request_data.get("params", {}).get("name")
             span_name = f"MCP send {request.method} {target}" if target else f"MCP send {request.method}"
@@ -284,6 +286,7 @@ class BaseSession(
 
                 jsonrpc_request = JSONRPCRequest(jsonrpc="2.0", id=request_id, **request_data)
                 await self._write_stream.send(SessionMessage(message=jsonrpc_request, metadata=metadata))
+                request_sent = True
 
                 # request read timeout takes precedence over session read timeout
                 timeout = request_read_timeout_seconds or self._session_read_timeout_seconds
@@ -300,6 +303,26 @@ class BaseSession(
                     raise MCPError.from_jsonrpc_error(response_or_error)
                 else:
                     return result_type.model_validate(response_or_error.result, by_name=False)
+
+        except anyio.get_cancelled_exc_class():
+            # Automatically notify the other side when a task/scope is cancelled,
+            # so the peer can abort work for a request nobody is waiting for.
+            if request_sent:
+                with anyio.CancelScope(shield=True):
+                    try:
+                        # Add a short timeout to prevent deadlock if the transport buffer is full
+                        with anyio.move_on_after(2.0):
+                            await self.send_notification(
+                                CancelledNotification(  # type: ignore[arg-type]
+                                    params=CancelledNotificationParams(
+                                        request_id=request_id,
+                                        reason="Task cancelled",
+                                    )
+                                )
+                            )
+                    except Exception:
+                        pass  # Transport may already be closed
+            raise
 
         finally:
             self._response_streams.pop(request_id, None)

--- a/tests/server/test_cancel_handling.py
+++ b/tests/server/test_cancel_handling.py
@@ -248,3 +248,64 @@ async def test_server_handles_transport_close_with_pending_server_to_client_requ
             # Without the fixes: RuntimeError (dict mutation) or ClosedResourceError
             # (respond after write-stream close) escapes run_server and this hangs.
             await server_run_returned.wait()
+
+
+@pytest.mark.anyio
+async def test_anyio_cancel_scope_sends_cancelled_notification() -> None:
+    """Cancelling a call_tool via anyio cancel scope should automatically
+    send notifications/cancelled to the server, causing it to abort the handler."""
+
+    tool_started = anyio.Event()
+    handler_cancelled = anyio.Event()
+
+    async def handle_list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+        return ListToolsResult(
+            tools=[
+                Tool(
+                    name="slow_tool",
+                    description="A slow tool for testing cancellation",
+                    input_schema={},
+                )
+            ]
+        )
+
+    async def handle_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+        if params.name == "slow_tool":
+            tool_started.set()
+            try:
+                await anyio.sleep_forever()
+            except anyio.get_cancelled_exc_class():
+                handler_cancelled.set()
+                raise
+        raise ValueError(f"Unknown tool: {params.name}")  # pragma: no cover
+
+    server = Server(
+        "test-server",
+        on_list_tools=handle_list_tools,
+        on_call_tool=handle_call_tool,
+    )
+
+    async with Client(server) as client:
+        # Cancel the call_tool via anyio scope cancellation.
+        # send_request should automatically send notifications/cancelled.
+        async with anyio.create_task_group() as tg:
+
+            async def do_call() -> None:
+                with anyio.CancelScope() as scope:
+                    # Store scope so the outer task can cancel it
+                    do_call.scope = scope  # type: ignore[attr-defined]
+                    await client.call_tool("slow_tool", {})
+
+            tg.start_soon(do_call)
+
+            # Wait for the server handler to start
+            await tool_started.wait()
+
+            # Cancel the client-side scope — this should trigger auto-notification
+            do_call.scope.cancel()  # type: ignore[attr-defined]
+
+        # Give the server a moment to process the cancellation
+        await anyio.sleep(0.1)
+
+        # The server handler should have been cancelled via the notification
+        assert handler_cancelled.is_set(), "Server handler was not cancelled — notifications/cancelled was not sent"


### PR DESCRIPTION
Fixes #1410.

## Motivation and Context

The friction here is pretty specific: when you use high-level request wrappers like `client.call_tool()`, the generated `request_id` stays hidden internally inside `send_request`. So if you need to abort that task from the outside using standard Python async patterns (like `anyio.fail_after` or `CancelScope.cancel()`), the client aborts locally, but it has no way to tell the server. The server continues executing an orphaned request that the client has already stopped waiting for. 

So I moved the cancellation hook into `BaseSession.send_request`. The idea is simple: intercept the `anyio` cancellation before it bubbles up, read the `request_id` we just generated, and automatically dispatch a `notifications/cancelled` straight to the peer. 

## How Has This Been Tested?

I made sure it runs cleanly end-to-end. Added `test_anyio_cancel_scope_sends_cancelled_notification` to `tests/server/test_cancel_handling.py` which:
- Kicks off `call_tool`
- Triggers an outer `CancelScope.cancel()` 
- Asserts the server handler actually got aborted

(Side note: Verified locally against the full regression suite using `anyio` 4.10.0 on Windows.)

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

A few quick implementation details:
- **It uses a `request_sent` flag:** Cancels are only dispatched if the request actually hit the wire (so we don't spam the server for requests that failed on `_write_stream.send()`).
- **It's shielded:** The dispatch runs inside `with anyio.CancelScope(shield=True)` so it survives the very cancellation it's reacting to.
- **It has a deadlock timeout:** Added `with anyio.move_on_after(2.0)` inside the shield. If the transport buffer is completely full, we don't want to hang the user's cancellation handler forever. 
- **It's bidirectional:** Since this lives in `BaseSession`, it automatically works for both client→server and server→client directions.

Happy to tweak the timeout value or the notification reason string if there's a preference. Let me know if I should squash anything.

Just a heads-up for reviewers — the CI failures here are pre-existing and not related to the changes in this PR. 

The `pyright` hook in `.pre-commit-config.yaml` runs against the whole repo. Currently, the upstream `main` branch (commit `3d7b311`) has 21 Pyright errors located entirely in `src/mcp/os/win32/utilities.py`. 

Because pre-commit is configured with `fail_fast: true`, it aborts early and cascades all 20 test matrix jobs (`checks / test`) to fail with exit code 2 before Pytest even gets a chance to run. (I noticed this is happening on other recent PRs like #2475 as well).

I have verified the test suite locally using parallel workers (`pytest -n auto`):
- **1170 passed, 101 skipped, 1 xfailed**, exit 0.
- `uv run pyright src/mcp/shared/session.py` returns **0 errors**.

Happy to rebase to trigger a clean run once the upstream Pyright issue on `main` is resolved, or if a maintainer wants to merge this as-is!

