### PR TITLE
fix(client): propagate SSE POST errors to caller instead of hanging (#2110)

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -120,15 +120,24 @@ async def sse_client(
 
                         async def _send_message(session_message: SessionMessage) -> None:
                             logger.debug(f"Sending client message: {session_message}")
-                            response = await client.post(
-                                endpoint_url,
-                                json=session_message.message.model_dump(
-                                    by_alias=True,
-                                    mode="json",
-                                    exclude_unset=True,
-                                ),
-                            )
-                            response.raise_for_status()
+                            try:
+                                response = await client.post(
+                                    endpoint_url,
+                                    json=session_message.message.model_dump(
+                                        by_alias=True,
+                                        mode="json",
+                                        exclude_unset=True,
+                                    ),
+                                )
+                                response.raise_for_status()
+                            except httpx.HTTPError as exc:
+                                # Forward the failure to the caller via the read stream instead of
+                                # letting it surface as a swallowed task-group error, which would
+                                # leave read_stream.receive() blocked forever (#2110). Mirrors the
+                                # stream-error handling in stdio.py and streamable_http.py.
+                                logger.exception("Error sending client message")
+                                await read_stream_writer.send(exc)
+                                return
                             logger.debug(f"Client message sent successfully: {response.status_code}")
 
                         async for session_message in write_stream_reader:

--- a/tests/shared/test_sse.py
+++ b/tests/shared/test_sse.py
@@ -13,7 +13,7 @@ from httpx_sse import ServerSentEvent
 from inline_snapshot import snapshot
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import Response, StreamingResponse
 from starlette.routing import Mount, Route
 
 import mcp.client.sse
@@ -25,6 +25,7 @@ from mcp.server.sse import SseServerTransport
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared._httpx_utils import McpHttpClientFactory
 from mcp.shared.exceptions import MCPError
+from mcp.shared.message import SessionMessage
 from mcp.types import (
     CallToolRequestParams,
     CallToolResult,
@@ -106,6 +107,52 @@ def make_app(server: Server) -> Starlette:
 
 def make_server_app() -> Starlette:
     return make_app(Server(SERVER_NAME, on_read_resource=_handle_read_resource))
+
+
+def make_failing_post_app() -> Starlette:
+    """An SSE app that completes the handshake but fails every message POST with 503.
+
+    The `/sse` stream announces a valid endpoint (so the client reaches the POST path) and
+    stays open until the client disconnects; `/messages/` always returns 503. Used to drive
+    the client's POST-error propagation path (#2110).
+    """
+
+    async def handle_sse(request: Request) -> Response:
+        async def event_stream() -> AsyncGenerator[bytes, None]:
+            yield b"event: endpoint\r\ndata: /messages/\r\n\r\n"
+            # Hold the stream open with a single, branch-free wait (so coverage is
+            # deterministic) that comfortably outlasts the in-process POST round trip.
+            # The client tears the connection down as soon as it receives the error.
+            await anyio.sleep(1.0)
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    async def handle_message(request: Request) -> Response:
+        return Response("upstream exploded", status_code=503)
+
+    return Starlette(
+        routes=[
+            Route("/sse", endpoint=handle_sse),
+            Route("/messages/", endpoint=handle_message, methods=["POST"]),
+        ]
+    )
+
+
+@pytest.mark.anyio
+async def test_sse_client_post_error_propagates_to_caller() -> None:
+    """A non-2xx on the message POST surfaces to the caller via the read stream.
+
+    Regression test for #2110: the error was previously swallowed by the post_writer task
+    group and `read_stream.receive()` blocked forever.
+    """
+    factory = in_process_client_factory(make_failing_post_app())
+    async with sse_client(f"{BASE_URL}/sse", httpx_client_factory=factory) as (read_stream, write_stream):
+        await write_stream.send(SessionMessage(types.JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")))
+        with anyio.fail_after(10):
+            item = await read_stream.receive()
+
+    assert isinstance(item, httpx.HTTPStatusError)
+    assert item.response.status_code == 503
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes the remaining client-side hang from #2110, in **`sse_client`**.

`_send_message` (the message-POST coroutine) called `response.raise_for_status()` with no handler. On a non-2xx (401/403/404/5xx) or a network error, the exception propagated into the `post_writer` task group and was swallowed by its `except Exception: logger.exception("Error in post_writer")`. The failure never reached the read stream, so a caller blocked on `read_stream.receive()` — e.g. `ClientSession.initialize()` — **hung forever**.

The fix catches `httpx.HTTPError` inside `_send_message` and forwards it to `read_stream_writer`, the pattern `stdio.py` and `websocket.py` already use, and that `streamable_http.py` uses for its `>= 400` responses. The caller now receives the error promptly.

## Scope note

This PR was originally broader. Since it was opened, **`main` independently landed the equivalent fix for `streamable_http_client`** (the `status_code >= 400` branch in `_handle_post_request` now sends a `JSONRPCError` to the read stream with `data={"http_status": ...}`). That half is therefore dropped here — this is rebased on current `main` and scoped to the **one remaining swallow path: `sse_client`**. It's also distinct from #2340, which addresses the `sse_reader`/connection path rather than the message-POST path.

## Verification

- New regression test `test_sse_client_post_error_propagates_to_caller`: drives a real SSE handshake whose message POST returns `503` and asserts the caller receives the `HTTPStatusError` via the read stream within a bounded timeout.
- **Negative control:** the test **times out (fails)** against the unpatched client, and passes with the fix — confirming it reproduces the hang.
- `./scripts/test`: full suite green, **100.00%** coverage (branch), `strict-no-cover` clean.
- `ruff format` / `ruff check` / `pyright`: clean.

Closes #2110.
