### PR TITLE
fix: don't send a response for cancelled requests

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -502,9 +502,9 @@ class Server(Generic[LifespanResultT]):
                     response = err.error
                 except anyio.get_cancelled_exc_class():
                     if message.cancelled:
-                        # Client sent CancelledNotification; responder.cancel() already
-                        # sent an error response, so skip the duplicate.
-                        logger.info("Request %s cancelled - duplicate response suppressed", message.request_id)
+                        # Client sent CancelledNotification; per spec receivers must
+                        # not send a response for a cancelled request, so return.
+                        logger.info("Request %s cancelled", message.request_id)
                         return
                     # Transport-close cancellation from the TG in run(); re-raise so the
                     # TG swallows its own cancellation.

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -148,11 +148,8 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
 
         self._cancel_scope.cancel()
         self._completed = True  # Mark as completed so it's removed from in_flight
-        # Send an error response to indicate cancellation
-        await self._session._send_response(  # type: ignore[reportPrivateUsage]
-            request_id=self.request_id,
-            response=ErrorData(code=0, message="Request cancelled"),
-        )
+        # Per spec, receivers of notifications/cancelled must NOT send a response.
+        # The sender is responsible for resolving its own pending request.
 
     @property
     def in_flight(self) -> bool:  # pragma: no cover
@@ -313,6 +310,18 @@ class BaseSession(
         related_request_id: RequestId | None = None,
     ) -> None:
         """Emits a notification, which is a one-way message that does not expect a response."""
+        # When we cancel a request we sent, immediately resolve the pending
+        # response stream so send_request() returns instead of hanging.
+        # The receiver must not send a response (per spec), so we own the
+        # resolution on this side.
+        if isinstance(notification, CancelledNotification):
+            cancelled_id = notification.params.request_id
+            if cancelled_id in self._response_streams:
+                error = ErrorData(code=REQUEST_TIMEOUT, message="Request cancelled")
+                await self._response_streams[cancelled_id].send(
+                    JSONRPCError(jsonrpc="2.0", id=cancelled_id, error=error)
+                )
+
         # Some transport implementations may need to set the related_request_id
         # to attribute to the notifications to the request that triggered them.
         jsonrpc_notification = JSONRPCNotification(

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -99,6 +99,19 @@ async def test_request_cancellation():
 
 
 @pytest.mark.anyio
+async def test_cancel_notification_for_unknown_request_id():
+    """Sending notifications/cancelled for a request ID with no pending stream is a no-op."""
+    server = Server(name="test server")
+    async with Client(server) as client:
+        # ID 99999 has no pending send_request, so no response stream exists.
+        # Should return without raising.
+        with anyio.fail_after(1):
+            await client.session.send_notification(
+                CancelledNotification(params=CancelledNotificationParams(request_id=99999))
+            )
+
+
+@pytest.mark.anyio
 async def test_response_id_type_mismatch_string_to_int():
     """Test that responses with string IDs are correctly matched to requests sent with
     integer IDs.


### PR DESCRIPTION
## Summary

- Remove the `_send_response` call from `RequestResponder.cancel()`. The MCP cancellation spec says receivers must not send a response for a cancelled request.
- When `send_notification` is called with a `CancelledNotification`, immediately resolve the pending response stream so `send_request()` returns instead of waiting indefinitely.
- Update a now-stale comment in `lowlevel/server.py` that said "responder.cancel() already sent an error response."

## Motivation and Context

`RequestResponder.cancel()` was sending `ErrorData(code=0, message="Request cancelled")` back to the sender after receiving `notifications/cancelled`. The [cancellation spec](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/draft/basic/utilities/cancellation.mdx#L33-L36) says receivers SHOULD NOT do this. Claude Code, for example, logs "Received a response for an unknown message ID" and reconnects every time a long-running tool gets cancelled.

The TypeScript SDK already gets this right: the sender rejects its own pending promise locally when it sends the cancellation ([source](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/shared/protocol.ts#L1184-L1186)), and the receiver just calls `controller.abort()` without sending anything back. This PR brings the Python SDK in line with that behavior.

## How Has This Been Tested?

- `uv run --frozen pytest tests/shared/test_session.py` — all 9 tests pass, including `test_request_cancellation` (unchanged) and the new `test_cancel_notification_for_unknown_request_id`
- `uv run --frozen pytest tests/server/test_cancel_handling.py` — all 3 tests pass
- `./scripts/test` — 1172 tests, 100% branch coverage

## Breaking Changes

Code that inspects `e.code` on a cancellation `MCPError` will see `-32001` (`REQUEST_TIMEOUT`) instead of `0`. The message `"Request cancelled"` is unchanged. The TypeScript SDK uses `ErrorCode.RequestTimeout` for this same case, so the behavior now matches across SDKs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

Fixes #2480