### PR TITLE
fix: default encoding_error_handler to 'replace' in StdioServerParameters

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -151,7 +151,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                     for line in lines:
                         try:
                             message = types.jsonrpc_message_adapter.validate_json(line, by_name=False)
-                        except Exception as exc:  # pragma: no cover
+                        except Exception as exc:
                             logger.exception("Failed to parse JSONRPC message from server")
                             await read_stream_writer.send(exc)
                             continue

--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -92,7 +92,7 @@ class StdioServerParameters(BaseModel):
     Defaults to utf-8.
     """
 
-    encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
+    encoding_error_handler: Literal["strict", "ignore", "replace"] = "replace"
     """
     The text encoding error handler.
 

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -528,8 +528,7 @@ async def test_stdio_client_invalid_utf8():
 
     with anyio.fail_after(5.0):
         async with stdio_client(server_params) as (read_stream, _write_stream):
-            async for item in read_stream:
-                items.append(item)
+            items.extend([item async for item in read_stream])
 
     assert len(items) == 2
     assert isinstance(items[0], Exception)

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -528,7 +528,7 @@ async def test_stdio_client_invalid_utf8():
     items: list[SessionMessage | Exception] = []
 
     with anyio.fail_after(5.0):
-        async with stdio_client(server_params) as (read_stream, write_stream):
+        async with stdio_client(server_params) as (read_stream, _write_stream):
             async for item in read_stream:
                 items.append(item)
                 if len(items) >= 2:

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -512,11 +512,10 @@ async def test_stdio_client_invalid_utf8():
     valid_line = '{"jsonrpc":"2.0","id":1,"method":"ping"}'
     script = textwrap.dedent(
         f"""
-        import sys, time
+        import sys
         sys.stdout.buffer.write(b"\\xff\\xfe\\n")
         sys.stdout.buffer.write({valid_line!r}.encode() + b"\\n")
         sys.stdout.buffer.flush()
-        time.sleep(1)
         """
     )
 
@@ -531,8 +530,6 @@ async def test_stdio_client_invalid_utf8():
         async with stdio_client(server_params) as (read_stream, _write_stream):
             async for item in read_stream:
                 items.append(item)
-                if len(items) >= 2:
-                    break
 
     assert len(items) == 2
     assert isinstance(items[0], Exception)

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -502,6 +502,44 @@ async def test_stdio_client_graceful_stdin_exit():
 
 
 @pytest.mark.anyio
+async def test_stdio_client_invalid_utf8():
+    """Malformed UTF-8 from the child must not crash the transport.
+
+    Invalid bytes are replaced with U+FFFD (default encoding_error_handler),
+    which fails JSON parsing and arrives as an in-stream exception.  The
+    following valid JSON-RPC line must still be delivered as a SessionMessage.
+    """
+    valid_line = '{"jsonrpc":"2.0","id":1,"method":"ping"}'
+    script = textwrap.dedent(
+        f"""
+        import sys, time
+        sys.stdout.buffer.write(b"\\xff\\xfe\\n")
+        sys.stdout.buffer.write({valid_line!r}.encode() + b"\\n")
+        sys.stdout.buffer.flush()
+        time.sleep(1)
+        """
+    )
+
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-c", script],
+    )
+
+    items: list[SessionMessage | Exception] = []
+
+    with anyio.fail_after(5.0):
+        async with stdio_client(server_params) as (read_stream, write_stream):
+            async for item in read_stream:
+                items.append(item)
+                if len(items) >= 2:
+                    break
+
+    assert len(items) == 2
+    assert isinstance(items[0], Exception)
+    assert isinstance(items[1], SessionMessage)
+
+
+@pytest.mark.anyio
 async def test_stdio_client_stdin_close_ignored():
     """Test that when a process ignores stdin closure, the shutdown sequence
     properly escalates to SIGTERM.


### PR DESCRIPTION
## Summary

`stdio_client` crashed with an `ExceptionGroup` when the child process wrote invalid UTF-8 bytes to stdout because `StdioServerParameters.encoding_error_handler` defaulted to `"strict"`.

This was already fixed on the server side in PR #2302; this PR applies the same one-line fix to the client side.

**Change:** default `encoding_error_handler` from `"strict"` to `"replace"` so malformed bytes are replaced with U+FFFD, which then fails JSON parsing and is delivered as an in-stream `Exception` — keeping the transport alive for subsequent valid messages.

## Test

Added `test_stdio_client_invalid_utf8` to `tests/client/test_stdio.py`: spawns a child that writes `b"\xff\xfe\n"` followed by a valid JSON-RPC line, and asserts the first stream item is an `Exception` and the second is a `SessionMessage`.

Fixes #2454