### PR TITLE
Fix Windows CRLF in stdio server TextIOWrapper

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -39,9 +39,9 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
+        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace", newline=""))
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8", newline=""))
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)


### PR DESCRIPTION
## Summary

`stdio_server()` creates `TextIOWrapper` around `sys.stdin.buffer` and `sys.stdout.buffer` without specifying `newline=""`. On Windows, the default `newline=None` causes `\n` → `\r\n` translation on stdout and universal newline mode on stdin, violating the NDJSON wire format used by the MCP spec (which specifies LF-only line endings).

## Fix

Add `newline=""` to both `TextIOWrapper` calls. `newline=""` disables translation while still operating in text mode, ensuring consistent `\n`-only output across all platforms.

## Testing

- Existing tests pass (they use `StringIO`/`BytesIO` which don't go through the `TextIOWrapper` default path)
- Verified the fix produces correct `b'...\n'` output on Windows 11 with Python 3.12

Fixes #2433