### PR TITLE
Remove dead commented-out code in register_client

### DIFF
--- a/src/mcp/client/auth/utils.py
+++ b/src/mcp/client/auth/utils.py
@@ -240,8 +240,6 @@ async def handle_registration_response(response: Response) -> OAuthClientInforma
         content = await response.aread()
         client_info = OAuthClientInformationFull.model_validate_json(content)
         return client_info
-        # self.context.client_info = client_info
-        # await self.context.storage.set_client_info(client_info)
     except ValidationError as e:  # pragma: no cover
         raise OAuthRegistrationError(f"Invalid registration response: {e}")
 


### PR DESCRIPTION
## Summary

Remove two commented-out lines after a `return` statement in `src/mcp/client/auth/utils.py`. They are unreachable and appear to be leftover from a refactor.

## Test plan

- [ ] Existing tests pass