### PR TITLE
[v1.x] Drop responses/notifications when write stream is already closed

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -38,6 +38,8 @@ SendRequestT = TypeVar("SendRequestT", ClientRequest, ServerRequest)
 SendResultT = TypeVar("SendResultT", ClientResult, ServerResult)
 SendNotificationT = TypeVar("SendNotificationT", ClientNotification, ServerNotification)
 ReceiveRequestT = TypeVar("ReceiveRequestT", ClientRequest, ServerRequest)
+
+logger = logging.getLogger(__name__)
 ReceiveResultT = TypeVar("ReceiveResultT", bound=BaseModel)
 ReceiveNotificationT = TypeVar("ReceiveNotificationT", ClientNotification, ServerNotification)
 
@@ -332,13 +334,16 @@ class BaseSession(
             message=JSONRPCMessage(jsonrpc_notification),
             metadata=ServerMessageMetadata(related_request_id=related_request_id) if related_request_id else None,
         )
-        await self._write_stream.send(session_message)
+        try:
+            await self._write_stream.send(session_message)
+        except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+            logger.debug("Notification dropped - transport closed")
+            return
 
     async def _send_response(self, request_id: RequestId, response: SendResultT | ErrorData) -> None:
         if isinstance(response, ErrorData):
             jsonrpc_error = JSONRPCError(jsonrpc="2.0", id=request_id, error=response)
             session_message = SessionMessage(message=JSONRPCMessage(jsonrpc_error))
-            await self._write_stream.send(session_message)
         else:
             jsonrpc_response = JSONRPCResponse(
                 jsonrpc="2.0",
@@ -346,7 +351,12 @@ class BaseSession(
                 result=response.model_dump(by_alias=True, mode="json", exclude_none=True),
             )
             session_message = SessionMessage(message=JSONRPCMessage(jsonrpc_response))
+
+        try:
             await self._write_stream.send(session_message)
+        except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+            logger.debug("Response for %s dropped - transport closed", request_id)
+            return
 
     async def _receive_loop(self) -> None:
         async with (

--- a/tests/server/test_lowlevel_exception_handling.py
+++ b/tests/server/test_lowlevel_exception_handling.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, Mock
 
+import anyio
 import pytest
 
 import mcp.types as types
@@ -72,3 +73,24 @@ async def test_normal_message_handling_not_affected():
 
     # Verify _handle_request was called
     server._handle_request.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_handle_request_drops_response_when_transport_is_closed():
+    """Closed write streams during respond should be treated as expected drops."""
+    server = Server("test-server")
+    session = Mock(spec=ServerSession)
+
+    responder = Mock(spec=RequestResponder)
+    responder.request_id = 1
+    responder.respond = AsyncMock(side_effect=anyio.ClosedResourceError())
+
+    await server._handle_request(
+        responder,
+        types.PingRequest(method="ping"),
+        session,
+        {},
+        raise_exceptions=False,
+    )
+
+    responder.respond.assert_called_once()

--- a/tests/server/test_session.py
+++ b/tests/server/test_session.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 
 import anyio
 import pytest
@@ -221,7 +221,7 @@ async def test_server_session_initialize_with_older_protocol_version():
 
 
 class _ClosedWriteStream:
-    async def send(self, item):
+    async def send(self, item: SessionMessage) -> None:
         raise anyio.ClosedResourceError
 
 
@@ -229,7 +229,7 @@ class _OpenWriteStream:
     def __init__(self):
         self.items: list[SessionMessage] = []
 
-    async def send(self, item):
+    async def send(self, item: SessionMessage) -> None:
         self.items.append(item)
 
 
@@ -237,7 +237,7 @@ class _FakeResult:
     def __init__(self, payload: dict[str, Any]):
         self._payload = payload
 
-    def model_dump(self, **kwargs):
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
         return dict(self._payload)
 
 
@@ -245,24 +245,24 @@ class _FakeNotification:
     def __init__(self, payload: dict[str, Any]):
         self._payload = payload
 
-    def model_dump(self, **kwargs):
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
         return dict(self._payload)
 
 
 @pytest.mark.anyio
 async def test_base_session_send_response_ignores_closed_write_stream():
-    session = object.__new__(BaseSession)
+    session = cast(Any, object.__new__(BaseSession))
     session._write_stream = _ClosedWriteStream()
 
-    await BaseSession._send_response(session, 1, _FakeResult({"ok": True}))
+    await cast(Any, BaseSession)._send_response(session, 1, _FakeResult({"ok": True}))
 
 
 @pytest.mark.anyio
 async def test_base_session_send_notification_ignores_closed_write_stream():
-    session = object.__new__(BaseSession)
+    session = cast(Any, object.__new__(BaseSession))
     session._write_stream = _ClosedWriteStream()
 
-    await BaseSession.send_notification(
+    await cast(Any, BaseSession).send_notification(
         session,
         _FakeNotification({"method": "notifications/progress", "params": {"progress": 1}}),
     )
@@ -270,15 +270,16 @@ async def test_base_session_send_notification_ignores_closed_write_stream():
 
 @pytest.mark.anyio
 async def test_base_session_send_notification_still_writes_when_open():
-    session = object.__new__(BaseSession)
-    session._write_stream = _OpenWriteStream()
+    open_stream = _OpenWriteStream()
+    session = cast(Any, object.__new__(BaseSession))
+    session._write_stream = open_stream
 
-    await BaseSession.send_notification(
+    await cast(Any, BaseSession).send_notification(
         session,
         _FakeNotification({"method": "notifications/progress", "params": {"progress": 1}}),
     )
 
-    assert len(session._write_stream.items) == 1
+    assert len(open_stream.items) == 1
 
 
 @pytest.mark.anyio

--- a/tests/server/test_session.py
+++ b/tests/server/test_session.py
@@ -11,7 +11,7 @@ from mcp.server.models import InitializationOptions
 from mcp.server.session import ServerSession
 from mcp.shared.exceptions import McpError
 from mcp.shared.message import SessionMessage
-from mcp.shared.session import RequestResponder
+from mcp.shared.session import BaseSession, RequestResponder
 from mcp.types import (
     ClientNotification,
     Completion,
@@ -218,6 +218,67 @@ async def test_server_session_initialize_with_older_protocol_version():
 
     assert received_initialized
     assert received_protocol_version == "2024-11-05"
+
+
+class _ClosedWriteStream:
+    async def send(self, item):
+        raise anyio.ClosedResourceError
+
+
+class _OpenWriteStream:
+    def __init__(self):
+        self.items: list[SessionMessage] = []
+
+    async def send(self, item):
+        self.items.append(item)
+
+
+class _FakeResult:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def model_dump(self, **kwargs):
+        return dict(self._payload)
+
+
+class _FakeNotification:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def model_dump(self, **kwargs):
+        return dict(self._payload)
+
+
+@pytest.mark.anyio
+async def test_base_session_send_response_ignores_closed_write_stream():
+    session = object.__new__(BaseSession)
+    session._write_stream = _ClosedWriteStream()
+
+    await BaseSession._send_response(session, 1, _FakeResult({"ok": True}))
+
+
+@pytest.mark.anyio
+async def test_base_session_send_notification_ignores_closed_write_stream():
+    session = object.__new__(BaseSession)
+    session._write_stream = _ClosedWriteStream()
+
+    await BaseSession.send_notification(
+        session,
+        _FakeNotification({"method": "notifications/progress", "params": {"progress": 1}}),
+    )
+
+
+@pytest.mark.anyio
+async def test_base_session_send_notification_still_writes_when_open():
+    session = object.__new__(BaseSession)
+    session._write_stream = _OpenWriteStream()
+
+    await BaseSession.send_notification(
+        session,
+        _FakeNotification({"method": "notifications/progress", "params": {"progress": 1}}),
+    )
+
+    assert len(session._write_stream.items) == 1
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Audience / Scope / Status
| If you are… | Read this section | Why |
| --- | --- | --- |
| reviewing the runtime fix | Summary, Topology, Invariants, Changes | shows why the catch belongs in `BaseSession`, not only in outer server layers |
| reviewing the test/CI follow-up | Validation | explains the coverage and `pyright` failures on the first push |
| looking for broader transport redesign | Non-goals | this PR intentionally hardens closed-write semantics only |

Last verified against: `v1.x` on 2026-04-24

## Relevant upstream issues
- #1219: stateless request handling can still trip `ClosedResourceError` after client disconnect. Relevant because the failing write path here is also in the shared session layer.
- #1967: closed-stream writes during shutdown/logging should be treated as expected drops. Same class of failure, different send site.
- #2422: request lifecycle races still exist around response timing. Relevant because this PR makes the final write idempotent with respect to disconnect.
- PrefectHQ/fastmcp#823: downstream repro of the same symptom from a StreamableHTTP/FastMCP stack. Relevant because it demonstrates this is not just a local application bug.

## Summary
This PR makes `BaseSession.send_notification()` and `BaseSession._send_response()` treat writes to an already-closed transport as expected no-ops rather than exceptions.

The goal is narrow: if the peer has already gone away, a late response or notification should be dropped cleanly at the session send boundary.

## Failure topology
```mermaid
flowchart LR
  H["Request handler\n`mcp.server.lowlevel.server`"]:::server
  R["RequestResponder.respond()\n`src/mcp/shared/session.py:121`"]:::fyr
  S["BaseSession._send_response() / send_notification()\n`src/mcp/shared/session.py:318-357`"]:::fyr
  W["write_stream.send(SessionMessage)\nanyio memory/object stream"]:::transport
  C["Client transport\nstream already closed"]:::client

  H -- "handler result / late progress" --> R
  R -- "JSON-RPC response" --> S
  S -- "SessionMessage write" --> W
  W -. "peer disconnected earlier" .-> C

  classDef client fill:#bfdbfe,stroke:#1e3a8a,stroke-width:2px,color:#0f172a
  classDef transport fill:#e5e7eb,stroke:#6b7280,stroke-width:1px,color:#374151
  classDef server fill:#dcfce7,stroke:#166534,stroke-width:2px,color:#0f172a
  classDef fyr fill:#ddd6fe,stroke:#5b21b6,stroke-width:2px,color:#0f172a
```

### Why the catch belongs here
| Layer | Existing behavior | Gap |
| --- | --- | --- |
| `mcp.server.lowlevel.server` | already has an outer closed-transport catch around `await message.respond(response)` at `src/mcp/server/lowlevel/server.py:799-809` | only covers the `RequestResponder` path that reaches this exact outer frame |
| `BaseSession.send_notification()` | previously wrote directly to `_write_stream.send(...)` | late notifications could still bubble `ClosedResourceError` / `BrokenResourceError` |
| `BaseSession._send_response()` | previously wrote directly to `_write_stream.send(...)` | any caller below the outer server frame still relied on higher layers to catch transport-close races |

## Invariants
- INV-1: A closed peer transport is not a recoverable write target, but it is also not a server bug. Late writes should be dropped, not escalated.
- INV-2: The session send boundary is the narrowest shared seam that sees both responses and notifications. If violated: one call site gets hardened while sibling send paths still leak the same failure.
- INV-3: Higher-layer transport-close catches may remain for defense in depth. If violated: removing all outer guards in the same PR would expand scope from behavior hardening into control-flow refactoring.

## Changes
- Catch `anyio.BrokenResourceError` / `anyio.ClosedResourceError` in `BaseSession.send_notification()` at `src/mcp/shared/session.py:318-339`.
- Catch `anyio.BrokenResourceError` / `anyio.ClosedResourceError` in `BaseSession._send_response()` at `src/mcp/shared/session.py:343-357`.
- Add session-layer regression tests for closed and open write streams at `tests/server/test_session.py:223-282`.
- Add a low-level regression test that exercises the existing outer server catch at `tests/server/test_lowlevel_exception_handling.py:78-96` and `src/mcp/server/lowlevel/server.py:799-809`.

## Validation
### Functional
```bash
PYTHONPATH=src python3 -m pytest -o addopts='' \
  tests/server/test_session.py \
  tests/server/test_lowlevel_exception_handling.py -q
```
Local result after the CI-fix follow-up:
- `17 passed`

### CI follow-up
The first push exposed two CI-only problems, not a runtime regression:

| Check | Initial failure | Follow-up in this PR |
| --- | --- | --- |
| `test` matrix | coverage dropped because the new session-layer catch made the old outer catch in `lowlevel/server.py` unexercised | added `test_handle_request_drops_response_when_transport_is_closed()` to cover the existing outer branch |
| `pre-commit` | strict `pyright` rejected loosely typed fake session/write-stream helpers | tightened annotations and cast sites in `tests/server/test_session.py` |

Targeted local follow-up verification:
```bash
/tmp/python-sdk-upstream/.venv-ci/bin/pyright \
  tests/server/test_session.py \
  tests/server/test_lowlevel_exception_handling.py
```
Local result:
- `0 errors, 0 warnings, 0 informations`

## Non-goals
- This PR does not redesign cancellation or stateless request lifecycle.
- This PR does not remove the outer guard in `lowlevel/server.py`; it keeps defense in depth.
- This PR does not claim to solve every disconnect race in the stack. It narrows one shared failure seam so downstream servers stop surfacing expected closed-write conditions as crashes.
