### PR TITLE
Avoid configuring logging during MCPServer initialization

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -36,7 +36,7 @@ from mcp.server.mcpserver.prompts import Prompt, PromptManager
 from mcp.server.mcpserver.resources import FunctionResource, Resource, ResourceManager
 from mcp.server.mcpserver.tools import Tool, ToolManager
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
-from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
+from mcp.server.mcpserver.utilities.logging import get_logger
 from mcp.server.sse import SseServerTransport
 from mcp.server.stdio import stdio_server
 from mcp.server.streamable_http import EventStore
@@ -202,9 +202,6 @@ class MCPServer(Generic[LifespanResultT]):
         if auth_server_provider and not token_verifier:  # pragma: no cover
             self._token_verifier = ProviderTokenVerifier(auth_server_provider)
         self._custom_starlette_routes: list[Route] = []
-
-        # Configure logging
-        configure_logging(self.settings.log_level)
 
     @property
     def name(self) -> str:

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -43,6 +44,15 @@ from mcp.types import (
 )
 
 pytestmark = pytest.mark.anyio
+
+
+async def test_create_server_does_not_configure_logging(monkeypatch: pytest.MonkeyPatch):
+    basic_config = MagicMock()
+    monkeypatch.setattr(logging, "basicConfig", basic_config)
+
+    MCPServer()
+
+    basic_config.assert_not_called()
 
 
 class TestServer:

--- a/tests/server/mcpserver/utilities/test_logging.py
+++ b/tests/server/mcpserver/utilities/test_logging.py
@@ -1,0 +1,27 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from rich.logging import RichHandler
+
+from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
+
+
+def test_get_logger_returns_named_logger():
+    logger = get_logger("mcp.test")
+
+    assert logger is logging.getLogger("mcp.test")
+
+
+def test_configure_logging_uses_rich_handler(monkeypatch: pytest.MonkeyPatch):
+    basic_config = MagicMock()
+    monkeypatch.setattr(logging, "basicConfig", basic_config)
+
+    configure_logging("DEBUG")
+
+    basic_config.assert_called_once()
+    kwargs = basic_config.call_args.kwargs
+    assert kwargs["level"] == "DEBUG"
+    assert kwargs["format"] == "%(message)s"
+    assert len(kwargs["handlers"]) == 1
+    assert isinstance(kwargs["handlers"][0], RichHandler)


### PR DESCRIPTION
## Summary
- remove the `configure_logging()` call from `MCPServer.__init__()` so constructing a server does not mutate application-level logging
- add a regression test that verifies `MCPServer()` does not call `logging.basicConfig()`
- add direct coverage for the MCPServer logging utilities now that logging is no longer configured as an initialization side effect

Fixes #1656

## Tests
- `uv run --frozen pytest tests/server/mcpserver/test_server.py::test_create_server_does_not_configure_logging tests/server/mcpserver/test_server.py::TestServer::test_create_server tests/server/mcpserver/utilities/test_logging.py -q`
- `uv run --frozen ruff check src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py tests/server/mcpserver/utilities/test_logging.py`
- `uv run --frozen ruff format --check src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py tests/server/mcpserver/utilities/test_logging.py`
- `uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/server/mcpserver/test_server.py::test_create_server_does_not_configure_logging tests/server/mcpserver/test_server.py::TestServer::test_create_server tests/server/mcpserver/utilities/test_logging.py && uv run --frozen coverage combine && uv run --frozen coverage report --include='src/mcp/server/mcpserver/server.py,src/mcp/server/mcpserver/utilities/logging.py' --fail-under=0 && UV_FROZEN=1 uv run --frozen strict-no-cover`
- `uv run --frozen pyright src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py tests/server/mcpserver/utilities/test_logging.py`
