### PR TITLE
fix: skip outputSchema validation when CallToolResult.is_error=True

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -103,7 +103,7 @@ class FuncMetadata(BaseModel):
         the structured output.
         """
         if isinstance(result, CallToolResult):
-            if self.output_schema is not None:
+            if self.output_schema is not None and not result.is_error:
                 assert self.output_model is not None, "Output model must be set if output schema is defined"
                 self.output_model.model_validate(result.structured_content)
             return result

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -875,6 +875,24 @@ def test_tool_call_result_annotated_is_structured_and_invalid():
         meta.convert_result(func_returning_annotated_tool_call_result())
 
 
+def test_tool_call_result_with_is_error_skips_output_schema_validation():
+    """Test that convert_result skips outputSchema validation when is_error=True."""
+
+    class PersonClass(BaseModel):
+        name: str
+
+    def func_with_error() -> Annotated[CallToolResult, PersonClass]:
+        return CallToolResult(content=[], is_error=True)
+
+    meta = func_metadata(func_with_error)
+    assert meta.output_schema is not None
+
+    result = meta.convert_result(func_with_error())
+
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is True
+
+
 def test_tool_call_result_in_optional_is_rejected():
     """Test that Optional[CallToolResult] raises InvalidSignature"""
 


### PR DESCRIPTION
Resolves #2429.

When a tool function with an `output_schema` returns `CallToolResult(is_error=True)`, `convert_result()` was unconditionally calling `output_model.model_validate(result.structured_content)`. For an error result, `structured_content` is `None`, so `model_validate(None)` raises a Pydantic `ValidationError` that replaces the tool's actual error message before it reaches the client.

Skipping schema validation when `is_error` is true matches the resolution that landed in [typescript-sdk#655](https://github.com/modelcontextprotocol/typescript-sdk/pull/655).

## Motivation and Context

Closes #2429.

## How Has This Been Tested?

Added `test_tool_call_result_with_is_error_skips_output_schema_validation` in `tests/server/mcpserver/test_func_metadata.py`. The test registers a function with an inferred output schema, returns `CallToolResult(content=[], is_error=True)`, and asserts `convert_result()` returns the result unchanged. Without the fix the test fails with `pydantic.ValidationError` (because `model_validate(None)` runs against a model with required fields); with the fix it passes.

Verified locally:
- `uv run --frozen ruff check src tests` — clean
- `uv run --frozen ruff format --check src tests` — clean
- `uv run --frozen pyright` — 0 errors
- `./scripts/test` — 100.00% coverage, `strict-no-cover` passes

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed (no doc change needed for a behavioral fix)

## Additional context

While reviewing, I noticed `src/mcp/client/session.py:336` has the same bug pattern client-side: it raises `RuntimeError("Tool ... has an output schema but did not return structured content")` without first checking `result.is_error`. I'm scoping that out of this PR (different surface, separate code path) — happy to file a follow-up issue once this is in.

A `v1.x` backport will follow as a separate PR after this lands (`src/mcp/server/fastmcp/utilities/func_metadata.py:115`, same change with the v1.x camelCase fields).