### PR TITLE
fix(server): return 405 on GET/DELETE in stateless HTTP mode

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -152,6 +152,29 @@ class StreamableHTTPSessionManager:
 
     async def _handle_stateless_request(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Process request in stateless mode - creating a new transport for each request."""
+        # In stateless mode, only POST is meaningful. GET (SSE stream) and DELETE
+        # (session termination) both require session state that stateless mode does
+        # not maintain, so reject them with 405 before creating a transport.
+        request = Request(scope, receive)
+        if request.method in ("GET", "DELETE"):
+            logger.debug(f"Stateless mode: rejecting {request.method} with 405")
+            error_response = JSONRPCError(
+                jsonrpc="2.0",
+                id=None,
+                error=ErrorData(
+                    code=INVALID_REQUEST,
+                    message=(f"Method Not Allowed: {request.method} is not supported in stateless mode"),
+                ),
+            )
+            response = Response(
+                content=error_response.model_dump_json(by_alias=True, exclude_unset=True),
+                status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+                headers={"Allow": "POST"},
+                media_type="application/json",
+            )
+            await response(scope, receive, send)
+            return
+
         logger.debug("Stateless mode: Creating new transport for this request")
         # No session ID needed in stateless mode
         http_transport = StreamableHTTPServerTransport(

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -413,3 +413,116 @@ def test_session_idle_timeout_rejects_non_positive():
 def test_session_idle_timeout_rejects_stateless():
     with pytest.raises(RuntimeError, match="not supported in stateless"):
         StreamableHTTPSessionManager(app=Server("test"), session_idle_timeout=30, stateless=True)
+
+
+async def _collect_stateless_response(
+    method: str,
+) -> tuple[Message | None, bytes]:
+    """Send a request of the given method to a stateless manager and return
+    (response.start message, response body)."""
+    app = Server("test-stateless-method")
+    manager = StreamableHTTPSessionManager(app=app, stateless=True)
+
+    sent_messages: list[Message] = []
+    response_body = b""
+
+    async def mock_send(message: Message):
+        nonlocal response_body
+        sent_messages.append(message)
+        if message["type"] == "http.response.body":
+            response_body += message.get("body", b"")
+
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": "/mcp",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"accept", b"application/json, text/event-stream"),
+        ],
+    }
+
+    async def mock_receive():  # pragma: no cover
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async with manager.run():
+        await manager.handle_request(scope, mock_receive, mock_send)
+
+    response_start = next(
+        (msg for msg in sent_messages if msg["type"] == "http.response.start"),
+        None,
+    )
+    return response_start, response_body
+
+
+@pytest.mark.anyio
+async def test_stateless_get_returns_405():
+    """GET requests return 405 in stateless mode since SSE streams require session state."""
+    response_start, response_body = await _collect_stateless_response("GET")
+
+    assert response_start is not None
+    assert response_start["status"] == 405
+
+    headers = {name.decode().lower(): value.decode() for name, value in response_start.get("headers", [])}
+    assert headers.get("allow") == "POST"
+
+    error_data = json.loads(response_body)
+    assert error_data["jsonrpc"] == "2.0"
+    assert error_data["id"] is None
+    assert error_data["error"]["code"] == INVALID_REQUEST
+    assert "GET" in error_data["error"]["message"]
+    assert "stateless" in error_data["error"]["message"].lower()
+
+
+@pytest.mark.anyio
+async def test_stateless_delete_returns_405():
+    """DELETE requests return 405 in stateless mode since there is no session to terminate."""
+    response_start, response_body = await _collect_stateless_response("DELETE")
+
+    assert response_start is not None
+    assert response_start["status"] == 405
+
+    headers = {name.decode().lower(): value.decode() for name, value in response_start.get("headers", [])}
+    assert headers.get("allow") == "POST"
+
+    error_data = json.loads(response_body)
+    assert error_data["jsonrpc"] == "2.0"
+    assert error_data["id"] is None
+    assert error_data["error"]["code"] == INVALID_REQUEST
+    assert "DELETE" in error_data["error"]["message"]
+
+
+@pytest.mark.anyio
+async def test_stateless_get_does_not_create_transport():
+    """A GET in stateless mode should short-circuit without spinning up a transport."""
+    app = Server("test-stateless-no-transport")
+    manager = StreamableHTTPSessionManager(app=app, stateless=True)
+
+    created_transports: list[StreamableHTTPServerTransport] = []
+    original_constructor = StreamableHTTPServerTransport
+
+    def track_transport(*args: Any, **kwargs: Any) -> StreamableHTTPServerTransport:
+        transport = original_constructor(*args, **kwargs)  # pragma: no cover
+        created_transports.append(transport)  # pragma: no cover
+        return transport  # pragma: no cover
+
+    with patch.object(streamable_http_manager, "StreamableHTTPServerTransport", side_effect=track_transport):
+        async with manager.run():
+            sent_messages: list[Message] = []
+
+            async def mock_send(message: Message):
+                sent_messages.append(message)
+
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/mcp",
+                "headers": [(b"accept", b"text/event-stream")],
+            }
+
+            async def mock_receive():  # pragma: no cover
+                return {"type": "http.request", "body": b"", "more_body": False}
+
+            await manager.handle_request(scope, mock_receive, mock_send)
+
+    assert created_transports == [], "Stateless GET must not create a transport"


### PR DESCRIPTION
## Summary

In stateless HTTP mode (`stateless_http=True`), GET requests to the MCP endpoint were creating a transport and opening an SSE stream that could never receive server-initiated messages, idling until timeout. DELETE had the same shape (no session to terminate). This wastes connections, especially on serverless platforms (Cloud Run, Lambda).

This PR makes `StreamableHTTPSessionManager._handle_stateless_request` short-circuit GET and DELETE with HTTP 405 before any transport is spawned. POST is unchanged. Stateful mode is unchanged.

The MCP spec permits this: *"Servers MAY return HTTP 405 Method Not Allowed if an SSE stream is not offered at the endpoint."* The TypeScript SDK already implements this behavior.

Closes #2474.

## What changed

- `src/mcp/server/streamable_http_manager.py` — early-return guard at the top of `_handle_stateless_request`. If `request.method` is `GET` or `DELETE`, return a JSON-RPC formatted 405 with `Allow: POST` and bail out before transport creation.
- `tests/server/test_streamable_http_manager.py` — three new tests:
  - `test_stateless_get_returns_405` — status, `Allow` header, JSON-RPC error body
  - `test_stateless_delete_returns_405` — same checks for DELETE
  - `test_stateless_get_does_not_create_transport` — asserts no `StreamableHTTPServerTransport` is instantiated for a stateless GET

## Design notes

- **Layer placement.** The guard lives in the manager, not the transport. The manager already owns the stateless/stateful routing decision; `StreamableHTTPServerTransport` stays mode-agnostic.
- **Response format.** Mirrors the existing 404 "Session not found" handler (`JSONRPCError(jsonrpc="2.0", id=None, error=ErrorData(code=INVALID_REQUEST, ...))` serialized via `model_dump_json(by_alias=True, exclude_unset=True)`), with an added `Allow: POST` header.
- **`Allow` header.** Returns `Allow: POST` (not `GET, POST, DELETE` like the stateful transport's `_handle_unsupported_request`). The difference is intentional — stateless mode genuinely only supports POST.
- **HEAD/OPTIONS in stateless.** Not caught by this guard; they fall through to the transport's `_handle_unsupported_request` and still return 405. The `Allow` header from that path advertises GET/DELETE that stateless doesn't actually support — minor inconsistency, happy to extend the guard if reviewers prefer.
- **No new imports.** `Request`, `Response`, `HTTPStatus`, `INVALID_REQUEST`, `ErrorData`, `JSONRPCError` were all already imported in this module.

## Test plan

- [x] `uv run --frozen pytest tests/server/test_streamable_http_manager.py` — 14/14 pass
- [x] `uv run --frozen pytest tests/ -k stateless` — 13/13 pass
- [x] `uv run --frozen pytest tests/server/` — 477/477 pass (no regressions)
- [x] `uv run --frozen ruff format` + `ruff check` — clean
- [x] `uv run --frozen pyright` — 0 errors
- [x] Targeted coverage on `streamable_http_manager.py` — 100% (branch-covered)
- [x] `strict-no-cover` — clean
- [x] `pre-commit run` on changed files — all applicable hooks pass