### PR TITLE
fix: prevent infinite reconnection loop when SSE stream drops without response

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -380,8 +380,17 @@ class StreamableHTTPTransport:
     ) -> None:
         """Reconnect with Last-Event-ID to resume stream after server disconnect."""
         # Bail if max retries exceeded
-        if attempt >= MAX_RECONNECTION_ATTEMPTS:  # pragma: no cover
-            logger.debug(f"Max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
+        if attempt >= MAX_RECONNECTION_ATTEMPTS:
+            logger.warning(f"Max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
+            if isinstance(ctx.session_message.message, JSONRPCRequest):
+                error_data = ErrorData(
+                    code=INTERNAL_ERROR,
+                    message=f"SSE stream disconnected after {MAX_RECONNECTION_ATTEMPTS} reconnection attempts",
+                )
+                error_msg = SessionMessage(
+                    JSONRPCError(jsonrpc="2.0", id=ctx.session_message.message.id, error=error_data)
+                )
+                await ctx.read_stream_writer.send(error_msg)
             return
 
         # Always wait - use server value or default
@@ -404,12 +413,15 @@ class StreamableHTTPTransport:
                 # Track for potential further reconnection
                 reconnect_last_event_id: str = last_event_id
                 reconnect_retry_ms = retry_interval_ms
+                received_data = False
 
                 async for sse in event_source.aiter_sse():
                     if sse.id:  # pragma: no branch
                         reconnect_last_event_id = sse.id
                     if sse.retry is not None:
                         reconnect_retry_ms = sse.retry
+                    if sse.data:
+                        received_data = True
 
                     is_complete = await self._handle_sse_event(
                         sse,
@@ -421,9 +433,13 @@ class StreamableHTTPTransport:
                         await event_source.response.aclose()
                         return
 
-                # Stream ended again without response - reconnect again (reset attempt counter)
+                # Stream ended without response — reconnect.
+                # Reset attempt counter only when real data was received
+                # (server made progress). Otherwise increment to prevent
+                # infinite loops when server only sends priming events.
+                next_attempt = 0 if received_data else attempt + 1
                 logger.info("SSE stream disconnected, reconnecting...")
-                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, 0)
+                await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, next_attempt)
         except Exception as e:  # pragma: no cover
             logger.debug(f"Reconnection failed: {e}")
             # Try to reconnect again if we still have an event ID

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -382,7 +382,7 @@ class StreamableHTTPTransport:
         # Bail if max retries exceeded
         if attempt >= MAX_RECONNECTION_ATTEMPTS:
             logger.warning(f"Max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
-            if isinstance(ctx.session_message.message, JSONRPCRequest):
+            if isinstance(ctx.session_message.message, JSONRPCRequest):  # pragma: no branch
                 error_data = ErrorData(
                     code=INTERNAL_ERROR,
                     message=f"SSE stream disconnected after {MAX_RECONNECTION_ATTEMPTS} reconnection attempts",

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -57,6 +57,7 @@ from mcp.types import (
     CallToolRequestParams,
     CallToolResult,
     InitializeResult,
+    JSONRPCError,
     JSONRPCRequest,
     ListToolsResult,
     PaginatedRequestParams,
@@ -2318,3 +2319,76 @@ async def test_streamable_http_client_preserves_custom_with_mcp_headers(
 
                 assert "content-type" in headers_data
                 assert headers_data["content-type"] == "application/json"
+
+
+@pytest.mark.anyio
+async def test_handle_reconnection_stops_after_max_attempts() -> None:
+    """_handle_reconnection must not reset attempt counter on stream drop.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2393.
+    When the server accepts the SSE connection but closes the stream without
+    sending a complete JSON-RPC response, the client must give up after
+    MAX_RECONNECTION_ATTEMPTS total attempts and report an error — not retry
+    forever.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from mcp.client.streamable_http import MAX_RECONNECTION_ATTEMPTS, RequestContext
+
+    transport = StreamableHTTPTransport("http://test/mcp")
+    connect_count = 0
+
+    @asynccontextmanager
+    async def fake_aconnect_sse(*_args: object, **_kwargs: object):
+        nonlocal connect_count
+        connect_count += 1
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.aclose = AsyncMock()
+
+        event_source = MagicMock()
+        event_source.response = response
+
+        async def aiter_sse():
+            yield ServerSentEvent(event="message", data="", id=f"evt-{connect_count}", retry=None)
+
+        event_source.aiter_sse = aiter_sse
+        yield event_source
+
+    write_stream, read_stream = create_context_streams[SessionMessage | Exception](1)
+
+    request = JSONRPCRequest(
+        jsonrpc="2.0",
+        id="req-1",
+        method="tools/call",
+        params={"name": "test_tool", "arguments": {}},
+    )
+    ctx = RequestContext(
+        client=MagicMock(),
+        session_id="test-session",
+        session_message=SessionMessage(request),
+        metadata=None,
+        read_stream_writer=write_stream,
+    )
+
+    import mcp.client.streamable_http as _mod
+
+    original = _mod.aconnect_sse
+    _mod.aconnect_sse = fake_aconnect_sse  # type: ignore[assignment]
+    try:
+        await transport._handle_reconnection(ctx, "evt-0", 0)
+    finally:
+        _mod.aconnect_sse = original
+
+    assert connect_count == MAX_RECONNECTION_ATTEMPTS
+
+    with anyio.fail_after(1):
+        msg = await read_stream.receive()
+    assert isinstance(msg, SessionMessage)
+    assert isinstance(msg.message, JSONRPCError)
+    assert "reconnection attempts" in msg.message.error.message.lower()
+    assert msg.message.id == "req-1"
+
+    await write_stream.aclose()
+    await read_stream.aclose()


### PR DESCRIPTION
## Motivation and Context

Fixes #2393. `_handle_reconnection()` resets the `attempt` counter to `0` when a reconnection succeeds at the HTTP level but the stream ends without delivering a complete JSON-RPC response. This makes `MAX_RECONNECTION_ATTEMPTS` ineffective — the counter only applies to consecutive exceptions, not total reconnection attempts. If the server accepts the connection but the stream drops repeatedly (sending only priming events), the client retries forever.

In production this causes MCP client coroutines to hang indefinitely when a server experiences transient stream drops.

## How Has This Been Tested?

- Regression test (`test_handle_reconnection_stops_after_max_attempts`) that mocks `aconnect_sse` to simulate a server sending only priming events then dropping. Verifies the client gives up after `MAX_RECONNECTION_ATTEMPTS` and sends a `JSONRPCError` back to the caller.
- All 62 existing `test_streamable_http.py` tests pass, including `test_streamable_http_multiple_reconnections` (3 legitimate reconnections with real data).

## Changes

1. **Smart attempt counter**: track whether real SSE data (not just priming events) was received during reconnection. Reset counter only when progress was made; increment when server only sends empty priming events.
2. **Error reporting**: when max attempts are exceeded, send a `JSONRPCError` back through `read_stream_writer` so `call_tool` returns an error instead of hanging forever.
3. **Regression test**: in-memory unit test with mocked SSE to verify the fix.

## Breaking Changes

No.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed