### PR TITLE
fix: move logging configuration from MCPServer.__init__ to run()

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -203,9 +203,6 @@ class MCPServer(Generic[LifespanResultT]):
             self._token_verifier = ProviderTokenVerifier(auth_server_provider)
         self._custom_starlette_routes: list[Route] = []
 
-        # Configure logging
-        configure_logging(self.settings.log_level)
-
     @property
     def name(self) -> str:
         return self._lowlevel_server.name
@@ -290,6 +287,8 @@ class MCPServer(Generic[LifespanResultT]):
         TRANSPORTS = Literal["stdio", "sse", "streamable-http"]
         if transport not in TRANSPORTS.__args__:  # type: ignore  # pragma: no cover
             raise ValueError(f"Unknown transport: {transport}")
+
+        configure_logging(self.settings.log_level)
 
         match transport:
             case "stdio":

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1516,3 +1516,22 @@ async def test_report_progress_passes_related_request_id():
         message="halfway",
         related_request_id="req-abc-123",
     )
+
+
+def test_mcpserver_init_does_not_configure_logging() -> None:
+    """MCPServer.__init__ must not call logging.basicConfig or add handlers.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/1656.
+    Library code should never configure the root logger — that is the
+    application's responsibility.
+    """
+    import logging
+
+    root = logging.getLogger()
+    handlers_before = list(root.handlers)
+    level_before = root.level
+
+    MCPServer("test-logging")
+
+    assert root.handlers == handlers_before
+    assert root.level == level_before


### PR DESCRIPTION
## Motivation and Context

Fixes #1656. `MCPServer.__init__()` calls `configure_logging()` which invokes `logging.basicConfig()`, adding handlers and setting the level on the root logger. This violates the [Python logging best practice](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) that library code should never configure the root logger.

Applications embedding `MCPServer` as a library had their logging config silently overwritten at construction time.

## Changes

- Move `configure_logging()` call from `MCPServer.__init__()` to `MCPServer.run()` — the actual application entrypoint for standalone server processes
- Add regression test verifying that constructing `MCPServer` does not modify the root logger

## How Has This Been Tested?

- Regression test (`test_mcpserver_init_does_not_configure_logging`) that captures root logger state before/after `MCPServer()` construction and asserts no handlers were added and log level was not changed
- All 90 existing `test_server.py` tests pass

## Breaking Changes

No. `run()` still configures logging before starting the server. Only consumers who instantiate `MCPServer` without calling `run()` (library usage) are affected — they now keep full control of their logging setup, which is the desired behavior.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed