### PR TITLE
fix: send notifications/cancelled on request timeout and caller cancellation

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -144,7 +144,7 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
         """Cancel this request and mark it as completed."""
         if not self._entered:
             raise RuntimeError("RequestResponder must be used as a context manager")
-        if not self._cancel_scope:
+        if not self._cancel_scope:  # pragma: no cover
             raise RuntimeError("No active cancel scope")
 
         self._cancel_scope.cancel()

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -23,6 +23,7 @@ from mcp.types import (
     INVALID_PARAMS,
     REQUEST_TIMEOUT,
     CancelledNotification,
+    CancelledNotificationParams,
     ClientNotification,
     ClientRequest,
     ClientResult,
@@ -292,9 +293,13 @@ class BaseSession(
                     with anyio.fail_after(timeout):
                         response_or_error = await response_stream_reader.receive()
                 except TimeoutError:
+                    await self._send_cancelled_notification(request_id, "request timed out")
                     class_name = request.__class__.__name__
                     message = f"Timed out while waiting for response to {class_name}. Waited {timeout} seconds."
                     raise MCPError(code=REQUEST_TIMEOUT, message=message)
+                except anyio.get_cancelled_exc_class():
+                    await self._send_cancelled_notification(request_id, "request cancelled by caller")
+                    raise
 
                 if isinstance(response_or_error, JSONRPCError):
                     raise MCPError.from_jsonrpc_error(response_or_error)
@@ -539,6 +544,26 @@ class BaseSession(
         message: str | None = None,
     ) -> None:
         """Sends a progress notification for a request that is currently being processed."""
+
+    async def _send_cancelled_notification(self, request_id: RequestId, reason: str) -> None:
+        """Send a cancellation notification to the remote side (best-effort).
+
+        Uses a shielded cancel scope so the notification is delivered even
+        when called from inside a cancelled task.
+        """
+        try:
+            with anyio.CancelScope(shield=True):
+                notification = CancelledNotification(
+                    method="notifications/cancelled",
+                    params=CancelledNotificationParams(request_id=request_id, reason=reason),
+                )
+                jsonrpc_notification = JSONRPCNotification(
+                    jsonrpc="2.0",
+                    **notification.model_dump(by_alias=True, mode="json", exclude_none=True),
+                )
+                await self._write_stream.send(SessionMessage(message=jsonrpc_notification))
+        except Exception:
+            logging.warning("Failed to send cancellation notification for request %s", request_id)
 
     async def _handle_incoming(
         self, req: RequestResponder[ReceiveRequestT, SendResultT] | ReceiveNotificationT | Exception

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -548,20 +548,22 @@ class BaseSession(
     async def _send_cancelled_notification(self, request_id: RequestId, reason: str) -> None:
         """Send a cancellation notification to the remote side (best-effort).
 
-        Uses a shielded cancel scope so the notification is delivered even
-        when called from inside a cancelled task.
+        Uses a shielded cancel scope with a timeout so the notification is
+        delivered even when called from inside a cancelled task, but does not
+        block shutdown if the write stream is unavailable.
         """
         try:
             with anyio.CancelScope(shield=True):
-                notification = CancelledNotification(
-                    method="notifications/cancelled",
-                    params=CancelledNotificationParams(request_id=request_id, reason=reason),
-                )
-                jsonrpc_notification = JSONRPCNotification(
-                    jsonrpc="2.0",
-                    **notification.model_dump(by_alias=True, mode="json", exclude_none=True),
-                )
-                await self._write_stream.send(SessionMessage(message=jsonrpc_notification))
+                with anyio.fail_after(2):
+                    notification = CancelledNotification(
+                        method="notifications/cancelled",
+                        params=CancelledNotificationParams(request_id=request_id, reason=reason),
+                    )
+                    jsonrpc_notification = JSONRPCNotification(
+                        jsonrpc="2.0",
+                        **notification.model_dump(by_alias=True, mode="json", exclude_none=True),
+                    )
+                    await self._write_stream.send(SessionMessage(message=jsonrpc_notification))
         except Exception:
             logging.warning("Failed to send cancellation notification for request %s", request_id)
 

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -142,9 +142,9 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
 
     async def cancel(self) -> None:
         """Cancel this request and mark it as completed."""
-        if not self._entered:  # pragma: no cover
+        if not self._entered:
             raise RuntimeError("RequestResponder must be used as a context manager")
-        if not self._cancel_scope:  # pragma: no cover
+        if not self._cancel_scope:
             raise RuntimeError("No active cancel scope")
 
         self._cancel_scope.cancel()
@@ -423,7 +423,7 @@ class BaseSession(
                                 await self._handle_incoming(notification)
                         except Exception:
                             # For other validation errors, log and continue
-                            logging.warning(  # pragma: no cover
+                            logging.warning(
                                 f"Failed to validate notification:. Message was: {message.message}",
                                 exc_info=True,
                             )

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -428,7 +428,7 @@ async def test_send_request_sends_cancelled_notification_on_timeout():
 
     async with create_client_server_memory_streams() as (client_streams, server_streams):
         client_read, client_write = client_streams
-        server_read, server_write = server_streams
+        server_read, _ = server_streams
 
         async def mock_server():
             async for message in server_read:
@@ -473,7 +473,7 @@ async def test_send_request_sends_cancelled_notification_on_caller_cancel():
 
     async with create_client_server_memory_streams() as (client_streams, server_streams):
         client_read, client_write = client_streams
-        server_read, server_write = server_streams
+        server_read, _ = server_streams
 
         async def mock_server():
             async for message in server_read:

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -431,7 +431,7 @@ async def test_send_request_sends_cancelled_notification_on_timeout():
         server_read, _ = server_streams
 
         async def mock_server():
-            async for message in server_read:
+            async for message in server_read:  # pragma: no branch
                 assert isinstance(message, SessionMessage)
                 if isinstance(message.message, JSONRPCRequest):
                     pass
@@ -476,7 +476,7 @@ async def test_send_request_sends_cancelled_notification_on_caller_cancel():
         server_read, _ = server_streams
 
         async def mock_server():
-            async for message in server_read:
+            async for message in server_read:  # pragma: no branch
                 assert isinstance(message, SessionMessage)
                 if isinstance(message.message, JSONRPCRequest):
                     ev_request_sent.set()

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -416,3 +416,97 @@ async def test_null_id_error_does_not_affect_pending_request():
     # Pending request completed successfully
     assert len(result_holder) == 1
     assert isinstance(result_holder[0], EmptyResult)
+
+
+@pytest.mark.anyio
+async def test_send_request_sends_cancelled_notification_on_timeout():
+    """Client must send notifications/cancelled when a request times out.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2507.
+    """
+    cancelled_notifications: list[SessionMessage] = []
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+
+        async def mock_server():
+            async for message in server_read:
+                assert isinstance(message, SessionMessage)
+                if isinstance(message.message, JSONRPCRequest):
+                    pass
+                elif isinstance(message.message, types.JSONRPCNotification):
+                    cancelled_notifications.append(message)
+
+        async with (
+            anyio.create_task_group() as tg,
+            ClientSession(
+                read_stream=client_read,
+                write_stream=client_write,
+                read_timeout_seconds=0.1,
+            ) as client_session,
+        ):
+            tg.start_soon(mock_server)
+
+            with pytest.raises(MCPError, match="Timed out"):
+                await client_session.send_ping()
+
+            await anyio.sleep(0.05)
+            tg.cancel_scope.cancel()
+
+    assert len(cancelled_notifications) == 1
+    notif = cancelled_notifications[0].message
+    assert isinstance(notif, types.JSONRPCNotification)
+    assert notif.method == "notifications/cancelled"
+    assert notif.params is not None
+    assert notif.params.get("reason") == "request timed out"
+
+
+@pytest.mark.anyio
+async def test_send_request_sends_cancelled_notification_on_caller_cancel():
+    """Client must send notifications/cancelled when caller cancels the request.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2507.
+    """
+    cancelled_notifications: list[SessionMessage] = []
+    ev_request_sent = anyio.Event()
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+
+        async def mock_server():
+            async for message in server_read:
+                assert isinstance(message, SessionMessage)
+                if isinstance(message.message, JSONRPCRequest):
+                    ev_request_sent.set()
+                elif isinstance(message.message, types.JSONRPCNotification):
+                    cancelled_notifications.append(message)
+
+        async def make_request(client_session: ClientSession):
+            await client_session.send_ping()
+
+        async with (
+            anyio.create_task_group() as tg,
+            ClientSession(
+                read_stream=client_read,
+                write_stream=client_write,
+            ) as client_session,
+        ):
+            tg.start_soon(mock_server)
+
+            async with anyio.create_task_group() as request_tg:
+                request_tg.start_soon(make_request, client_session)
+                with anyio.fail_after(1):
+                    await ev_request_sent.wait()
+                request_tg.cancel_scope.cancel()
+
+            await anyio.sleep(0.05)
+            tg.cancel_scope.cancel()
+
+    assert len(cancelled_notifications) == 1
+    notif = cancelled_notifications[0].message
+    assert isinstance(notif, types.JSONRPCNotification)
+    assert notif.method == "notifications/cancelled"
+    assert notif.params is not None
+    assert notif.params.get("reason") == "request cancelled by caller"

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -433,9 +433,7 @@ async def test_send_request_sends_cancelled_notification_on_timeout():
         async def mock_server():
             async for message in server_read:  # pragma: no branch
                 assert isinstance(message, SessionMessage)
-                if isinstance(message.message, JSONRPCRequest):
-                    pass
-                elif isinstance(message.message, types.JSONRPCNotification):
+                if isinstance(message.message, types.JSONRPCNotification):
                     cancelled_notifications.append(message)
 
         async with (
@@ -480,7 +478,7 @@ async def test_send_request_sends_cancelled_notification_on_caller_cancel():
                 assert isinstance(message, SessionMessage)
                 if isinstance(message.message, JSONRPCRequest):
                     ev_request_sent.set()
-                elif isinstance(message.message, types.JSONRPCNotification):
+                if isinstance(message.message, types.JSONRPCNotification):
                     cancelled_notifications.append(message)
 
         async def make_request(client_session: ClientSession):


### PR DESCRIPTION
## Motivation and Context

Fixes #2507. `ClientSession.send_request()` never emits a `notifications/cancelled` message when a request is interrupted — either by the SDK's own `anyio.fail_after` timeout or by external cancellation (e.g. `asyncio.wait_for`). The [MCP spec requires](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/draft/basic/utilities/cancellation.mdx) the sender to issue this notification on timeout, and cooperative cancellation likewise needs it.

**Impact:** Server-side tool coroutines remain suspended after a client cancellation, holding DB connections, cursors, locks, and file handles until the session ends. With long-lived sessions, every cancelled call is a silent resource leak. The issue author demonstrated 50 cancelled `call_tool` invocations → 50 leaked server-side coroutines.

The server already handles `CancelledNotification` correctly (cancels the in-flight request). Only the client-side emit is missing.

## Changes

1. **Timeout path** (`TimeoutError`): send `notifications/cancelled` before raising `MCPError`
2. **External cancellation path** (`CancelledError`): catch `anyio.get_cancelled_exc_class()`, send notification, re-raise
3. **`_send_cancelled_notification` helper**: builds and sends the notification inside a shielded cancel scope to guarantee delivery even when called from a cancelled task
4. **Two regression tests**: one for each cancellation path, using in-memory streams

## How Has This Been Tested?

- `test_send_request_sends_cancelled_notification_on_timeout` — verifies the notification is sent when `read_timeout_seconds` triggers
- `test_send_request_sends_cancelled_notification_on_caller_cancel` — verifies the notification is sent when the caller cancels the task externally
- All 10 existing `test_session.py` tests pass

## Breaking Changes

No. The only behavioral change is that the client now sends an additional notification that the server already expects and handles.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed