### PR TITLE
fix(examples/simple-chatbot): align declared deps with actual usage

### DIFF
--- a/examples/clients/simple-chatbot/README.MD
+++ b/examples/clients/simple-chatbot/README.MD
@@ -4,9 +4,9 @@ This example demonstrates how to integrate the Model Context Protocol (MCP) into
 
 ## Requirements
 
-- Python 3.10
+- Python 3.10+
 - `python-dotenv`
-- `requests`
+- `httpx`
 - `mcp`
 - `uvicorn`
 

--- a/examples/clients/simple-chatbot/mcp_simple_chatbot/requirements.txt
+++ b/examples/clients/simple-chatbot/mcp_simple_chatbot/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv>=1.0.0
-requests>=2.31.0
+httpx>=0.27.0
 mcp>=1.0.0
 uvicorn>=0.32.1

--- a/examples/clients/simple-chatbot/pyproject.toml
+++ b/examples/clients/simple-chatbot/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 ]
 dependencies = [
     "python-dotenv>=1.0.0",
+    "httpx>=0.27.0",
     "mcp",
     "uvicorn>=0.32.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1056,6 +1056,7 @@ name = "mcp-simple-chatbot"
 version = "0.1.0"
 source = { editable = "examples/clients/simple-chatbot" }
 dependencies = [
+    { name = "httpx" },
     { name = "mcp" },
     { name = "python-dotenv" },
     { name = "uvicorn" },
@@ -1070,6 +1071,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", editable = "." },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "uvicorn", specifier = ">=0.32.1" },


### PR DESCRIPTION
## Summary

The `examples/clients/simple-chatbot` example imports `httpx` in `mcp_simple_chatbot/main.py`, but the dependency declarations didn't match what the code actually uses:

- `requirements.txt` still listed `requests>=2.31.0`, even though no code imports `requests`. PR #1959 (merged 2026-01-26) removed `requests` from `pyproject.toml` but did not update the sibling `requirements.txt`.
- `pyproject.toml` did not declare `httpx` despite `main.py` importing it. A fresh `pip install .` followed by running the chatbot fails with `ModuleNotFoundError: httpx`.
- `README.MD` still listed `requests` in the Requirements section and showed Python 3.10 (no plus), while `pyproject.toml` declares `requires-python = \">=3.10\"`.

## Why

Drive-by users following the README copy the install commands verbatim. Today they get a confusing `ModuleNotFoundError: httpx` once the chatbot starts. This PR aligns the three sources of truth (README, requirements.txt, pyproject.toml) with what `main.py` actually imports.

## Changes

- `examples/clients/simple-chatbot/mcp_simple_chatbot/requirements.txt`: replace `requests>=2.31.0` with `httpx>=0.27.0`.
- `examples/clients/simple-chatbot/pyproject.toml`: add `httpx>=0.27.0` to `dependencies`.
- `examples/clients/simple-chatbot/README.MD`: replace `requests` with `httpx`, and update Python requirement to `3.10+`.

No code changes — pure docs/dep alignment.

## How to test

```bash
cd examples/clients/simple-chatbot
pip install .
python -c "import httpx; import mcp_simple_chatbot.main"  # should not fail
```

Or with the requirements.txt path:
```bash
pip install -r mcp_simple_chatbot/requirements.txt
```

Both routes now succeed without the missing-import error.