### PR TITLE
fix(types): correct FastMCP.call_tool and convert_result return types (#1251)

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -323,7 +323,7 @@ class MCPServer(Generic[LifespanResultT]):
                 structured_content=structured_content,  # type: ignore[arg-type]
             )
         if isinstance(result, dict):  # pragma: no cover
-            # TODO: this code path is unreachable — convert_result never returns a raw dict.
+            # TODO: this code path is unreachable, convert_result never returns a raw dict.
             # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong
             # and needs to be cleaned up.
             return CallToolResult(
@@ -617,7 +617,7 @@ class MCPServer(Generic[LifespanResultT]):
                     completion=result if result is not None else Completion(values=[], total=None, has_more=None),
                 )
 
-            # TODO(maxisbey): remove private access — completion needs post-construction
+            # TODO(maxisbey): remove private access, completion needs post-construction
             #   handler registration, find a better pattern for this
             self._lowlevel_server._add_request_handler(  # pyright: ignore[reportPrivateUsage]
                 "completion/complete", handler

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -399,8 +399,18 @@ class MCPServer(Generic[LifespanResultT]):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
-        """Call a tool by name with arguments."""
+    ) -> Sequence[ContentBlock] | CallToolResult | tuple[Sequence[ContentBlock], dict[str, Any]]:
+        """Call a tool by name with arguments.
+
+        Because ``convert_result=True`` is always passed to the tool manager, the
+        return value comes from ``FuncMetadata.convert_result``:
+
+        - ``Sequence[ContentBlock]`` when the tool has no output schema and
+          returned a regular value
+        - ``CallToolResult`` when the tool returned a ``CallToolResult`` directly
+        - ``tuple[Sequence[ContentBlock], dict[str, Any]]`` when the tool has
+          an output schema, where the second element is the structured content
+        """
         if context is None:
             context = Context(mcp_server=self)
         return await self._tool_manager.call_tool(name, arguments, context, convert_result=True)

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -88,12 +88,17 @@ class FuncMetadata(BaseModel):
         else:
             return await anyio.to_thread.run_sync(functools.partial(fn, **arguments_parsed_dict))
 
-    def convert_result(self, result: Any) -> Any:
+    def convert_result(
+        self, result: Any
+    ) -> Sequence[ContentBlock] | CallToolResult | tuple[Sequence[ContentBlock], dict[str, Any]]:
         """Convert a function call result to the format for the lowlevel tool call handler.
 
-        - If output_model is None, return the unstructured content directly.
-        - If output_model is not None, convert the result to structured output format
-            (dict[str, Any]) and return both unstructured and structured content.
+        - If the function returned a ``CallToolResult`` directly, return it unchanged.
+        - If ``output_model`` is None, return the unstructured content
+          (``Sequence[ContentBlock]``) directly.
+        - If ``output_model`` is not None, convert the result to structured output
+          format (``dict[str, Any]``) and return both unstructured and structured
+          content as a tuple.
 
         Note: we return unstructured content here **even though the lowlevel server
         tool call handler provides generic backwards compatibility serialization of

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1038,7 +1038,9 @@ def test_structured_output_aliases():
 
     # Check that the actual output uses aliases too
     result = ModelWithAliases(**{"first": "hello", "second": "world"})
-    _, structured_content = meta.convert_result(result)
+    converted = meta.convert_result(result)
+    assert isinstance(converted, tuple)
+    _, structured_content = converted
 
     # The structured content should use aliases to match the schema
     assert "first" in structured_content
@@ -1050,7 +1052,9 @@ def test_structured_output_aliases():
 
     # Also test the case where we have a model with defaults to ensure aliases work in all cases
     result_with_defaults = ModelWithAliases()  # Uses default None values
-    _, structured_content_defaults = meta.convert_result(result_with_defaults)
+    converted_defaults = meta.convert_result(result_with_defaults)
+    assert isinstance(converted_defaults, tuple)
+    _, structured_content_defaults = converted_defaults
 
     # Even with defaults, should use aliases in output
     assert "first" in structured_content_defaults

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1038,7 +1038,7 @@ def test_structured_output_aliases():
 
     # Check that the actual output uses aliases too. ``convert_result``
     # returns either a sequence, a CallToolResult, or a 2-tuple of
-    # (unstructured, structured) — for a model with an output schema the
+    # (unstructured, structured), for a model with an output schema the
     # 2-tuple branch fires, so cast accordingly to keep pyright happy
     # without runtime narrowing surprises.
     from typing import cast

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1036,11 +1036,18 @@ def test_structured_output_aliases():
     assert "field_first" not in meta.output_schema["properties"]
     assert "field_second" not in meta.output_schema["properties"]
 
-    # Check that the actual output uses aliases too
+    # Check that the actual output uses aliases too. ``convert_result``
+    # returns either a sequence, a CallToolResult, or a 2-tuple of
+    # (unstructured, structured) — for a model with an output schema the
+    # 2-tuple branch fires, so cast accordingly to keep pyright happy
+    # without runtime narrowing surprises.
+    from typing import cast
+
     result = ModelWithAliases(**{"first": "hello", "second": "world"})
-    converted = meta.convert_result(result)
-    assert isinstance(converted, tuple)
-    _, structured_content = converted
+    structured_content = cast(
+        "tuple[Any, dict[str, Any]]",
+        meta.convert_result(result),
+    )[1]
 
     # The structured content should use aliases to match the schema
     assert "first" in structured_content
@@ -1052,9 +1059,10 @@ def test_structured_output_aliases():
 
     # Also test the case where we have a model with defaults to ensure aliases work in all cases
     result_with_defaults = ModelWithAliases()  # Uses default None values
-    converted_defaults = meta.convert_result(result_with_defaults)
-    assert isinstance(converted_defaults, tuple)
-    _, structured_content_defaults = converted_defaults
+    structured_content_defaults = cast(
+        "tuple[Any, dict[str, Any]]",
+        meta.convert_result(result_with_defaults),
+    )[1]
 
     # Even with defaults, should use aliases in output
     assert "first" in structured_content_defaults


### PR DESCRIPTION
## Summary

Fixes #1251 (labelled ``ready for work``). ``FastMCP.call_tool`` was annotated as returning ``Sequence[ContentBlock] | dict[str, Any]``, but it always passes ``convert_result=True`` to the tool manager and the actual return shape from ``FuncMetadata.convert_result`` is one of:

- ``Sequence[ContentBlock]``, tool with no output schema returning a regular value
- ``CallToolResult``, tool that returned a ``CallToolResult`` directly
- ``tuple[Sequence[ContentBlock], dict[str, Any]]``, tool with an output schema (the second element is the structured content; **not** a bare dict)

So the existing annotation was wrong on two counts: it claimed a bare ``dict`` instead of the tuple shape, and it omitted the ``CallToolResult`` branch.

## Changes

- ``src/mcp/server/mcpserver/server.py:402``, update ``FastMCP.call_tool`` return type to the precise three-arm union and add a docstring listing each branch.
- ``src/mcp/server/mcpserver/utilities/func_metadata.py:91``, replace ``Any`` on ``convert_result`` with the same three-arm union and tighten the docstring; reuses the existing ``Sequence``, ``ContentBlock``, and ``CallToolResult`` imports already in scope.

No runtime behaviour change, pure typing fix.

## Test plan

- [x] ``pytest tests/server/mcpserver/test_server.py tests/server/mcpserver/test_func_metadata.py tests/server/mcpserver/test_tool_manager.py``, 172 passed
- [x] ``inspect.signature`` round-trip on both functions returns the new annotations as expected