### PR TITLE
fix(server): skip output schema validation for tool errors

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -112,7 +112,7 @@ class FuncMetadata(BaseModel):
         the structured output.
         """
         if isinstance(result, CallToolResult):
-            if self.output_schema is not None:
+            if self.output_schema is not None and not result.isError:
                 assert self.output_model is not None, "Output model must be set if output schema is defined"
                 self.output_model.model_validate(result.structuredContent)
             return result

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -878,6 +878,20 @@ def test_tool_call_result_annotated_is_structured_and_invalid():
         meta.convert_result(func_returning_annotated_tool_call_result())
 
 
+def test_tool_call_result_annotated_error_skips_structured_validation():
+    class PersonClass(BaseModel):
+        name: str
+
+    def func_returning_annotated_tool_call_result_error() -> Annotated[CallToolResult, PersonClass]:  # pragma: no cover
+        return CallToolResult(content=[], isError=True)
+
+    meta = func_metadata(func_returning_annotated_tool_call_result_error)
+    result = func_returning_annotated_tool_call_result_error()
+
+    assert meta.output_schema is not None
+    assert meta.convert_result(result) is result
+
+
 def test_tool_call_result_in_optional_is_rejected():
     """Test that Optional[CallToolResult] raises InvalidSignature"""
 


### PR DESCRIPTION
## Summary

Fixes #2429.

When a typed FastMCP tool returns a `CallToolResult` with `isError=True`, the v1.x server should preserve that error result. Previously, `FuncMetadata.convert_result()` still validated `structuredContent` against the inferred output schema, so error results without structured content raised a Pydantic validation error and replaced the intended tool error.

This gates schema validation to non-error `CallToolResult` values while preserving validation for successful structured tool results.

## Validation

- `uv run pytest tests/server/fastmcp/test_func_metadata.py -q`
- `uv run pytest tests/server/fastmcp -q`
- `uv run ruff check src/mcp/server/fastmcp/utilities/func_metadata.py tests/server/fastmcp/test_func_metadata.py`
- `uv run pyright src/mcp/server/fastmcp/utilities/func_metadata.py tests/server/fastmcp/test_func_metadata.py`
- `git diff --check`
