### PR TITLE
Stop FastMCP from configuring application logging

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -324,7 +324,7 @@ def run(
             help="Transport protocol to use (stdio or sse)",
         ),
     ] = None,
-) -> None:  # pragma: no cover
+) -> None:
     """Run an MCP server.
 
     The server can be specified in two ways:
@@ -359,7 +359,7 @@ def run(
 
         server.run(**kwargs)
 
-    except Exception:
+    except Exception:  # pragma: no cover
         logger.exception(
             "Failed to run server",
             extra={

--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from mcp.server import MCPServer
 from mcp.server import Server as LowLevelServer
@@ -19,7 +19,7 @@ except ImportError:  # pragma: no cover
 
 try:
     from mcp.cli import claude
-    from mcp.server.mcpserver.utilities.logging import get_logger
+    from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
 except ImportError:  # pragma: no cover
     print("Error: mcp.server is not installed or not in PYTHONPATH")
     sys.exit(1)
@@ -30,6 +30,8 @@ except ImportError:  # pragma: no cover
     dotenv = None
 
 logger = get_logger("cli")
+
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 app = typer.Typer(
     name="mcp",
@@ -114,6 +116,14 @@ def _parse_file_path(file_spec: str) -> tuple[Path, str | None]:
         sys.exit(1)
 
     return file_path, server_object
+
+
+def _get_server_log_level(server: Any) -> LogLevel:
+    settings = getattr(server, "settings", None)
+    log_level = getattr(settings, "log_level", "INFO")
+    if log_level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        return log_level
+    return "INFO"
 
 
 def _import_server(file: Path, server_object: str | None = None):  # pragma: no cover
@@ -339,6 +349,8 @@ def run(
     try:
         # Import and get server object
         server = _import_server(file, server_object)
+
+        configure_logging(_get_server_log_level(server))
 
         # Run the server
         kwargs = {}

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -36,7 +36,7 @@ from mcp.server.mcpserver.prompts import Prompt, PromptManager
 from mcp.server.mcpserver.resources import FunctionResource, Resource, ResourceManager
 from mcp.server.mcpserver.tools import Tool, ToolManager
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
-from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
+from mcp.server.mcpserver.utilities.logging import get_logger
 from mcp.server.sse import SseServerTransport
 from mcp.server.stdio import stdio_server
 from mcp.server.streamable_http import EventStore
@@ -202,9 +202,6 @@ class MCPServer(Generic[LifespanResultT]):
         if auth_server_provider and not token_verifier:  # pragma: no cover
             self._token_verifier = ProviderTokenVerifier(auth_server_provider)
         self._custom_starlette_routes: list[Route] = []
-
-        # Configure logging
-        configure_logging(self.settings.log_level)
 
     @property
     def name(self) -> str:

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -44,7 +44,19 @@ def test_parse_file_exit_on_dir(tmp_path: Path):
         _parse_file_path(str(dir_path))
 
 
-def test_run_configures_logging_at_cli_entrypoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+@pytest.mark.parametrize(
+    ("transport", "expected_kwargs"),
+    [
+        (None, {}),
+        ("stdio", {"transport": "stdio"}),
+    ],
+)
+def test_run_configures_logging_at_cli_entrypoint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    transport: str | None,
+    expected_kwargs: dict[str, str],
+):
     """The CLI owns process logging setup; importing or constructing the server does not."""
     file = tmp_path / "server.py"
     file.write_text("server = object()")
@@ -71,11 +83,11 @@ def test_run_configures_logging_at_cli_entrypoint(monkeypatch: pytest.MonkeyPatc
         fake_configure_logging,
     )
 
-    run(f"{file}:server", transport="stdio")
+    run(f"{file}:server", transport=transport)
 
     assert calls == [
         ("logging", "DEBUG"),
-        ("run", {"transport": "stdio"}),
+        ("run", expected_kwargs),
     ]
 
 

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -5,7 +5,12 @@ from typing import Any
 
 import pytest
 
-from mcp.cli.cli import _build_uv_command, _get_npx_command, _parse_file_path  # type: ignore[reportPrivateUsage]
+from mcp.cli.cli import (  # type: ignore[reportPrivateUsage]
+    _build_uv_command,
+    _get_npx_command,
+    _parse_file_path,
+    run,
+)
 
 
 @pytest.mark.parametrize(
@@ -36,6 +41,41 @@ def test_parse_file_exit_on_dir(tmp_path: Path):
     dir_path.mkdir()
     with pytest.raises(SystemExit):
         _parse_file_path(str(dir_path))
+
+
+def test_run_configures_logging_at_cli_entrypoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """The CLI owns process logging setup; importing or constructing the server does not."""
+    file = tmp_path / "server.py"
+    file.write_text("server = object()")
+    calls: list[tuple[str, Any]] = []
+
+    class Settings:
+        log_level = "DEBUG"
+
+    class ImportedServer:
+        settings = Settings()
+
+        def run(self, **kwargs: Any) -> None:
+            calls.append(("run", kwargs))
+
+    def fake_import_server(*_args: Any) -> ImportedServer:
+        return ImportedServer()
+
+    def fake_configure_logging(level: str) -> None:
+        calls.append(("logging", level))
+
+    monkeypatch.setattr("mcp.cli.cli._import_server", fake_import_server)
+    monkeypatch.setattr(
+        "mcp.cli.cli.configure_logging",
+        fake_configure_logging,
+    )
+
+    run(f"{file}:server", transport="stdio")
+
+    assert calls == [
+        ("logging", "DEBUG"),
+        ("run", {"transport": "stdio"}),
+    ]
 
 
 def test_build_uv_command_minimal():

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 from mcp.cli.cli import (  # type: ignore[reportPrivateUsage]
     _build_uv_command,
     _get_npx_command,
+    _get_server_log_level,
     _parse_file_path,
     run,
 )
@@ -76,6 +77,16 @@ def test_run_configures_logging_at_cli_entrypoint(monkeypatch: pytest.MonkeyPatc
         ("logging", "DEBUG"),
         ("run", {"transport": "stdio"}),
     ]
+
+
+def test_get_server_log_level_defaults_invalid_setting():
+    class Settings:
+        log_level = "VERBOSE"
+
+    class Server:
+        settings = Settings()
+
+    assert _get_server_log_level(Server()) == "INFO"
 
 
 def test_build_uv_command_minimal():

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -46,6 +47,18 @@ pytestmark = pytest.mark.anyio
 
 
 class TestServer:
+    def test_create_server_does_not_configure_application_logging(self, monkeypatch: pytest.MonkeyPatch):
+        calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+        def fake_basic_config(*args: Any, **kwargs: Any) -> None:
+            calls.append((args, kwargs))
+
+        monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+
+        MCPServer("test")
+
+        assert calls == []
+
     async def test_create_server(self):
         mcp = MCPServer(
             title="MCPServer Server",

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -48,16 +48,12 @@ pytestmark = pytest.mark.anyio
 
 class TestServer:
     def test_create_server_does_not_configure_application_logging(self, monkeypatch: pytest.MonkeyPatch):
-        calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
-
-        def fake_basic_config(*args: Any, **kwargs: Any) -> None:
-            calls.append((args, kwargs))
-
-        monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+        basic_config = MagicMock()
+        monkeypatch.setattr(logging, "basicConfig", basic_config)
 
         MCPServer("test")
 
-        assert calls == []
+        basic_config.assert_not_called()
 
     async def test_create_server(self):
         mcp = MCPServer(

--- a/tests/server/mcpserver/utilities/test_logging.py
+++ b/tests/server/mcpserver/utilities/test_logging.py
@@ -1,0 +1,34 @@
+import logging
+from typing import Any
+
+import pytest
+
+from mcp.server.mcpserver.utilities.logging import configure_logging, get_logger
+
+
+def test_get_logger_returns_named_logger():
+    logger = get_logger("mcp.test")
+
+    assert logger is logging.getLogger("mcp.test")
+
+
+def test_configure_logging_uses_rich_handler(monkeypatch: pytest.MonkeyPatch):
+    calls: list[dict[str, Any]] = []
+
+    def fake_basic_config(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+
+    configure_logging("WARNING")
+
+    handlers = calls[0]["handlers"]
+    assert calls == [
+        {
+            "level": "WARNING",
+            "format": "%(message)s",
+            "handlers": handlers,
+        }
+    ]
+    assert len(handlers) == 1
+    assert isinstance(handlers[0], logging.Handler)


### PR DESCRIPTION
Fixes #1656.

## Summary
- remove process-wide logging configuration from `MCPServer.__init__`
- configure logging in the `mcp run` CLI entrypoint instead, where the process is owned by the SDK CLI
- preserve server log-level settings for CLI-run servers and fall back to INFO for non-FastMCP server objects

## Validation
- `uv run ruff format --check src/mcp/cli/cli.py src/mcp/server/mcpserver/server.py tests/cli/test_utils.py tests/server/mcpserver/test_server.py`
- `uv run ruff check src/mcp/cli/cli.py src/mcp/server/mcpserver/server.py tests/cli/test_utils.py tests/server/mcpserver/test_server.py`
- `uv run pyright src/mcp/cli/cli.py tests/cli/test_utils.py tests/server/mcpserver/test_server.py`
- `uv run pytest tests/cli/test_utils.py tests/server/mcpserver/test_server.py -q`
- `git diff --check`