### PR TITLE
fix: chain exceptions in get_prompt and read_resource handlers

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -447,8 +447,8 @@ class MCPServer(Generic[LifespanResultT]):
             context = Context(mcp_server=self)
         try:
             resource = await self._resource_manager.get_resource(uri, context)
-        except ValueError:
-            raise ResourceError(f"Unknown resource: {uri}")
+        except ValueError as exc:
+            raise ResourceError(f"Unknown resource: {uri}") from exc
 
         try:
             content = await resource.read()
@@ -1109,4 +1109,4 @@ class MCPServer(Generic[LifespanResultT]):
             )
         except Exception as e:
             logger.exception(f"Error getting prompt {name}")
-            raise ValueError(str(e))
+            raise ValueError(str(e)) from e


### PR DESCRIPTION
## Summary

Two `raise` statements in `server/mcpserver/server.py` discard the causal exception chain:

- Line 1112: `raise ValueError(str(e))` → `raise ValueError(str(e)) from e`
- Line 451: `raise ResourceError(...)` → `raise ResourceError(...) from exc`

## Motivation and Context

The same file uses `from exc` correctly at line 459. These two sites are inconsistent and lose the original traceback, making it impossible for callers to programmatically inspect the root cause via `__cause__`.

Without `from`, Python shows "During handling of the above exception, another exception occurred" which is confusing. With `from`, it shows "The above exception was the direct cause of the following exception" and preserves the chain for `isinstance()` checks on `__cause__`.

## How Has This Been Tested?

The change is purely additive (adds `from` clause) and does not alter control flow or exception types. Existing tests pass unchanged.

Fixes #2541