### PR TITLE
fix: exclude None optional fields from task result serialization

### DIFF
--- a/src/mcp/server/experimental/task_result_handler.py
+++ b/src/mcp/server/experimental/task_result_handler.py
@@ -114,9 +114,11 @@ class TaskResultHandler:
                 # The stored result contains the actual payload data
                 # Per spec: tasks/result MUST include _meta with related-task metadata
                 related_task = RelatedTaskMetadata(task_id=task_id)
-                related_task_meta: dict[str, Any] = {RELATED_TASK_METADATA_KEY: related_task.model_dump(by_alias=True)}
+                related_task_meta: dict[str, Any] = {
+                    RELATED_TASK_METADATA_KEY: related_task.model_dump(by_alias=True, exclude_none=True)
+                }
                 if result is not None:
-                    result_data = result.model_dump(by_alias=True)
+                    result_data = result.model_dump(by_alias=True, mode="json", exclude_none=True)
                     existing_meta: dict[str, Any] = result_data.get("_meta") or {}
                     result_data["_meta"] = {**existing_meta, **related_task_meta}
                     return GetTaskPayloadResult.model_validate(result_data)

--- a/tests/experimental/tasks/server/test_task_result_handler.py
+++ b/tests/experimental/tasks/server/test_task_result_handler.py
@@ -292,6 +292,33 @@ async def test_deliver_skips_resolver_registration_when_no_original_id(
 
 
 @pytest.mark.anyio
+async def test_handle_omits_none_optional_fields_in_result(
+    store: InMemoryTaskStore, queue: InMemoryTaskMessageQueue, handler: TaskResultHandler
+) -> None:
+    """None optional fields (e.g. TextContent.annotations) must be omitted, not serialized as null.
+
+    The Node SDK Zod schema marks these fields as optional (absent), not nullable,
+    so sending null breaks validation.
+    """
+    task = await store.create_task(TaskMetadata(ttl=60000), task_id="test-task")
+    result = CallToolResult(content=[TextContent(type="text", text="hello")])
+    await store.store_result(task.task_id, result)
+    await store.update_task(task.task_id, status="completed")
+
+    mock_session = Mock()
+    mock_session.send_message = AsyncMock()
+
+    request = GetTaskPayloadRequest(params=GetTaskPayloadRequestParams(task_id=task.task_id))
+    response = await handler.handle(request, mock_session, "req-1")
+
+    wire_data = response.model_dump(by_alias=True, mode="json", exclude_none=True)
+    content_items = wire_data.get("content", [])
+    assert len(content_items) == 1
+    assert "annotations" not in content_items[0]
+    assert "_meta" not in content_items[0]
+
+
+@pytest.mark.anyio
 async def test_wait_for_task_update_handles_store_exception(
     store: InMemoryTaskStore, queue: InMemoryTaskMessageQueue, handler: TaskResultHandler
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #2539

`task_result_handler.py` called `model_dump(by_alias=True)` without `exclude_none=True`, causing optional fields like `TextContent.annotations` to be emitted as JSON `null`. The Node SDK Zod schema marks these fields as optional (absent), not nullable, so receiving `null` fails validation.

**Root cause:** The `result_data` dict built at line 119 carried `null` values into `GetTaskPayloadResult.model_validate()`. Since `GetTaskPayloadResult` uses `extra="allow"`, the nested content is stored as raw dict values — the transport-level `exclude_none=True` does not recursively clean them.

**Fix:** Add `exclude_none=True, mode="json"` to both `model_dump()` calls in the terminal-state path, consistent with every other serialization site in `shared/session.py` and `server/session.py`.

## Changes

- `src/mcp/server/experimental/task_result_handler.py`: add `exclude_none=True, mode="json"` to `result.model_dump()`, and `exclude_none=True` to `related_task.model_dump()`
- `tests/experimental/tasks/server/test_task_result_handler.py`: regression test asserting `annotations` and `_meta` are absent (not null) in the serialized wire output