### PR TITLE
build: pin PEP 517 build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,24 @@ mcp = "mcp.cli:app [cli]"
 [tool.uv]
 default-groups = ["dev", "docs"]
 required-version = ">=0.9.5"
+# PEP 517 build isolation fetches [build-system].requires (and transitives) at
+# floating-latest with no hash check on every fresh sync; uv does not lock them
+# (astral-sh/uv#5190). Pinning here narrows that to known-good versions. Covers
+# the workspace builds (hatchling + uv-dynamic-versioning) and the legacy
+# setuptools fallback used by the strict-no-cover git dep.
+build-constraint-dependencies = [
+    "hatchling==1.29.0",
+    "uv-dynamic-versioning==0.14.0",
+    "dunamai==1.26.1",
+    "jinja2==3.1.6",
+    "markupsafe==3.0.3",
+    "packaging==26.1",
+    "pathspec==1.0.4",
+    "pluggy==1.6.0",
+    "tomlkit==0.14.0",
+    "trove-classifiers==2026.1.14.14",
+    "setuptools==82.0.1",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,19 @@ members = [
     "mcp-sse-polling-demo",
     "mcp-structured-output-lowlevel",
 ]
+build-constraints = [
+    { name = "dunamai", specifier = "==1.26.1" },
+    { name = "hatchling", specifier = "==1.29.0" },
+    { name = "jinja2", specifier = "==3.1.6" },
+    { name = "markupsafe", specifier = "==3.0.3" },
+    { name = "packaging", specifier = "==26.1" },
+    { name = "pathspec", specifier = "==1.0.4" },
+    { name = "pluggy", specifier = "==1.6.0" },
+    { name = "setuptools", specifier = "==82.0.1" },
+    { name = "tomlkit", specifier = "==0.14.0" },
+    { name = "trove-classifiers", specifier = "==2026.1.14.14" },
+    { name = "uv-dynamic-versioning", specifier = "==0.14.0" },
+]
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
<!-- Provide a brief description of your changes -->

`uv` does not lock `[build-system].requires` or its transitives ([astral-sh/uv#5190](https://github.com/astral-sh/uv/issues/5190)). On every fresh `uv sync`, the build-isolation step for the workspace packages resolves `hatchling`, `uv-dynamic-versioning`, and ~8 transitives at floating-latest with no hash check. The `strict-no-cover` git dep additionally pulls latest `setuptools` via the legacy fallback.

This pins those packages via `[tool.uv].build-constraint-dependencies` so the build environment is reproducible across machines and CI. uv records the constraints in `uv.lock`'s `[manifest]` section but does not add them to the resolution graph.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

Reproducible builds — without this, two fresh syncs on different days can use different build-backend versions.

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes -->

`uv sync --frozen --reinstall-package mcp -v` shows the build-isolation resolver now selecting the pinned versions. `uv lock --check` is a no-op.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update / build configuration

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [CONTRIBUTING](https://github.com/modelcontextprotocol/python-sdk/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, screenshots, or relevant information -->

If/when `strict-no-cover` moves from a git dep to a PyPI release, the `setuptools` pin can be dropped.
