### PR TITLE
fix(client/stdio): fall back to os.devnull when sys.stderr is None

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -102,10 +102,24 @@ class StdioServerParameters(BaseModel):
 
 
 @asynccontextmanager
-async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stderr):
+async def stdio_client(server: StdioServerParameters, errlog: TextIO | None = None):
     """Client transport for stdio: this will connect to a server by spawning a
     process and communicating with it over stdin/stdout.
+
+    ``errlog`` is the sink for the spawned subprocess's stderr. When omitted,
+    falls back to ``sys.stderr`` if it is a real handle, otherwise to
+    ``os.devnull``. The ``os.devnull`` fallback is required for callers
+    running under ``pythonw.exe`` on Windows (desktop shortcuts, silent
+    ``.bat`` launches, anything without a console attached): in that
+    environment ``sys.stderr`` is ``None``, and passing a ``None`` handle
+    as the subprocess's stderr corrupts asyncio's Windows ProactorEventLoop
+    subprocess transport, producing ``ClosedResourceError`` on the first
+    real RPC after ``initialize()``. Callers that want subprocess stderr
+    captured can still pass an explicit file handle.
     """
+    if errlog is None:
+        errlog = sys.stderr if sys.stderr is not None else open(os.devnull, "w")
+
     read_stream: MemoryObjectReceiveStream[SessionMessage | Exception]
     read_stream_writer: MemoryObjectSendStream[SessionMessage | Exception]
 
@@ -230,14 +244,21 @@ async def _create_platform_compatible_process(
     command: str,
     args: list[str],
     env: dict[str, str] | None = None,
-    errlog: TextIO = sys.stderr,
+    errlog: TextIO | None = None,
     cwd: Path | str | None = None,
 ):
     """Creates a subprocess in a platform-compatible way.
 
     Unix: Creates process in a new session/process group for killpg support
     Windows: Creates process in a Job Object for reliable child termination
+
+    ``errlog`` defaults to ``sys.stderr`` when available, ``os.devnull``
+    when not. The ``os.devnull`` fallback prevents asyncio's Windows
+    ProactorEventLoop from receiving a ``None`` stderr handle under
+    ``pythonw.exe``, which would otherwise corrupt subprocess pipe setup.
     """
+    if errlog is None:
+        errlog = sys.stderr if sys.stderr is not None else open(os.devnull, "w")
     if sys.platform == "win32":  # pragma: no cover
         process = await create_windows_process(command, args, env, errlog, cwd)
     else:  # pragma: lax no cover


### PR DESCRIPTION
## Summary

Make `stdio_client` (and the internal `_create_platform_compatible_process`) tolerate `sys.stderr is None`, which is the case under `pythonw.exe` on Windows — i.e. every desktop shortcut, every silent `.bat` launch, and anything else launched without a console attached.

## Motivation

When a stdio MCP client is hosted in a Python process whose `sys.stderr` is `None`, the current default `errlog: TextIO = sys.stderr` propagates that `None` into the spawned subprocess as its stderr handle. asyncio's Windows ProactorEventLoop subprocess transport mishandles a `None` stderr — the symptom is **`ClosedResourceError` on the first real RPC after `initialize()` succeeds**.

Bursty servers like [`@modelcontextprotocol/server-filesystem`](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) (whose `initialize` → `list_tools` traffic happens within milliseconds) hit this consistently. Quieter servers (e.g. typical Gmail clients) usually slip through with the same broken setup, which made this bug elusive — the affected client developers see "filesystem-server is broken in my app but Gmail works fine."

The triggering condition is purely the launch context, not the application logic:

| Launch | `sys.stderr` | filesystem MCP works? |
|---|---|---|
| `python.exe MyApp.py` (console) | real handle | ✅ |
| `pythonw.exe MyApp.py 2> log.txt` (redirected) | real handle | ✅ |
| `pythonw.exe MyApp.py` (no console, no redirect) | **None** | ❌ ClosedResourceError |
| Desktop shortcut → `pythonw.exe MyApp.py` | **None** | ❌ ClosedResourceError |

## Repro

A complete repro requires a Windows host plus pythonw.exe. From within a Tk/non-console Python app launched via `pythonw.exe MyApp.py` (no stderr redirect), connect to `@modelcontextprotocol/server-filesystem` via `stdio_client(StdioServerParameters(command=\"node\", args=[\"index.js\", path]))`, call `await session.initialize()`, then `await session.list_tools()`. The list_tools call fails with `anyio.ClosedResourceError`. Switching the host to `python.exe` (console) makes the same code work without any other change.

## Fix

Change the public default from `errlog: TextIO = sys.stderr` to `errlog: TextIO | None = None`, and resolve at call time:

```python
if errlog is None:
    errlog = sys.stderr if sys.stderr is not None else open(os.devnull, \"w\")
```

Same fallback applied in `_create_platform_compatible_process` as defense in depth, so any internal call path that omits `errlog` is safe regardless of `sys.stderr` state.

## Compatibility

- **Callers passing an explicit `errlog`**: unchanged behavior. The runtime check only fires when `errlog is None`.
- **Callers using the old default** (`stdio_client(server)`): now safe under pythonw, identical under python.exe (since `sys.stderr` is a real handle in that case).
- **Type annotation**: widens from `TextIO` to `TextIO | None`. Existing typed callers passing `TextIO` continue to satisfy the new signature; mypy/pyright won't break.

## Test plan

- [x] Repro the bug under pythonw.exe (`ClosedResourceError` on list_tools after initialize, against `@modelcontextprotocol/server-filesystem`).
- [x] Apply patch, confirm list_tools succeeds in same launch context.
- [x] Confirm no regression under python.exe or with explicit `errlog=...`.
- [ ] Add a unit test that monkeypatches `sys.stderr = None` and asserts `stdio_client` does not raise (suggested follow-up; not in this PR to keep the diff minimal).

Discovered while integrating the SDK into a tkinter desktop agent launched via Windows shortcut.