### PR TITLE
fix: default encoding_error_handler to replace in stdio_client for UTF-8 resilience

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -92,9 +92,14 @@ class StdioServerParameters(BaseModel):
     Defaults to utf-8.
     """
 
-    encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
+    encoding_error_handler: Literal["strict", "ignore", "replace"] = "replace"
     """
     The text encoding error handler.
+
+    Defaults to "replace" so that malformed bytes from the child process are
+    substituted with U+FFFD rather than crashing the transport.  The invalid
+    line will then fail JSON validation and be surfaced as an in-stream
+    exception, keeping the transport alive for subsequent valid messages.
 
     See https://docs.python.org/3/library/codecs.html#codec-base-classes for
     explanations of possible values.
@@ -151,8 +156,8 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
                     for line in lines:
                         try:
                             message = types.jsonrpc_message_adapter.validate_json(line, by_name=False)
-                        except Exception as exc:  # pragma: no cover
-                            logger.exception("Failed to parse JSONRPC message from server")
+                        except Exception as exc:
+                            logger.warning("Failed to parse JSONRPC message from server: %s", exc)
                             await read_stream_writer.send(exc)
                             continue
 

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -104,6 +104,53 @@ async def test_stdio_client_nonexistent_command():
 
 
 @pytest.mark.anyio
+async def test_stdio_client_invalid_utf8_resilience():
+    """Malformed UTF-8 from child stdout must not crash the transport.
+
+    With encoding_error_handler="replace" (now the default), invalid bytes
+    are replaced with U+FFFD. The resulting line fails JSON validation and
+    is surfaced as an in-stream Exception. Subsequent valid messages must
+    still be delivered.
+    """
+    # Child script writes one malformed line, then one valid JSON-RPC line
+    child_script = textwrap.dedent(
+        """
+        import sys
+        # Write invalid UTF-8 bytes followed by newline
+        sys.stdout.buffer.write(b"\\xff\\xfe\\n")
+        sys.stdout.buffer.flush()
+        # Write a valid JSON-RPC message
+        sys.stdout.buffer.write(b'{"jsonrpc":"2.0","id":1,"method":"ping"}\\n')
+        sys.stdout.buffer.flush()
+        # Exit cleanly
+        """
+    )
+
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-c", child_script],
+    )
+
+    async with stdio_client(server_params) as (read_stream, write_stream):
+        received: list[SessionMessage | Exception] = []
+        async with read_stream:
+            async for item in read_stream:
+                received.append(item)
+                if len(received) == 2:
+                    break
+
+    # First item: the malformed line should surface as a parse exception
+    assert isinstance(received[0], Exception), (
+        f"Expected Exception for malformed UTF-8 line, got {type(received[0])}"
+    )
+    # Second item: the valid JSON-RPC message should come through
+    assert isinstance(received[1], SessionMessage), (
+        f"Expected SessionMessage for valid line, got {type(received[1])}"
+    )
+    assert received[1].message == JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")
+
+
+@pytest.mark.anyio
 async def test_stdio_client_universal_cleanup():
     """Test that stdio_client completes cleanup within reasonable time
     even when connected to processes that exit slowly.


### PR DESCRIPTION
Fixes #2454

## Summary

The `stdio_client` transport crashes when the spawned child process writes invalid UTF-8 bytes to stdout. The transport decodes child stdout with `encoding_error_handler="strict"` by default, so malformed bytes raise during `TextReceiveStream` iteration. That exception escapes the decoding loop and brings down the transport task group instead of surfacing the bad line as an in-stream parse error.

## Asymmetry with server side

The SDK already hardened the server side for the analogous case in PR #2302 (`fix: handle non-UTF-8 bytes in stdio server stdin`). That change explicitly preferred:

- Replace invalid bytes with U+FFFD
- Let JSON validation fail on the malformed line
- Keep the transport alive so subsequent valid messages can still be processed

The client side was still using `"strict"`, creating an inconsistency.

## Changes

**`src/mcp/client/stdio.py`**
- Changed `StdioServerParameters.encoding_error_handler` default from `"strict"` to `"replace"`
- Updated docstring to explain the rationale
- Changed `logger.exception` to `logger.warning` for JSON parse failures (avoids noisy full tracebacks for expected validation errors on malformed input)
- Removed `# pragma: no cover` from the now-reachable exception handling path

**`tests/client/test_stdio.py`**
- Added `test_stdio_client_invalid_utf8_resilience` — spawns a child that writes `\xff\xfe\n` (invalid UTF-8) followed by a valid JSON-RPC message, then asserts:
  - First item from read stream is an `Exception` (JSON validation failure on the U+FFFD-replaced line)
  - Second item is a valid `SessionMessage` with the expected payload

## Backward compatibility

- Users who explicitly set `encoding_error_handler="strict"` retain the old behavior
- The default change is safe: any code consuming the read stream already handles `Exception` items (the type signature is `MemoryObjectReceiveStream[SessionMessage | Exception]`)
- No new dependencies
