### PR TITLE
fix: handle Optional[str] in pre_parse_json to prevent incorrect type coercion

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -29,6 +29,22 @@ from mcp.types import CallToolResult, ContentBlock, TextContent
 logger = get_logger(__name__)
 
 
+def _annotation_accepts_str(annotation: Any) -> bool:
+    """Check if an annotation only accepts str (or None), not other complex types.
+
+    Returns True for `str` and `Optional[str]` (str | None), where JSON parsing
+    a string value would be incorrect. Returns False for unions like `str | list[str]`
+    where the other types benefit from JSON pre-parsing.
+    """
+    if annotation is str:
+        return True
+    if is_union_origin(get_origin(annotation)):
+        args = get_args(annotation)
+        non_none_args = [a for a in args if a is not type(None)]
+        return non_none_args == [str]
+    return False
+
+
 class StrictJsonSchema(GenerateJsonSchema):
     """A JSON schema generator that raises exceptions instead of emitting warnings.
 
@@ -148,7 +164,7 @@ class FuncMetadata(BaseModel):
                 continue
 
             field_info = key_to_field_info[data_key]
-            if isinstance(data_value, str) and field_info.annotation is not str:
+            if isinstance(data_value, str) and not _annotation_accepts_str(field_info.annotation):
                 try:
                     pre_parsed = json.loads(data_value)
                 except json.JSONDecodeError:

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -551,6 +551,74 @@ async def test_str_annotation_runtime_validation():
     assert result == f"Handled payload of length {len(json_array_payload)}"
 
 
+def test_optional_str_preserves_json_string():
+    """Regression test for issue #381: Ensure that when a parameter is annotated
+    as Optional[str] or str | None, valid JSON strings are NOT parsed into Python
+    objects. The pre_parse_json check must recognize that union types containing
+    str should be treated as string-accepting annotations.
+    """
+    from typing import Optional
+
+    def func_optional_str(cid: Optional[str]) -> str:  # pragma: no cover
+        return cid or ""
+
+    meta = func_metadata(func_optional_str)
+
+    # A numeric string like "1.2" must NOT be parsed into float
+    result = meta.pre_parse_json({"cid": "1.2"})
+    assert result["cid"] == "1.2"
+    assert isinstance(result["cid"], str)
+
+    # A JSON object string must NOT be parsed into dict
+    result = meta.pre_parse_json({"cid": '{"key": "value"}'})
+    assert result["cid"] == '{"key": "value"}'
+    assert isinstance(result["cid"], str)
+
+    # A JSON array string must NOT be parsed into list
+    result = meta.pre_parse_json({"cid": '["a", "b"]'})
+    assert result["cid"] == '["a", "b"]'
+    assert isinstance(result["cid"], str)
+
+
+def test_pipe_none_str_preserves_json_string():
+    """Same as test_optional_str but using str | None syntax."""
+
+    def func_str_or_none(data: str | None) -> str:  # pragma: no cover
+        return data or ""
+
+    meta = func_metadata(func_str_or_none)
+
+    # Numeric string must stay as str
+    result = meta.pre_parse_json({"data": "42"})
+    assert result["data"] == "42"
+    assert isinstance(result["data"], str)
+
+    # JSON dict must stay as str
+    result = meta.pre_parse_json({"data": '{"x": 1}'})
+    assert result["data"] == '{"x": 1}'
+    assert isinstance(result["data"], str)
+
+
+@pytest.mark.anyio
+async def test_optional_str_runtime_validation():
+    """End-to-end test: calling a function with Optional[str] param and JSON-like input."""
+    from typing import Optional
+
+    def process(config: Optional[str] = None) -> str:
+        assert config is None or isinstance(config, str)
+        return f"got: {config}"
+
+    meta = func_metadata(process)
+
+    result = await meta.call_fn_with_arg_validation(
+        process,
+        fn_is_async=False,
+        arguments_to_validate={"config": '{"db": "postgres"}'},
+        arguments_to_pass_directly=None,
+    )
+    assert result == 'got: {"db": "postgres"}'
+
+
 # Tests for structured output functionality
 
 


### PR DESCRIPTION
Fixes #381

## Summary

The `pre_parse_json` method in `func_metadata.py` uses `field_info.annotation is not str` to decide whether to attempt JSON parsing of string values. This check fails for union types like `Optional[str]` (`str | None`) because the annotation object is `str | None`, not `str`.

This causes string values like `"1.2"` or `'{"key": "value"}'` to be parsed via `json.loads` into `float`/`dict`, which then fails Pydantic validation with `Input should be a valid string`.

## Reproducer (from issue)

```python
@server.tool()
async def getinfo(cid: Optional[str] = Field(..., description="xxx.")) -> bool:
    ...

# Client calls with: {"cid": "1.2"}
# Result: ValidationError - Input should be a valid string [input_value=1.2, input_type=float]
```

## Changes

**`src/mcp/server/mcpserver/utilities/func_metadata.py`**
- Added `_annotation_accepts_str()` helper that correctly identifies str-only unions (`Optional[str]`, `str | None`) as string-accepting annotations
- Uses `is_union_origin` (already imported) and `get_origin`/`get_args` (already imported) for introspection
- Preserves existing behavior for unions with other complex types (e.g. `str | list[str]` still gets JSON pre-parsing)

**`tests/server/mcpserver/test_func_metadata.py`**
- Added `test_optional_str_preserves_json_string`: numeric strings, JSON objects, and JSON arrays all stay as `str` when annotation is `Optional[str]`
- Added `test_pipe_none_str_preserves_json_string`: same coverage for `str | None` syntax
- Added `test_optional_str_runtime_validation`: end-to-end `call_fn_with_arg_validation` with `Optional[str]` param

## Backward compatibility

- No change for `str` annotations (already handled by PR #1113)
- No change for `str | list[str]` unions (still parses JSON arrays into lists)
- Fixes `Optional[str]` and `str | None` to correctly preserve string values
- All 36 existing tests in `test_func_metadata.py` continue to pass
