### PR TITLE
[v1.x] build: restrict httpx to <1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "anyio>=4.5",
-    "httpx>=0.27.1",
+    "httpx>=0.27.1,<1.0.0",
     "httpx-sse>=0.4",
     "pydantic>=2.11.0,<3.0.0",
     "starlette>=0.27",

--- a/uv.lock
+++ b/uv.lock
@@ -819,7 +819,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.5" },
-    { name = "httpx", specifier = ">=0.27.1" },
+    { name = "httpx", specifier = ">=0.27.1,<1.0.0" },
     { name = "httpx-sse", specifier = ">=0.4" },
     { name = "jsonschema", specifier = ">=4.20.0" },
     { name = "pydantic", specifier = ">=2.11.0,<3.0.0" },


### PR DESCRIPTION
Backport of #2345 to the `v1.x` release branch. Closes #2543.

## Motivation and Context

httpx publishes `1.0.dev1`/`1.0.dev2`/`1.0.dev3` pre-releases on PyPI. These are a ground-up rewrite with an incompatible public API — no `AsyncClient`, `Auth`, `Timeout`, `BasicAuth`, `codes`, or the `TransportError`/`StreamError` exception hierarchy.

The current v1.x constraint is unbounded (`httpx>=0.27.1`), so when a downstream package is installed with `pip install --pre` (common for alpha/beta libraries built on mcp), pip resolves `httpx 1.0.dev3` and `import mcp` fails immediately:

```
File ".../httpx_sse/_exceptions.py", line 4, in <module>
  class SSEError(httpx.TransportError):
                 ^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'httpx' has no attribute 'TransportError'
```

This was already fixed on `main` in #2345 but never backported, so all published 1.x releases (including 1.27.0) are affected.

## How Has This Been Tested?

Reproduced in a fresh venv:

```bash
python -m venv /tmp/repro && /tmp/repro/bin/pip install --pre 'mcp==1.27.0'
/tmp/repro/bin/python -c 'import mcp'
# AttributeError: module 'httpx' has no attribute 'TransportError'
```

Confirmed that constraining to `httpx<1.0` (resolves 0.28.1) restores all of `import mcp`, `stdio_client`, `sse_client`, and `streamablehttp_client`.

## Breaking Changes

None. httpx 0.28.1 remains the latest stable; this only excludes the incompatible 1.0 dev pre-releases.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Re the alternatives raised in #2543:
- `<2.0` wouldn't help — httpx 1.x is API-incompatible by design, not just pre-release churn.
- Not adding a speculative `httpx-sse<1.0` cap; no such release exists and we'd rather not pre-emptively constrain a dep that hasn't broken.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>