### PR TITLE
refactor: import SSEError from httpx_sse public API

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -7,8 +7,7 @@ from urllib.parse import parse_qs, urljoin, urlparse
 import anyio
 import httpx
 from anyio.abc import TaskStatus
-from httpx_sse import aconnect_sse
-from httpx_sse._exceptions import SSEError
+from httpx_sse import SSEError, aconnect_sse
 
 from mcp import types
 from mcp.shared._context_streams import create_context_streams


### PR DESCRIPTION
`src/mcp/client/sse.py` imports `SSEError` from the private `httpx_sse._exceptions` submodule (introduced in #975). `SSEError` is part of httpx-sse's public API — re-exported at the package top level and listed in `__all__` in every release ≥0.4.0 — so this switches to the public path.

## Motivation and Context

Underscore-prefixed modules are private; httpx-sse could reorganise `_exceptions.py` in any patch release without it being a breaking change. The public re-export is the stable surface.

Surfaced while investigating #2543.

## How Has This Been Tested?

Verified `from httpx_sse import SSEError` works against every published httpx-sse ≥0.4 (0.4.0, 0.4.1, 0.4.2, 0.4.3) and that it resolves to the identical class object as the private path. CI's `lowest-direct` matrix exercises httpx-sse==0.4.0 directly.

## Breaking Changes

None — same class object, no behaviour change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>