### PR TITLE
[v1.x] refactor: import SSEError from httpx_sse public API

### DIFF
--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -8,8 +8,7 @@ import anyio
 import httpx
 from anyio.abc import TaskStatus
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
-from httpx_sse import aconnect_sse
-from httpx_sse._exceptions import SSEError
+from httpx_sse import SSEError, aconnect_sse
 
 import mcp.types as types
 from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client


### PR DESCRIPTION
Backport of #2560.

`src/mcp/client/sse.py` imports `SSEError` from the private `httpx_sse._exceptions` submodule (introduced in #975). `SSEError` is part of httpx-sse's public API — re-exported at the package top level and listed in `__all__` in every release ≥0.4.0 — so this switches to the public path.

No behaviour change (same class object). Verified against httpx-sse 0.4.0 (the `>=0.4` floor) through 0.4.3.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>