### PR TITLE
fix: chain exceptions with `from` in 12 remaining raise sites

### DIFF
--- a/src/mcp/client/auth/utils.py
+++ b/src/mcp/client/auth/utils.py
@@ -243,7 +243,7 @@ async def handle_registration_response(response: Response) -> OAuthClientInforma
         # self.context.client_info = client_info
         # await self.context.storage.set_client_info(client_info)
     except ValidationError as e:  # pragma: no cover
-        raise OAuthRegistrationError(f"Invalid registration response: {e}")
+        raise OAuthRegistrationError(f"Invalid registration response: {e}") from e
 
 
 def is_valid_client_metadata_url(url: str | None) -> bool:
@@ -336,4 +336,4 @@ async def handle_token_response_scopes(
         token_response = OAuthToken.model_validate_json(content)
         return token_response
     except ValidationError as e:  # pragma: no cover
-        raise OAuthTokenError(f"Invalid token response: {e}")
+        raise OAuthTokenError(f"Invalid token response: {e}") from e

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -343,9 +343,9 @@ class ClientSession(
             try:
                 validate(result.structured_content, output_schema)
             except ValidationError as e:
-                raise RuntimeError(f"Invalid structured content returned by tool {name}: {e}")
+                raise RuntimeError(f"Invalid structured content returned by tool {name}: {e}") from e
             except SchemaError as e:  # pragma: no cover
-                raise RuntimeError(f"Invalid schema for tool {name}: {e}")  # pragma: no cover
+                raise RuntimeError(f"Invalid schema for tool {name}: {e}") from e  # pragma: no cover
 
     async def list_prompts(self, *, params: types.PaginatedRequestParams | None = None) -> types.ListPromptsResult:
         """Send a prompts/list request.

--- a/src/mcp/server/auth/middleware/client_auth.py
+++ b/src/mcp/server/auth/middleware/client_auth.py
@@ -80,8 +80,8 @@ class ClientAuthenticator:
 
                 if basic_client_id != client_id:
                     raise AuthenticationError("Client ID mismatch in Basic auth")
-            except (ValueError, UnicodeDecodeError, binascii.Error):
-                raise AuthenticationError("Invalid Basic authentication header")
+            except (ValueError, UnicodeDecodeError, binascii.Error) as exc:
+                raise AuthenticationError("Invalid Basic authentication header") from exc
 
         elif client.token_endpoint_auth_method == "client_secret_post":
             raw_form_data = form_data.get("client_secret")

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -181,9 +181,9 @@ class Prompt(BaseModel):
                     else:  # pragma: no cover
                         content = pydantic_core.to_json(msg, fallback=str, indent=2).decode()
                         messages.append(Message(role="user", content=content))
-                except Exception:  # pragma: no cover
-                    raise ValueError(f"Could not convert prompt result to message: {msg}")
+                except Exception as e:  # pragma: no cover
+                    raise ValueError(f"Could not convert prompt result to message: {msg}") from e
 
             return messages
         except Exception as e:  # pragma: no cover
-            raise ValueError(f"Error rendering prompt {self.name}: {e}")
+            raise ValueError(f"Error rendering prompt {self.name}: {e}") from e

--- a/src/mcp/server/mcpserver/resources/resource_manager.py
+++ b/src/mcp/server/mcpserver/resources/resource_manager.py
@@ -93,7 +93,7 @@ class ResourceManager:
                 try:
                     return await template.create_resource(uri_str, params, context=context)
                 except Exception as e:  # pragma: no cover
-                    raise ValueError(f"Error creating resource from template: {e}")
+                    raise ValueError(f"Error creating resource from template: {e}") from e
 
         raise ValueError(f"Unknown resource: {uri}")
 

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -130,4 +130,4 @@ class ResourceTemplate(BaseModel):
                 fn=lambda: result,  # Capture result in closure
             )
         except Exception as e:
-            raise ValueError(f"Error creating resource from template: {e}")
+            raise ValueError(f"Error creating resource from template: {e}") from e

--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -72,7 +72,7 @@ class FunctionResource(Resource):
             else:
                 return pydantic_core.to_json(result, fallback=str, indent=2).decode()
         except Exception as e:
-            raise ValueError(f"Error reading resource {self.uri}: {e}")
+            raise ValueError(f"Error reading resource {self.uri}: {e}") from e
 
     @classmethod
     def from_function(
@@ -148,7 +148,7 @@ class FileResource(Resource):
                 return await anyio.to_thread.run_sync(self.path.read_bytes)
             return await anyio.to_thread.run_sync(self.path.read_text)
         except Exception as e:
-            raise ValueError(f"Error reading file {self.path}: {e}")
+            raise ValueError(f"Error reading file {self.path}: {e}") from e
 
 
 class HttpResource(Resource):
@@ -193,7 +193,7 @@ class DirectoryResource(Resource):
                 return list(self.path.glob(self.pattern)) if not self.recursive else list(self.path.rglob(self.pattern))
             return list(self.path.glob("*")) if not self.recursive else list(self.path.rglob("*"))
         except Exception as e:
-            raise ValueError(f"Error listing directory {self.path}: {e}")
+            raise ValueError(f"Error listing directory {self.path}: {e}") from e
 
     async def read(self) -> str:  # Always returns JSON string  # pragma: no cover
         """Read the directory listing."""
@@ -202,4 +202,4 @@ class DirectoryResource(Resource):
             file_list = [str(f.relative_to(self.path)) for f in files if f.is_file()]
             return json.dumps({"files": file_list}, indent=2)
         except Exception as e:
-            raise ValueError(f"Error reading directory {self.path}: {e}")
+            raise ValueError(f"Error reading directory {self.path}: {e}") from e


### PR DESCRIPTION
## Summary

Follow-up to #2542. Adds `from` to 12 remaining `raise` statements inside `except` blocks that discard the original exception chain.

Fixes #2564

## Changes

7 files, 12 sites. Each change adds `from e` (or `from exc`) to an existing `raise` inside an `except` block:

- `client/session.py`: `ValidationError`, `SchemaError` re-raised as `RuntimeError`
- `client/auth/utils.py`: `ValidationError` re-raised as `OAuthRegistrationError`, `OAuthTokenError`
- `server/auth/middleware/client_auth.py`: `ValueError`/`UnicodeDecodeError`/`binascii.Error` re-raised as `AuthenticationError`
- `server/mcpserver/resources/types.py`: 4 sites in `FunctionResource`, `FileResource`, `DirectoryResource`
- `server/mcpserver/resources/resource_manager.py`: 1 site
- `server/mcpserver/resources/templates.py`: 1 site
- `server/mcpserver/prompts/base.py`: 2 sites (also adds `as e` binding on line 184 which was missing)

## How Has This Been Tested?

All changes are purely additive (`from` clause) and do not alter control flow or exception types. Existing tests pass unchanged:

```
1172 passed, 98 skipped, 0 failures
```

Ruff and pyright pass with zero errors on all changed files.