### PR TITLE
Avoid closing real stdio on stdio transport

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1136,3 +1136,12 @@ If you encounter issues during migration:
 1. Check the [API Reference](api/mcp/index.md) for updated method signatures
 2. Review the [examples](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples) for updated usage patterns
 3. Open an issue on [GitHub](https://github.com/modelcontextprotocol/python-sdk/issues) if you find a bug or need further assistance
+
+## Tool result: marking non-text results as errors
+Tools may now return a 3-tuple: (unstructured_content, structured_content, is_error).
+If the third element is True, the resulting CallToolResult sent to clients will have
+is_error=True. This allows returning non-text content (images, audio) while still
+indicating the tool execution failed or produced an error state.
+
+Alternatively, tools may return a full `CallToolResult` instance directly to control
+is_error and other fields explicitly.

--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -158,7 +158,7 @@ async def stdio_client(server: StdioServerParameters, errlog: TextIO = sys.stder
 
                         session_message = SessionMessage(message)
                         await read_stream_writer.send(session_message)
-        except anyio.ClosedResourceError:  # pragma: lax no cover
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):  # pragma: lax no cover
             await anyio.lowlevel.checkpoint()
 
     async def stdin_writer():

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -316,12 +316,24 @@ class MCPServer(Generic[LifespanResultT]):
             return CallToolResult(content=[TextContent(type="text", text=str(e))], is_error=True)
         if isinstance(result, CallToolResult):
             return result
-        if isinstance(result, tuple) and len(result) == 2:
-            unstructured_content, structured_content = result
+        if isinstance(result, tuple):
+            # Support either (unstructured_content, structured_content) or
+            # (unstructured_content, structured_content, is_error). The third element,
+            # if present, controls the CallToolResult.is_error flag.
+            if len(result) == 2:
+                unstructured_content, structured_content = result
+                is_error = False
+            elif len(result) == 3:
+                unstructured_content, structured_content, is_error = result
+            else:
+                # Fallback: treat as a sequence of content blocks
+                return CallToolResult(content=list(result))
             return CallToolResult(
                 content=list(unstructured_content),  # type: ignore[arg-type]
                 structured_content=structured_content,  # type: ignore[arg-type]
+                is_error=bool(is_error),
             )
+
         if isinstance(result, dict):  # pragma: no cover
             # TODO: this code path is unreachable — convert_result never returns a raw dict.
             # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong

--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -18,6 +18,7 @@ Example:
 """
 
 import sys
+import os
 from contextlib import asynccontextmanager
 from io import TextIOWrapper
 
@@ -39,9 +40,13 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
+        # Duplicate the underlying file descriptors so closing the wrapper
+        # does not close the real process stdio (fixes issue #1933).
+        stdin_dup = os.fdopen(os.dup(sys.stdin.buffer.fileno()), 'rb')
+        stdin = anyio.wrap_file(TextIOWrapper(stdin_dup, encoding="utf-8", errors="replace"))
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout_dup = os.fdopen(os.dup(sys.stdout.buffer.fileno()), 'wb')
+        stdout = anyio.wrap_file(TextIOWrapper(stdout_dup, encoding="utf-8"))
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)


### PR DESCRIPTION
Fixes #1933 — duplicate underlying stdio file descriptors before wrapping so closing wrappers doesn't close the real process stdio. See issue: https://github.com/modelcontextprotocol/python-sdk/issues/1933