### PR TITLE
Fix MCPServer.call_tool return type

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import base64
 import inspect
-import json
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Generic, Literal, TypeAlias, TypeVar, cast, overload
 
 import anyio
 import pydantic_core
@@ -319,8 +318,8 @@ class MCPServer(Generic[LifespanResultT]):
             return CallToolResult(content=[TextContent(type="text", text=str(e))], is_error=True)
         if isinstance(result, CallToolResult):
             return result
-        if isinstance(result, tuple) and len(result) == 2:
-            unstructured_content, structured_content = result
+        if isinstance(result, tuple):
+            unstructured_content, structured_content = cast(tuple[Sequence[ContentBlock], dict[str, Any]], result)
             return CallToolResult(
                 content=list(unstructured_content),
                 structured_content=structured_content,

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -8,7 +8,7 @@ import json
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import Any, Generic, Literal, TypeVar, overload
+from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload
 
 import anyio
 import pydantic_core
@@ -75,6 +75,9 @@ from mcp.types import Tool as MCPTool
 logger = get_logger(__name__)
 
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
+_MCPServerToolResult: TypeAlias = (
+    Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]] | CallToolResult
+)
 
 
 class Settings(BaseSettings, Generic[LifespanResultT]):
@@ -319,16 +322,8 @@ class MCPServer(Generic[LifespanResultT]):
         if isinstance(result, tuple) and len(result) == 2:
             unstructured_content, structured_content = result
             return CallToolResult(
-                content=list(unstructured_content),  # type: ignore[arg-type]
-                structured_content=structured_content,  # type: ignore[arg-type]
-            )
-        if isinstance(result, dict):  # pragma: no cover
-            # TODO: this code path is unreachable — convert_result never returns a raw dict.
-            # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong
-            # and needs to be cleaned up.
-            return CallToolResult(
-                content=[TextContent(type="text", text=json.dumps(result, indent=2))],
-                structured_content=result,
+                content=list(unstructured_content),
+                structured_content=structured_content,
             )
         return CallToolResult(content=list(result))
 
@@ -399,7 +394,7 @@ class MCPServer(Generic[LifespanResultT]):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
+    ) -> _MCPServerToolResult:
         """Call a tool by name with arguments."""
         if context is None:
             context = Context(mcp_server=self)

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -519,6 +519,23 @@ class TestServerTools:
             assert result.structured_content is not None
             assert result.structured_content == {"result": 12}
 
+    async def test_call_tool_direct_returns_structured_tuple(self):
+        """Test direct call_tool returns both content and structured output."""
+
+        def calculate_sum(a: int, b: int) -> int:
+            """Add two numbers"""
+            return a + b
+
+        mcp = MCPServer()
+        mcp.add_tool(calculate_sum)
+
+        result = await mcp.call_tool("calculate_sum", {"a": 5, "b": 7})
+
+        assert isinstance(result, tuple)
+        content, structured_content = result
+        assert list(content) == [TextContent(text="12")]
+        assert structured_content == {"result": 12}
+
     async def test_tool_structured_output_list(self):
         """Test tool with structured output returning list"""
 


### PR DESCRIPTION
## Motivation and Context
Closes #1251.

`MCPServer.call_tool` always requests converted tool results from the tool manager, so its return annotation should match the actual converted shapes: content-only sequences, structured `(content, structured_content)` tuples, or direct `CallToolResult` values. The previous `dict[str, Any]` return type also left an unreachable handler branch in `_handle_call_tool`.

## How Has This Been Tested?
- `python3 -m py_compile src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py`
- `git diff --check`
- `uv run --frozen --no-default-groups --with pytest --with inline-snapshot pytest -c /dev/null tests/server/mcpserver/test_server.py -k 'call_tool_direct_returns_structured_tuple or tool_structured_output_primitive'`

## Breaking Changes
None. This is a type annotation and cleanup change with direct coverage for the runtime return shape.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
I kept the scope limited to the incorrect direct `call_tool` type and the unreachable code path it created. I attempted the full project-style `uv` dev-tool run locally, but dependency downloads for dev tooling stalled; the targeted regression test above passed.