### PR TITLE
fix(server): classify structured file MIME types as text

### DIFF
--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -18,6 +18,27 @@ from mcp.server.mcpserver.resources.base import Resource
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.types import Annotations, Icon
 
+_TEXT_LIKE_MIME_TYPES = {
+    "application/ecmascript",
+    "application/javascript",
+    "application/json",
+    "application/xml",
+    "application/x-yaml",
+    "application/yaml",
+    "image/svg+xml",
+}
+
+_TEXT_LIKE_MIME_SUFFIXES = ("+json", "+xml", "+yaml")
+
+
+def _is_text_like_mime_type(mime_type: str) -> bool:
+    media_type = mime_type.split(";", 1)[0].strip().lower()
+    return (
+        media_type.startswith("text/")
+        or media_type in _TEXT_LIKE_MIME_TYPES
+        or media_type.endswith(_TEXT_LIKE_MIME_SUFFIXES)
+    )
+
 
 class TextResource(Resource):
     """A resource that reads from a string."""
@@ -139,7 +160,7 @@ class FileResource(Resource):
         if is_binary:
             return True
         mime_type = info.data.get("mime_type", "text/plain")
-        return not mime_type.startswith("text/")
+        return not _is_text_like_mime_type(mime_type)
 
     async def read(self) -> str | bytes:
         """Read the file content."""

--- a/tests/server/mcpserver/resources/test_file_resources.py
+++ b/tests/server/mcpserver/resources/test_file_resources.py
@@ -114,3 +114,60 @@ class TestFileResource:
                 await resource.read()
         finally:
             temp_file.chmod(0o644)  # Restore permissions
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "mime_type",
+    [
+        "application/json",
+        "application/ld+json; charset=utf-8",
+        "application/xml",
+        "application/atom+xml",
+        "application/x-yaml",
+        "image/svg+xml",
+    ],
+)
+async def test_file_resource_reads_text_like_mime_types_as_text(temp_file: Path, mime_type: str):
+    resource = FileResource(
+        uri=temp_file.as_uri(),
+        name="test",
+        path=temp_file,
+        mime_type=mime_type,
+    )
+
+    content = await resource.read()
+
+    assert resource.is_binary is False
+    assert content == "test content"
+
+
+@pytest.mark.anyio
+async def test_file_resource_reads_octet_stream_as_binary(temp_file: Path):
+    resource = FileResource(
+        uri=temp_file.as_uri(),
+        name="test",
+        path=temp_file,
+        mime_type="application/octet-stream",
+    )
+
+    content = await resource.read()
+
+    assert resource.is_binary is True
+    assert content == b"test content"
+
+
+@pytest.mark.anyio
+async def test_file_resource_explicit_binary_overrides_text_like_mime_type(temp_file: Path):
+    resource = FileResource(
+        uri=temp_file.as_uri(),
+        name="test",
+        path=temp_file,
+        mime_type="application/json",
+        is_binary=True,
+    )
+
+    content = await resource.read()
+
+    assert resource.is_binary is True
+    assert content == b"test content"


### PR DESCRIPTION
## Summary
- Treat structured text MIME types such as `application/json`, `application/*+json`, XML, YAML, JavaScript, and SVG as text for `FileResource`.
- Preserve binary behavior for `application/octet-stream` and explicit `is_binary=True` overrides.
- Add regression coverage for common text-like non-`text/*` MIME types.

## Motivation and Context
`FileResource` currently marks every non-`text/*` MIME type as binary. That makes common textual resources like JSON files return `bytes`, which are then exposed as blob resource contents instead of text resource contents.

## How Has This Been Tested?
- `uv run --frozen pytest tests/server/mcpserver/resources/test_file_resources.py`
- `uv run --frozen ruff check src/mcp/server/mcpserver/resources/types.py tests/server/mcpserver/resources/test_file_resources.py`
- `git diff --check`
