### PR TITLE
fix(shared): strip envelope fields when forwarding JSONRPCRequest

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -282,6 +282,12 @@ class BaseSession(
                 meta: dict[str, Any] = request_data.setdefault("params", {}).setdefault("_meta", {})
                 inject_trace_context(meta)
 
+                # Strip envelope fields that would collide with the explicit kwargs below.
+                # Happens when request_data comes from model_dump() on a JSONRPCRequest
+                # (e.g. forwarding/proxy scenarios). See issue #2548.
+                request_data.pop("jsonrpc", None)
+                request_data.pop("id", None)
+
                 jsonrpc_request = JSONRPCRequest(jsonrpc="2.0", id=request_id, **request_data)
                 await self._write_stream.send(SessionMessage(message=jsonrpc_request, metadata=metadata))
 

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -416,3 +416,56 @@ async def test_null_id_error_does_not_affect_pending_request():
     # Pending request completed successfully
     assert len(result_holder) == 1
     assert isinstance(result_holder[0], EmptyResult)
+
+
+@pytest.mark.anyio
+async def test_send_request_strips_envelope_fields_when_forwarding():
+    """Test that send_request does not raise TypeError when request_data contains
+    jsonrpc and id fields (e.g. from model_dump() on a JSONRPCRequest).
+
+    This is the forwarding/proxy scenario: a session receives an incoming
+    JSONRPCRequest and re-emits it via another session's send_request.
+    model_dump() on a JSONRPCRequest preserves the envelope fields jsonrpc and
+    id, which used to collide with the explicit kwargs at the construction site.
+    Regression test for issue #2548.
+    """
+    ev_response_received = anyio.Event()
+    result_holder: list[EmptyResult] = []
+
+    async with create_client_server_memory_streams() as (client_streams, server_streams):
+        client_read, client_write = client_streams
+        server_read, server_write = server_streams
+
+        async def mock_server() -> None:
+            """Receive the forwarded request and send back an empty response."""
+            message = await server_read.receive()
+            assert isinstance(message, SessionMessage)
+            assert isinstance(message.message, JSONRPCRequest)
+            request_id = message.message.id
+            await server_write.send(SessionMessage(message=JSONRPCResponse(jsonrpc="2.0", id=request_id, result={})))
+
+        async def forward_request(client_session: ClientSession) -> None:
+            """Simulate a proxy forwarding an incoming JSONRPCRequest."""
+            # Build a JSONRPCRequest as a proxy would receive it from an upstream
+            # server. model_dump() on this object includes jsonrpc and id, which
+            # previously caused TypeError: got multiple values for keyword argument.
+            incoming = JSONRPCRequest(jsonrpc="2.0", id=99, method="ping", params=None)
+            result = await client_session.send_request(
+                incoming,  # type: ignore[arg-type]
+                EmptyResult,
+            )
+            result_holder.append(result)
+            ev_response_received.set()
+
+        async with (
+            anyio.create_task_group() as tg,
+            ClientSession(read_stream=client_read, write_stream=client_write) as client_session,
+        ):
+            tg.start_soon(mock_server)
+            tg.start_soon(forward_request, client_session)
+
+            with anyio.fail_after(2):  # pragma: no branch
+                await ev_response_received.wait()
+
+    assert len(result_holder) == 1
+    assert isinstance(result_holder[0], EmptyResult)


### PR DESCRIPTION
## Summary

Fixes #2548.

`BaseSession.send_request` builds the outgoing wire object as:
```python
JSONRPCRequest(jsonrpc="2.0", id=request_id, **request_data)
```

When `request_data` originates from `model_dump()` on an existing `JSONRPCRequest` (a typical forwarding/proxy scenario — e.g. a `ServerSession` receiving an incoming request and re-emitting it via a `ClientSession`), the dump preserves the envelope fields `jsonrpc` and `id`, which collide with the explicit kwargs above:

```
TypeError: got multiple values for keyword argument 'jsonrpc'
```

## Approach

Conservative: pop `jsonrpc` and `id` from `request_data` before unpacking. This keeps the wire-envelope construction authoritative at this call site and doesn't change any model-layer dump behavior (which would have wider blast radius).

As mentioned in the issue thread, I'm happy to take the model-layer approach instead (e.g. excluding envelope fields from `model_dump` on forwarded requests) if the maintainers prefer that — let me know.

## Test

Added `test_send_request_strips_envelope_fields_when_forwarding` in `tests/shared/test_session.py` that reproduces the bug (test fails without the fix, passes with it) and verifies clean forwarding end-to-end with a mock server.

## Checklist
- [x] Tests added that fail without the fix
- [x] Full `tests/shared/test_session.py` suite passes (9/9)
- [x] Full `tests/` suite passes (1173 passed, 98 skipped, 1 xfailed)
- [x] `ruff format` / `ruff check` clean
- [x] `pyright` clean (0 errors, 0 warnings)
- [x] No changes to public API