### PR TITLE
fix: chain exceptions with 'from' in 4 missed raise sites

### DIFF
--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -182,8 +182,8 @@ class Prompt(BaseModel):
                         content = pydantic_core.to_json(msg, fallback=str, indent=2).decode()
                         messages.append(Message(role="user", content=content))
                 except Exception:  # pragma: no cover
-                    raise ValueError(f"Could not convert prompt result to message: {msg}")
+                    raise ValueError(f"Could not convert prompt result to message: {msg}") from None
 
             return messages
         except Exception as e:  # pragma: no cover
-            raise ValueError(f"Error rendering prompt {self.name}: {e}")
+            raise ValueError(f"Error rendering prompt {self.name}: {e}") from e

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -130,4 +130,4 @@ class ResourceTemplate(BaseModel):
                 fn=lambda: result,  # Capture result in closure
             )
         except Exception as e:
-            raise ValueError(f"Error creating resource from template: {e}")
+            raise ValueError(f"Error creating resource from template: {e}") from e

--- a/src/mcp/shared/experimental/tasks/in_memory_task_store.py
+++ b/src/mcp/shared/experimental/tasks/in_memory_task_store.py
@@ -169,7 +169,7 @@ class InMemoryTaskStore(TaskStore):
                 cursor_index = all_task_ids.index(cursor)
                 start_index = cursor_index + 1
             except ValueError:
-                raise ValueError(f"Invalid cursor: {cursor}")
+                raise ValueError(f"Invalid cursor: {cursor}") from None
 
         page_task_ids = all_task_ids[start_index : start_index + self._page_size]
         tasks = [Task(**self._tasks[tid].task.model_dump()) for tid in page_task_ids]


### PR DESCRIPTION
Closes #2575

Follow-up to #2564 which fixed 12 sites. These 4 were missed:

| File | Line | Fix |
|------|------|-----|
| server/mcpserver/resources/templates.py | 133 | `from e` |
| shared/experimental/tasks/in_memory_task_store.py | 172 | `from None` |
| server/mcpserver/prompts/base.py | 184 | `from None` |
| server/mcpserver/prompts/base.py | 189 | `from e` |

Without `from`, Python shows "During handling of the above exception, 
another exception occurred" instead of "The above exception was the 
direct cause". Callers cannot inspect `__cause__` programmatically.