### PR TITLE
fix: strip trailing slash from resource URL in get_resource_url()

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -151,7 +151,7 @@ class OAuthContext:
 
         # If PRM provides a resource that's a valid parent, use it
         if self.protected_resource_metadata and self.protected_resource_metadata.resource:
-            prm_resource = str(self.protected_resource_metadata.resource)
+            prm_resource = str(self.protected_resource_metadata.resource).rstrip("/")
             if check_resource_allowed(requested_resource=resource, configured_resource=prm_resource):
                 resource = prm_resource
 


### PR DESCRIPTION
Fixes #2578

## Problem
Pydantic v2 `AnyHttpUrl` adds a trailing slash to bare-domain URLs 
when `str()` is called:

```python
>>> str(AnyHttpUrl("https://mcp-server.example.com"))
'https://mcp-server.example.com/'  # trailing slash added
```

This causes an audience mismatch with Microsoft Entra ID v2.0, which 
registers the resource as `https://mcp-server.example.com` (no slash), 
resulting in AADSTS9010010 errors after token refresh.

## Fix
Strip the trailing slash in `get_resource_url()`:

```python
prm_resource = str(self.protected_resource_metadata.resource).rstrip("/")
```

## Files Changed
- `src/mcp/client/auth/oauth2.py` line 154