### PR TITLE
fix: omit OAuth resource on token refresh

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -53,6 +53,13 @@ from mcp.shared.auth_utils import (
 logger = logging.getLogger(__name__)
 
 
+def _normalize_resource_url(resource: str) -> str:
+    parsed = urlparse(resource)
+    if parsed.path == "/" and not parsed.params and not parsed.query and not parsed.fragment:
+        return f"{parsed.scheme}://{parsed.netloc}"
+    return resource
+
+
 class PKCEParameters(BaseModel):
     """PKCE (Proof Key for Code Exchange) parameters."""
 
@@ -151,7 +158,7 @@ class OAuthContext:
 
         # If PRM provides a resource that's a valid parent, use it
         if self.protected_resource_metadata and self.protected_resource_metadata.resource:
-            prm_resource = str(self.protected_resource_metadata.resource)
+            prm_resource = _normalize_resource_url(str(self.protected_resource_metadata.resource))
             if check_resource_allowed(requested_resource=resource, configured_resource=prm_resource):
                 resource = prm_resource
 
@@ -441,10 +448,6 @@ class OAuthClientProvider(httpx.Auth):
             "refresh_token": self.context.current_tokens.refresh_token,
             "client_id": self.context.client_info.client_id,
         }
-
-        # Only include resource param if conditions are met
-        if self.context.should_include_resource_param(self.context.protocol_version):
-            refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
         headers = {"Content-Type": "application/x-www-form-urlencoded"}

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -745,7 +745,7 @@ class TestProtectedResourceMetadata:
 
     @pytest.mark.anyio
     async def test_resource_param_included_with_recent_protocol_version(self, oauth_provider: OAuthClientProvider):
-        """Test resource parameter is included for protocol version >= 2025-06-18."""
+        """Test resource parameter is included for initial token requests on newer protocol versions."""
         # Set protocol version to 2025-06-18
         oauth_provider.context.protocol_version = "2025-06-18"
         oauth_provider.context.client_info = OAuthClientInformationFull(
@@ -762,7 +762,8 @@ class TestProtectedResourceMetadata:
         expected_resource = quote(oauth_provider.context.get_resource_url(), safe="")
         assert f"resource={expected_resource}" in content
 
-        # Test in refresh token
+        # Refresh tokens should not resend the resource parameter. Some providers
+        # reject RFC 8707 resource values on refresh_token grants.
         oauth_provider.context.current_tokens = OAuthToken(
             access_token="test_access",
             token_type="Bearer",
@@ -770,7 +771,7 @@ class TestProtectedResourceMetadata:
         )
         refresh_request = await oauth_provider._refresh_token()
         refresh_content = refresh_request.content.decode()
-        assert "resource=" in refresh_content
+        assert "resource=" not in refresh_content
 
     @pytest.mark.anyio
     async def test_resource_param_excluded_with_old_protocol_version(self, oauth_provider: OAuthClientProvider):
@@ -800,7 +801,7 @@ class TestProtectedResourceMetadata:
 
     @pytest.mark.anyio
     async def test_resource_param_included_with_protected_resource_metadata(self, oauth_provider: OAuthClientProvider):
-        """Test resource parameter is always included when protected resource metadata exists."""
+        """Test resource parameter is included in initial token requests when PRM exists."""
         # Set old protocol version but with protected resource metadata
         oauth_provider.context.protocol_version = "2025-03-26"
         oauth_provider.context.protected_resource_metadata = ProtectedResourceMetadata(
@@ -817,6 +818,15 @@ class TestProtectedResourceMetadata:
         request = await oauth_provider._exchange_token_authorization_code("test_code", "test_verifier")
         content = request.content.decode()
         assert "resource=" in content
+
+        oauth_provider.context.current_tokens = OAuthToken(
+            access_token="test_access",
+            token_type="Bearer",
+            refresh_token="test_refresh",
+        )
+        refresh_request = await oauth_provider._refresh_token()
+        refresh_content = refresh_request.content.decode()
+        assert "resource=" not in refresh_content
 
 
 @pytest.mark.anyio
@@ -947,6 +957,25 @@ async def test_get_resource_url_uses_canonical_when_prm_mismatches(
 
     # get_resource_url should return the canonical server URL, not the PRM resource
     assert provider.context.get_resource_url() == snapshot("https://api.example.com/v1/mcp")
+
+
+@pytest.mark.anyio
+async def test_get_resource_url_removes_root_prm_trailing_slash(
+    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
+) -> None:
+    """Bare-domain PRM resources should not pick up Pydantic's root slash."""
+    provider = OAuthClientProvider(
+        server_url="https://api.example.com",
+        client_metadata=client_metadata,
+        storage=mock_storage,
+    )
+    provider._initialized = True
+    provider.context.protected_resource_metadata = ProtectedResourceMetadata(
+        resource=AnyHttpUrl("https://api.example.com"),
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+    )
+
+    assert provider.context.get_resource_url() == snapshot("https://api.example.com")
 
 
 class TestRegistrationResponse:


### PR DESCRIPTION
## Summary
- omit RFC 8707 `resource` from `refresh_token` requests
- normalize root protected-resource URLs so Pydantic's bare-domain trailing slash does not leak into the OAuth resource value
- keep `resource` on authorization and initial token exchange requests

Fixes #2578.

## To verify
- `python -m py_compile src\mcp\client\auth\oauth2.py tests\client\test_auth.py`
- `uv run pytest tests\client\test_auth.py -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check src\mcp\client\auth\oauth2.py tests\client\test_auth.py`
- `uv run ruff format --check src\mcp\client\auth\oauth2.py tests\client\test_auth.py`
- `uv run pyright src\mcp\client\auth\oauth2.py tests\client\test_auth.py`
- `git diff --check`
