### PR TITLE
fix: support PEP 604 structured output unions

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -478,7 +478,7 @@ def _create_wrapped_model(func_name: str, annotation: Any) -> type[BaseModel]:
     """
     model_name = f"{func_name}Output"
 
-    return create_model(model_name, result=annotation)
+    return create_model(model_name, result=(annotation, ...))
 
 
 def _create_dict_model(func_name: str, dict_annotation: Any) -> type[BaseModel]:

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -680,6 +680,9 @@ def test_structured_output_generic_types():
     def func_optional() -> str | None:  # pragma: no cover
         return None
 
+    def func_builtin_union() -> dict[str, str] | list[str] | str:  # pragma: no cover
+        return {"hello": "world"}
+
     # Test list
     meta = func_metadata(func_list_str)
     assert meta.output_schema == {
@@ -713,6 +716,23 @@ def test_structured_output_generic_types():
         "properties": {"result": {"title": "Result", "anyOf": [{"type": "string"}, {"type": "null"}]}},
         "required": ["result"],
         "title": "func_optionalOutput",
+    }
+
+    meta = func_metadata(func_builtin_union)
+    assert meta.output_schema == {
+        "type": "object",
+        "properties": {
+            "result": {
+                "title": "Result",
+                "anyOf": [
+                    {"type": "object", "additionalProperties": {"type": "string"}},
+                    {"type": "array", "items": {"type": "string"}},
+                    {"type": "string"},
+                ],
+            }
+        },
+        "required": ["result"],
+        "title": "func_builtin_unionOutput",
     }
 
 


### PR DESCRIPTION
﻿## Summary
- wrap FastMCP structured output annotations with Pydantic's explicit `(annotation, ...)` field form
- add regression coverage for `dict | list | str` return annotations

Fixes #2591.

## To verify
- `uv run pytest tests\server\mcpserver\test_func_metadata.py -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check src\mcp\server\mcpserver\utilities\func_metadata.py tests\server\mcpserver\test_func_metadata.py`
- `uv run ruff format --check src\mcp\server\mcpserver\utilities\func_metadata.py tests\server\mcpserver\test_func_metadata.py`
- `git diff --check`
