### PR TITLE
fix: omit resource from OAuth refresh grants

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -151,7 +151,7 @@ class OAuthContext:
 
         # If PRM provides a resource that's a valid parent, use it
         if self.protected_resource_metadata and self.protected_resource_metadata.resource:
-            prm_resource = str(self.protected_resource_metadata.resource)
+            prm_resource = str(self.protected_resource_metadata.resource).rstrip("/")
             if check_resource_allowed(requested_resource=resource, configured_resource=prm_resource):
                 resource = prm_resource
 
@@ -441,10 +441,6 @@ class OAuthClientProvider(httpx.Auth):
             "refresh_token": self.context.current_tokens.refresh_token,
             "client_id": self.context.client_info.client_id,
         }
-
-        # Only include resource param if conditions are met
-        if self.context.should_include_resource_param(self.context.protocol_version):
-            refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
         headers = {"Content-Type": "application/x-www-form-urlencoded"}

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -762,7 +762,7 @@ class TestProtectedResourceMetadata:
         expected_resource = quote(oauth_provider.context.get_resource_url(), safe="")
         assert f"resource={expected_resource}" in content
 
-        # Test in refresh token
+        # Refresh grants don't carry resource; some OAuth providers reject it.
         oauth_provider.context.current_tokens = OAuthToken(
             access_token="test_access",
             token_type="Bearer",
@@ -770,7 +770,7 @@ class TestProtectedResourceMetadata:
         )
         refresh_request = await oauth_provider._refresh_token()
         refresh_content = refresh_request.content.decode()
-        assert "resource=" in refresh_content
+        assert "resource=" not in refresh_content
 
     @pytest.mark.anyio
     async def test_resource_param_excluded_with_old_protocol_version(self, oauth_provider: OAuthClientProvider):
@@ -800,7 +800,7 @@ class TestProtectedResourceMetadata:
 
     @pytest.mark.anyio
     async def test_resource_param_included_with_protected_resource_metadata(self, oauth_provider: OAuthClientProvider):
-        """Test resource parameter is always included when protected resource metadata exists."""
+        """Test resource parameter is included when protected resource metadata exists."""
         # Set old protocol version but with protected resource metadata
         oauth_provider.context.protocol_version = "2025-03-26"
         oauth_provider.context.protected_resource_metadata = ProtectedResourceMetadata(
@@ -817,6 +817,15 @@ class TestProtectedResourceMetadata:
         request = await oauth_provider._exchange_token_authorization_code("test_code", "test_verifier")
         content = request.content.decode()
         assert "resource=" in content
+
+        oauth_provider.context.current_tokens = OAuthToken(
+            access_token="test_access",
+            token_type="Bearer",
+            refresh_token="test_refresh",
+        )
+        refresh_request = await oauth_provider._refresh_token()
+        refresh_content = refresh_request.content.decode()
+        assert "resource=" not in refresh_content
 
 
 @pytest.mark.anyio
@@ -947,6 +956,27 @@ async def test_get_resource_url_uses_canonical_when_prm_mismatches(
 
     # get_resource_url should return the canonical server URL, not the PRM resource
     assert provider.context.get_resource_url() == snapshot("https://api.example.com/v1/mcp")
+
+
+@pytest.mark.anyio
+async def test_get_resource_url_omits_pydantic_root_slash(
+    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
+) -> None:
+    """Bare-domain PRM resources should not inherit Pydantic's trailing slash."""
+    provider = OAuthClientProvider(
+        server_url="https://api.example.com",
+        client_metadata=client_metadata,
+        storage=mock_storage,
+    )
+    provider._initialized = True
+
+    provider.context.protected_resource_metadata = ProtectedResourceMetadata(
+        resource=AnyHttpUrl("https://api.example.com"),
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+    )
+
+    assert str(provider.context.protected_resource_metadata.resource) == "https://api.example.com/"
+    assert provider.context.get_resource_url() == "https://api.example.com"
 
 
 class TestRegistrationResponse:


### PR DESCRIPTION
﻿## Summary
- omit RFC 8707 `resource` from refresh-token grants while keeping it on authorization-code token exchange when required
- avoid leaking Pydantic's bare-domain trailing slash into `get_resource_url()`
- add regression coverage for recent protocol versions, PRM-backed resources, and bare-domain PRM resources

Closes #2578

## To verify
- `.venv\Scripts\python.exe -m pytest tests\client\test_auth.py::TestProtectedResourceMetadata tests\client\test_auth.py::test_get_resource_url_omits_pydantic_root_slash tests\client\test_auth.py::test_get_resource_url_uses_canonical_when_prm_mismatches tests\client\test_auth.py::TestOAuthFallback::test_refresh_token_request -q --basetemp .tmp\pytest -p no:cacheprovider`
- `.venv\Scripts\python.exe -m ruff check src\mcp\client\auth\oauth2.py tests\client\test_auth.py`
- `.venv\Scripts\python.exe -m ruff format --check src\mcp\client\auth\oauth2.py tests\client\test_auth.py`
- `.venv\Scripts\python.exe -m py_compile src\mcp\client\auth\oauth2.py tests\client\test_auth.py`
- `git diff --check`
