### PR TITLE
Fix task result payload null fields

### DIFF
--- a/src/mcp/server/experimental/task_result_handler.py
+++ b/src/mcp/server/experimental/task_result_handler.py
@@ -116,7 +116,7 @@ class TaskResultHandler:
                 related_task = RelatedTaskMetadata(task_id=task_id)
                 related_task_meta: dict[str, Any] = {RELATED_TASK_METADATA_KEY: related_task.model_dump(by_alias=True)}
                 if result is not None:
-                    result_data = result.model_dump(by_alias=True)
+                    result_data = result.model_dump(by_alias=True, mode="json", exclude_none=True)
                     existing_meta: dict[str, Any] = result_data.get("_meta") or {}
                     result_data["_meta"] = {**existing_meta, **related_task_meta}
                     return GetTaskPayloadResult.model_validate(result_data)

--- a/tests/experimental/tasks/server/test_task_result_handler.py
+++ b/tests/experimental/tasks/server/test_task_result_handler.py
@@ -68,6 +68,25 @@ async def test_handle_returns_result_for_completed_task(
 
 
 @pytest.mark.anyio
+async def test_handle_omits_none_fields_from_result_payload(
+    store: InMemoryTaskStore, queue: InMemoryTaskMessageQueue, handler: TaskResultHandler
+) -> None:
+    task = await store.create_task(TaskMetadata(ttl=60000), task_id="test-task")
+    await store.store_result(task.task_id, CallToolResult(content=[TextContent(type="text", text="Done!")]))
+    await store.update_task(task.task_id, status="completed")
+
+    mock_session = Mock()
+    mock_session.send_message = AsyncMock()
+
+    request = GetTaskPayloadRequest(params=GetTaskPayloadRequestParams(task_id=task.task_id))
+    response = await handler.handle(request, mock_session, "req-1")
+
+    payload = response.model_dump(by_alias=True, mode="json")
+    assert payload["content"] == [{"type": "text", "text": "Done!"}]
+    assert "structuredContent" not in payload
+
+
+@pytest.mark.anyio
 async def test_handle_raises_for_nonexistent_task(
     store: InMemoryTaskStore, queue: InMemoryTaskMessageQueue, handler: TaskResultHandler
 ) -> None:


### PR DESCRIPTION
## Summary
- serialize stored task results with `mode="json", exclude_none=True`
- keep `tasks/result` payloads from emitting optional fields as explicit `null`
- add a regression test for `TextContent` results returned through `TaskResultHandler`

Fixes #2539.

## To verify
- `uv run pytest tests\experimental\tasks\server\test_task_result_handler.py::test_handle_omits_none_fields_from_result_payload tests\experimental\tasks\server\test_task_result_handler.py::test_handle_returns_result_for_completed_task -q --basetemp .tmp\pytest -p no:cacheprovider`
- `uv run ruff check src\mcp\server\experimental\task_result_handler.py tests\experimental\tasks\server\test_task_result_handler.py`
- `uv run ruff format --check src\mcp\server\experimental\task_result_handler.py tests\experimental\tasks\server\test_task_result_handler.py`
- `uv run pyright src\mcp\server\experimental\task_result_handler.py tests\experimental\tasks\server\test_task_result_handler.py`
- `uv run python -m py_compile src\mcp\server\experimental\task_result_handler.py tests\experimental\tasks\server\test_task_result_handler.py`
- `git diff --check`
