### PR TITLE
fix(fastmcp): support PEP 604 union return types

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -478,7 +478,7 @@ def _create_wrapped_model(func_name: str, annotation: Any) -> type[BaseModel]:
     """
     model_name = f"{func_name}Output"
 
-    return create_model(model_name, result=annotation)
+    return create_model(model_name, result=(annotation, ...))
 
 
 def _create_dict_model(func_name: str, dict_annotation: Any) -> type[BaseModel]:

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -716,6 +716,30 @@ def test_structured_output_generic_types():
     }
 
 
+def test_structured_output_pep604_union_of_container_and_primitives():
+    """Test structured output with PEP 604 unions that combine containers and primitives."""
+
+    def func_container_union() -> dict | list | str:  # pragma: no cover
+        return {"hello": "world"}
+
+    meta = func_metadata(func_container_union)
+    assert meta.output_schema == {
+        "type": "object",
+        "properties": {
+            "result": {
+                "title": "Result",
+                "anyOf": [
+                    {"additionalProperties": True, "type": "object"},
+                    {"items": {}, "type": "array"},
+                    {"type": "string"},
+                ],
+            }
+        },
+        "required": ["result"],
+        "title": "func_container_unionOutput",
+    }
+
+
 def test_structured_output_dataclass():
     """Test structured output with dataclass return types"""
 


### PR DESCRIPTION
## Summary
- define wrapped structured-output fields using Pydantic's explicit required field tuple
- add regression coverage for FastMCP tools returning container/primitive PEP 604 unions like `dict | list | str`

Fixes #2591

## Test plan
- `uv run pytest tests/server/mcpserver/test_func_metadata.py -k "structured_output"`
- `uv run pytest tests/server/mcpserver/test_func_metadata.py`