### PR TITLE
fix: request json token responses

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -402,7 +402,10 @@ class OAuthClientProvider(httpx.Auth):
             token_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
         token_data, headers = self.context.prepare_token_auth(token_data, headers)
 
         return httpx.Request("POST", token_url, data=token_data, headers=headers)
@@ -447,7 +450,10 @@ class OAuthClientProvider(httpx.Auth):
             refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
         refresh_data, headers = self.context.prepare_token_auth(refresh_data, headers)
 
         return httpx.Request("POST", token_url, data=refresh_data, headers=headers)

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -596,6 +596,7 @@ class TestOAuthFallback:
 
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
+        assert request.headers["Accept"] == "application/json"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
 
         # Check form data
@@ -622,6 +623,7 @@ class TestOAuthFallback:
 
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
+        assert request.headers["Accept"] == "application/json"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
 
         # Check form data


### PR DESCRIPTION
﻿## Summary
- Send Accept: application/json on OAuth token exchange requests.
- Apply the same header to refresh-token requests, which use the same JSON token response parser.
- Add assertions for both request builders.

Fixes #1523.

## To verify
- uv run pytest tests/client/test_auth.py -q -k "token_exchange_request_authorization_code or refresh_token_request"
- uv run ruff check src/mcp/client/auth/oauth2.py tests/client/test_auth.py
- uv run python -m py_compile src/mcp/client/auth/oauth2.py tests/client/test_auth.py
