### PR TITLE
fix: reject changed duplicate initialize

### DIFF
--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -398,7 +398,12 @@ class ServerRunner(Generic[LifespanT]):
 
     def _handle_initialize(self, params: Mapping[str, Any] | None) -> InitializeResult:
         """Build the `initialize` result; state commits later in `_on_request`."""
-        _, negotiated = self._negotiate_initialize(params)
+        init, negotiated = self._negotiate_initialize(params)
+        if self.connection.client_params is not None and init != self.connection.client_params:
+            raise MCPError(
+                code=INVALID_PARAMS,
+                message="Session already initialized with different parameters",
+            )
         opts = self.init_options if self.init_options is not None else self.server.create_initialization_options()
         return InitializeResult(
             protocol_version=negotiated,

--- a/tests/server/test_runner.py
+++ b/tests/server/test_runner.py
@@ -173,6 +173,25 @@ async def test_runner_handles_initialize_and_populates_connection(server: SrvT):
 
 
 @pytest.mark.anyio
+async def test_runner_rejects_changed_duplicate_initialize(server: SrvT):
+    async with connected_runner(server, initialized=False) as (client, runner):
+        first_params = _initialize_params()
+        await client.send_raw_request("initialize", first_params)
+        assert runner.connection.client_params is not None
+        assert runner.connection.client_params.client_info.name == "test-client"
+
+        second_params = _initialize_params()
+        second_params["clientInfo"] = {"name": "second-client", "version": "1.0"}
+        with pytest.raises(MCPError) as exc:
+            await client.send_raw_request("initialize", second_params)
+
+        assert exc.value.error.code == INVALID_PARAMS
+        assert "already initialized" in exc.value.error.message
+        assert runner.connection.client_params is not None
+        assert runner.connection.client_params.client_info.name == "test-client"
+
+
+@pytest.mark.anyio
 async def test_runner_initialize_opens_gate_but_event_fires_only_after_initialized_notification(server: SrvT):
     """`initialize` commits the gate flag and peer info, but the public
     `connection.initialized` event waits for `notifications/initialized` (the


### PR DESCRIPTION
﻿## Summary
- reject a second `initialize` request if it tries to change the session's client parameters
- keep the first `client_params` intact so later capability checks cannot be spoofed by a duplicate handshake
- add a regression test covering the changed-params path

## To verify
- `uv run pytest tests/server/test_session.py -q -k "duplicate_initialize or server_session_initialize"`
- `uv run ruff check src/mcp/server/session.py tests/server/test_session.py`
- `uv run pyright src/mcp/server/session.py tests/server/test_session.py`
- `uv run python -m py_compile src/mcp/server/session.py tests/server/test_session.py`
- `git diff --check`

Closes #2605
