### PR TITLE
docs: list Python 3.14 in README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 [pypi-url]: https://pypi.org/project/mcp/
 [mit-badge]: https://img.shields.io/pypi/l/mcp.svg
 [mit-url]: https://github.com/modelcontextprotocol/python-sdk/blob/main/LICENSE
-[python-badge]: https://img.shields.io/pypi/pyversions/mcp.svg
+[python-badge]: https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg
 [python-url]: https://www.python.org/downloads/
 [docs-badge]: https://img.shields.io/badge/docs-python--sdk-blue.svg
 [docs-url]: https://modelcontextprotocol.github.io/python-sdk/

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 [pypi-url]: https://pypi.org/project/mcp/
 [mit-badge]: https://img.shields.io/pypi/l/mcp.svg
 [mit-url]: https://github.com/modelcontextprotocol/python-sdk/blob/main/LICENSE
-[python-badge]: https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg
+[python-badge]: https://img.shields.io/pypi/pyversions/mcp.svg
 [python-url]: https://www.python.org/downloads/
 [docs-badge]: https://img.shields.io/badge/docs-python--sdk-blue.svg
 [docs-url]: https://modelcontextprotocol.github.io/python-sdk/

--- a/README.v2.md
+++ b/README.v2.md
@@ -81,7 +81,7 @@
 [pypi-url]: https://pypi.org/project/mcp/
 [mit-badge]: https://img.shields.io/pypi/l/mcp.svg
 [mit-url]: https://github.com/modelcontextprotocol/python-sdk/blob/main/LICENSE
-[python-badge]: https://img.shields.io/pypi/pyversions/mcp.svg
+[python-badge]: https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg
 [python-url]: https://www.python.org/downloads/
 [docs-badge]: https://img.shields.io/badge/docs-python--sdk-blue.svg
 [docs-url]: https://modelcontextprotocol.github.io/python-sdk/


### PR DESCRIPTION
## Summary
- replace the PyPI-supported-versions badge with an explicit README badge that includes Python 3.14
- align the displayed support range with pyproject classifiers and the CI matrix

Fixes #2537

## Tests
- git diff --check

Note: no runtime tests were run; this is a README-only badge update.