### PR TITLE
fix: suppress completed request cancellation leak

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -108,8 +108,9 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
-    ) -> None:
+    ) -> bool | None:
         """Exit the context manager, performing cleanup and notifying completion."""
+        suppress = False
         try:
             if self._completed:
                 self._on_complete(self)
@@ -117,7 +118,19 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
             self._entered = False
             if not self._cancel_scope:  # pragma: no cover
                 raise RuntimeError("No active cancel scope")
-            self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+            try:
+                suppress = self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+            except BaseException as exc:
+                if (
+                    self._completed
+                    and self._cancel_scope.cancel_called
+                    and isinstance(exc, anyio.get_cancelled_exc_class())
+                ):
+                    suppress = True
+                else:
+                    raise
+
+        return suppress
 
     async def respond(self, response: SendResultT | ErrorData) -> None:
         """Send a response for this request.

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import anyio
 import pytest
 
@@ -21,6 +23,11 @@ from mcp.types import (
     ServerNotification,
     ServerRequest,
 )
+
+
+class _DummySession:
+    async def _send_response(self, request_id: int | str, response: ClientResult | ErrorData) -> None:
+        pass
 
 
 @pytest.mark.anyio
@@ -96,6 +103,87 @@ async def test_request_cancellation():
             # Give cancellation time to process
             with anyio.fail_after(1):  # pragma: no branch
                 await ev_cancelled.wait()
+
+
+@pytest.mark.anyio
+async def test_request_responder_suppresses_completed_cancellation():
+    """A request-local cancellation should not leak out after cancel() responds."""
+
+    completed: list[RequestResponder[ServerRequest, ClientResult]] = []
+    responder = RequestResponder[ServerRequest, ClientResult](
+        request_id=1,
+        request_meta=None,
+        request=types.PingRequest(),
+        session=cast(Any, _DummySession()),
+        on_complete=completed.append,
+    )
+
+    with responder:
+        await responder.cancel()
+        await anyio.sleep(0)
+
+    assert completed == [responder]
+
+
+@pytest.mark.anyio
+async def test_request_responder_ignores_late_completed_cancellation():
+    """Some backends can surface cancellation while leaving an already-cancelled scope."""
+
+    class _CancelScope:
+        cancel_called = True
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: object,
+        ) -> bool:
+            raise anyio.get_cancelled_exc_class()
+
+    completed: list[RequestResponder[ServerRequest, ClientResult]] = []
+    responder = RequestResponder[ServerRequest, ClientResult](
+        request_id=1,
+        request_meta=None,
+        request=types.PingRequest(),
+        session=cast(Any, _DummySession()),
+        on_complete=completed.append,
+    )
+    responder._entered = True
+    responder._completed = True
+    responder._cancel_scope = cast(Any, _CancelScope())
+
+    assert responder.__exit__(None, None, None) is True
+    assert completed == [responder]
+
+
+@pytest.mark.anyio
+async def test_request_responder_reraises_unexpected_exit_error():
+    """Unexpected cancel scope errors should still propagate."""
+
+    class _CancelScope:
+        cancel_called = False
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: object,
+        ) -> bool:
+            raise RuntimeError("boom")
+
+    responder = RequestResponder[ServerRequest, ClientResult](
+        request_id=1,
+        request_meta=None,
+        request=types.PingRequest(),
+        session=cast(Any, _DummySession()),
+        on_complete=lambda _: None,
+    )
+    responder._entered = True
+    responder._completed = True
+    responder._cancel_scope = cast(Any, _CancelScope())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        responder.__exit__(None, None, None)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- return the underlying CancelScope.__exit__ suppression result from RequestResponder.__exit__
- swallow a late cancellation from an already-cancelled/completed responder so cancelled requests do not tear down sibling tasks
- add regressions for completed responder cancellations

Fixes #2610.

## Tests
- uv run pytest tests/shared/test_session.py -q -k "request_responder or request_cancellation"
- uv run pytest tests/server/test_cancel_handling.py tests/shared/test_session.py -q
- uv run ruff check src/mcp/shared/session.py tests/shared/test_session.py
- uv run ruff format --check src/mcp/shared/session.py tests/shared/test_session.py
- uv run pyright src/mcp/shared/session.py tests/shared/test_session.py