### PR TITLE
Fix Issue #2614 - changed the publishing url for Python docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ strict: true
 repo_name: modelcontextprotocol/python-sdk
 repo_url: https://github.com/modelcontextprotocol/python-sdk
 edit_uri: edit/main/docs/
-site_url: https://modelcontextprotocol.github.io/python-sdk
+site_url: https://py.sdk.modelcontextprotocol.io/
 
 # TODO(Marcelo): Add Anthropic copyright?
 # copyright: © Model Context Protocol 2025 to present


### PR DESCRIPTION
## Motivation and Context
Fixing issue #2614 to make sure the link from [MCP Docs SDKs page](https://modelcontextprotocol.io/docs/sdk) is not broken anymore and that Python docs are published to the right URL:
https://py.sdk.modelcontextprotocol.io/

## How Has This Been Tested?
Since I don't have publishing rights in this project, I tested on another project.

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Since the docs are published manually for the Python SDK, this change will require one of SDK maintainers with sufficient rights to publish docs to the new URL.
