### PR TITLE
fix: preserve optional string JSON arguments

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -148,7 +148,7 @@ class FuncMetadata(BaseModel):
                 continue
 
             field_info = key_to_field_info[data_key]
-            if isinstance(data_value, str) and field_info.annotation is not str:
+            if isinstance(data_value, str) and _should_pre_parse_json(field_info.annotation):
                 try:
                     pre_parsed = json.loads(data_value)
                 except json.JSONDecodeError:
@@ -165,6 +165,20 @@ class FuncMetadata(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )
+
+
+_SIMPLE_PRE_PARSE_TYPES = {str, int, float, bool, bytes, type(None)}
+
+
+def _should_pre_parse_json(annotation: Any) -> bool:
+    """Return whether string inputs for an annotation should be JSON-decoded."""
+    if annotation in _SIMPLE_PRE_PARSE_TYPES:
+        return False
+
+    if is_union_origin(get_origin(annotation)):
+        return not all(arg in _SIMPLE_PRE_PARSE_TYPES for arg in get_args(annotation))
+
+    return True
 
 
 def func_metadata(

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -182,6 +182,59 @@ def test_str_vs_list_str():
     assert result["str_or_list"] == ["hello", "world"]
 
 
+def test_optional_str_preserves_json_strings():
+    """String-like unions should preserve JSON-looking strings as strings."""
+
+    def func_optional_str(config: str | None = None):
+        return config
+
+    meta = func_metadata(func_optional_str)
+
+    json_obj_str = '{"database": "postgres", "port": 5432}'
+    result = meta.pre_parse_json({"config": json_obj_str})
+    assert result["config"] == json_obj_str
+    assert func_optional_str(result["config"]) == json_obj_str
+
+    json_array_str = '["item1", "item2", "item3"]'
+    result = meta.pre_parse_json({"config": json_array_str})
+    assert result["config"] == json_array_str
+    assert func_optional_str(result["config"]) == json_array_str
+
+
+@pytest.mark.anyio
+async def test_optional_str_runtime_validation_preserves_json_string():
+    """Ensure optional string values reach the function without JSON pre-parsing."""
+
+    def handle_json_payload(payload: str | None = None) -> str:
+        assert isinstance(payload, str)
+        return payload
+
+    meta = func_metadata(handle_json_payload)
+    json_payload = '{"action": "create", "resource": "user"}'
+
+    result = await meta.call_fn_with_arg_validation(
+        handle_json_payload,
+        fn_is_async=False,
+        arguments_to_validate={"payload": json_payload},
+        arguments_to_pass_directly=None,
+    )
+
+    assert result == json_payload
+
+
+def test_optional_list_still_pre_parses_json_string():
+    """Complex optional types still accept JSON-encoded structured values."""
+
+    def func_optional_list(items: list[str] | None = None):
+        return items
+
+    meta = func_metadata(func_optional_list)
+
+    result = meta.pre_parse_json({"items": '["hello", "world"]'})
+    assert result["items"] == ["hello", "world"]
+    assert func_optional_list(result["items"]) == ["hello", "world"]
+
+
 def test_skip_names():
     """Test that skipped parameters are not included in the model"""
 


### PR DESCRIPTION
## Summary

- skip JSON pre-parsing for simple scalar union annotations such as `str | None`
- keep JSON pre-parsing for structured optional types such as `list[str] | None`
- add FastMCP metadata regressions for optional string and optional list arguments

Fixes #1873.

## Context

FastMCP already preserves JSON-looking values for plain `str` arguments, but `str | None` still went through `json.loads(...)` during argument pre-parsing. That means an optional string receiving a JSON object or array string was converted to a `dict`/`list` before Pydantic validation, then rejected or corrupted instead of reaching the tool as the annotated string value.

This keeps structured annotations parseable while treating unions of simple scalar types like simple scalar fields.

## Validation

- `uv run --frozen pytest tests/server/mcpserver/test_func_metadata.py` -> 36 passed
- `uv run --frozen pytest tests/server/mcpserver/test_tool_manager.py` -> 50 passed
- `uv run --frozen ruff check src/mcp/server/mcpserver/utilities/func_metadata.py tests/server/mcpserver/test_func_metadata.py` -> passed
- `uv run --frozen pyright src/mcp/server/mcpserver/utilities/func_metadata.py tests/server/mcpserver/test_func_metadata.py` -> 0 errors
- `git diff --check` -> passed
