### PR TITLE
Fix completed request cancellation cleanup

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -117,7 +117,11 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
             self._entered = False
             if not self._cancel_scope:  # pragma: no cover
                 raise RuntimeError("No active cancel scope")
-            self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+            try:
+                self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+            except BaseException as exc:
+                if not (self._completed and isinstance(exc, anyio.get_cancelled_exc_class())):
+                    raise
 
     async def respond(self, response: SendResultT | ErrorData) -> None:
         """Send a response for this request.

--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -114,7 +114,11 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
             self._entered = False
             if not self._cancel_scope:  # pragma: no cover
                 raise RuntimeError("No active cancel scope")
-            self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+            try:
+                self._cancel_scope.__exit__(exc_type, exc_val, exc_tb)
+            except BaseException as exc:
+                if not (self._completed and isinstance(exc, anyio.get_cancelled_exc_class())):
+                    raise
 
     async def respond(self, response: SendResultT | ErrorData) -> None:
         """Send a response for this request.

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import anyio
 import pytest
 
@@ -21,6 +23,18 @@ from mcp.types import (
     ServerNotification,
     ServerRequest,
 )
+
+
+class _CancelScopeThatRaisesOnExit:
+    cancel_called = True
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ) -> None:
+        raise anyio.get_cancelled_exc_class()()
 
 
 @pytest.mark.anyio
@@ -96,6 +110,44 @@ async def test_request_cancellation():
             # Give cancellation time to process
             with anyio.fail_after(1):  # pragma: no branch
                 await ev_cancelled.wait()
+
+
+@pytest.mark.anyio
+async def test_completed_request_responder_suppresses_cancel_scope_exit() -> None:
+    completed: list[Any] = []
+    responder = RequestResponder(
+        request_id=1,
+        request_meta=None,
+        request=types.PingRequest(),
+        session=cast(Any, object()),
+        on_complete=completed.append,
+    )
+    responder._completed = True  # type: ignore[reportPrivateUsage]
+    responder._cancel_scope = cast(  # type: ignore[reportPrivateUsage]
+        anyio.CancelScope, _CancelScopeThatRaisesOnExit()
+    )
+
+    responder.__exit__(None, None, None)
+
+    assert completed == [responder]
+    assert not responder._entered  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.anyio
+async def test_incomplete_request_responder_propagates_cancel_scope_exit() -> None:
+    responder = RequestResponder(
+        request_id=1,
+        request_meta=None,
+        request=types.PingRequest(),
+        session=cast(Any, object()),
+        on_complete=lambda _: None,
+    )
+    responder._cancel_scope = cast(  # type: ignore[reportPrivateUsage]
+        anyio.CancelScope, _CancelScopeThatRaisesOnExit()
+    )
+
+    with pytest.raises(anyio.get_cancelled_exc_class()):
+        responder.__exit__(None, None, None)
 
 
 @pytest.mark.anyio

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -1,5 +1,5 @@
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, cast
 
 import anyio
 import pytest
@@ -10,6 +10,7 @@ from mcp.server.lowlevel.server import Server
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_client_server_memory_streams, create_connected_server_and_client_session
 from mcp.shared.message import SessionMessage
+from mcp.shared.session import RequestResponder
 from mcp.types import (
     CancelledNotification,
     CancelledNotificationParams,
@@ -23,6 +24,18 @@ from mcp.types import (
     JSONRPCResponse,
     TextContent,
 )
+
+
+class _CancelScopeThatRaisesOnExit:
+    cancel_called = True
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object | None,
+    ) -> None:
+        raise anyio.get_cancelled_exc_class()()
 
 
 @pytest.fixture
@@ -126,6 +139,44 @@ async def test_request_cancellation():
             # Give cancellation time to process
             with anyio.fail_after(1):  # pragma: no cover
                 await ev_cancelled.wait()
+
+
+@pytest.mark.anyio
+async def test_completed_request_responder_suppresses_cancel_scope_exit() -> None:
+    completed: list[Any] = []
+    responder = RequestResponder(
+        request_id=1,
+        request_meta=None,
+        request=types.ClientRequest(types.PingRequest()),
+        session=cast(Any, object()),
+        on_complete=completed.append,
+    )
+    responder._completed = True  # type: ignore[reportPrivateUsage]
+    responder._cancel_scope = cast(  # type: ignore[reportPrivateUsage]
+        anyio.CancelScope, _CancelScopeThatRaisesOnExit()
+    )
+
+    responder.__exit__(None, None, None)
+
+    assert completed == [responder]
+    assert not responder._entered  # type: ignore[reportPrivateUsage]
+
+
+@pytest.mark.anyio
+async def test_incomplete_request_responder_propagates_cancel_scope_exit() -> None:
+    responder = RequestResponder(
+        request_id=1,
+        request_meta=None,
+        request=types.ClientRequest(types.PingRequest()),
+        session=cast(Any, object()),
+        on_complete=lambda _: None,
+    )
+    responder._cancel_scope = cast(  # type: ignore[reportPrivateUsage]
+        anyio.CancelScope, _CancelScopeThatRaisesOnExit()
+    )
+
+    with pytest.raises(anyio.get_cancelled_exc_class()):
+        responder.__exit__(None, None, None)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes #2610.

- Suppress the cancellation raised by `CancelScope.__exit__` only after a `RequestResponder` has completed and sent its response.
- Keep cancellation propagation unchanged for incomplete responders.
- Add focused regression coverage for the completed and incomplete cleanup paths.

The implementation is rebased onto the maintained `v1.x` line (v1.29.0), where `BaseSession` and this cleanup path remain active.

## Validation

- `pytest tests/shared/test_session.py tests/server/test_cancel_handling.py -q` — 11 passed
- `ruff format --check src/mcp/shared/session.py tests/shared/test_session.py`
- `ruff check src/mcp/shared/session.py tests/shared/test_session.py`
- `pyright --pythonpath .venv/bin/python src/mcp/shared/session.py tests/shared/test_session.py`
- `git diff --check`