### PR TITLE
fix: fail fast when session is not started

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -365,6 +365,7 @@ class ClientSession:
         self._task_group: anyio.abc.TaskGroup | None = None
         # subscriptions/listen demux routes; membership decides ack consumption (raw listens are never registered)
         self._listen_routes: dict[RequestId, ListenRoute] = {}
+        self._entered = False
         if dispatcher is not None:
             if read_stream is not None or write_stream is not None:
                 raise ValueError("pass read_stream/write_stream or dispatcher, not both")
@@ -386,6 +387,8 @@ class ClientSession:
             )
 
     async def __aenter__(self) -> Self:
+        if self._entered:
+            raise RuntimeError("Session is already running")
         self._task_group = anyio.create_task_group()
         await self._task_group.__aenter__()
         try:
@@ -414,6 +417,7 @@ class ClientSession:
             finally:
                 self._close_binding_queues()
             raise
+        self._entered = True
         return self
 
     async def __aexit__(
@@ -427,11 +431,12 @@ class ClientSession:
         self._task_group.cancel_scope.cancel()
         try:
             result = await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
+            await resync_tracer()
+            return result
         finally:
+            self._entered = False
             self._close_binding_queues()
             self._settle_listen_routes_closed()
-        await resync_tracer()
-        return result
 
     def _close_binding_queues(self) -> None:
         # Unclosed memory object streams warn at garbage collection; close is idempotent.
@@ -472,6 +477,11 @@ class ClientSession:
             pydantic.ValidationError: The server returned a result that does not
                 conform to the negotiated protocol version.
         """
+        if self._task_group is None:
+            raise RuntimeError(
+                "Session is not running. Use it as an async context manager "
+                "(e.g. `async with ClientSession(...) as session:`)."
+            )
         data = request.model_dump(by_alias=True, mode="json", exclude_none=True)
         method: str = data["method"]
         opts: CallOptions = {}

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -156,6 +156,23 @@ async def test_client_session_initialize():
 
 
 @pytest.mark.anyio
+async def test_client_session_requires_context_manager():
+    client_to_server_send, _client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    _server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+
+    async with (
+        client_to_server_send,
+        _client_to_server_receive,
+        _server_to_client_send,
+        server_to_client_receive,
+    ):
+        session = ClientSession(server_to_client_receive, client_to_server_send)
+
+        with pytest.raises(RuntimeError, match="async context manager"):
+            await session.initialize()
+
+
+@pytest.mark.anyio
 async def test_client_session_custom_client_info():
     client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
     server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -173,6 +173,26 @@ async def test_client_session_requires_context_manager():
 
 
 @pytest.mark.anyio
+async def test_client_session_reentry_raises_runtime_error():
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+
+    async with (
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        session = ClientSession(server_to_client_receive, client_to_server_send)
+        await session.__aenter__()
+        try:
+            with pytest.raises(RuntimeError, match="already running"):
+                await session.__aenter__()
+        finally:
+            await session.__aexit__(None, None, None)
+
+
+@pytest.mark.anyio
 async def test_client_session_custom_client_info():
     client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
     server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
@@ -1282,12 +1302,12 @@ async def test_raising_notification_callbacks_over_direct_dispatch_cost_only_tha
 
 @pytest.mark.anyio
 async def test_dispatcher_keyword_send_request_before_enter_raises_runtimeerror():
-    """The documented pre-enter RuntimeError holds for dispatcher= sessions too."""
+    """The documented pre-enter RuntimeError holds before any dispatcher call."""
     client_side, _server_side = create_direct_dispatcher_pair()
     session = ClientSession(dispatcher=client_side)
     with anyio.fail_after(5), pytest.raises(RuntimeError) as exc:
         await session.send_ping()
-    assert str(exc.value) == "DirectDispatcher.send_raw_request called before run()"
+    assert "async context manager" in str(exc.value)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
﻿When `ClientSession`/`BaseSession` is used without entering the async context manager, the receive loop never starts and `initialize()` can hang indefinitely waiting for a response.

This change fails fast: `send_request()` and `send_notification()` now raise a `RuntimeError` if the session hasn't been started via `async with ... as session`.

Fixes #1452.

Tests:
- uv run --frozen python -m ruff check src/mcp/shared/session.py tests/client/test_session.py
- uv run --frozen python -m ruff format src/mcp/shared/session.py tests/client/test_session.py
- uv run --frozen pytest tests/client/test_session.py -q
