### PR TITLE
fix(streamable-http): close SSE responses on errors

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -270,7 +270,7 @@ class StreamableHTTPTransport:
                     if is_complete:
                         break
         finally:
-            if event_source is not None:
+            if event_source is not None:  # pragma: no branch
                 await event_source.response.aclose()
 
     def _consume_modern_cancellation(self, session_message: SessionMessage) -> bool:

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -253,20 +253,25 @@ class StreamableHTTPTransport:
         if isinstance(ctx.session_message.message, JSONRPCRequest):  # pragma: no branch
             original_request_id = ctx.session_message.message.id
 
-        async with ctx.client.sse(self.url, headers=headers) as event_source:
-            event_source.response.raise_for_status()
-            logger.debug("Resumption GET SSE connection established")
+        event_source: EventSource | None = None
+        try:
+            async with ctx.client.sse(self.url, headers=headers) as es:
+                event_source = es
+                event_source.response.raise_for_status()
+                logger.debug("Resumption GET SSE connection established")
 
-            async for sse in event_source:  # pragma: no branch
-                is_complete = await self._handle_sse_event(
-                    sse,
-                    ctx.read_stream_writer,
-                    original_request_id,
-                    ctx.metadata.on_resumption_token_update if ctx.metadata else None,
-                )
-                if is_complete:
-                    await event_source.response.aclose()
-                    break
+                async for sse in event_source:  # pragma: no branch
+                    is_complete = await self._handle_sse_event(
+                        sse,
+                        ctx.read_stream_writer,
+                        original_request_id,
+                        ctx.metadata.on_resumption_token_update if ctx.metadata else None,
+                    )
+                    if is_complete:
+                        break
+        finally:
+            if event_source is not None:
+                await event_source.response.aclose()
 
     def _consume_modern_cancellation(self, session_message: SessionMessage) -> bool:
         """Translate an outbound `notifications/cancelled` at 2026; True means "do not POST".
@@ -442,10 +447,11 @@ class StreamableHTTPTransport:
                 # If the SSE event indicates completion, like returning response/error
                 # break the loop
                 if is_complete:
-                    await response.aclose()
                     return  # Normal completion, no reconnect needed
         except Exception:
             logger.debug("SSE stream ended", exc_info=True)  # pragma: lax no cover
+        finally:
+            await response.aclose()
 
         # Stream ended without response - reconnect if we received an event with ID
         if last_event_id is not None:

--- a/tests/client/test_streamable_http_response_cleanup.py
+++ b/tests/client/test_streamable_http_response_cleanup.py
@@ -3,11 +3,11 @@ import contextlib
 import httpx
 import pytest
 from httpx_sse import ServerSentEvent
+from mcp_types import JSONRPCRequest
 
 from mcp.client.streamable_http import RequestContext, StreamableHTTPTransport
 from mcp.shared._context_streams import create_context_streams
 from mcp.shared.message import ClientMessageMetadata, SessionMessage
-from mcp.types import JSONRPCRequest
 
 
 class _RaiseEventSource:

--- a/tests/client/test_streamable_http_response_cleanup.py
+++ b/tests/client/test_streamable_http_response_cleanup.py
@@ -1,11 +1,11 @@
 import contextlib
 
-import anyio
 import httpx
 import pytest
 from httpx_sse import ServerSentEvent
 
 from mcp.client.streamable_http import RequestContext, StreamableHTTPTransport
+from mcp.shared._context_streams import create_context_streams
 from mcp.shared.message import ClientMessageMetadata, SessionMessage
 from mcp.types import JSONRPCRequest
 
@@ -32,7 +32,7 @@ async def test_handle_sse_response_closes_response_on_exception(monkeypatch: pyt
 
     monkeypatch.setattr("mcp.client.streamable_http.EventSource", _RaiseEventSource)
 
-    send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    send_stream, receive_stream = create_context_streams[SessionMessage | Exception](1)
     async with send_stream, receive_stream:
         transport = StreamableHTTPTransport("http://example.invalid/mcp")
         async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
@@ -53,13 +53,13 @@ async def test_handle_resumption_request_closes_response_when_aconnect_sse_raise
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     @contextlib.asynccontextmanager
-    async def fake_aconnect_sse(*_args, **_kwargs):
+    async def fake_aconnect_sse(*_args: object, **_kwargs: object):
         raise RuntimeError("connect failed")
         yield
 
     monkeypatch.setattr("mcp.client.streamable_http.aconnect_sse", fake_aconnect_sse)
 
-    send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    send_stream, receive_stream = create_context_streams[SessionMessage | Exception](1)
     async with send_stream, receive_stream:
         transport = StreamableHTTPTransport("http://example.invalid/mcp")
         metadata = ClientMessageMetadata(resumption_token="1")
@@ -72,8 +72,14 @@ async def test_handle_resumption_request_closes_response_when_aconnect_sse_raise
                 read_stream_writer=send_stream,
             )
 
-            with pytest.raises(RuntimeError, match="connect failed"):
+            error: RuntimeError | None = None
+            try:
                 await transport._handle_resumption_request(ctx)
+            except RuntimeError as exc:
+                error = exc
+
+            assert error is not None
+            assert str(error) == "connect failed"
 
 
 @pytest.mark.anyio
@@ -92,12 +98,12 @@ async def test_handle_resumption_request_closes_response_on_exception(monkeypatc
     response.aclose = spy_aclose  # type: ignore[method-assign]
 
     @contextlib.asynccontextmanager
-    async def fake_aconnect_sse(*_args, **_kwargs):
+    async def fake_aconnect_sse(*_args: object, **_kwargs: object):
         yield _RaiseEventSource(response)
 
     monkeypatch.setattr("mcp.client.streamable_http.aconnect_sse", fake_aconnect_sse)
 
-    send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    send_stream, receive_stream = create_context_streams[SessionMessage | Exception](1)
     async with send_stream, receive_stream:
         transport = StreamableHTTPTransport("http://example.invalid/mcp")
         metadata = ClientMessageMetadata(resumption_token="1")
@@ -110,7 +116,13 @@ async def test_handle_resumption_request_closes_response_on_exception(monkeypatc
                 read_stream_writer=send_stream,
             )
 
-            with pytest.raises(RuntimeError, match="boom"):
+            error: RuntimeError | None = None
+            try:
                 await transport._handle_resumption_request(ctx)
+            except RuntimeError as exc:
+                error = exc
+
+            assert error is not None
+            assert str(error) == "boom"
 
     assert closed

--- a/tests/client/test_streamable_http_response_cleanup.py
+++ b/tests/client/test_streamable_http_response_cleanup.py
@@ -1,0 +1,116 @@
+import contextlib
+
+import anyio
+import httpx
+import pytest
+from httpx_sse import ServerSentEvent
+
+from mcp.client.streamable_http import RequestContext, StreamableHTTPTransport
+from mcp.shared.message import ClientMessageMetadata, SessionMessage
+from mcp.types import JSONRPCRequest
+
+
+class _RaiseEventSource:
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+
+    async def aiter_sse(self):
+        yield ServerSentEvent(event="message", data="", id=None, retry=None)
+        raise RuntimeError("boom")
+
+
+@pytest.mark.anyio
+async def test_handle_sse_response_closes_response_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    closed = False
+
+    async def spy_aclose() -> None:
+        nonlocal closed
+        closed = True
+
+    response = httpx.Response(200, headers={"content-type": "text/event-stream"})
+    response.aclose = spy_aclose  # type: ignore[method-assign]
+
+    monkeypatch.setattr("mcp.client.streamable_http.EventSource", _RaiseEventSource)
+
+    send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    async with send_stream, receive_stream:
+        transport = StreamableHTTPTransport("http://example.invalid/mcp")
+        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+            ctx = RequestContext(
+                client=client,
+                session_id=None,
+                session_message=SessionMessage(JSONRPCRequest(method="initialize", params={}, jsonrpc="2.0", id=1)),
+                metadata=ClientMessageMetadata(),
+                read_stream_writer=send_stream,
+            )
+            await transport._handle_sse_response(response, ctx)
+
+    assert closed
+
+
+@pytest.mark.anyio
+async def test_handle_resumption_request_closes_response_when_aconnect_sse_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @contextlib.asynccontextmanager
+    async def fake_aconnect_sse(*_args, **_kwargs):
+        raise RuntimeError("connect failed")
+        yield
+
+    monkeypatch.setattr("mcp.client.streamable_http.aconnect_sse", fake_aconnect_sse)
+
+    send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    async with send_stream, receive_stream:
+        transport = StreamableHTTPTransport("http://example.invalid/mcp")
+        metadata = ClientMessageMetadata(resumption_token="1")
+        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+            ctx = RequestContext(
+                client=client,
+                session_id=None,
+                session_message=SessionMessage(JSONRPCRequest(method="initialize", params={}, jsonrpc="2.0", id=1)),
+                metadata=metadata,
+                read_stream_writer=send_stream,
+            )
+
+            with pytest.raises(RuntimeError, match="connect failed"):
+                await transport._handle_resumption_request(ctx)
+
+
+@pytest.mark.anyio
+async def test_handle_resumption_request_closes_response_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    closed = False
+
+    async def spy_aclose() -> None:
+        nonlocal closed
+        closed = True
+
+    response = httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        request=httpx.Request("GET", "http://example.invalid/mcp"),
+    )
+    response.aclose = spy_aclose  # type: ignore[method-assign]
+
+    @contextlib.asynccontextmanager
+    async def fake_aconnect_sse(*_args, **_kwargs):
+        yield _RaiseEventSource(response)
+
+    monkeypatch.setattr("mcp.client.streamable_http.aconnect_sse", fake_aconnect_sse)
+
+    send_stream, receive_stream = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    async with send_stream, receive_stream:
+        transport = StreamableHTTPTransport("http://example.invalid/mcp")
+        metadata = ClientMessageMetadata(resumption_token="1")
+        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+            ctx = RequestContext(
+                client=client,
+                session_id=None,
+                session_message=SessionMessage(JSONRPCRequest(method="initialize", params={}, jsonrpc="2.0", id=1)),
+                metadata=metadata,
+                read_stream_writer=send_stream,
+            )
+
+            with pytest.raises(RuntimeError, match="boom"):
+                await transport._handle_resumption_request(ctx)
+
+    assert closed

--- a/tests/client/test_streamable_http_response_cleanup.py
+++ b/tests/client/test_streamable_http_response_cleanup.py
@@ -1,8 +1,8 @@
 import contextlib
 
-import httpx
+import httpx2
 import pytest
-from httpx_sse import ServerSentEvent
+from httpx2 import ServerSentEvent
 from mcp_types import JSONRPCRequest
 
 from mcp.client.streamable_http import RequestContext, StreamableHTTPTransport
@@ -11,10 +11,10 @@ from mcp.shared.message import ClientMessageMetadata, SessionMessage
 
 
 class _RaiseEventSource:
-    def __init__(self, response: httpx.Response) -> None:
+    def __init__(self, response: httpx2.Response) -> None:
         self.response = response
 
-    async def aiter_sse(self):
+    async def __aiter__(self):
         yield ServerSentEvent(event="message", data="", id=None, retry=None)
         raise RuntimeError("boom")
 
@@ -27,7 +27,7 @@ async def test_handle_sse_response_closes_response_on_exception(monkeypatch: pyt
         nonlocal closed
         closed = True
 
-    response = httpx.Response(200, headers={"content-type": "text/event-stream"})
+    response = httpx2.Response(200, headers={"content-type": "text/event-stream"})
     response.aclose = spy_aclose  # type: ignore[method-assign]
 
     monkeypatch.setattr("mcp.client.streamable_http.EventSource", _RaiseEventSource)
@@ -35,7 +35,7 @@ async def test_handle_sse_response_closes_response_on_exception(monkeypatch: pyt
     send_stream, receive_stream = create_context_streams[SessionMessage | Exception](1)
     async with send_stream, receive_stream:
         transport = StreamableHTTPTransport("http://example.invalid/mcp")
-        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+        async with httpx2.AsyncClient(transport=httpx2.MockTransport(lambda _: httpx2.Response(200))) as client:
             ctx = RequestContext(
                 client=client,
                 session_id=None,
@@ -49,21 +49,20 @@ async def test_handle_sse_response_closes_response_on_exception(monkeypatch: pyt
 
 
 @pytest.mark.anyio
-async def test_handle_resumption_request_closes_response_when_aconnect_sse_raises(
+async def test_handle_resumption_request_closes_response_when_sse_connect_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     @contextlib.asynccontextmanager
-    async def fake_aconnect_sse(*_args: object, **_kwargs: object):
+    async def fake_sse(*_args: object, **_kwargs: object):
         raise RuntimeError("connect failed")
         yield
-
-    monkeypatch.setattr("mcp.client.streamable_http.aconnect_sse", fake_aconnect_sse)
 
     send_stream, receive_stream = create_context_streams[SessionMessage | Exception](1)
     async with send_stream, receive_stream:
         transport = StreamableHTTPTransport("http://example.invalid/mcp")
         metadata = ClientMessageMetadata(resumption_token="1")
-        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+        async with httpx2.AsyncClient(transport=httpx2.MockTransport(lambda _: httpx2.Response(200))) as client:
+            monkeypatch.setattr(client, "sse", fake_sse)
             ctx = RequestContext(
                 client=client,
                 session_id=None,
@@ -90,24 +89,23 @@ async def test_handle_resumption_request_closes_response_on_exception(monkeypatc
         nonlocal closed
         closed = True
 
-    response = httpx.Response(
+    response = httpx2.Response(
         200,
         headers={"content-type": "text/event-stream"},
-        request=httpx.Request("GET", "http://example.invalid/mcp"),
+        request=httpx2.Request("GET", "http://example.invalid/mcp"),
     )
     response.aclose = spy_aclose  # type: ignore[method-assign]
 
     @contextlib.asynccontextmanager
-    async def fake_aconnect_sse(*_args: object, **_kwargs: object):
+    async def fake_sse(*_args: object, **_kwargs: object):
         yield _RaiseEventSource(response)
-
-    monkeypatch.setattr("mcp.client.streamable_http.aconnect_sse", fake_aconnect_sse)
 
     send_stream, receive_stream = create_context_streams[SessionMessage | Exception](1)
     async with send_stream, receive_stream:
         transport = StreamableHTTPTransport("http://example.invalid/mcp")
         metadata = ClientMessageMetadata(resumption_token="1")
-        async with httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+        async with httpx2.AsyncClient(transport=httpx2.MockTransport(lambda _: httpx2.Response(200))) as client:
+            monkeypatch.setattr(client, "sse", fake_sse)
             ctx = RequestContext(
                 client=client,
                 session_id=None,

--- a/tests/client/test_streamable_http_response_cleanup.py
+++ b/tests/client/test_streamable_http_response_cleanup.py
@@ -15,7 +15,7 @@ class _RaiseEventSource:
         self.response = response
 
     async def __aiter__(self):
-        yield ServerSentEvent(event="message", data="", id=None, retry=None)
+        yield ServerSentEvent(event="message", data="", id="", retry=None)
         raise RuntimeError("boom")
 
 


### PR DESCRIPTION
﻿SSE response objects can be leaked when streaming fails or ends unexpectedly.

This ensures HTTP responses are always closed in:
- `_handle_sse_response`
- `_handle_resumption_request`

Fixes #1450.

Tests:
- uv run --frozen python -m ruff check src/mcp/client/streamable_http.py tests/client/test_streamable_http_response_cleanup.py
- uv run --frozen python -m ruff format src/mcp/client/streamable_http.py tests/client/test_streamable_http_response_cleanup.py
- uv run --frozen pytest tests/client/test_streamable_http_response_cleanup.py -q
