### PR TITLE
fix: validate registered redirect uris

### DIFF
--- a/src/mcp/server/auth/handlers/register.py
+++ b/src/mcp/server/auth/handlers/register.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
 
-from pydantic import BaseModel, ValidationError
+from pydantic import AnyUrl, BaseModel, ValidationError
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -18,10 +18,20 @@ from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
 # provider from what we use in the HTTP handler
 RegistrationRequest = OAuthClientMetadata
 
+_LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "[::1]"}
+
 
 class RegistrationErrorResponse(BaseModel):
     error: RegistrationErrorCode
     error_description: str | None
+
+
+def _validate_redirect_uri(url: AnyUrl) -> None:
+    if url.scheme != "https" and not (url.scheme == "http" and url.host in _LOOPBACK_HOSTS):
+        raise ValueError("redirect_uris must use HTTPS unless they are HTTP loopback URLs")
+
+    if url.fragment is not None:
+        raise ValueError("redirect_uris must not include a fragment")
 
 
 @dataclass
@@ -44,6 +54,19 @@ class RegistrationHandler:
                 ),
                 status_code=400,
             )
+
+        if client_metadata.redirect_uris is not None:
+            try:
+                for redirect_uri in client_metadata.redirect_uris:
+                    _validate_redirect_uri(redirect_uri)
+            except ValueError as error:
+                return PydanticJSONResponse(
+                    content=RegistrationErrorResponse(
+                        error="invalid_redirect_uri",
+                        error_description=str(error),
+                    ),
+                    status_code=400,
+                )
 
         client_id = str(uuid4())
 

--- a/tests/server/mcpserver/auth/test_auth_integration.py
+++ b/tests/server/mcpserver/auth/test_auth_integration.py
@@ -672,6 +672,20 @@ class TestAuthEndpoints:
         assert response.json()["redirect_uris"] == ["http://localhost:3030/callback"]
 
     @pytest.mark.anyio
+    async def test_client_registration_allows_null_redirect_uris(self, test_client: httpx.AsyncClient):
+        client_metadata = {
+            "redirect_uris": None,
+            "client_name": "No Redirect Client",
+        }
+
+        response = await test_client.post(
+            "/register",
+            json=client_metadata,
+        )
+        assert response.status_code == 201, response.content
+        assert "redirect_uris" not in response.json()
+
+    @pytest.mark.anyio
     @pytest.mark.parametrize(
         "redirect_uri",
         [

--- a/tests/server/mcpserver/auth/test_auth_integration.py
+++ b/tests/server/mcpserver/auth/test_auth_integration.py
@@ -657,6 +657,50 @@ class TestAuthEndpoints:
         # ) is not None
 
     @pytest.mark.anyio
+    async def test_client_registration_allows_loopback_redirect_uri(self, test_client: httpx.AsyncClient):
+        """Test client registration with an HTTP loopback redirect URI."""
+        client_metadata = {
+            "redirect_uris": ["http://localhost:3030/callback"],
+            "client_name": "Loopback Client",
+        }
+
+        response = await test_client.post(
+            "/register",
+            json=client_metadata,
+        )
+        assert response.status_code == 201, response.content
+        assert response.json()["redirect_uris"] == ["http://localhost:3030/callback"]
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "redirect_uri",
+        [
+            "http://client.example.com/callback",
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "file:///tmp/callback",
+            "https://client.example.com/callback#fragment",
+            "https://client.example.com/callback#",
+        ],
+    )
+    async def test_client_registration_rejects_unsafe_redirect_uris(
+        self, test_client: httpx.AsyncClient, redirect_uri: str
+    ):
+        """Test client registration rejects unsafe redirect URI schemes and fragments."""
+        client_metadata = {
+            "redirect_uris": [redirect_uri],
+            "client_name": "Test Client",
+        }
+
+        response = await test_client.post(
+            "/register",
+            json=client_metadata,
+        )
+        assert response.status_code == 400
+        error_data = response.json()
+        assert error_data["error"] == "invalid_redirect_uri"
+
+    @pytest.mark.anyio
     async def test_client_registration_missing_required_fields(self, test_client: httpx.AsyncClient):
         """Test client registration with missing required fields."""
         # Missing redirect_uris which is a required field


### PR DESCRIPTION
## Summary
- validate DCR `redirect_uris` before registering the client
- allow HTTPS redirect URIs and HTTP loopback redirect URIs
- reject non-loopback HTTP, non-HTTP(S) schemes, and fragments with `invalid_redirect_uri`

Fixes #2629

## To verify
- `.\.venv\Scripts\python.exe -m pytest tests\server\mcpserver\auth\test_auth_integration.py -q -k "client_registration"`
- `.\.venv\Scripts\python.exe -m pytest tests\server\mcpserver\auth\test_auth_integration.py -q`
- `.\.venv\Scripts\python.exe -m ruff check src\mcp\server\auth\handlers\register.py tests\server\mcpserver\auth\test_auth_integration.py`
- `.\.venv\Scripts\python.exe -m ruff format --check src\mcp\server\auth\handlers\register.py tests\server\mcpserver\auth\test_auth_integration.py`
- `.\.venv\Scripts\pyright.exe src\mcp\server\auth\handlers\register.py tests\server\mcpserver\auth\test_auth_integration.py`
- `git diff --check upstream/main..HEAD`