### PR TITLE
fix: add 'invalid_target' to AuthorizationErrorCode (RFC 8707)

### DIFF
--- a/src/mcp/server/auth/provider.py
+++ b/src/mcp/server/auth/provider.py
@@ -64,6 +64,7 @@ AuthorizationErrorCode = Literal[
     "invalid_scope",
     "server_error",
     "temporarily_unavailable",
+    "invalid_target",  # RFC 8707 §2 — resource indicator mismatch
 ]
 
 

--- a/src/mcp/server/auth/provider.py
+++ b/src/mcp/server/auth/provider.py
@@ -64,7 +64,7 @@ AuthorizationErrorCode = Literal[
     "invalid_scope",
     "server_error",
     "temporarily_unavailable",
-    "invalid_target",  # RFC 8707 §2 — resource indicator mismatch
+    "invalid_target",
 ]
 
 


### PR DESCRIPTION
Fixes #2641

RFC 8707 §2 defines `invalid_target` as the error code for resource
indicator mismatches. Without it, `AuthorizeError(error="invalid_target")`
triggers a pydantic `ValidationError` instead of an OAuth-compliant
error response, masking the real cause with a generic `server_error`.

## Change
Added `"invalid_target"` to `AuthorizationErrorCode` in
`src/mcp/server/auth/provider.py`:

```python
AuthorizationErrorCode = Literal[
    ...
    "temporarily_unavailable",
    "invalid_target",  # RFC 8707 §2 — resource indicator mismatch
]
```

No other changes required — `AuthorizationErrorResponse` and
`AuthorizeError` already accept the Literal type by reference.

This also removes the `# type: ignore` annotations in FastMCP's
`OAuthProxy` that worked around this gap.