### PR TITLE
fix(oauth): omit resource param on token refresh

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -151,7 +151,10 @@ class OAuthContext:
 
         # If PRM provides a resource that's a valid parent, use it
         if self.protected_resource_metadata and self.protected_resource_metadata.resource:
-            prm_resource = str(self.protected_resource_metadata.resource)
+            # Pydantic v2 AnyHttpUrl normalizes bare-domain URLs by appending a trailing
+            # slash (e.g. "https://example.com" -> "https://example.com/"). OAuth
+            # providers may treat that as a distinct audience, so strip it.
+            prm_resource = str(self.protected_resource_metadata.resource).rstrip("/")
             if check_resource_allowed(requested_resource=resource, configured_resource=prm_resource):
                 resource = prm_resource
 
@@ -441,10 +444,6 @@ class OAuthClientProvider(httpx.Auth):
             "refresh_token": self.context.current_tokens.refresh_token,
             "client_id": self.context.client_info.client_id,
         }
-
-        # Only include resource param if conditions are met
-        if self.context.should_include_resource_param(self.context.protocol_version):
-            refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
         headers = {"Content-Type": "application/x-www-form-urlencoded"}

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -650,35 +650,6 @@ class TestOAuthFallback:
         assert "client_secret=test_secret" in content
 
     @pytest.mark.anyio
-    async def test_refresh_token_request_omits_resource_even_when_required_by_protocol(
-        self, client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
-    ) -> None:
-        """refresh_token request should not include RFC8707 resource parameter."""
-        provider = OAuthClientProvider(
-            server_url="https://api.example.com/v1/mcp",
-            client_metadata=client_metadata,
-            storage=mock_storage,
-        )
-        provider._initialized = True
-        provider.context.protocol_version = "2025-06-18"
-        provider.context.current_tokens = OAuthToken(
-            access_token="test_access_token",
-            token_type="Bearer",
-            expires_in=3600,
-            refresh_token="test_refresh_token",
-        )
-        provider.context.client_info = OAuthClientInformationFull(
-            client_id="test_client",
-            client_secret="test_secret",
-            redirect_uris=[AnyUrl("http://localhost:3030/callback")],
-            token_endpoint_auth_method="client_secret_post",
-        )
-
-        request = await provider._refresh_token()
-        content = request.content.decode()
-        assert "resource=" not in content
-
-    @pytest.mark.anyio
     async def test_basic_auth_token_exchange(self, oauth_provider: OAuthClientProvider):
         """Test token exchange with client_secret_basic authentication."""
         # Set up OAuth metadata to support basic auth
@@ -817,7 +788,7 @@ class TestProtectedResourceMetadata:
         )
         refresh_request = await oauth_provider._refresh_token()
         refresh_content = refresh_request.content.decode()
-        assert "resource=" in refresh_content
+        assert "resource=" not in refresh_content
 
     @pytest.mark.anyio
     async def test_resource_param_excluded_with_old_protocol_version(self, oauth_provider: OAuthClientProvider):

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -762,8 +762,10 @@ class TestProtectedResourceMetadata:
     """Test protected resource handling."""
 
     @pytest.mark.anyio
-    async def test_resource_param_included_with_recent_protocol_version(self, oauth_provider: OAuthClientProvider):
-        """Test resource parameter is included for protocol version >= 2025-06-18."""
+    async def test_resource_param_included_in_auth_code_exchange_but_not_refresh_with_recent_protocol_version(
+        self, oauth_provider: OAuthClientProvider
+    ):
+        """Resource parameter is included for auth code exchange, not refresh."""
         # Set protocol version to 2025-06-18
         oauth_provider.context.protocol_version = "2025-06-18"
         oauth_provider.context.client_info = OAuthClientInformationFull(

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -259,6 +259,24 @@ class TestOAuthContext:
         assert context.current_tokens is None
         assert context.token_expiry_time is None
 
+    def test_get_resource_url_strips_trailing_slash_from_bare_domain_prm(
+        self, client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
+    ) -> None:
+        """get_resource_url strips Pydantic AnyHttpUrl trailing slash for bare-domain PRM."""
+        provider = OAuthClientProvider(
+            server_url="https://api.example.com/v1/mcp",
+            client_metadata=client_metadata,
+            storage=mock_storage,
+        )
+        provider._initialized = True
+
+        provider.context.protected_resource_metadata = ProtectedResourceMetadata(
+            resource=AnyHttpUrl("https://api.example.com"),
+            authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+        )
+
+        assert provider.context.get_resource_url() == snapshot("https://api.example.com")
+
 
 class TestOAuthFlow:
     """Test OAuth flow methods."""
@@ -630,6 +648,35 @@ class TestOAuthFallback:
         assert "refresh_token=test_refresh_token" in content
         assert "client_id=test_client" in content
         assert "client_secret=test_secret" in content
+
+    @pytest.mark.anyio
+    async def test_refresh_token_request_omits_resource_even_when_required_by_protocol(
+        self, client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
+    ) -> None:
+        """refresh_token request should not include RFC8707 resource parameter."""
+        provider = OAuthClientProvider(
+            server_url="https://api.example.com/v1/mcp",
+            client_metadata=client_metadata,
+            storage=mock_storage,
+        )
+        provider._initialized = True
+        provider.context.protocol_version = "2025-06-18"
+        provider.context.current_tokens = OAuthToken(
+            access_token="test_access_token",
+            token_type="bearer",
+            expires_in=3600,
+            refresh_token="test_refresh_token",
+        )
+        provider.context.client_info = OAuthClientInformationFull(
+            client_id="test_client",
+            client_secret="test_secret",
+            redirect_uris=[AnyUrl("http://localhost:3030/callback")],
+            token_endpoint_auth_method="client_secret_post",
+        )
+
+        request = await provider._refresh_token()
+        content = request.content.decode()
+        assert "resource=" not in content
 
     @pytest.mark.anyio
     async def test_basic_auth_token_exchange(self, oauth_provider: OAuthClientProvider):

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -663,7 +663,7 @@ class TestOAuthFallback:
         provider.context.protocol_version = "2025-06-18"
         provider.context.current_tokens = OAuthToken(
             access_token="test_access_token",
-            token_type="bearer",
+            token_type="Bearer",
             expires_in=3600,
             refresh_token="test_refresh_token",
         )


### PR DESCRIPTION
Fixes #2578.

Entra ID v2.0 rejects RFC 8707 esource on refresh token requests, and Pydantic AnyHttpUrl normalizes bare-domain URLs with a trailing slash.

Changes:
- Strip the trailing slash when deriving the RFC8707 resource from PRM metadata.
- Do not include esource in efresh_token grant requests.

Tests:
- uv run --frozen pytest tests/client/test_auth.py -k get_resource_url_strips_trailing_slash_from_bare_domain_prm
- uv run --frozen pytest tests/client/test_auth.py -k refresh_token_request_omits_resource_even_when_required_by_protocol
- uv run --frozen python -m ruff check src/mcp/client/auth/oauth2.py tests/client/test_auth.py
- uv run --frozen python -m ruff format src/mcp/client/auth/oauth2.py tests/client/test_auth.py