### PR TITLE
docs: fix TypeScript capitalization in streamable HTTP example

### DIFF
--- a/examples/servers/simple-streamablehttp/README.md
+++ b/examples/servers/simple-streamablehttp/README.md
@@ -48,4 +48,4 @@ Note: The InMemoryEventStore is designed for demonstration purposes only. For pr
 
 ## Client
 
-You can connect to this server using an HTTP client, for now only Typescript SDK has streamable HTTP client examples or you can use [Inspector](https://github.com/modelcontextprotocol/inspector)
+You can connect to this server using an HTTP client, for now only TypeScript SDK has streamable HTTP client examples or you can use [Inspector](https://github.com/modelcontextprotocol/inspector)


### PR DESCRIPTION
## Summary
- fix the TypeScript capitalization in the Streamable HTTP example README

## Validation
- Confirmed "Typescript SDK" is absent and "TypeScript SDK" is present in examples/servers/simple-streamablehttp/README.md
- git diff --check

PDLC: PDLC-028