### PR TITLE
ci: add zizmor for GitHub Actions security analysis

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,12 +30,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@2f8ba26a219c06cfb0f468eef8d97055fa814f97 # v1.0.53
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }} # zizmor: ignore[secrets-outside-env]
           use_commit_signing: true
           additional_permissions: |
             actions: read

--- a/.github/workflows/comment-on-release.yml
+++ b/.github/workflows/comment-on-release.yml
@@ -16,13 +16,16 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Get previous release
         id: previous_release
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          CURRENT_TAG: ${{ github.event.release.tag_name }}
         with:
           script: |
-            const currentTag = '${{ github.event.release.tag_name }}';
+            const currentTag = process.env.CURRENT_TAG;
 
             // Get all releases
             const { data: releases } = await github.rest.repos.listReleases({
@@ -54,10 +57,13 @@ jobs:
       - name: Get merged PRs between releases
         id: get_prs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          CURRENT_TAG: ${{ github.event.release.tag_name }}
+          PREVIOUS_TAG_JSON: ${{ steps.previous_release.outputs.result }}
         with:
           script: |
-            const currentTag = '${{ github.event.release.tag_name }}';
-            const previousTag = ${{ steps.previous_release.outputs.result }};
+            const currentTag = process.env.CURRENT_TAG;
+            const previousTag = JSON.parse(process.env.PREVIOUS_TAG_JSON);
 
             if (!previousTag) {
               console.log('No previous release found, skipping');
@@ -104,11 +110,15 @@ jobs:
 
       - name: Comment on PRs
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBERS_JSON: ${{ steps.get_prs.outputs.result }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
         with:
           script: |
-            const prNumbers = ${{ steps.get_prs.outputs.result }};
-            const releaseTag = '${{ github.event.release.tag_name }}';
-            const releaseUrl = '${{ github.event.release.html_url }}';
+            const prNumbers = JSON.parse(process.env.PR_NUMBERS_JSON);
+            const releaseTag = process.env.RELEASE_TAG;
+            const releaseUrl = process.env.RELEASE_URL;
 
             const comment = `This pull request is included in [${releaseTag}](${releaseUrl})`;
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,6 +19,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:
           enable-cache: true
@@ -34,6 +36,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:
           enable-cache: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release-build:
     name: Build distribution
@@ -11,6 +14,8 @@ jobs:
     needs: [checks]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:
-          enable-cache: true
+          enable-cache: false
           version: 0.9.5
 
       - name: Set up Python 3.12

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:
@@ -57,6 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
@@ -83,6 +87,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:

--- a/.github/workflows/weekly-lockfile-update.yml
+++ b/.github/workflows/weekly-lockfile-update.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,4 +22,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Summary

- Add a `zizmor` workflow that audits all GitHub Actions workflows on push to `main` and on PRs, mirroring the [setup in uvicorn](https://github.com/encode/uvicorn/blob/master/.github/workflows/zizmor.yml).
- Address every finding zizmor reports against the existing workflows so the new job is green from the start:
  - Add `persist-credentials: false` to all `actions/checkout` invocations (artipacked).
  - Add top-level `permissions: contents: read` to `publish-pypi.yml` (excessive-permissions).
  - Move `github.event.release.*` and `steps.*.outputs.result` template expansions in `comment-on-release.yml` into `env:` vars consumed via `process.env` (template-injection).
- The one remaining warning (`secrets-outside-env` on the Claude Code action) is suppressed inline because the proper fix is to put `ANTHROPIC_API_KEY` behind a dedicated GitHub environment, which is a repo-settings change rather than a code change. Happy to follow up if a maintainer creates the environment.

Ran `uvx zizmor .github/workflows/` locally; reports `No findings to report. Good job!` after these changes.

## Test plan

- [ ] CI passes, including the new `GitHub Actions Security Analysis` job.
- [ ] On the next release, `comment-on-release.yml` still comments on the right PRs (the script logic is unchanged, just reads values from `process.env`).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.