### PR TITLE
fix: request identity encoding for streamable HTTP

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -90,6 +90,7 @@ class StreamableHTTPTransport:
         """
         headers: dict[str, str] = {
             "accept": "application/json, text/event-stream",
+            "accept-encoding": "identity",
             "content-type": "application/json",
         }
         # Add session headers if available

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2283,6 +2283,8 @@ async def test_streamable_http_client_mcp_headers_override_defaults(
                 assert "content-type" in headers_data
                 assert headers_data["content-type"] == "application/json"
 
+                assert headers_data.get("accept-encoding") == "identity"
+
 
 @pytest.mark.anyio
 async def test_streamable_http_client_preserves_custom_with_mcp_headers(
@@ -2318,3 +2320,5 @@ async def test_streamable_http_client_preserves_custom_with_mcp_headers(
 
                 assert "content-type" in headers_data
                 assert headers_data["content-type"] == "application/json"
+
+                assert headers_data.get("accept-encoding") == "identity"


### PR DESCRIPTION
﻿## Summary
- send `Accept-Encoding: identity` on streamable HTTP client requests
- keep the MCP `Accept` and `Content-Type` request headers overriding client defaults
- add coverage that the actual server-visible request headers use identity encoding

Fixes #2649.

## To verify
- `uv run pytest tests/shared/test_streamable_http.py::test_streamable_http_client_mcp_headers_override_defaults tests/shared/test_streamable_http.py::test_streamable_http_client_preserves_custom_with_mcp_headers -q --basetemp .tmp/pytest`
- `uv run pytest tests/shared/test_streamable_http.py::test_streamable_http_client_json_response -q --basetemp .tmp/pytest-json`
- `uv run ruff check src/mcp/client/streamable_http.py tests/shared/test_streamable_http.py`
- `uv run python -m py_compile src/mcp/client/streamable_http.py tests/shared/test_streamable_http.py`
- `git diff --check`
