### PR TITLE
feat: add protocol version override support for client session initialization

### DIFF
--- a/src/mcp/client/_probe.py
+++ b/src/mcp/client/_probe.py
@@ -44,7 +44,7 @@ def _parse_supported(data: Any) -> list[str] | None:
         return None
 
 
-async def negotiate_auto(session: ClientSession) -> None:
+async def negotiate_auto(session: ClientSession, protocol_version: str | None = None) -> None:
     """Drive the ``mode='auto'`` connect-time policy on ``session``.
 
     Probes ``server/discover`` once (twice if the server names a mutual
@@ -73,7 +73,10 @@ async def negotiate_auto(session: ClientSession) -> None:
                 if supported is not None and not any(v in HANDSHAKE_PROTOCOL_VERSIONS for v in supported):
                     raise  # server is modern-only and disjoint — real incompatibility
             try:
-                await session.initialize()  # every other rpc-error → legacy (the denylist)
+                if protocol_version is not None:
+                    await session.initialize(protocol_version=protocol_version)
+                else:
+                    await session.initialize()  # every other rpc-error → legacy (the denylist)
             except MCPError as handshake_exc:
                 if handshake_exc.code != UNSUPPORTED_PROTOCOL_VERSION or attempt != 0:
                     raise
@@ -94,7 +97,10 @@ async def negotiate_auto(session: ClientSession) -> None:
         try:
             result = types.DiscoverResult.model_validate(raw)
         except ValidationError:
-            await session.initialize()  # unparseable result → not modern evidence
+            if protocol_version is not None:
+                await session.initialize(protocol_version=protocol_version)
+            else:
+                await session.initialize()  # unparseable result → not modern evidence
             return
         session.adopt(result)
         return

--- a/src/mcp/client/_probe.py
+++ b/src/mcp/client/_probe.py
@@ -49,7 +49,7 @@ def _parse_supported(data: Any) -> list[str] | None:
         return None
 
 
-async def negotiate_auto(session: ClientSession) -> None:
+async def negotiate_auto(session: ClientSession, protocol_version: str | None = None) -> None:
     """Drive the ``mode='auto'`` connect-time policy on ``session``.
 
     Probes ``server/discover`` once (twice if the server names a mutual
@@ -78,7 +78,10 @@ async def negotiate_auto(session: ClientSession) -> None:
                 if supported is not None and not any(v in HANDSHAKE_PROTOCOL_VERSIONS for v in supported):
                     raise  # server is modern-only and disjoint — real incompatibility
             try:
-                await session.initialize()  # every other rpc-error → legacy (the denylist)
+                if protocol_version is not None:
+                    await session.initialize(protocol_version=protocol_version)
+                else:
+                    await session.initialize()  # every other rpc-error → legacy (the denylist)
             except MCPError as handshake_exc:
                 if handshake_exc.code != UNSUPPORTED_PROTOCOL_VERSION or attempt != 0:
                     raise
@@ -99,7 +102,10 @@ async def negotiate_auto(session: ClientSession) -> None:
         try:
             result = types.DiscoverResult.model_validate(raw)
         except ValidationError:
-            await session.initialize()  # unparseable result → not modern evidence
+            if protocol_version is not None:
+                await session.initialize(protocol_version=protocol_version)
+            else:
+                await session.initialize()  # unparseable result → not modern evidence
             return
         if not any(v in result.supported_versions for v in MODERN_PROTOCOL_VERSIONS):
             # A discover-answering server that advertises no modern version

--- a/src/mcp/client/_probe.py
+++ b/src/mcp/client/_probe.py
@@ -58,12 +58,21 @@ async def negotiate_auto(session: ClientSession, protocol_version: str | None = 
     ``session.discover_result`` / ``session.initialize_result`` is set on
     return.
 
+    ``protocol_version`` pins the legacy handshake to a specific version. A
+    caller supplying it wants that exact version, so this skips the
+    ``server/discover`` probe entirely and goes straight to the handshake —
+    otherwise a server with modern support would win discovery and the pin
+    would be silently ignored.
+
     Raises:
         MCPError: The server is modern-only and shares no version with this
             client (-32022 with a disjoint ``supported`` list), or the
             fallback handshake failed and one corrective re-probe did too.
         Exception: Any transport/network error from the probe propagates as-is.
     """
+    if protocol_version is not None:
+        await session.initialize(protocol_version=protocol_version)
+        return
     version = LATEST_MODERN_VERSION
     for attempt in range(2):
         try:
@@ -78,10 +87,7 @@ async def negotiate_auto(session: ClientSession, protocol_version: str | None = 
                 if supported is not None and not any(v in HANDSHAKE_PROTOCOL_VERSIONS for v in supported):
                     raise  # server is modern-only and disjoint — real incompatibility
             try:
-                if protocol_version is not None:
-                    await session.initialize(protocol_version=protocol_version)
-                else:
-                    await session.initialize()  # every other rpc-error → legacy (the denylist)
+                await session.initialize()  # every other rpc-error → legacy (the denylist)
             except MCPError as handshake_exc:
                 if handshake_exc.code != UNSUPPORTED_PROTOCOL_VERSION or attempt != 0:
                     raise
@@ -102,10 +108,7 @@ async def negotiate_auto(session: ClientSession, protocol_version: str | None = 
         try:
             result = types.DiscoverResult.model_validate(raw)
         except ValidationError:
-            if protocol_version is not None:
-                await session.initialize(protocol_version=protocol_version)
-            else:
-                await session.initialize()  # unparseable result → not modern evidence
+            await session.initialize()  # unparseable result → not modern evidence
             return
         if not any(v in result.supported_versions for v in MODERN_PROTOCOL_VERSIONS):
             # A discover-answering server that advertises no modern version

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -354,6 +354,8 @@ class Client:
     `target_id` when the server is not a URL (no identity can be derived)."""
 
     _entered: bool = field(init=False, default=False)
+    protocol_version_override: str | None = None
+    """The protocol version to request during initialization. Defaults to the latest version."""
     _session: ClientSession | None = field(init=False, default=None)
     _exit_stack: AsyncExitStack | None = field(init=False, default=None)
     _connect: _Connector = field(init=False, repr=False, compare=False)
@@ -439,9 +441,12 @@ class Client:
             session = await exit_stack.enter_async_context(session)
 
             if self.mode == "legacy":
-                await session.initialize()
+                if self.protocol_version_override is not None:
+                    await session.initialize(protocol_version=self.protocol_version_override)
+                else:
+                    await session.initialize()
             elif self.mode == "auto":
-                await negotiate_auto(session)
+                await negotiate_auto(session, protocol_version=self.protocol_version_override)
             else:
                 session.adopt(self.prior_discover or _synthesize_discover(self.mode))
 

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -366,6 +366,8 @@ class Client:
     derived)."""
 
     _entered: bool = field(init=False, default=False)
+    protocol_version_override: str | None = None
+    """The protocol version to request during initialization. Defaults to the latest version."""
     _session: ClientSession | None = field(init=False, default=None)
     _exit_stack: AsyncExitStack | None = field(init=False, default=None)
     _connect: _Connector = field(init=False, repr=False, compare=False)
@@ -455,9 +457,12 @@ class Client:
             session = await exit_stack.enter_async_context(session)
 
             if self.mode == "legacy":
-                await session.initialize()
+                if self.protocol_version_override is not None:
+                    await session.initialize(protocol_version=self.protocol_version_override)
+                else:
+                    await session.initialize()
             elif self.mode == "auto":
-                await negotiate_auto(session)
+                await negotiate_auto(session, protocol_version=self.protocol_version_override)
             else:
                 session.adopt(self.prior_discover or _synthesize_discover(self.mode))
 

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -550,15 +550,14 @@ class ClientSession:
             sampling=sampling, elicitation=elicitation, experimental=None, extensions=extensions, roots=roots
         )
 
-    async def initialize(self) -> types.InitializeResult:
+    async def initialize(self, protocol_version: str = LATEST_HANDSHAKE_VERSION) -> types.InitializeResult:
         if self._initialize_result is not None:
             return self._initialize_result
         result = await self.send_request(
             types.InitializeRequest(
                 params=types.InitializeRequestParams(
-                    protocol_version=LATEST_HANDSHAKE_VERSION,
-                    # The handshake negotiates only legacy versions, where no claim is active.
-                    capabilities=self._build_capabilities(LATEST_HANDSHAKE_VERSION),
+                    protocol_version=protocol_version,
+                    capabilities=self._build_capabilities(protocol_version),
                     client_info=self._client_info,
                 ),
             ),

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -648,15 +648,14 @@ class ClientSession:
             sampling=sampling, elicitation=elicitation, experimental=None, extensions=extensions, roots=roots
         )
 
-    async def initialize(self) -> types.InitializeResult:
+    async def initialize(self, protocol_version: str = LATEST_HANDSHAKE_VERSION) -> types.InitializeResult:
         if self._initialize_result is not None:
             return self._initialize_result
         result = await self.send_request(
             types.InitializeRequest(
                 params=types.InitializeRequestParams(
-                    protocol_version=LATEST_HANDSHAKE_VERSION,
-                    # The handshake negotiates only legacy versions, where no claim is active.
-                    capabilities=self._build_capabilities(LATEST_HANDSHAKE_VERSION),
+                    protocol_version=protocol_version,
+                    capabilities=self._build_capabilities(protocol_version),
                     client_info=self._client_info,
                 ),
             ),

--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -80,6 +80,7 @@ class ClientSessionParameters:
     logging_callback: LoggingFnT | None = None
     message_handler: MessageHandlerFnT | None = None
     client_info: types.Implementation | None = None
+    protocol_version: str | None = None
 
 
 class ClientSessionGroup:
@@ -352,7 +353,10 @@ class ClientSessionGroup:
                 )
             )
 
-            result = await session.initialize()
+            if session_params.protocol_version is not None:
+                result = await session.initialize(protocol_version=session_params.protocol_version)
+            else:
+                result = await session.initialize()
 
             # Session successfully initialized.
             # Store its stack and register the stack with the main group stack.

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -128,6 +128,13 @@ async def test_client_exposes_negotiated_protocol_version(app: MCPServer):
         assert client.protocol_version == LATEST_HANDSHAKE_VERSION
 
 
+async def test_client_custom_protocol_version(app: MCPServer):
+    """Test that the client negotiates a custom protocol version when configured."""
+    async with Client(app, mode="legacy", protocol_version_override="2024-11-05") as client:
+        assert client.protocol_version == "2024-11-05"
+        assert client.server_info.name == "test"
+
+
 async def test_client_with_simple_server(simple_server: Server):
     """Test that from_server works with a basic Server instance."""
     async with Client(simple_server) as client:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -130,6 +130,13 @@ async def test_client_exposes_negotiated_protocol_version(app: MCPServer):
         assert client.protocol_version == LATEST_HANDSHAKE_VERSION
 
 
+async def test_client_custom_protocol_version(app: MCPServer):
+    """Test that the client negotiates a custom protocol version when configured."""
+    async with Client(app, mode="legacy", protocol_version_override="2024-11-05") as client:
+        assert client.protocol_version == "2024-11-05"
+        assert client.server_info.name == "test"
+
+
 async def test_client_with_simple_server(simple_server: Server):
     """Test that from_server works with a basic Server instance."""
     async with Client(simple_server) as client:

--- a/tests/client/test_probe.py
+++ b/tests/client/test_probe.py
@@ -57,6 +57,7 @@ class _StubSession:
         self.probed_at: list[str] = []
         self.initialize_calls: int = 0
         self.initialized: bool = False
+        self.initialize_version: str | None = None
         self.adopted: types.DiscoverResult | None = None
 
     async def send_discover(self, version: str) -> dict[str, Any]:
@@ -66,19 +67,20 @@ class _StubSession:
             raise step
         return step
 
-    async def initialize(self) -> None:
+    async def initialize(self, protocol_version: str | None = None) -> None:
         self.initialize_calls += 1
         if self._handshake:
             raise self._handshake.pop(0)
         self.initialized = True
+        self.initialize_version = protocol_version
 
     def adopt(self, result: types.DiscoverResult) -> None:
         self.adopted = result
 
 
-async def _negotiate(session: _StubSession) -> None:
+async def _negotiate(session: _StubSession, protocol_version: str | None = None) -> None:
     """Drive `negotiate_auto` against the stub; cast at one seam so the tests stay suppression-free."""
-    await negotiate_auto(cast("ClientSession", session))
+    await negotiate_auto(cast("ClientSession", session), protocol_version=protocol_version)
 
 
 def _discover_dict(versions: list[str] | None = None) -> dict[str, Any]:
@@ -319,3 +321,20 @@ def test_parse_supported_returns_none_for_anything_not_shaped_like_the_spec_erro
     """`_parse_supported` returns the `supported` list when `error.data` validates as
     `UnsupportedProtocolVersionErrorData`, and `None` otherwise — never raises."""
     assert _parse_supported(data) == expected
+
+
+async def test_negotiate_auto_mcp_error_with_custom_protocol_version() -> None:
+    """Test that negotiate_auto initializes with a custom protocol version when discover returns an MCPError."""
+    session = _StubSession(MCPError(code=METHOD_NOT_FOUND, message="nope"))
+    await _negotiate(session, protocol_version="2024-11-05")
+    assert session.initialized
+    assert session.initialize_version == "2024-11-05"
+
+
+async def test_negotiate_auto_validation_error_with_custom_protocol_version() -> None:
+    """Test that negotiate_auto initializes with a custom protocol version when discover returns unparseable result."""
+    session = _StubSession({"not": "a discover result"})
+    await _negotiate(session, protocol_version="2024-11-05")
+    assert session.initialized
+    assert session.initialize_version == "2024-11-05"
+

--- a/tests/client/test_probe.py
+++ b/tests/client/test_probe.py
@@ -337,4 +337,3 @@ async def test_negotiate_auto_validation_error_with_custom_protocol_version() ->
     await _negotiate(session, protocol_version="2024-11-05")
     assert session.initialized
     assert session.initialize_version == "2024-11-05"
-

--- a/tests/client/test_probe.py
+++ b/tests/client/test_probe.py
@@ -349,4 +349,3 @@ async def test_negotiate_auto_validation_error_with_custom_protocol_version() ->
     await _negotiate(session, protocol_version="2024-11-05")
     assert session.initialized
     assert session.initialize_version == "2024-11-05"
-

--- a/tests/client/test_probe.py
+++ b/tests/client/test_probe.py
@@ -335,17 +335,18 @@ def test_parse_supported_returns_none_for_anything_not_shaped_like_the_spec_erro
     assert _parse_supported(data) == expected
 
 
-async def test_negotiate_auto_mcp_error_with_custom_protocol_version() -> None:
-    """Test that negotiate_auto initializes with a custom protocol version when discover returns an MCPError."""
-    session = _StubSession(MCPError(code=METHOD_NOT_FOUND, message="nope"))
-    await _negotiate(session, protocol_version="2024-11-05")
-    assert session.initialized
-    assert session.initialize_version == "2024-11-05"
+# --- protocol_version override forces the legacy handshake, unconditionally ---
 
 
-async def test_negotiate_auto_validation_error_with_custom_protocol_version() -> None:
-    """Test that negotiate_auto initializes with a custom protocol version when discover returns unparseable result."""
-    session = _StubSession({"not": "a discover result"})
+async def test_a_protocol_version_override_skips_discovery_and_forces_the_legacy_handshake() -> None:
+    """`protocol_version` pins an explicit legacy version, so the caller wants exactly that
+    version - the probe is skipped entirely and the handshake runs unconditionally, even
+    though the stub's discover script would otherwise return a valid modern result (regression:
+    the override used to only reach `initialize()` via the fallback paths, so a successful
+    discover silently dropped it)."""
+    session = _StubSession(_discover_dict())
     await _negotiate(session, protocol_version="2024-11-05")
+    assert session.probed_at == []
     assert session.initialized
     assert session.initialize_version == "2024-11-05"
+    assert session.adopted is None

--- a/tests/client/test_probe.py
+++ b/tests/client/test_probe.py
@@ -57,6 +57,7 @@ class _StubSession:
         self.probed_at: list[str] = []
         self.initialize_calls: int = 0
         self.initialized: bool = False
+        self.initialize_version: str | None = None
         self.adopted: types.DiscoverResult | None = None
 
     async def send_discover(self, version: str) -> dict[str, Any]:
@@ -66,19 +67,20 @@ class _StubSession:
             raise step
         return step
 
-    async def initialize(self) -> None:
+    async def initialize(self, protocol_version: str | None = None) -> None:
         self.initialize_calls += 1
         if self._handshake:
             raise self._handshake.pop(0)
         self.initialized = True
+        self.initialize_version = protocol_version
 
     def adopt(self, result: types.DiscoverResult) -> None:
         self.adopted = result
 
 
-async def _negotiate(session: _StubSession) -> None:
+async def _negotiate(session: _StubSession, protocol_version: str | None = None) -> None:
     """Drive `negotiate_auto` against the stub; cast at one seam so the tests stay suppression-free."""
-    await negotiate_auto(cast("ClientSession", session))
+    await negotiate_auto(cast("ClientSession", session), protocol_version=protocol_version)
 
 
 def _discover_dict(versions: list[str] | None = None) -> dict[str, Any]:
@@ -331,3 +333,20 @@ def test_parse_supported_returns_none_for_anything_not_shaped_like_the_spec_erro
     """`_parse_supported` returns the `supported` list when `error.data` validates as
     `UnsupportedProtocolVersionErrorData`, and `None` otherwise — never raises."""
     assert _parse_supported(data) == expected
+
+
+async def test_negotiate_auto_mcp_error_with_custom_protocol_version() -> None:
+    """Test that negotiate_auto initializes with a custom protocol version when discover returns an MCPError."""
+    session = _StubSession(MCPError(code=METHOD_NOT_FOUND, message="nope"))
+    await _negotiate(session, protocol_version="2024-11-05")
+    assert session.initialized
+    assert session.initialize_version == "2024-11-05"
+
+
+async def test_negotiate_auto_validation_error_with_custom_protocol_version() -> None:
+    """Test that negotiate_auto initializes with a custom protocol version when discover returns unparseable result."""
+    session = _StubSession({"not": "a discover result"})
+    await _negotiate(session, protocol_version="2024-11-05")
+    assert session.initialized
+    assert session.initialize_version == "2024-11-05"
+

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -154,6 +154,90 @@ async def test_client_session_initialize():
 
 
 @pytest.mark.anyio
+async def test_client_session_initialize_custom_protocol_version():
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+
+    initialized_notification = None
+    result = None
+
+    async def mock_server():
+        nonlocal initialized_notification
+
+        session_message = await client_to_server_receive.receive()
+        jsonrpc_request = session_message.message
+        assert isinstance(jsonrpc_request, JSONRPCRequest)
+        request = client_request_adapter.validate_python(
+            jsonrpc_request.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )
+        assert isinstance(request, InitializeRequest)
+        assert request.params.protocol_version == "2024-11-05"
+
+        result = InitializeResult(
+            protocol_version="2024-11-05",
+            capabilities=ServerCapabilities(
+                logging=None,
+                resources=None,
+                tools=None,
+                experimental=None,
+                prompts=None,
+            ),
+            server_info=Implementation(name="mock-server", version="0.1.0"),
+            instructions="The server instructions.",
+        )
+
+        async with server_to_client_send:
+            await server_to_client_send.send(
+                SessionMessage(
+                    JSONRPCResponse(
+                        jsonrpc="2.0",
+                        id=jsonrpc_request.id,
+                        result=result.model_dump(by_alias=True, mode="json", exclude_none=True),
+                    )
+                )
+            )
+            session_notification = await client_to_server_receive.receive()
+            jsonrpc_notification = session_notification.message
+            assert isinstance(jsonrpc_notification, JSONRPCNotification)
+            initialized_notification = client_notification_adapter.validate_python(
+                jsonrpc_notification.model_dump(by_alias=True, mode="json", exclude_none=True)
+            )
+
+    # Create a message handler to catch exceptions
+    async def message_handler(  # pragma: no cover
+        message: RequestResponder[types.ServerRequest, types.ClientResult] | types.ServerNotification | Exception,
+    ) -> None:
+        if isinstance(message, Exception):
+            raise message
+
+    async with (
+        ClientSession(
+            server_to_client_receive,
+            client_to_server_send,
+            message_handler=message_handler,
+        ) as session,
+        anyio.create_task_group() as tg,
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        tg.start_soon(mock_server)
+        result = await session.initialize(protocol_version="2024-11-05")
+
+    # Assert the result
+    assert isinstance(result, InitializeResult)
+    assert result.protocol_version == "2024-11-05"
+    assert isinstance(result.capabilities, ServerCapabilities)
+    assert result.server_info == Implementation(name="mock-server", version="0.1.0")
+    assert result.instructions == "The server instructions."
+
+    # Check that the client sent the initialized notification
+    assert initialized_notification
+    assert isinstance(initialized_notification, InitializedNotification)
+
+
+@pytest.mark.anyio
 async def test_client_session_custom_client_info():
     client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
     server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -155,6 +155,90 @@ async def test_client_session_initialize():
 
 
 @pytest.mark.anyio
+async def test_client_session_initialize_custom_protocol_version():
+    client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
+    server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)
+
+    initialized_notification = None
+    result = None
+
+    async def mock_server():
+        nonlocal initialized_notification
+
+        session_message = await client_to_server_receive.receive()
+        jsonrpc_request = session_message.message
+        assert isinstance(jsonrpc_request, JSONRPCRequest)
+        request = client_request_adapter.validate_python(
+            jsonrpc_request.model_dump(by_alias=True, mode="json", exclude_none=True)
+        )
+        assert isinstance(request, InitializeRequest)
+        assert request.params.protocol_version == "2024-11-05"
+
+        result = InitializeResult(
+            protocol_version="2024-11-05",
+            capabilities=ServerCapabilities(
+                logging=None,
+                resources=None,
+                tools=None,
+                experimental=None,
+                prompts=None,
+            ),
+            server_info=Implementation(name="mock-server", version="0.1.0"),
+            instructions="The server instructions.",
+        )
+
+        async with server_to_client_send:
+            await server_to_client_send.send(
+                SessionMessage(
+                    JSONRPCResponse(
+                        jsonrpc="2.0",
+                        id=jsonrpc_request.id,
+                        result=result.model_dump(by_alias=True, mode="json", exclude_none=True),
+                    )
+                )
+            )
+            session_notification = await client_to_server_receive.receive()
+            jsonrpc_notification = session_notification.message
+            assert isinstance(jsonrpc_notification, JSONRPCNotification)
+            initialized_notification = client_notification_adapter.validate_python(
+                jsonrpc_notification.model_dump(by_alias=True, mode="json", exclude_none=True)
+            )
+
+    # Create a message handler to catch exceptions
+    async def message_handler(  # pragma: no cover
+        message: RequestResponder[types.ServerRequest, types.ClientResult] | types.ServerNotification | Exception,
+    ) -> None:
+        if isinstance(message, Exception):
+            raise message
+
+    async with (
+        ClientSession(
+            server_to_client_receive,
+            client_to_server_send,
+            message_handler=message_handler,
+        ) as session,
+        anyio.create_task_group() as tg,
+        client_to_server_send,
+        client_to_server_receive,
+        server_to_client_send,
+        server_to_client_receive,
+    ):
+        tg.start_soon(mock_server)
+        result = await session.initialize(protocol_version="2024-11-05")
+
+    # Assert the result
+    assert isinstance(result, InitializeResult)
+    assert result.protocol_version == "2024-11-05"
+    assert isinstance(result.capabilities, ServerCapabilities)
+    assert result.server_info == Implementation(name="mock-server", version="0.1.0")
+    assert result.instructions == "The server instructions."
+
+    # Check that the client sent the initialized notification
+    assert initialized_notification
+    assert isinstance(initialized_notification, InitializedNotification)
+
+
+@pytest.mark.anyio
 async def test_client_session_custom_client_info():
     client_to_server_send, client_to_server_receive = anyio.create_memory_object_stream[SessionMessage](1)
     server_to_client_send, server_to_client_receive = anyio.create_memory_object_stream[SessionMessage](1)

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -205,9 +205,7 @@ async def test_client_session_initialize_custom_protocol_version():
             )
 
     # Create a message handler to catch exceptions
-    async def message_handler(  # pragma: no cover
-        message: RequestResponder[types.ServerRequest, types.ClientResult] | types.ServerNotification | Exception,
-    ) -> None:
+    async def message_handler(message: IncomingMessage) -> None:  # pragma: no cover
         if isinstance(message, Exception):
             raise message
 

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -402,3 +402,37 @@ async def test_client_session_group_establish_session_parameterized(
             # 3. Assert returned values
             assert returned_server_info is mock_initialize_result.server_info
             assert returned_session is mock_entered_session
+
+
+@pytest.mark.anyio
+async def test_client_session_group_establish_session_custom_protocol_version():
+    with mock.patch("mcp.client.session_group.mcp.ClientSession") as mock_ClientSession_class:
+        with mock.patch("mcp.client.session_group.mcp.stdio_client") as mock_stdio_client:
+            mock_client_cm_instance = mock.AsyncMock(name="stdioClientCM")
+            mock_read_stream = mock.AsyncMock(name="stdioRead")
+            mock_write_stream = mock.AsyncMock(name="stdioWrite")
+
+            mock_client_cm_instance.__aenter__.return_value = (mock_read_stream, mock_write_stream)
+            mock_client_cm_instance.__aexit__ = mock.AsyncMock(return_value=None)
+            mock_stdio_client.return_value = mock_client_cm_instance
+
+            mock_raw_session_cm = mock.AsyncMock(name="RawSessionCM")
+            mock_ClientSession_class.return_value = mock_raw_session_cm
+
+            mock_entered_session = mock.AsyncMock(name="EnteredSessionInstance")
+            mock_raw_session_cm.__aenter__.return_value = mock_entered_session
+            mock_raw_session_cm.__aexit__ = mock.AsyncMock(return_value=None)
+
+            mock_initialize_result = mock.AsyncMock(name="InitializeResult")
+            mock_initialize_result.server_info = types.Implementation(name="foo", version="1")
+            mock_entered_session.initialize.return_value = mock_initialize_result
+
+            group = ClientSessionGroup()
+            server_params = StdioServerParameters(command="test_stdio_cmd")
+            session_params = ClientSessionParameters(protocol_version="2024-11-05")
+
+            async with contextlib.AsyncExitStack() as stack:
+                group._exit_stack = stack
+                await group._establish_session(server_params, session_params)
+
+            mock_entered_session.initialize.assert_awaited_once_with(protocol_version="2024-11-05")

--- a/tests/interaction/_requirements.py
+++ b/tests/interaction/_requirements.py
@@ -465,6 +465,15 @@ REQUIREMENTS: dict[str, Requirement] = {
         ),
         added_in="2026-07-28",
     ),
+    "lifecycle:mode:auto-override-skips-discover": Requirement(
+        source="sdk",
+        behavior=(
+            "A Client constructed with mode='auto' and protocol_version_override=<version> sends "
+            "initialize at that version as its first request and never sends server/discover, even "
+            "when the server would answer discover successfully."
+        ),
+        added_in="2026-07-28",
+    ),
     # ═══════════════════════════════════════════════════════════════════════════
     # Protocol primitives: cancellation, timeout, progress, errors, _meta
     # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/interaction/lowlevel/test_client_connect.py
+++ b/tests/interaction/lowlevel/test_client_connect.py
@@ -178,6 +178,34 @@ async def test_auto_mode_probes_server_discover_and_adopts_the_result() -> None:
     assert "initialize" not in [b["method"] for b in bodies]
 
 
+@requirement("lifecycle:mode:auto-override-skips-discover")
+async def test_auto_mode_with_a_protocol_version_override_skips_discover_and_initializes() -> None:
+    """`Client(..., mode='auto', protocol_version_override=...)` sends `initialize` at the
+    override version and never probes `server/discover`, even though the mounted server answers
+    discover successfully. Regression: the override used to only reach `negotiate_auto`'s
+    `initialize()` fallback calls, so a successful discover silently dropped it and the client
+    ended up modern-negotiated at the server's latest version instead of the pinned one.
+    """
+    requests, on_request = _request_recorder()
+    server = _tools_server("discoverable")
+
+    with anyio.fail_after(5):
+        async with (
+            mounted_app(server, on_request=on_request) as (http, _),
+            Client(
+                streamable_http_client(f"{BASE_URL}/mcp", http_client=http),
+                mode="auto",
+                protocol_version_override="2024-11-05",
+            ) as client,
+        ):
+            assert client.protocol_version == "2024-11-05"
+            assert client.server_info.name == "discoverable"
+
+    bodies = [json.loads(r.content)["method"] for r in requests if r.method == "POST"]
+    assert bodies[0] == "initialize"
+    assert "server/discover" not in bodies
+
+
 @requirement("lifecycle:discover:retry-on-32022")
 async def test_auto_mode_retries_discover_once_on_unsupported_protocol_version() -> None:
     """A -32022 from `server/discover` triggers exactly one retry at the highest mutual modern version.


### PR DESCRIPTION
## Description
This PR adds support for client session protocol version overrides during initialization, enabling clients to negotiate older or custom protocol versions (e.g. `2024-11-05`) with MCP servers.

### Changes
- Updated `ClientSession.initialize(...)` to accept a custom `protocol_version`.
- Added `protocol_version` field to the high-level `Client` dataclass.
- Added `protocol_version` field to `ClientSessionParameters` in `ClientSessionGroup`.
- Implemented corresponding unit and integration tests.
