### PR TITLE
docs(experimental): add docstrings to default task handler functions

### DIFF
--- a/src/mcp/client/experimental/task_handlers.py
+++ b/src/mcp/client/experimental/task_handlers.py
@@ -118,6 +118,7 @@ async def default_get_task_handler(
     context: RequestContext[ClientSession],
     params: types.GetTaskRequestParams,
 ) -> types.GetTaskResult | types.ErrorData:
+    """Default handler for tasks/get requests; returns METHOD_NOT_FOUND."""
     return types.ErrorData(
         code=types.METHOD_NOT_FOUND,
         message="tasks/get not supported",
@@ -128,6 +129,7 @@ async def default_get_task_result_handler(
     context: RequestContext[ClientSession],
     params: types.GetTaskPayloadRequestParams,
 ) -> types.GetTaskPayloadResult | types.ErrorData:
+    """Default handler for tasks/result requests; returns METHOD_NOT_FOUND."""
     return types.ErrorData(
         code=types.METHOD_NOT_FOUND,
         message="tasks/result not supported",
@@ -138,6 +140,7 @@ async def default_list_tasks_handler(
     context: RequestContext[ClientSession],
     params: types.PaginatedRequestParams | None,
 ) -> types.ListTasksResult | types.ErrorData:
+    """Default handler for tasks/list requests; returns METHOD_NOT_FOUND."""
     return types.ErrorData(
         code=types.METHOD_NOT_FOUND,
         message="tasks/list not supported",
@@ -148,6 +151,7 @@ async def default_cancel_task_handler(
     context: RequestContext[ClientSession],
     params: types.CancelTaskRequestParams,
 ) -> types.CancelTaskResult | types.ErrorData:
+    """Default handler for tasks/cancel requests; returns METHOD_NOT_FOUND."""
     return types.ErrorData(
         code=types.METHOD_NOT_FOUND,
         message="tasks/cancel not supported",
@@ -159,6 +163,7 @@ async def default_task_augmented_sampling(
     params: types.CreateMessageRequestParams,
     task_metadata: types.TaskMetadata,
 ) -> types.CreateTaskResult | types.ErrorData:
+    """Default handler for task-augmented sampling; returns INVALID_REQUEST."""
     return types.ErrorData(
         code=types.INVALID_REQUEST,
         message="Task-augmented sampling not supported",
@@ -170,6 +175,7 @@ async def default_task_augmented_elicitation(
     params: types.ElicitRequestParams,
     task_metadata: types.TaskMetadata,
 ) -> types.CreateTaskResult | types.ErrorData:
+    """Default handler for task-augmented elicitation; returns INVALID_REQUEST."""
     return types.ErrorData(
         code=types.INVALID_REQUEST,
         message="Task-augmented elicitation not supported",


### PR DESCRIPTION
## Summary

Six public async functions in `src/mcp/client/experimental/task_handlers.py` were missing docstrings, while the surrounding module docstrings and `CONTRIBUTING.md` ("Include docstrings for public APIs") establish the convention.

Functions fixed:
- `default_get_task_handler`
- `default_get_task_result_handler`
- `default_list_tasks_handler`
- `default_cancel_task_handler`
- `default_task_augmented_sampling`
- `default_task_augmented_elicitation`

Each docstring describes the function's purpose and the error code it returns by default, consistent with the style used elsewhere in the same file.

## Changes

- `src/mcp/client/experimental/task_handlers.py`: +6 one-line docstrings, no logic changes

## Checklist

- [x] Change is trivial (docs-only, no logic change)
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pyright` passes (0 errors)
- [x] `pytest tests/client/` passes (200 passed, 1 xfailed)
- [x] No breaking changes