### PR TITLE
docs(auth): clarify that resource_server_url must include the transport path

### DIFF
--- a/README.v2.md
+++ b/README.v2.md
@@ -1024,8 +1024,8 @@ mcp = MCPServer(
     # Auth settings for RFC 9728 Protected Resource Metadata.
     # `resource_server_url` MUST be the full public URL of the MCP endpoint, including
     # the transport path (e.g. `/mcp` for streamable-http, `/sse` for sse). RFC 9728
-    # §3.3 requires strict equality between the client's resource identifier and the
-    # `resource` value advertised in the protected resource metadata.
+    # section 3.3 requires strict equality between the client's resource identifier and
+    # the `resource` value advertised in the protected resource metadata.
     auth=AuthSettings(
         issuer_url=AnyHttpUrl("https://auth.example.com"),  # Authorization Server URL
         resource_server_url=AnyHttpUrl("http://localhost:3001/mcp"),  # Public MCP endpoint URL

--- a/README.v2.md
+++ b/README.v2.md
@@ -1021,10 +1021,14 @@ mcp = MCPServer(
     "Weather Service",
     # Token verifier for authentication
     token_verifier=SimpleTokenVerifier(),
-    # Auth settings for RFC 9728 Protected Resource Metadata
+    # Auth settings for RFC 9728 Protected Resource Metadata.
+    # `resource_server_url` MUST be the full public URL of the MCP endpoint, including
+    # the transport path (e.g. `/mcp` for streamable-http, `/sse` for sse). RFC 9728
+    # §3.3 requires strict equality between the client's resource identifier and the
+    # `resource` value advertised in the protected resource metadata.
     auth=AuthSettings(
         issuer_url=AnyHttpUrl("https://auth.example.com"),  # Authorization Server URL
-        resource_server_url=AnyHttpUrl("http://localhost:3001"),  # This server's URL
+        resource_server_url=AnyHttpUrl("http://localhost:3001/mcp"),  # Public MCP endpoint URL
         required_scopes=["user"],
     ),
 )

--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -128,7 +128,7 @@ def main(port: int, auth_server: str, transport: Literal["sse", "streamable-http
 
         # Create settings. server_url is the public URL of the MCP endpoint and must
         # include the transport path so it matches the URL the client used to reach
-        # the server (RFC 9728 §3.3 strict equality).
+        # the server (RFC 9728 section 3.3 strict equality).
         host = "localhost"
         transport_path = "/sse" if transport == "sse" else "/mcp"
         server_url = f"http://{host}:{port}{transport_path}"

--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -126,9 +126,12 @@ def main(port: int, auth_server: str, transport: Literal["sse", "streamable-http
         # Parse auth server URL
         auth_server_url = AnyHttpUrl(auth_server)
 
-        # Create settings
+        # Create settings. server_url is the public URL of the MCP endpoint and must
+        # include the transport path so it matches the URL the client used to reach
+        # the server (RFC 9728 §3.3 strict equality).
         host = "localhost"
-        server_url = f"http://{host}:{port}/mcp"
+        transport_path = "/sse" if transport == "sse" else "/mcp"
+        server_url = f"http://{host}:{port}{transport_path}"
         settings = ResourceServerSettings(
             host=host,
             port=port,

--- a/examples/snippets/servers/oauth_server.py
+++ b/examples/snippets/servers/oauth_server.py
@@ -21,10 +21,14 @@ mcp = MCPServer(
     "Weather Service",
     # Token verifier for authentication
     token_verifier=SimpleTokenVerifier(),
-    # Auth settings for RFC 9728 Protected Resource Metadata
+    # Auth settings for RFC 9728 Protected Resource Metadata.
+    # `resource_server_url` MUST be the full public URL of the MCP endpoint, including
+    # the transport path (e.g. `/mcp` for streamable-http, `/sse` for sse). RFC 9728
+    # §3.3 requires strict equality between the client's resource identifier and the
+    # `resource` value advertised in the protected resource metadata.
     auth=AuthSettings(
         issuer_url=AnyHttpUrl("https://auth.example.com"),  # Authorization Server URL
-        resource_server_url=AnyHttpUrl("http://localhost:3001"),  # This server's URL
+        resource_server_url=AnyHttpUrl("http://localhost:3001/mcp"),  # Public MCP endpoint URL
         required_scopes=["user"],
     ),
 )

--- a/examples/snippets/servers/oauth_server.py
+++ b/examples/snippets/servers/oauth_server.py
@@ -24,8 +24,8 @@ mcp = MCPServer(
     # Auth settings for RFC 9728 Protected Resource Metadata.
     # `resource_server_url` MUST be the full public URL of the MCP endpoint, including
     # the transport path (e.g. `/mcp` for streamable-http, `/sse` for sse). RFC 9728
-    # §3.3 requires strict equality between the client's resource identifier and the
-    # `resource` value advertised in the protected resource metadata.
+    # section 3.3 requires strict equality between the client's resource identifier and
+    # the `resource` value advertised in the protected resource metadata.
     auth=AuthSettings(
         issuer_url=AnyHttpUrl("https://auth.example.com"),  # Authorization Server URL
         resource_server_url=AnyHttpUrl("http://localhost:3001/mcp"),  # Public MCP endpoint URL

--- a/src/mcp/server/auth/settings.py
+++ b/src/mcp/server/auth/settings.py
@@ -31,7 +31,7 @@ class AuthSettings(BaseModel):
             "Must include the transport path (e.g. https://example.com/mcp for "
             "streamable-http, https://example.com/sse for sse) so that the value "
             "advertised in protected resource metadata exactly matches the URL the "
-            "client used to reach the server. RFC 9728 §3.3 requires strict equality "
-            "between the client's resource identifier and this value."
+            "client used to reach the server. RFC 9728 section 3.3 requires strict "
+            "equality between the client's resource identifier and this value."
         ),
     )

--- a/src/mcp/server/auth/settings.py
+++ b/src/mcp/server/auth/settings.py
@@ -25,6 +25,13 @@ class AuthSettings(BaseModel):
     # Resource Server settings (when operating as RS only)
     resource_server_url: AnyHttpUrl | None = Field(
         ...,
-        description="The URL of the MCP server to be used as the resource identifier "
-        "and base route to look up OAuth Protected Resource Metadata.",
+        description=(
+            "The full public URL of this MCP server, used as the resource identifier "
+            "and base route to look up OAuth Protected Resource Metadata (RFC 9728). "
+            "Must include the transport path (e.g. https://example.com/mcp for "
+            "streamable-http, https://example.com/sse for sse) so that the value "
+            "advertised in protected resource metadata exactly matches the URL the "
+            "client used to reach the server. RFC 9728 §3.3 requires strict equality "
+            "between the client's resource identifier and this value."
+        ),
     )


### PR DESCRIPTION
Issue #1264 keeps surfacing because RFC 9728 §3.3 requires strict equality between the client's resource identifier and the `resource` value advertised in protected resource metadata, but the public surface of `AuthSettings.resource_server_url` does not say this. PR #1407 established the contract that `resource_server_url` must be the full endpoint URL including the transport path, and the `simple-auth` example was updated, but the matching `examples/snippets/servers/oauth_server.py` snippet (which is rendered into `README.v2.md` by `scripts/update_readme_snippets.py`) still passes `http://localhost:3001` with no path, the `AuthSettings.resource_server_url` description still says only "URL of the MCP server", and `simple-auth/server.py` hardcodes `/mcp` even when the user passes `--transport=sse`.

This change updates the `AuthSettings.resource_server_url` field description to spell out the contract, including the requirement that the URL include the transport path and the reference to RFC 9728 §3.3. The `oauth_server.py` snippet is changed to `http://localhost:3001/mcp` with a comment explaining why, and `README.v2.md` is regenerated so the embedded snippet matches. In `simple-auth/server.py`, the override that built `server_url` picks `/sse` or `/mcp` based on the `--transport` flag so the SSE path no longer produces an RFC 9728 mismatch.

Per the closing comment on #2189, the maintainer asked for a docs and example fix here rather than auto-appending `streamable_http_path`, because `streamable_http_path` is an internal Starlette route and not always the public URL (for example when the app is mounted at `/api` with `streamable_http_path="/"`, or behind a reverse proxy). Verified with `uv run --frozen ruff check`, `uv run --frozen pyright`, `uv run --frozen pytest tests/server/auth/ tests/server/mcpserver/` (388 passed), and `uv run --frozen python scripts/update_readme_snippets.py --check`.

Refs #1264