### PR TITLE
fix: wrap pipe union structured outputs

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -478,7 +478,7 @@ def _create_wrapped_model(func_name: str, annotation: Any) -> type[BaseModel]:
     """
     model_name = f"{func_name}Output"
 
-    return create_model(model_name, result=annotation)
+    return create_model(model_name, result=(annotation, ...))
 
 
 def _create_dict_model(func_name: str, dict_annotation: Any) -> type[BaseModel]:

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -677,6 +677,9 @@ def test_structured_output_generic_types():
     def func_union() -> str | int:  # pragma: no cover
         return "hello"
 
+    def func_pipe_union_containers() -> dict | list | str:  # pragma: no cover
+        return {"a": 1}
+
     def func_optional() -> str | None:  # pragma: no cover
         return None
 
@@ -704,6 +707,24 @@ def test_structured_output_generic_types():
         "properties": {"result": {"title": "Result", "anyOf": [{"type": "string"}, {"type": "integer"}]}},
         "required": ["result"],
         "title": "func_unionOutput",
+    }
+
+    # Test PEP 604 union with containers
+    meta = func_metadata(func_pipe_union_containers)
+    assert meta.output_schema == {
+        "type": "object",
+        "properties": {
+            "result": {
+                "title": "Result",
+                "anyOf": [
+                    {"additionalProperties": True, "type": "object"},
+                    {"items": {}, "type": "array"},
+                    {"type": "string"},
+                ],
+            }
+        },
+        "required": ["result"],
+        "title": "func_pipe_union_containersOutput",
     }
 
     # Test Optional

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -677,7 +677,7 @@ def test_structured_output_generic_types():
     def func_union() -> str | int:  # pragma: no cover
         return "hello"
 
-    def func_pipe_union_containers() -> dict | list | str:  # pragma: no cover
+    def func_pipe_union_containers() -> dict[str, int] | list[str] | str:  # pragma: no cover
         return {"a": 1}
 
     def func_optional() -> str | None:  # pragma: no cover
@@ -717,8 +717,8 @@ def test_structured_output_generic_types():
             "result": {
                 "title": "Result",
                 "anyOf": [
-                    {"additionalProperties": True, "type": "object"},
-                    {"items": {}, "type": "array"},
+                    {"additionalProperties": {"type": "integer"}, "type": "object"},
+                    {"items": {"type": "string"}, "type": "array"},
                     {"type": "string"},
                 ],
             }

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1,5 +1,6 @@
 import base64
 from pathlib import Path
+from types import TracebackType
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -64,6 +65,41 @@ class TestServer:
         assert isinstance(mcp.icons, list)
         assert len(mcp.icons) == 1
         assert mcp.icons[0].src == "https://example.com/icon.png"
+
+    def test_run_stdio_transport(self):
+        mcp = MCPServer("test")
+
+        with patch("mcp.server.mcpserver.server.anyio.run") as run:
+            mcp.run("stdio")
+
+        run.assert_called_once_with(mcp.run_stdio_async)
+
+    async def test_run_stdio_async_uses_stdio_transport(self):
+        class StdioServer:
+            async def __aenter__(self):
+                return "read", "write"
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                tb: TracebackType | None,
+            ) -> None:
+                return None
+
+        mcp = MCPServer("test")
+        run = AsyncMock()
+
+        with (
+            patch("mcp.server.mcpserver.server.stdio_server", return_value=StdioServer()),
+            patch.object(mcp._lowlevel_server, "run", run),
+        ):
+            await mcp.run_stdio_async()
+
+        run.assert_awaited_once()
+        await_args = run.await_args
+        assert await_args is not None
+        assert await_args.args[:2] == ("read", "write")
 
     def test_dependencies(self):
         """Dependencies list is read by `mcp install` / `mcp dev` CLI commands."""


### PR DESCRIPTION
﻿## Summary
- use Pydantic's explicit `(annotation, ...)` field form for wrapped structured outputs
- add a regression test for PEP 604 unions that include container types

Fixes #2591

## To verify
- `.\.venv\Scripts\python.exe -m pytest tests\server\mcpserver\test_func_metadata.py::test_structured_output_generic_types -q`
- `.\.venv\Scripts\python.exe -m pytest tests\server\mcpserver\test_func_metadata.py -q`
- `.\.venv\Scripts\python.exe -m ruff check src\mcp\server\mcpserver\utilities\func_metadata.py tests\server\mcpserver\test_func_metadata.py`
- `.\.venv\Scripts\python.exe -m py_compile src\mcp\server\mcpserver\utilities\func_metadata.py tests\server\mcpserver\test_func_metadata.py`
- `git diff --check`
