### PR TITLE
fix: include transport path in protected resource metadata URL (RFC 9728 §3)

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -46,6 +46,7 @@ from typing import Any, Generic, cast
 
 import anyio
 from opentelemetry.trace import SpanKind, StatusCode
+from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
@@ -633,8 +634,11 @@ class Server(Generic[LifespanResultT]):
             # Determine resource metadata URL
             resource_metadata_url = None
             if auth and auth.resource_server_url:
+                # RFC 9728: resource identifier must match the URL clients use to access
+                # the protected resource, including the transport path (e.g. /mcp)
+                actual_resource_url = AnyHttpUrl(str(auth.resource_server_url).rstrip("/") + streamable_http_path)
                 # Build compliant metadata URL for WWW-Authenticate header
-                resource_metadata_url = build_resource_metadata_url(auth.resource_server_url)
+                resource_metadata_url = build_resource_metadata_url(actual_resource_url)
 
             routes.append(
                 Route(
@@ -653,9 +657,10 @@ class Server(Generic[LifespanResultT]):
 
         # Add protected resource metadata endpoint if configured as RS
         if auth and auth.resource_server_url:  # pragma: no cover
+            actual_resource_url = AnyHttpUrl(str(auth.resource_server_url).rstrip("/") + streamable_http_path)
             routes.extend(
                 create_protected_resource_routes(
-                    resource_url=auth.resource_server_url,
+                    resource_url=actual_resource_url,
                     authorization_servers=[auth.issuer_url],
                     scopes_supported=auth.required_scopes,
                 )

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -12,6 +12,7 @@ from typing import Any, Generic, Literal, TypeVar, overload
 
 import anyio
 import pydantic_core
+from pydantic import AnyHttpUrl
 from pydantic.networks import AnyUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from starlette.applications import Starlette
@@ -987,8 +988,11 @@ class MCPServer(Generic[LifespanResultT]):
             if self.settings.auth and self.settings.auth.resource_server_url:
                 from mcp.server.auth.routes import build_resource_metadata_url
 
+                # RFC 9728: resource identifier must match the URL clients use to access
+                # the protected resource, including the transport path (e.g. /sse)
+                actual_resource_url = AnyHttpUrl(str(self.settings.auth.resource_server_url).rstrip("/") + sse_path)
                 # Build compliant metadata URL for WWW-Authenticate header
-                resource_metadata_url = build_resource_metadata_url(self.settings.auth.resource_server_url)
+                resource_metadata_url = build_resource_metadata_url(actual_resource_url)
 
             # Auth is enabled, wrap the endpoints with RequireAuthMiddleware
             routes.append(
@@ -1028,9 +1032,10 @@ class MCPServer(Generic[LifespanResultT]):
         if self.settings.auth and self.settings.auth.resource_server_url:  # pragma: no cover
             from mcp.server.auth.routes import create_protected_resource_routes
 
+            actual_resource_url = AnyHttpUrl(str(self.settings.auth.resource_server_url).rstrip("/") + sse_path)
             routes.extend(
                 create_protected_resource_routes(
-                    resource_url=self.settings.auth.resource_server_url,
+                    resource_url=actual_resource_url,
                     authorization_servers=[self.settings.auth.issuer_url],
                     scopes_supported=self.settings.auth.required_scopes,
                 )

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -196,3 +196,68 @@ def test_route_consistency_consistent_paths_for_various_resources(resource_url: 
     assert url_path == expected_path
     assert route_path == expected_path
     assert url_path == route_path
+
+
+# Tests for issue #1264: resource URL must include transport path
+
+
+@pytest.mark.parametrize(
+    "resource_server_url,transport_path,expected_resource,expected_metadata_url",
+    [
+        (
+            "http://localhost:8000",
+            "/mcp",
+            "http://localhost:8000/mcp",
+            "http://localhost:8000/.well-known/oauth-protected-resource/mcp",
+        ),
+        (
+            "http://localhost:8000/",
+            "/mcp",
+            "http://localhost:8000/mcp",
+            "http://localhost:8000/.well-known/oauth-protected-resource/mcp",
+        ),
+        (
+            "https://mcp.example.com",
+            "/sse",
+            "https://mcp.example.com/sse",
+            "https://mcp.example.com/.well-known/oauth-protected-resource/sse",
+        ),
+    ],
+)
+def test_resource_url_includes_transport_path(
+    resource_server_url: str,
+    transport_path: str,
+    expected_resource: str,
+    expected_metadata_url: str,
+):
+    """Transport path must be appended to resource_server_url (issue #1264).
+
+    Per RFC 9728, the resource identifier must match the URL clients use to access
+    the protected resource — e.g. http://localhost:8000/mcp, not http://localhost:8000/.
+    """
+    actual_resource_url = AnyHttpUrl(resource_server_url.rstrip("/") + transport_path)
+
+    assert str(actual_resource_url) == expected_resource
+
+    metadata_url = build_resource_metadata_url(actual_resource_url)
+    assert str(metadata_url) == expected_metadata_url
+
+
+@pytest.mark.anyio
+async def test_protected_resource_metadata_contains_transport_path():
+    """Metadata endpoint returns resource URL with transport path, not bare server URL."""
+    resource_url = AnyHttpUrl("http://localhost:8000/mcp")
+    routes = create_protected_resource_routes(
+        resource_url=resource_url,
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+        scopes_supported=["read", "write"],
+    )
+    app = Starlette(routes=routes)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://localhost:8000") as client:
+        response = await client.get("/.well-known/oauth-protected-resource/mcp")
+        assert response.status_code == 200
+        data = response.json()
+        # resource must be the full endpoint URL, not the bare server base
+        assert data["resource"] == "http://localhost:8000/mcp"
+        assert data["resource"] != "http://localhost:8000/"


### PR DESCRIPTION
## Problem

Fixes #1264.

The `resource` field in `/.well-known/oauth-protected-resource` is supposed to identify the protected resource server as defined in [RFC 9728 §2](https://www.rfc-editor.org/rfc/rfc9728#section-2):

> The `resource` parameter [...] **MUST** be a URI that identifies the protected resource.

When a server mounts its MCP transport at a path (e.g. `/mcp` or `/sse`), the `resource` field must include that path — `https://example.com/mcp`, not just `https://example.com`.

Before this fix, both `StreamableHTTPServerTransport` and the SSE server always used the bare `resource_server_url` (without the transport path), so the metadata URL was derived incorrectly.

## Root cause

`build_protected_resource_metadata_url` strips the path from the resource URL and reconstructs `/.well-known/oauth-protected-resource/<path>`. When the resource URL lacks the transport path, the well-known URL is wrong and RFC 9728 §3 lookup fails for path-mounted servers.

## Fix

In both `lowlevel/server.py` (StreamableHTTP) and `mcpserver/server.py` (SSE), compute `actual_resource_url` by appending the transport path to `resource_server_url` before passing it to `build_protected_resource_metadata_url` and embedding it in the metadata:

```python
actual_resource_url = AnyHttpUrl(
    str(auth.resource_server_url).rstrip("/") + streamable_http_path
)
```

## Tests

- `test_resource_url_includes_transport_path` — parametrized unit test: verifies correct `resource` value and correct metadata URL for `/mcp`, trailing-slash base URL + `/mcp`, and `/sse` transport paths
- `test_protected_resource_metadata_contains_transport_path` — async integration test using a real `TestClient`