### PR TITLE
fix: exit cleanly on stdio KeyboardInterrupt

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -293,7 +293,10 @@ class MCPServer(Generic[LifespanResultT]):
 
         match transport:
             case "stdio":
-                anyio.run(self.run_stdio_async)
+                try:
+                    anyio.run(self.run_stdio_async)
+                except KeyboardInterrupt:
+                    return
             case "sse":  # pragma: no cover
                 anyio.run(lambda: self.run_sse_async(**kwargs))
             case "streamable-http":  # pragma: no cover

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -74,6 +74,17 @@ class TestServer:
         mcp_no_deps = MCPServer("test")
         assert mcp_no_deps.dependencies == []
 
+    def test_run_stdio_exits_cleanly_on_keyboard_interrupt(self, monkeypatch: pytest.MonkeyPatch):
+        mcp = MCPServer("test")
+
+        def raise_keyboard_interrupt(func: Any) -> None:
+            assert func == mcp.run_stdio_async
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("mcp.server.mcpserver.server.anyio.run", raise_keyboard_interrupt)
+
+        mcp.run("stdio")
+
     async def test_sse_app_returns_starlette_app(self):
         """Test that sse_app returns a Starlette application with correct routes."""
         mcp = MCPServer("test")


### PR DESCRIPTION
Fixes #2663. Handles Ctrl-C for FastMCP stdio runs at the stdio transport boundary so shutdown does not print a traceback. HTTP transports keep their existing behavior. Validation: uv run pytest tests\server\mcpserver\test_server.py::TestServer::test_run_stdio_exits_cleanly_on_keyboard_interrupt -q; uv run pytest tests\server\mcpserver\test_server.py -q; uv run python -m py_compile src\mcp\server\mcpserver\server.py tests\server\mcpserver\test_server.py; uv run ruff check src\mcp\server\mcpserver\server.py tests\server\mcpserver\test_server.py; uv run ruff format --check src\mcp\server\mcpserver\server.py tests\server\mcpserver\test_server.py; git diff --check.