### PR TITLE
Clarify CLI subprocess environment comment

### DIFF
--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -277,7 +277,7 @@ def dev(
             [npx_cmd, "@modelcontextprotocol/inspector"] + uv_cmd,
             check=True,
             shell=shell,
-            env=dict(os.environ.items()),  # Convert to list of tuples for env update
+            env=dict(os.environ.items()),  # Copy the environment for subprocess launch
         )
         sys.exit(process.returncode)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary\n- clarify the CLI subprocess environment comment to match the dict being passed\n\n## Testing\n- python3 -m py_compile src/mcp/cli/cli.py\n\nNo dependencies were installed and no project code was executed beyond Python syntax compilation.