### PR TITLE
fix(auth): get_access_token reflects current request in stateful sessions

### DIFF
--- a/src/mcp/server/auth/middleware/auth_context.py
+++ b/src/mcp/server/auth/middleware/auth_context.py
@@ -31,7 +31,16 @@ def _push_auth_context_from_request(request: Request | None) -> Token[Authentica
     """
     if request is None:
         return None
-    user = getattr(request, "user", None)
+    # Avoid Request.user, which asserts AuthenticationMiddleware is installed.
+    user = None
+    scope = getattr(request, "scope", None)
+    if isinstance(scope, dict):
+        user = scope.get("user")
+    if user is None:
+        try:
+            user = getattr(request, "user", None)
+        except AssertionError:
+            user = None
     if isinstance(user, AuthenticatedUser):
         return auth_context_var.set(user)
     return None

--- a/src/mcp/server/auth/middleware/auth_context.py
+++ b/src/mcp/server/auth/middleware/auth_context.py
@@ -1,6 +1,6 @@
 import contextvars
-
 from contextvars import Token
+from typing import Any
 
 from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -23,7 +23,7 @@ def get_access_token() -> AccessToken | None:
     return auth_user.access_token if auth_user else None
 
 
-def _push_auth_context_from_request(request: Request | None) -> Token[AuthenticatedUser | None] | None:
+def push_auth_context_from_request(request: Request | None) -> Token[AuthenticatedUser | None] | None:
     """Set auth context for the current task from an incoming request.
 
     This is primarily used by server transports where request handlers may run
@@ -32,10 +32,7 @@ def _push_auth_context_from_request(request: Request | None) -> Token[Authentica
     if request is None:
         return None
     # Avoid Request.user, which asserts AuthenticationMiddleware is installed.
-    user = None
-    scope = getattr(request, "scope", None)
-    if isinstance(scope, dict):
-        user = scope.get("user")
+    user: Any | None = request.scope.get("user")
     if user is None:
         try:
             user = getattr(request, "user", None)
@@ -46,7 +43,7 @@ def _push_auth_context_from_request(request: Request | None) -> Token[Authentica
     return None
 
 
-def _pop_auth_context(token: Token[AuthenticatedUser | None] | None) -> None:
+def pop_auth_context(token: Token[AuthenticatedUser | None] | None) -> None:
     if token is None:
         return
     auth_context_var.reset(token)

--- a/src/mcp/server/auth/middleware/auth_context.py
+++ b/src/mcp/server/auth/middleware/auth_context.py
@@ -38,9 +38,7 @@ def push_auth_context_from_request(request: Request | None) -> Token[Authenticat
             user = getattr(request, "user", None)
         except AssertionError:
             user = None
-    if isinstance(user, AuthenticatedUser):
-        return auth_context_var.set(user)
-    return None
+    return auth_context_var.set(user if isinstance(user, AuthenticatedUser) else None)
 
 
 def pop_auth_context(token: Token[AuthenticatedUser | None] | None) -> None:

--- a/src/mcp/server/auth/middleware/auth_context.py
+++ b/src/mcp/server/auth/middleware/auth_context.py
@@ -1,5 +1,8 @@
 import contextvars
 
+from contextvars import Token
+
+from starlette.requests import Request
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
@@ -18,6 +21,26 @@ def get_access_token() -> AccessToken | None:
     """
     auth_user = auth_context_var.get()
     return auth_user.access_token if auth_user else None
+
+
+def _push_auth_context_from_request(request: Request | None) -> Token[AuthenticatedUser | None] | None:
+    """Set auth context for the current task from an incoming request.
+
+    This is primarily used by server transports where request handlers may run
+    in background tasks that are not part of the original ASGI request task.
+    """
+    if request is None:
+        return None
+    user = getattr(request, "user", None)
+    if isinstance(user, AuthenticatedUser):
+        return auth_context_var.set(user)
+    return None
+
+
+def _pop_auth_context(token: Token[AuthenticatedUser | None] | None) -> None:
+    if token is None:
+        return
+    auth_context_var.reset(token)
 
 
 class AuthContextMiddleware:

--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -55,6 +55,7 @@ from mcp_types.version import (
 from pydantic import BaseModel, ValidationError
 from typing_extensions import TypeVar
 
+from mcp.server.auth.middleware.auth_context import _pop_auth_context, _push_auth_context_from_request
 from mcp.server.caching import apply_cache_hint
 from mcp.server.connection import Connection, NotifyOnlyOutbound
 from mcp.server.context import CallNext, HandlerResult, ServerMiddleware, ServerRequestContext
@@ -227,7 +228,11 @@ class ServerRunner(Generic[LifespanT]):
         # without `call_next` is trusted to return its own well-formed result -
         # including its response envelope. The pipeline never patches it up after
         # the fact.
-        result = _dump_result(await call(ctx))
+        auth_token = _push_auth_context_from_request(ctx.request)
+        try:
+            result = _dump_result(await call(ctx))
+        finally:
+            _pop_auth_context(auth_token)
         if method == "initialize":
             # Commit only on chain success, so a middleware veto leaves no state.
             # Race-free: the read loop is parked until this call returns.

--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -55,7 +55,7 @@ from mcp_types.version import (
 from pydantic import BaseModel, ValidationError
 from typing_extensions import TypeVar
 
-from mcp.server.auth.middleware.auth_context import _pop_auth_context, _push_auth_context_from_request
+from mcp.server.auth.middleware.auth_context import pop_auth_context, push_auth_context_from_request
 from mcp.server.caching import apply_cache_hint
 from mcp.server.connection import Connection, NotifyOnlyOutbound
 from mcp.server.context import CallNext, HandlerResult, ServerMiddleware, ServerRequestContext
@@ -228,11 +228,11 @@ class ServerRunner(Generic[LifespanT]):
         # without `call_next` is trusted to return its own well-formed result -
         # including its response envelope. The pipeline never patches it up after
         # the fact.
-        auth_token = _push_auth_context_from_request(ctx.request)
+        auth_token = push_auth_context_from_request(ctx.request)
         try:
             result = _dump_result(await call(ctx))
         finally:
-            _pop_auth_context(auth_token)
+            pop_auth_context(auth_token)
         if method == "initialize":
             # Commit only on chain success, so a middleware veto leaves no state.
             # Race-free: the read loop is parked until this call returns.

--- a/tests/server/auth/test_get_access_token_streamable_http.py
+++ b/tests/server/auth/test_get_access_token_streamable_http.py
@@ -1,0 +1,100 @@
+import time
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.routing import Mount
+
+from mcp import Client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.server import Server, ServerRequestContext
+from mcp.server.auth.middleware.auth_context import AuthContextMiddleware, get_access_token
+from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
+from mcp.server.auth.provider import AccessToken
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
+
+
+class _EchoTokenVerifier:
+    """Accepts any bearer token and echoes it back as the verified AccessToken."""
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return AccessToken(token=token, client_id=token, scopes=[], expires_at=int(time.time()) + 3600)
+
+
+async def _handle_whoami(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+    access = get_access_token()
+    text = access.token if access else "<none>"
+    return CallToolResult(content=[TextContent(type="text", text=text)])
+
+
+async def _handle_list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+    return ListToolsResult(tools=[Tool(name="whoami", input_schema={"type": "object", "properties": {}})])
+
+
+class _MutableBearerAuth(httpx.Auth):
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def auth_flow(self, request: httpx.Request):
+        request.headers["Authorization"] = f"Bearer {self.token}"
+        yield request
+
+
+@pytest.mark.anyio
+async def test_get_access_token_reflects_current_request_in_stateful_session() -> None:
+    host = "testserver"
+
+    server = Server(
+        "auth-test-server",
+        on_call_tool=_handle_whoami,
+        on_list_tools=_handle_list_tools,
+    )
+
+    security = TransportSecuritySettings(
+        allowed_hosts=[host, f"{host}:*"],
+        allowed_origins=[f"http://{host}:*"],
+    )
+    session_manager = StreamableHTTPSessionManager(app=server, security_settings=security, stateless=False)
+
+    asgi_app = Starlette(
+        routes=[Mount("/mcp", app=session_manager.handle_request)],
+        middleware=[
+            Middleware(AuthenticationMiddleware, backend=BearerAuthBackend(_EchoTokenVerifier())),
+            Middleware(AuthContextMiddleware),
+        ],
+        lifespan=lambda app: session_manager.run(),
+    )
+
+    auth = _MutableBearerAuth("token-A")
+    async with asgi_app.router.lifespan_context(asgi_app):
+        async with (
+            httpx.ASGITransport(asgi_app) as transport,
+            httpx.AsyncClient(
+                transport=transport,
+                base_url=f"http://{host}",
+                auth=auth,
+                timeout=httpx.Timeout(30, read=30),
+                follow_redirects=True,
+            ) as http_client,
+        ):
+            transport_ctx = streamable_http_client(f"http://{host}/mcp", http_client=http_client)
+            async with Client(transport_ctx) as client:
+                r1 = await client.call_tool("whoami", {})
+                assert isinstance(r1.content[0], TextContent)
+                assert r1.content[0].text == "token-A"
+
+                auth.token = "token-B"
+                r2 = await client.call_tool("whoami", {})
+                assert isinstance(r2.content[0], TextContent)
+                assert r2.content[0].text == "token-B"

--- a/tests/server/auth/test_get_access_token_streamable_http.py
+++ b/tests/server/auth/test_get_access_token_streamable_http.py
@@ -2,6 +2,14 @@ import time
 
 import httpx
 import pytest
+from mcp_types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+)
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
@@ -14,15 +22,6 @@ from mcp.server.auth.middleware.auth_context import AuthContextMiddleware, get_a
 from mcp.server.auth.middleware.bearer_auth import BearerAuthBackend
 from mcp.server.auth.provider import AccessToken
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
-from mcp.server.transport_security import TransportSecuritySettings
-from mcp.types import (
-    CallToolRequestParams,
-    CallToolResult,
-    ListToolsResult,
-    PaginatedRequestParams,
-    TextContent,
-    Tool,
-)
 
 
 class _EchoTokenVerifier:
@@ -43,12 +42,32 @@ async def _handle_list_tools(ctx: ServerRequestContext, params: PaginatedRequest
 
 
 class _MutableBearerAuth(httpx.Auth):
-    def __init__(self, token: str) -> None:
+    def __init__(self, token: str | None) -> None:
         self.token = token
 
     def auth_flow(self, request: httpx.Request):
-        request.headers["Authorization"] = f"Bearer {self.token}"
+        if self.token is not None:
+            request.headers["Authorization"] = f"Bearer {self.token}"
         yield request
+
+
+async def _call_whoami(asgi_app: Starlette, host: str, token: str | None) -> str:
+    auth = _MutableBearerAuth(token)
+    async with (
+        httpx.ASGITransport(asgi_app) as transport,
+        httpx.AsyncClient(
+            transport=transport,
+            base_url=f"http://{host}",
+            auth=auth,
+            timeout=httpx.Timeout(30, read=30),
+            follow_redirects=True,
+        ) as http_client,
+    ):
+        transport_ctx = streamable_http_client(f"http://{host}/mcp", http_client=http_client)
+        async with Client(transport_ctx) as client:  # pragma: no branch
+            result = await client.call_tool("whoami", {})
+            assert isinstance(result.content[0], TextContent)
+            return result.content[0].text
 
 
 @pytest.mark.anyio
@@ -61,11 +80,7 @@ async def test_get_access_token_reflects_current_request_in_stateful_session() -
         on_list_tools=_handle_list_tools,
     )
 
-    security = TransportSecuritySettings(
-        allowed_hosts=[host, f"{host}:*"],
-        allowed_origins=[f"http://{host}:*"],
-    )
-    session_manager = StreamableHTTPSessionManager(app=server, security_settings=security, stateless=False)
+    session_manager = StreamableHTTPSessionManager(app=server, stateless=False)
 
     asgi_app = Starlette(
         routes=[Mount("/mcp", app=session_manager.handle_request)],
@@ -76,25 +91,7 @@ async def test_get_access_token_reflects_current_request_in_stateful_session() -
         lifespan=lambda app: session_manager.run(),
     )
 
-    auth = _MutableBearerAuth("token-A")
     async with asgi_app.router.lifespan_context(asgi_app):
-        async with (
-            httpx.ASGITransport(asgi_app) as transport,
-            httpx.AsyncClient(
-                transport=transport,
-                base_url=f"http://{host}",
-                auth=auth,
-                timeout=httpx.Timeout(30, read=30),
-                follow_redirects=True,
-            ) as http_client,
-        ):
-            transport_ctx = streamable_http_client(f"http://{host}/mcp", http_client=http_client)
-            async with Client(transport_ctx) as client:
-                r1 = await client.call_tool("whoami", {})
-                assert isinstance(r1.content[0], TextContent)
-                assert r1.content[0].text == "token-A"
-
-                auth.token = "token-B"
-                r2 = await client.call_tool("whoami", {})
-                assert isinstance(r2.content[0], TextContent)
-                assert r2.content[0].text == "token-B"
+        assert await _call_whoami(asgi_app, host, "token-A") == "token-A"
+        assert await _call_whoami(asgi_app, host, "token-B") == "token-B"
+        assert await _call_whoami(asgi_app, host, None) == "<none>"

--- a/tests/server/auth/test_get_access_token_streamable_http.py
+++ b/tests/server/auth/test_get_access_token_streamable_http.py
@@ -1,6 +1,6 @@
 import time
 
-import httpx
+import httpx2
 import pytest
 from mcp_types import (
     CallToolRequestParams,
@@ -41,11 +41,11 @@ async def _handle_list_tools(ctx: ServerRequestContext, params: PaginatedRequest
     return ListToolsResult(tools=[Tool(name="whoami", input_schema={"type": "object", "properties": {}})])
 
 
-class _MutableBearerAuth(httpx.Auth):
+class _MutableBearerAuth(httpx2.Auth):
     def __init__(self, token: str | None) -> None:
         self.token = token
 
-    def auth_flow(self, request: httpx.Request):
+    def auth_flow(self, request: httpx2.Request):
         if self.token is not None:
             request.headers["Authorization"] = f"Bearer {self.token}"
         yield request
@@ -54,12 +54,12 @@ class _MutableBearerAuth(httpx.Auth):
 async def _call_whoami(asgi_app: Starlette, host: str, token: str | None) -> str:
     auth = _MutableBearerAuth(token)
     async with (
-        httpx.ASGITransport(asgi_app) as transport,
-        httpx.AsyncClient(
+        httpx2.ASGITransport(asgi_app) as transport,
+        httpx2.AsyncClient(
             transport=transport,
             base_url=f"http://{host}",
             auth=auth,
-            timeout=httpx.Timeout(30, read=30),
+            timeout=httpx2.Timeout(30, read=30),
             follow_redirects=True,
         ) as http_client,
     ):

--- a/tests/server/auth/test_get_access_token_streamable_http.py
+++ b/tests/server/auth/test_get_access_token_streamable_http.py
@@ -1,5 +1,6 @@
 import time
 
+import anyio
 import httpx2
 import pytest
 from mcp_types import (
@@ -7,6 +8,7 @@ from mcp_types import (
     CallToolResult,
     ListToolsResult,
     PaginatedRequestParams,
+    ProgressNotificationParams,
     TextContent,
     Tool,
 )
@@ -28,7 +30,7 @@ class _EchoTokenVerifier:
     """Accepts any bearer token and echoes it back as the verified AccessToken."""
 
     async def verify_token(self, token: str) -> AccessToken | None:
-        return AccessToken(token=token, client_id=token, scopes=[], expires_at=int(time.time()) + 3600)
+        return AccessToken(token=token, client_id="test-client", scopes=[], expires_at=int(time.time()) + 3600)
 
 
 async def _handle_whoami(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
@@ -51,23 +53,10 @@ class _MutableBearerAuth(httpx2.Auth):
         yield request
 
 
-async def _call_whoami(asgi_app: Starlette, host: str, token: str | None) -> str:
-    auth = _MutableBearerAuth(token)
-    async with (
-        httpx2.ASGITransport(asgi_app) as transport,
-        httpx2.AsyncClient(
-            transport=transport,
-            base_url=f"http://{host}",
-            auth=auth,
-            timeout=httpx2.Timeout(30, read=30),
-            follow_redirects=True,
-        ) as http_client,
-    ):
-        transport_ctx = streamable_http_client(f"http://{host}/mcp", http_client=http_client)
-        async with Client(transport_ctx) as client:  # pragma: no branch
-            result = await client.call_tool("whoami", {})
-            assert isinstance(result.content[0], TextContent)
-            return result.content[0].text
+async def _call_whoami(client: Client) -> str:
+    result = await client.call_tool("whoami", {})
+    assert isinstance(result.content[0], TextContent)
+    return result.content[0].text
 
 
 @pytest.mark.anyio
@@ -92,6 +81,69 @@ async def test_get_access_token_reflects_current_request_in_stateful_session() -
     )
 
     async with asgi_app.router.lifespan_context(asgi_app):
-        assert await _call_whoami(asgi_app, host, "token-A") == "token-A"
-        assert await _call_whoami(asgi_app, host, "token-B") == "token-B"
-        assert await _call_whoami(asgi_app, host, None) == "<none>"
+        auth = _MutableBearerAuth("token-A")
+        async with (
+            httpx2.ASGITransport(asgi_app) as transport,
+            httpx2.AsyncClient(
+                transport=transport,
+                base_url=f"http://{host}",
+                auth=auth,
+                timeout=httpx2.Timeout(30, read=30),
+                follow_redirects=True,
+            ) as http_client,
+            Client(streamable_http_client(f"http://{host}/mcp", http_client=http_client), mode="legacy") as client,
+        ):
+            assert await _call_whoami(client) == "token-A"
+
+            auth.token = "token-B"
+            assert await _call_whoami(client) == "token-B"
+
+
+@pytest.mark.anyio
+async def test_notification_handler_get_access_token_reflects_current_request_in_stateful_session() -> None:
+    host = "testserver"
+    send_token, receive_token = anyio.create_memory_object_stream[str](10)
+
+    async def handle_progress(ctx: ServerRequestContext, params: ProgressNotificationParams) -> None:
+        access = get_access_token()
+        await send_token.send(access.token if access else "<none>")
+
+    server = Server(
+        "auth-test-server",
+        on_call_tool=_handle_whoami,
+        on_list_tools=_handle_list_tools,
+    )
+    server.add_notification_handler("notifications/progress", ProgressNotificationParams, handle_progress)
+
+    session_manager = StreamableHTTPSessionManager(app=server, stateless=False)
+
+    asgi_app = Starlette(
+        routes=[Mount("/mcp", app=session_manager.handle_request)],
+        middleware=[
+            Middleware(AuthenticationMiddleware, backend=BearerAuthBackend(_EchoTokenVerifier())),
+            Middleware(AuthContextMiddleware),
+        ],
+        lifespan=lambda app: session_manager.run(),
+    )
+
+    async with send_token, receive_token, asgi_app.router.lifespan_context(asgi_app):
+        auth = _MutableBearerAuth("token-A")
+        async with (
+            httpx2.ASGITransport(asgi_app) as transport,
+            httpx2.AsyncClient(
+                transport=transport,
+                base_url=f"http://{host}",
+                auth=auth,
+                timeout=httpx2.Timeout(30, read=30),
+                follow_redirects=True,
+            ) as http_client,
+            Client(streamable_http_client(f"http://{host}/mcp", http_client=http_client), mode="legacy") as client,
+        ):
+            await client.send_progress_notification("token-A", 0.1)  # pyright: ignore[reportDeprecated]
+            with anyio.fail_after(5):
+                assert await receive_token.receive() == "token-A"
+
+            auth.token = "token-B"
+            await client.send_progress_notification("token-B", 0.2)  # pyright: ignore[reportDeprecated]
+            with anyio.fail_after(5):
+                assert await receive_token.receive() == "token-B"

--- a/tests/server/auth/test_get_access_token_streamable_http.py
+++ b/tests/server/auth/test_get_access_token_streamable_http.py
@@ -144,5 +144,5 @@ async def test_notification_handler_get_access_token_reflects_current_request_in
 
             auth.token = "token-B"
             await client.send_progress_notification("token-B", 0.2)  # pyright: ignore[reportDeprecated]
-            with anyio.fail_after(5):
+            with anyio.fail_after(5):  # pragma: no branch - coverage misreports the normal context exit arc
                 assert await receive_token.receive() == "token-B"

--- a/tests/server/auth/test_get_access_token_streamable_http.py
+++ b/tests/server/auth/test_get_access_token_streamable_http.py
@@ -44,12 +44,11 @@ async def _handle_list_tools(ctx: ServerRequestContext, params: PaginatedRequest
 
 
 class _MutableBearerAuth(httpx2.Auth):
-    def __init__(self, token: str | None) -> None:
+    def __init__(self, token: str) -> None:
         self.token = token
 
     def auth_flow(self, request: httpx2.Request):
-        if self.token is not None:
-            request.headers["Authorization"] = f"Bearer {self.token}"
+        request.headers["Authorization"] = f"Bearer {self.token}"
         yield request
 
 


### PR DESCRIPTION
Fixes #2208.

Stateful Streamable HTTP sessions start the server task group on the first request. Anyio copies the request contextvars into that long-lived task, so get_access_token() could keep returning the token from the session-creating request even when later requests send a different Authorization header.

This change pushes the authenticated user into the auth contextvar at request-dispatch time (using the ServerMessageMetadata.request_context threaded through the transport), and resets it after the handler returns.

Tests:
- uv run python -m pytest tests/server/auth/middleware/test_auth_context.py tests/server/auth/test_get_access_token_streamable_http.py