### PR TITLE
fix(stdio): drain responses after stdin EOF

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -698,6 +698,15 @@ class Server(Generic[LifespanResultT]):
         # but also make tracing exceptions much easier during testing and when using
         # in-process servers.
         raise_exceptions: bool = False,
+        # When True, the server is stateless and
+        # clients can perform initialization with any node. The client must still follow
+        # the initialization lifecycle, but can do so with any available node
+        # rather than requiring initialization for each connection.
+        stateless: bool = False,
+        # When True, treat read EOF as a half-close and allow in-flight handlers
+        # to drain their responses via the still-open write stream (e.g. stdio
+        # with bash-redirected stdin).
+        drain_on_read_close: bool = False,
     ) -> None:
         """Serve a single connection over the given streams until the read side closes.
 
@@ -708,15 +717,20 @@ class Server(Generic[LifespanResultT]):
         call `serve_loop` directly instead.
         """
         async with self.lifespan(self) as lifespan_context:
-            await serve_dual_era_loop(
-                self,
-                read_stream,
-                write_stream,
-                lifespan_state=lifespan_context,
-                init_options=initialization_options,
-                raise_exceptions=raise_exceptions,
-                close_write_stream_on_read_close=False,
-            )
+            try:
+                await serve_dual_era_loop(
+                    self,
+                    read_stream,
+                    write_stream,
+                    lifespan_state=lifespan_context,
+                    init_options=initialization_options,
+                    raise_exceptions=raise_exceptions,
+                    session_id=None,
+                    close_write_stream_on_read_close=not drain_on_read_close,
+                )
+            finally:
+                if drain_on_read_close:
+                    await write_stream.aclose()
 
     def streamable_http_app(
         self,

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -715,6 +715,7 @@ class Server(Generic[LifespanResultT]):
                 lifespan_state=lifespan_context,
                 init_options=initialization_options,
                 raise_exceptions=raise_exceptions,
+                close_write_stream_on_read_close=False,
             )
 
     def streamable_http_app(

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -77,6 +77,8 @@ from mcp.shared.message import SessionMessage
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_READ_EOF_DRAIN_TIMEOUT_SECONDS = 1.0
+
 LifespanResultT = TypeVar("LifespanResultT", default=Any)
 
 _ParamsT = TypeVar("_ParamsT", bound=BaseModel, default=BaseModel)
@@ -707,6 +709,9 @@ class Server(Generic[LifespanResultT]):
         # to drain their responses via the still-open write stream (e.g. stdio
         # with bash-redirected stdin).
         drain_on_read_close: bool = False,
+        # Maximum time to wait for in-flight handlers to drain after read EOF.
+        # None means wait indefinitely.
+        read_eof_drain_timeout_seconds: float | None = DEFAULT_READ_EOF_DRAIN_TIMEOUT_SECONDS,
     ) -> None:
         """Serve a single connection over the given streams until the read side closes.
 
@@ -717,20 +722,17 @@ class Server(Generic[LifespanResultT]):
         call `serve_loop` directly instead.
         """
         async with self.lifespan(self) as lifespan_context:
-            try:
-                await serve_dual_era_loop(
-                    self,
-                    read_stream,
-                    write_stream,
-                    lifespan_state=lifespan_context,
-                    init_options=initialization_options,
-                    raise_exceptions=raise_exceptions,
-                    session_id=None,
-                    close_write_stream_on_read_close=not drain_on_read_close,
-                )
-            finally:
-                if drain_on_read_close:
-                    await write_stream.aclose()
+            await serve_dual_era_loop(
+                self,
+                read_stream,
+                write_stream,
+                lifespan_state=lifespan_context,
+                init_options=initialization_options,
+                raise_exceptions=raise_exceptions,
+                session_id=None,
+                close_write_stream_on_read_close=not drain_on_read_close,
+                read_eof_drain_timeout_seconds=read_eof_drain_timeout_seconds,
+            )
 
     def streamable_http_app(
         self,

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -1022,6 +1022,7 @@ class MCPServer(Generic[LifespanResultT]):
                 read_stream,
                 write_stream,
                 self._lowlevel_server.create_initialization_options(),
+                drain_on_read_close=True,
             )
 
     async def run_sse_async(  # pragma: no cover

--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -642,6 +642,7 @@ async def serve_dual_era_loop(
                     lifespan_state=lifespan_state,
                     raise_exceptions=raise_exceptions,
                     close_write_stream_on_read_close=close_write_stream_on_read_close,
+                    read_eof_drain_timeout_seconds=read_eof_drain_timeout_seconds,
                 )
             else:
                 await _serve_legacy_stream(
@@ -653,6 +654,7 @@ async def serve_dual_era_loop(
                     init_options=init_options,
                     raise_exceptions=raise_exceptions,
                     close_write_stream_on_read_close=close_write_stream_on_read_close,
+                    read_eof_drain_timeout_seconds=read_eof_drain_timeout_seconds,
                 )
     finally:
         await write_stream.aclose()
@@ -736,6 +738,7 @@ async def _serve_legacy_stream(
     init_options: InitializationOptions | None,
     raise_exceptions: bool,
     close_write_stream_on_read_close: bool,
+    read_eof_drain_timeout_seconds: float | None,
 ) -> None:
     """Serve a 2025 handshake connection; enveloped requests are refused."""
     dispatcher: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
@@ -775,6 +778,7 @@ async def _serve_modern_stream(
     lifespan_state: LifespanT,
     raise_exceptions: bool,
     close_write_stream_on_read_close: bool,
+    read_eof_drain_timeout_seconds: float | None,
 ) -> None:
     """Serve a 2026-07-28 connection: every request carries its own envelope."""
     dispatcher: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
@@ -782,6 +786,7 @@ async def _serve_modern_stream(
         write_stream,
         raise_handler_exceptions=raise_exceptions,
         close_write_stream_on_read_close=close_write_stream_on_read_close,
+        read_eof_drain_timeout_seconds=read_eof_drain_timeout_seconds,
     )
     outbound = NotifyOnlyOutbound(dispatcher)
 

--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -476,6 +476,7 @@ async def serve_loop(
     session_id: str | None = None,
     init_options: InitializationOptions | None = None,
     raise_exceptions: bool = False,
+    close_write_stream_on_read_close: bool = True,
 ) -> None:
     """Drive ``server`` in handshake-only loop mode over a stream pair until the channel closes.
 
@@ -494,6 +495,7 @@ async def serve_loop(
         # next request (spec: SHOULD NOT, not MUST NOT) sees the initialized
         # state instead of failing the init-gate.
         inline_methods=frozenset({"initialize"}),
+        close_write_stream_on_read_close=close_write_stream_on_read_close,
     )
     connection = Connection.for_loop(dispatcher, session_id=session_id)
     await serve_connection(

--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -477,6 +477,7 @@ async def serve_loop(
     init_options: InitializationOptions | None = None,
     raise_exceptions: bool = False,
     close_write_stream_on_read_close: bool = True,
+    read_eof_drain_timeout_seconds: float | None = None,
 ) -> None:
     """Drive ``server`` in handshake-only loop mode over a stream pair until the channel closes.
 
@@ -496,6 +497,7 @@ async def serve_loop(
         # state instead of failing the init-gate.
         inline_methods=frozenset({"initialize"}),
         close_write_stream_on_read_close=close_write_stream_on_read_close,
+        read_eof_drain_timeout_seconds=read_eof_drain_timeout_seconds,
     )
     connection = Connection.for_loop(dispatcher, session_id=session_id)
     await serve_connection(
@@ -611,6 +613,7 @@ async def serve_dual_era_loop(
     init_options: InitializationOptions | None = None,
     raise_exceptions: bool = False,
     close_write_stream_on_read_close: bool = True,
+    read_eof_drain_timeout_seconds: float | None = None,
 ) -> None:
     """Drive `server` over a duplex stream pair, in the era the client opens with.
 
@@ -742,6 +745,7 @@ async def _serve_legacy_stream(
         # `initialize` inline for the same pipelining reason as `serve_loop`.
         inline_methods=frozenset({"initialize"}),
         close_write_stream_on_read_close=close_write_stream_on_read_close,
+        read_eof_drain_timeout_seconds=read_eof_drain_timeout_seconds,
     )
     connection = Connection.for_loop(dispatcher, session_id=session_id)
     runner = ServerRunner(server, connection, lifespan_state, init_options=init_options)

--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -610,6 +610,7 @@ async def serve_dual_era_loop(
     session_id: str | None = None,
     init_options: InitializationOptions | None = None,
     raise_exceptions: bool = False,
+    close_write_stream_on_read_close: bool = True,
 ) -> None:
     """Drive `server` over a duplex stream pair, in the era the client opens with.
 
@@ -632,7 +633,12 @@ async def serve_dual_era_loop(
             )
             if opens_modern:
                 await _serve_modern_stream(
-                    server, replayed, write_stream, lifespan_state=lifespan_state, raise_exceptions=raise_exceptions
+                    server,
+                    replayed,
+                    write_stream,
+                    lifespan_state=lifespan_state,
+                    raise_exceptions=raise_exceptions,
+                    close_write_stream_on_read_close=close_write_stream_on_read_close,
                 )
             else:
                 await _serve_legacy_stream(
@@ -643,6 +649,7 @@ async def serve_dual_era_loop(
                     session_id=session_id,
                     init_options=init_options,
                     raise_exceptions=raise_exceptions,
+                    close_write_stream_on_read_close=close_write_stream_on_read_close,
                 )
     finally:
         await write_stream.aclose()
@@ -725,6 +732,7 @@ async def _serve_legacy_stream(
     session_id: str | None,
     init_options: InitializationOptions | None,
     raise_exceptions: bool,
+    close_write_stream_on_read_close: bool,
 ) -> None:
     """Serve a 2025 handshake connection; enveloped requests are refused."""
     dispatcher: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
@@ -733,6 +741,7 @@ async def _serve_legacy_stream(
         raise_handler_exceptions=raise_exceptions,
         # `initialize` inline for the same pipelining reason as `serve_loop`.
         inline_methods=frozenset({"initialize"}),
+        close_write_stream_on_read_close=close_write_stream_on_read_close,
     )
     connection = Connection.for_loop(dispatcher, session_id=session_id)
     runner = ServerRunner(server, connection, lifespan_state, init_options=init_options)
@@ -761,10 +770,14 @@ async def _serve_modern_stream(
     *,
     lifespan_state: LifespanT,
     raise_exceptions: bool,
+    close_write_stream_on_read_close: bool,
 ) -> None:
     """Serve a 2026-07-28 connection: every request carries its own envelope."""
     dispatcher: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
-        read_stream, write_stream, raise_handler_exceptions=raise_exceptions
+        read_stream,
+        write_stream,
+        raise_handler_exceptions=raise_exceptions,
+        close_write_stream_on_read_close=close_write_stream_on_read_close,
     )
     outbound = NotifyOnlyOutbound(dispatcher)
 

--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -530,7 +530,9 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                         # Cancel on crash/cancel paths. If read EOF also closed
                         # writes, handlers cannot drain responses anyway.
                         tg.cancel_scope.cancel()
-                    elif self._read_eof_drain_timeout_seconds is not None:
+                    elif self._read_eof_drain_timeout_seconds is None:
+                        pass
+                    else:
                         tg.cancel_scope.deadline = anyio.current_time() + self._read_eof_drain_timeout_seconds
         finally:
             # Covers cancel/crash paths that skip the inline fan-out; idempotent.

--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -274,6 +274,7 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
         raise_handler_exceptions: bool = False,
         inline_methods: frozenset[str] = frozenset(),
         close_write_stream_on_read_close: bool = True,
+        read_eof_drain_timeout_seconds: float | None = None,
         on_stream_exception: Callable[[Exception], Awaitable[None]] | None = None,
     ) -> None:
         """Wire a dispatcher over a transport's `SessionMessage` stream pair.
@@ -290,6 +291,9 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                 read stream closes. Full-duplex transports may set this to
                 false so in-flight handlers can finish writing responses after
                 input EOF.
+            read_eof_drain_timeout_seconds: Maximum time to wait for in-flight
+                handlers to drain after read EOF when the write stream stays
+                open; None waits indefinitely.
             on_stream_exception: Observer for `Exception` items on the read
                 stream; without it they are debug-logged and dropped. Awaited
                 inline in the read loop, so a slow observer stalls dispatch.
@@ -305,6 +309,7 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
         self._peer_cancel_mode: PeerCancelMode = peer_cancel_mode
         self._raise_handler_exceptions = raise_handler_exceptions
         self._close_write_stream_on_read_close = close_write_stream_on_read_close
+        self._read_eof_drain_timeout_seconds = read_eof_drain_timeout_seconds
         self._inline_methods = inline_methods
         self.on_stream_exception = on_stream_exception
         """Observer for ``Exception`` items on the read stream. Mutable so a session can
@@ -521,16 +526,21 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                     self._fan_out_closed()
                     normal_eof = True
                 finally:
-                    if not normal_eof:
-                        # Cancel on crash/cancel paths. On normal EOF, let
-                        # already received handlers drain their responses.
+                    if not normal_eof or self._close_write_stream_on_read_close:
+                        # Cancel on crash/cancel paths. If read EOF also closed
+                        # writes, handlers cannot drain responses anyway.
                         tg.cancel_scope.cancel()
+                    elif self._read_eof_drain_timeout_seconds is not None:
+                        tg.cancel_scope.deadline = anyio.current_time() + self._read_eof_drain_timeout_seconds
         finally:
             # Covers cancel/crash paths that skip the inline fan-out; idempotent.
             self._running = False
             self._closed = True
             self._tg = None
             self._fan_out_closed()
+            if not self._close_write_stream_on_read_close:
+                with anyio.CancelScope(shield=True):
+                    await self._write_stream.aclose()
             await resync_tracer()
 
     async def _dispatch(

--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import contextvars
 import logging
 from collections.abc import Awaitable, Callable, Mapping
+from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Generic, Literal, cast
@@ -272,6 +273,7 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
         peer_cancel_mode: PeerCancelMode = "interrupt",
         raise_handler_exceptions: bool = False,
         inline_methods: frozenset[str] = frozenset(),
+        close_write_stream_on_read_close: bool = True,
         on_stream_exception: Callable[[Exception], Awaitable[None]] | None = None,
     ) -> None:
         """Wire a dispatcher over a transport's `SessionMessage` stream pair.
@@ -284,6 +286,10 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
             inline_methods: Methods awaited in the read loop before the next
                 message is dequeued (e.g. `initialize`); an inline handler
                 that awaits the peer deadlocks the parked loop.
+            close_write_stream_on_read_close: Close the write stream when the
+                read stream closes. Full-duplex transports may set this to
+                false so in-flight handlers can finish writing responses after
+                input EOF.
             on_stream_exception: Observer for `Exception` items on the read
                 stream; without it they are debug-logged and dropped. Awaited
                 inline in the read loop, so a slow observer stalls dispatch.
@@ -298,6 +304,7 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
         )
         self._peer_cancel_mode: PeerCancelMode = peer_cancel_mode
         self._raise_handler_exceptions = raise_handler_exceptions
+        self._close_write_stream_on_read_close = close_write_stream_on_read_close
         self._inline_methods = inline_methods
         self.on_stream_exception = on_stream_exception
         """Observer for ``Exception`` items on the read stream. Mutable so a session can
@@ -487,33 +494,36 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
         Single-shot: once the loop ends the dispatcher stays closed and cannot be restarted.
         """
         self._on_notify_intercept = on_notify_intercept
+        normal_eof = False
         try:
-            # LIFO exits: the write stream closes only after the task-group join, so teardown writes still land.
-            async with self._write_stream:
-                async with anyio.create_task_group() as tg:
-                    self._tg = tg
-                    self._running = True
-                    task_status.started()
-                    try:
-                        async with self._read_stream:
-                            try:
-                                async for item in self._read_stream:
-                                    # Duck-typed: only `ContextReceiveStream` carries the
-                                    # sender's per-message contextvars snapshot.
-                                    sender_ctx: contextvars.Context | None = getattr(
-                                        self._read_stream, "last_context", None
-                                    )
-                                    await self._dispatch(item, on_request, on_notify, sender_ctx)
-                            except anyio.ClosedResourceError:
-                                # Receive end closed under us (stateless SHTTP teardown); same as EOF.
-                                logger.debug("read stream closed by transport; treating as EOF")
-                        # EOF: wake blocked `send_raw_request` waiters with CONNECTION_CLOSED.
-                        self._running = False
-                        self._closed = True
-                        self._fan_out_closed()
-                    finally:
-                        # Cancel in-flight handlers; otherwise the task-group join
-                        # waits on handlers whose callers are already gone.
+            async with anyio.create_task_group() as tg:
+                self._tg = tg
+                self._running = True
+                task_status.started()
+                try:
+                    async with AsyncExitStack() as stack:
+                        await stack.enter_async_context(self._read_stream)
+                        if self._close_write_stream_on_read_close:
+                            await stack.enter_async_context(self._write_stream)
+                        try:
+                            async for item in self._read_stream:
+                                # Duck-typed: only `ContextReceiveStream` carries the
+                                # sender's per-message contextvars snapshot.
+                                sender_ctx: contextvars.Context | None = getattr(
+                                    self._read_stream, "last_context", None
+                                )
+                                await self._dispatch(item, on_request, on_notify, sender_ctx)
+                        except anyio.ClosedResourceError:
+                            # Receive end closed under us (stateless SHTTP teardown); same as EOF.
+                            logger.debug("read stream closed by transport; treating as EOF")
+                    # EOF: wake blocked `send_raw_request` waiters with CONNECTION_CLOSED.
+                    self._running = False
+                    self._fan_out_closed()
+                    normal_eof = True
+                finally:
+                    if not normal_eof:
+                        # Cancel on crash/cancel paths. On normal EOF, let
+                        # already received handlers drain their responses.
                         tg.cancel_scope.cancel()
         finally:
             # Covers cancel/crash paths that skip the inline fan-out; idempotent.

--- a/tests/server/test_cancel_handling.py
+++ b/tests/server/test_cancel_handling.py
@@ -174,6 +174,123 @@ async def test_server_drains_in_flight_handlers_on_transport_read_eof():
 
 
 @pytest.mark.anyio
+async def test_server_reraises_handler_cancellation_when_server_is_cancelled():
+    """If the server task is cancelled (e.g. KeyboardInterrupt), in-flight
+    request handlers will get cancelled too. Cancellation must be re-raised so
+    the task group can unwind cleanly."""
+    handler_started = anyio.Event()
+    server_run_returned = anyio.Event()
+    cancel_scope = anyio.CancelScope()
+
+    async def handle_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+        handler_started.set()
+        await anyio.sleep_forever()
+        raise AssertionError  # pragma: no cover
+
+    server = Server("test", on_call_tool=handle_call_tool)
+
+    to_server, server_read = anyio.create_memory_object_stream[SessionMessage | Exception](10)
+    server_write, from_server = anyio.create_memory_object_stream[SessionMessage](10)
+
+    async def run_server():
+        try:
+            with cancel_scope:
+                await server.run(server_read, server_write, server.create_initialization_options())
+        finally:
+            server_run_returned.set()
+
+    init_req = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=1,
+        method="initialize",
+        params=InitializeRequestParams(
+            protocol_version=LATEST_PROTOCOL_VERSION,
+            capabilities=ClientCapabilities(),
+            client_info=Implementation(name="test", version="1.0"),
+        ).model_dump(by_alias=True, mode="json", exclude_none=True),
+    )
+    initialized = JSONRPCNotification(jsonrpc="2.0", method="notifications/initialized")
+    call_req = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=2,
+        method="tools/call",
+        params=CallToolRequestParams(name="slow", arguments={}).model_dump(by_alias=True, mode="json"),
+    )
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as tg, to_server, server_read, server_write, from_server:
+            tg.start_soon(run_server)
+
+            await to_server.send(SessionMessage(init_req))
+            await from_server.receive()  # init response
+            await to_server.send(SessionMessage(initialized))
+            await to_server.send(SessionMessage(call_req))
+
+            await handler_started.wait()
+            cancel_scope.cancel()
+            await server_run_returned.wait()
+
+
+@pytest.mark.anyio
+async def test_server_drops_response_when_write_stream_closes_mid_request():
+    """If the write side closes while a handler is in-flight, responding may
+    raise (ClosedResourceError/BrokenResourceError). The handler task should
+    exit without crashing the server."""
+    handler_started = anyio.Event()
+    allow_finish = anyio.Event()
+    server_run_returned = anyio.Event()
+
+    async def handle_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+        handler_started.set()
+        await allow_finish.wait()
+        return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    server = Server("test", on_call_tool=handle_call_tool)
+
+    to_server, server_read = anyio.create_memory_object_stream[SessionMessage | Exception](10)
+    server_write, from_server = anyio.create_memory_object_stream[SessionMessage](10)
+
+    async def run_server():
+        await server.run(server_read, server_write, server.create_initialization_options())
+        server_run_returned.set()
+
+    init_req = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=1,
+        method="initialize",
+        params=InitializeRequestParams(
+            protocol_version=LATEST_PROTOCOL_VERSION,
+            capabilities=ClientCapabilities(),
+            client_info=Implementation(name="test", version="1.0"),
+        ).model_dump(by_alias=True, mode="json", exclude_none=True),
+    )
+    initialized = JSONRPCNotification(jsonrpc="2.0", method="notifications/initialized")
+    call_req = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=2,
+        method="tools/call",
+        params=CallToolRequestParams(name="slow", arguments={}).model_dump(by_alias=True, mode="json"),
+    )
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as tg, to_server, server_read, server_write, from_server:
+            tg.start_soon(run_server)
+
+            await to_server.send(SessionMessage(init_req))
+            await from_server.receive()  # init response
+            await to_server.send(SessionMessage(initialized))
+            await to_server.send(SessionMessage(call_req))
+
+            await handler_started.wait()
+            await server_write.aclose()
+
+            allow_finish.set()
+            await to_server.aclose()
+
+            await server_run_returned.wait()
+
+
+@pytest.mark.anyio
 async def test_server_handles_transport_close_with_pending_server_to_client_requests():
     """When the transport closes while handlers are blocked on server→client
     requests (sampling, roots, elicitation), server.run() must still exit cleanly.

--- a/tests/server/test_cancel_handling.py
+++ b/tests/server/test_cancel_handling.py
@@ -274,7 +274,7 @@ async def test_server_reraises_handler_cancellation_when_server_is_cancelled():
         id=1,
         method="initialize",
         params=InitializeRequestParams(
-            protocol_version=LATEST_PROTOCOL_VERSION,
+            protocol_version=LATEST_HANDSHAKE_VERSION,
             capabilities=ClientCapabilities(),
             client_info=Implementation(name="test", version="1.0"),
         ).model_dump(by_alias=True, mode="json", exclude_none=True),
@@ -329,7 +329,7 @@ async def test_server_drops_response_when_write_stream_closes_mid_request():
         id=1,
         method="initialize",
         params=InitializeRequestParams(
-            protocol_version=LATEST_PROTOCOL_VERSION,
+            protocol_version=LATEST_HANDSHAKE_VERSION,
             capabilities=ClientCapabilities(),
             client_info=Implementation(name="test", version="1.0"),
         ).model_dump(by_alias=True, mode="json", exclude_none=True),

--- a/tests/server/test_cancel_handling.py
+++ b/tests/server/test_cancel_handling.py
@@ -13,6 +13,7 @@ from mcp_types import (
     InitializeRequestParams,
     JSONRPCNotification,
     JSONRPCRequest,
+    JSONRPCResponse,
     ListToolsResult,
     PaginatedRequestParams,
     TextContent,
@@ -107,29 +108,18 @@ async def test_server_remains_functional_after_cancel():
 
 
 @pytest.mark.anyio
-async def test_server_cancels_in_flight_handlers_on_transport_close():
-    """When the transport closes mid-request, server.run() must cancel in-flight
-    handlers rather than join on them.
-
-    Without the cancel, the task group waits for the handler, which then tries
-    to respond through a write stream that _receive_loop already closed,
-    raising ClosedResourceError and crashing server.run() with exit code 1.
-
-    This drives server.run() with raw memory streams because InMemoryTransport
-    wraps it in its own finally-cancel (_memory.py) which masks the bug.
-    """
+async def test_server_drains_in_flight_handlers_on_transport_read_eof():
+    """When the transport's read side hits EOF (e.g., stdio stdin closes), the
+    server must drain already-started handlers so their responses reach the
+    peer via the still-open write side."""
     handler_started = anyio.Event()
-    handler_cancelled = anyio.Event()
+    handler_allowed_to_finish = anyio.Event()
     server_run_returned = anyio.Event()
 
     async def handle_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
         handler_started.set()
-        try:
-            await anyio.sleep_forever()
-        finally:
-            handler_cancelled.set()
-        # unreachable: sleep_forever only exits via cancellation
-        raise AssertionError  # pragma: no cover
+        await handler_allowed_to_finish.wait()
+        return CallToolResult(content=[TextContent(type="text", text="ok")])
 
     server = Server("test", on_call_tool=handle_call_tool)
 
@@ -174,9 +164,13 @@ async def test_server_cancels_in_flight_handlers_on_transport_close():
             # handler gets CancelledError, server.run() returns.
             await to_server.aclose()
 
-            await server_run_returned.wait()
+            handler_allowed_to_finish.set()
 
-    assert handler_cancelled.is_set()
+            response = await from_server.receive()
+            assert isinstance(response.message, JSONRPCResponse)
+            assert response.message.id == 2
+
+            await server_run_returned.wait()
 
 
 @pytest.mark.anyio

--- a/tests/server/test_cancel_handling.py
+++ b/tests/server/test_cancel_handling.py
@@ -127,7 +127,7 @@ async def test_server_drains_in_flight_handlers_on_transport_read_eof():
     server_write, from_server = anyio.create_memory_object_stream[SessionMessage](10)
 
     async def run_server():
-        await server.run(server_read, server_write, server.create_initialization_options())
+        await server.run(server_read, server_write, server.create_initialization_options(), drain_on_read_close=True)
         server_run_returned.set()
 
     init_req = JSONRPCRequest(

--- a/tests/server/test_cancel_handling.py
+++ b/tests/server/test_cancel_handling.py
@@ -127,7 +127,13 @@ async def test_server_drains_in_flight_handlers_on_transport_read_eof():
     server_write, from_server = anyio.create_memory_object_stream[SessionMessage](10)
 
     async def run_server():
-        await server.run(server_read, server_write, server.create_initialization_options(), drain_on_read_close=True)
+        await server.run(
+            server_read,
+            server_write,
+            server.create_initialization_options(),
+            drain_on_read_close=True,
+            read_eof_drain_timeout_seconds=None,
+        )
         server_run_returned.set()
 
     init_req = JSONRPCRequest(
@@ -171,6 +177,70 @@ async def test_server_drains_in_flight_handlers_on_transport_read_eof():
             assert response.message.id == 2
 
             await server_run_returned.wait()
+
+
+@pytest.mark.anyio
+async def test_server_bounds_drain_on_read_eof_when_handler_never_finishes():
+    handler_started = anyio.Event()
+    handler_cancelled = anyio.Event()
+    server_run_returned = anyio.Event()
+
+    async def handle_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+        handler_started.set()
+        try:
+            await anyio.sleep_forever()
+        finally:
+            handler_cancelled.set()
+        raise AssertionError  # pragma: no cover
+
+    server = Server("test", on_call_tool=handle_call_tool)
+
+    to_server, server_read = anyio.create_memory_object_stream[SessionMessage | Exception](10)
+    server_write, from_server = anyio.create_memory_object_stream[SessionMessage](10)
+
+    async def run_server():
+        await server.run(
+            server_read,
+            server_write,
+            server.create_initialization_options(),
+            drain_on_read_close=True,
+            read_eof_drain_timeout_seconds=0.05,
+        )
+        server_run_returned.set()
+
+    init_req = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=1,
+        method="initialize",
+        params=InitializeRequestParams(
+            protocol_version=LATEST_HANDSHAKE_VERSION,
+            capabilities=ClientCapabilities(),
+            client_info=Implementation(name="test", version="1.0"),
+        ).model_dump(by_alias=True, mode="json", exclude_none=True),
+    )
+    initialized = JSONRPCNotification(jsonrpc="2.0", method="notifications/initialized")
+    call_req = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=2,
+        method="tools/call",
+        params=CallToolRequestParams(name="slow", arguments={}).model_dump(by_alias=True, mode="json"),
+    )
+
+    with anyio.fail_after(2):
+        async with anyio.create_task_group() as tg, to_server, server_read, server_write, from_server:
+            tg.start_soon(run_server)
+
+            await to_server.send(SessionMessage(init_req))
+            await from_server.receive()  # init response
+            await to_server.send(SessionMessage(initialized))
+            await to_server.send(SessionMessage(call_req))
+
+            await handler_started.wait()
+            await to_server.aclose()
+
+            await server_run_returned.wait()
+
+    assert handler_cancelled.is_set()
 
 
 @pytest.mark.anyio

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -13,15 +13,28 @@ import pytest
 from mcp_types import (
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
+    LATEST_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY,
     SERVER_INFO_META_KEY,
+    CallToolRequestParams,
+    CallToolResult,
+    ClientCapabilities,
+    Implementation,
+    InitializeRequestParams,
+    JSONRPCError,
     JSONRPCMessage,
+    JSONRPCNotification,
     JSONRPCRequest,
     JSONRPCResponse,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
     jsonrpc_message_adapter,
 )
 from typing_extensions import Buffer
 
+from mcp.server import Server, ServerRequestContext
 from mcp.server.mcpserver import MCPServer
 from mcp.server.stdio import stdio_server
 from mcp.shared.message import SessionMessage
@@ -692,3 +705,79 @@ def test_mcpserver_run_stdio_serves_a_modern_connection(monkeypatch: pytest.Monk
     # resultType is modern-only: proves the request was served at the discovered version.
     assert responses[1].result["tools"] == []
     assert responses[1].result["resultType"] == "complete"
+
+
+@pytest.mark.anyio
+async def test_stdio_server_drains_in_flight_responses_on_stdin_eof():
+    """When stdin reaches EOF (e.g., bash-redirected input), already-received
+    requests must still be able to emit their responses on stdout."""
+    stdin = io.StringIO()
+    stdout = io.StringIO()
+
+    tool_started_count = 0
+    both_tools_started = anyio.Event()
+    allow_tools_to_finish = anyio.Event()
+
+    async def handle_list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+        return ListToolsResult(tools=[Tool(name="slow", description="test", input_schema={})])
+
+    async def handle_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
+        nonlocal tool_started_count
+        tool_started_count += 1
+        if tool_started_count == 2:
+            both_tools_started.set()
+        await allow_tools_to_finish.wait()
+        return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    server = Server("test", on_list_tools=handle_list_tools, on_call_tool=handle_call_tool)
+
+    init_req = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=0,
+        method="initialize",
+        params=InitializeRequestParams(
+            protocol_version=LATEST_PROTOCOL_VERSION,
+            capabilities=ClientCapabilities(),
+            client_info=Implementation(name="test", version="1.0"),
+        ).model_dump(by_alias=True, mode="json", exclude_none=True),
+    )
+    initialized = JSONRPCNotification(jsonrpc="2.0", method="notifications/initialized")
+    call_1 = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=1,
+        method="tools/call",
+        params=CallToolRequestParams(name="slow", arguments={}).model_dump(by_alias=True, mode="json"),
+    )
+    call_2 = JSONRPCRequest(
+        jsonrpc="2.0",
+        id=2,
+        method="tools/call",
+        params=CallToolRequestParams(name="slow", arguments={}).model_dump(by_alias=True, mode="json"),
+    )
+
+    for message in (init_req, initialized, call_1, call_2):
+        stdin.write(message.model_dump_json(by_alias=True, exclude_none=True) + "\n")
+    stdin.seek(0)
+
+    async with stdio_server(stdin=anyio.AsyncFile(stdin), stdout=anyio.AsyncFile(stdout)) as (
+        read_stream,
+        write_stream,
+    ):
+        with anyio.fail_after(5):
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(server.run, read_stream, write_stream, server.create_initialization_options())
+                await both_tools_started.wait()
+                allow_tools_to_finish.set()
+
+    stdout.seek(0)
+    ids: set[int | str] = set()
+    for line in stdout.readlines():
+        line = line.strip()
+        if not line:
+            continue
+        message = jsonrpc_message_adapter.validate_json(line)
+        if isinstance(message, JSONRPCResponse | JSONRPCError):
+            assert message.id is not None
+            ids.add(message.id)
+    assert 1 in ids
+    assert 2 in ids

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -718,7 +718,7 @@ async def test_stdio_server_drains_in_flight_responses_on_stdin_eof():
     allow_tools_to_finish = anyio.Event()
 
     async def handle_list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
-        return ListToolsResult(tools=[Tool(name="slow", description="test", input_schema={})])
+        return ListToolsResult(tools=[Tool(name="slow", description="test", input_schema={"type": "object"})])
 
     async def handle_call_tool(ctx: ServerRequestContext, params: CallToolRequestParams) -> CallToolResult:
         nonlocal tool_started_count
@@ -765,7 +765,16 @@ async def test_stdio_server_drains_in_flight_responses_on_stdin_eof():
     ):
         with anyio.fail_after(5):
             async with anyio.create_task_group() as tg:  # pragma: no branch
-                tg.start_soon(server.run, read_stream, write_stream, server.create_initialization_options())
+
+                async def run_server() -> None:
+                    await server.run(
+                        read_stream,
+                        write_stream,
+                        server.create_initialization_options(),
+                        drain_on_read_close=True,
+                    )
+
+                tg.start_soon(run_server)
                 await both_tools_started.wait()
                 allow_tools_to_finish.set()
 

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -764,7 +764,7 @@ async def test_stdio_server_drains_in_flight_responses_on_stdin_eof():
         write_stream,
     ):
         with anyio.fail_after(5):
-            async with anyio.create_task_group() as tg:
+            async with anyio.create_task_group() as tg:  # pragma: no branch
                 tg.start_soon(server.run, read_stream, write_stream, server.create_initialization_options())
                 await both_tools_started.wait()
                 allow_tools_to_finish.set()

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -21,7 +21,6 @@ from mcp_types import (
     ClientCapabilities,
     Implementation,
     InitializeRequestParams,
-    JSONRPCError,
     JSONRPCMessage,
     JSONRPCNotification,
     JSONRPCRequest,
@@ -742,6 +741,7 @@ async def test_stdio_server_drains_in_flight_responses_on_stdin_eof():
         ).model_dump(by_alias=True, mode="json", exclude_none=True),
     )
     initialized = JSONRPCNotification(jsonrpc="2.0", method="notifications/initialized")
+    list_tools = JSONRPCRequest(jsonrpc="2.0", id=10, method="tools/list")
     call_1 = JSONRPCRequest(
         jsonrpc="2.0",
         id=1,
@@ -755,7 +755,7 @@ async def test_stdio_server_drains_in_flight_responses_on_stdin_eof():
         params=CallToolRequestParams(name="slow", arguments={}).model_dump(by_alias=True, mode="json"),
     )
 
-    for message in (init_req, initialized, call_1, call_2):
+    for message in (init_req, initialized, list_tools, call_1, call_2):
         stdin.write(message.model_dump_json(by_alias=True, exclude_none=True) + "\n")
     stdin.seek(0)
 
@@ -770,14 +770,12 @@ async def test_stdio_server_drains_in_flight_responses_on_stdin_eof():
                 allow_tools_to_finish.set()
 
     stdout.seek(0)
+    output_lines = [line.strip() for line in stdout.readlines()]
+    messages = [jsonrpc_message_adapter.validate_json(line) for line in output_lines]
     ids: set[int | str] = set()
-    for line in stdout.readlines():
-        line = line.strip()
-        if not line:
-            continue
-        message = jsonrpc_message_adapter.validate_json(line)
-        if isinstance(message, JSONRPCResponse | JSONRPCError):
-            assert message.id is not None
-            ids.add(message.id)
+    for message in messages:
+        assert isinstance(message, JSONRPCResponse)
+        ids.add(message.id)
+
     assert 1 in ids
     assert 2 in ids

--- a/tests/shared/test_jsonrpc_dispatcher.py
+++ b/tests/shared/test_jsonrpc_dispatcher.py
@@ -1098,10 +1098,14 @@ async def test_shutdown_error_response_write_is_bounded_when_the_transport_is_we
 ):
     """Cancelling the task group hosting run() completes even when the shutdown error write wedges:
     only `_SHUTDOWN_WRITE_TIMEOUT` releases the join (SDK-defined). A 0-buffer stream nobody reads
-    expresses the wedge: run() closes its write stream only after the join, so the send stays parked."""
+    expresses the wedge: drain-mode run() closes its write stream only after the join, so the send stays parked."""
     c2s_send, c2s_recv = anyio.create_memory_object_stream[SessionMessage | Exception](1)
     s2c_send, s2c_recv = anyio.create_memory_object_stream[SessionMessage | Exception](0)
-    server: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(c2s_recv, s2c_send)
+    server: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
+        c2s_recv,
+        s2c_send,
+        close_write_stream_on_read_close=False,
+    )
     handler_started = anyio.Event()
 
     async def park(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -1132,10 +1136,15 @@ async def test_shutdown_error_response_write_is_bounded_when_the_transport_is_we
 @pytest.mark.anyio
 async def test_shutdown_answers_in_flight_request_with_connection_closed():
     """Read-stream EOF answers a still-running request with CONNECTION_CLOSED (SDK-defined):
-    run() keeps the write stream open until the task-group join, so the shielded teardown write lands."""
+    drain-mode run() keeps the write stream open until the task-group join, so the shielded teardown write lands."""
     c2s_send, c2s_recv = anyio.create_memory_object_stream[SessionMessage | Exception](4)
     s2c_send, s2c_recv = anyio.create_memory_object_stream[SessionMessage | Exception](4)
-    server: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(c2s_recv, s2c_send)
+    server: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
+        c2s_recv,
+        s2c_send,
+        close_write_stream_on_read_close=False,
+        read_eof_drain_timeout_seconds=0.05,
+    )
     handler_started = anyio.Event()
 
     async def park(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:

--- a/tests/shared/test_jsonrpc_dispatcher.py
+++ b/tests/shared/test_jsonrpc_dispatcher.py
@@ -370,6 +370,62 @@ async def test_run_cancels_in_flight_handlers_when_read_stream_eofs():
 
 
 @pytest.mark.anyio
+async def test_run_closes_write_stream_after_clean_eof_without_drain_timeout():
+    c2s_send, c2s_recv = anyio.create_memory_object_stream[SessionMessage | Exception](32)
+    s2c_send, s2c_recv = anyio.create_memory_object_stream[SessionMessage | Exception](32)
+    server: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
+        c2s_recv,
+        s2c_send,
+        close_write_stream_on_read_close=False,
+        read_eof_drain_timeout_seconds=None,
+    )
+    on_request, on_notify = echo_handlers(Recorder())
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as tg, c2s_send, c2s_recv, s2c_send, s2c_recv:
+            await tg.start(server.run, on_request, on_notify)
+            c2s_send.close()
+            with pytest.raises(anyio.EndOfStream):  # pragma: no branch
+                await s2c_recv.receive()
+
+
+@pytest.mark.anyio
+async def test_run_drains_in_flight_handlers_on_clean_eof_without_timeout():
+    c2s_send, c2s_recv = anyio.create_memory_object_stream[SessionMessage | Exception](32)
+    s2c_send, s2c_recv = anyio.create_memory_object_stream[SessionMessage | Exception](32)
+    server: JSONRPCDispatcher[TransportContext] = JSONRPCDispatcher(
+        c2s_recv,
+        s2c_send,
+        close_write_stream_on_read_close=False,
+        read_eof_drain_timeout_seconds=None,
+    )
+    handler_started = anyio.Event()
+    handler_allowed_to_finish = anyio.Event()
+
+    async def handle_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
+        handler_started.set()
+        await handler_allowed_to_finish.wait()
+        return {"drained": True}
+
+    async def on_notify(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> None:
+        raise NotImplementedError
+
+    with anyio.fail_after(5):
+        async with anyio.create_task_group() as tg, c2s_send, c2s_recv, s2c_send, s2c_recv:
+            await tg.start(server.run, handle_request, on_notify)
+            await c2s_send.send(SessionMessage(message=JSONRPCRequest(jsonrpc="2.0", id=1, method="x", params=None)))
+            await handler_started.wait()
+            c2s_send.close()
+            handler_allowed_to_finish.set()
+
+            response = await s2c_recv.receive()
+            assert isinstance(response, SessionMessage)
+            assert isinstance(response.message, JSONRPCResponse)
+            assert response.message.id == 1
+            assert response.message.result == {"drained": True}
+
+
+@pytest.mark.anyio
 async def test_run_closes_write_stream_on_exit():
     """run() owns both streams; the write end is released once the EOF teardown completes."""
     c2s_send, c2s_recv = anyio.create_memory_object_stream[SessionMessage | Exception](32)


### PR DESCRIPTION
Fixes #2678.

When stdin hits EOF (e.g. python server.py < payload.jsonl > response.jsonl), the client is done sending requests but is still reading stdout for results. On main, BaseSession._receive_loop() closes the write stream as soon as the read stream ends, and Server.run() cancels the handler task group on transport close. That combination can cancel in-flight tool handlers before they respond, dropping the last 	ools/call responses.

This change lets ServerSession keep the write stream open when the read side closes, so Server.run() can drain already-started handlers and flush their responses before shutdown.

Tests:
- uv run --frozen pytest tests/server/test_cancel_handling.py tests/server/test_stdio.py