### PR TITLE
Add client example demonstrating pre-execution authorization check

### DIFF
--- a/examples/snippets/clients/client_with_authorization.py
+++ b/examples/snippets/clients/client_with_authorization.py
@@ -1,5 +1,4 @@
-"""
-Example: MCP client with a pre-execution authorization callback.
+"""Example: MCP client with a pre-execution authorization callback.
 
 This example shows how to build a tool-execution loop that evaluates
 every tool call against an authorization policy before execution.
@@ -19,7 +18,6 @@ from typing import Any
 
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
-
 
 # ---------------------------------------------------------------------------
 # Authorization layer
@@ -45,8 +43,7 @@ class AuthResult:
 
 
 def default_policy(request: AuthRequest) -> AuthResult:
-    """
-    A simple policy function that decides whether a tool call should
+    """A simple policy function that decides whether a tool call should
     be allowed, denied, or held for approval.
 
     Replace or extend this function with your own logic — for example,
@@ -74,8 +71,7 @@ async def authorized_call_tool(
     arguments: dict[str, Any],
     policy=default_policy,
 ) -> Any:
-    """
-    Evaluate the authorization policy before calling a tool.
+    """Evaluate the authorization policy before calling a tool.
     Only executes the tool if the decision is ALLOW.
     """
     request = AuthRequest(tool_name=tool_name, arguments=arguments)

--- a/examples/snippets/clients/client_with_authorization.py
+++ b/examples/snippets/clients/client_with_authorization.py
@@ -12,9 +12,10 @@ Run from the repository root:
 
 import asyncio
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable
+from typing import Any
 
 from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.stdio import stdio_client

--- a/examples/snippets/clients/client_with_authorization.py
+++ b/examples/snippets/clients/client_with_authorization.py
@@ -25,6 +25,7 @@ from mcp.client.stdio import stdio_client
 # Authorization layer
 # ---------------------------------------------------------------------------
 
+
 class Decision(str, Enum):
     ALLOW = "allow"
     DENY = "deny"
@@ -87,9 +88,9 @@ async def authorized_call_tool(
     if result.decision == Decision.ALLOW:
         try:
             tool_result = await session.call_tool(tool_name, arguments)
-            
+
             # Safely extract text output if present
-            output = tool_result.content[0].text if getattr(tool_result, 'content', None) else str(tool_result)
+            output = tool_result.content[0].text if getattr(tool_result, "content", None) else str(tool_result)
             print(f"  Result   : {output}")
             return tool_result
         except Exception as e:
@@ -114,7 +115,7 @@ async def authorized_call_tool(
 # We use mcpserver_quickstart to have a reliable server to connect to
 server_params = StdioServerParameters(
     command="uv",
-    args=["--directory", "examples/snippets", "run", "server", "mcpserver_quickstart", "stdio"], 
+    args=["--directory", "examples/snippets", "run", "server", "mcpserver_quickstart", "stdio"],
     env={"UV_INDEX": os.environ.get("UV_INDEX", "")},
 )
 

--- a/examples/snippets/clients/client_with_authorization.py
+++ b/examples/snippets/clients/client_with_authorization.py
@@ -1,0 +1,158 @@
+"""
+Example: MCP client with a pre-execution authorization callback.
+
+This example shows how to build a tool-execution loop that evaluates
+every tool call against an authorization policy before execution.
+This pattern is essential when connecting agents to MCP servers at
+scale, where some tools are safe to run freely and others require
+approval or should be blocked entirely.
+
+Run from the repository root:
+    uv run examples/snippets/clients/client_with_authorization.py
+"""
+
+import asyncio
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+# ---------------------------------------------------------------------------
+# Authorization layer
+# ---------------------------------------------------------------------------
+
+class Decision(str, Enum):
+    ALLOW = "allow"
+    DENY = "deny"
+    APPROVAL_REQUIRED = "approval_required"
+
+
+@dataclass
+class AuthRequest:
+    tool_name: str
+    arguments: dict[str, Any]
+
+
+@dataclass
+class AuthResult:
+    decision: Decision
+    reason: str
+
+
+def default_policy(request: AuthRequest) -> AuthResult:
+    """
+    A simple policy function that decides whether a tool call should
+    be allowed, denied, or held for approval.
+
+    Replace or extend this function with your own logic — for example,
+    reading from a policy file, checking roles, or calling an external
+    authorization service.
+    """
+    # Safe tools (e.g. arithmetic, reading data) are always allowed
+    if request.tool_name in ["add", "calculator", "get_weather"] or request.tool_name.startswith(("read_", "list_")):
+        return AuthResult(Decision.ALLOW, "safe tool, allowed by default")
+
+    # Destructive tools are always blocked
+    if request.tool_name.startswith(("delete_", "drop_", "destroy_", "execute_script")):
+        return AuthResult(Decision.DENY, "destructive tool, blocked by policy")
+
+    # Everything else needs a human to approve
+    return AuthResult(
+        Decision.APPROVAL_REQUIRED,
+        "tool has unknown side effects, requires approval before execution",
+    )
+
+
+async def authorized_call_tool(
+    session: ClientSession,
+    tool_name: str,
+    arguments: dict[str, Any],
+    policy=default_policy,
+) -> Any:
+    """
+    Evaluate the authorization policy before calling a tool.
+    Only executes the tool if the decision is ALLOW.
+    """
+    request = AuthRequest(tool_name=tool_name, arguments=arguments)
+    result = policy(request)
+
+    print(f"\n  Tool     : {tool_name}")
+    print(f"  Decision : {result.decision.value.upper()}")
+    print(f"  Reason   : {result.reason}")
+
+    if result.decision == Decision.ALLOW:
+        try:
+            tool_result = await session.call_tool(tool_name, arguments)
+            
+            # Safely extract text output if present
+            output = tool_result.content[0].text if getattr(tool_result, 'content', None) else str(tool_result)
+            print(f"  Result   : {output}")
+            return tool_result
+        except Exception as e:
+            print(f"  Error    : {e}")
+            return None
+
+    if result.decision == Decision.APPROVAL_REQUIRED:
+        # In a real system this would create a checkpoint and notify a
+        # human approver. Here we simply surface the requirement.
+        print("  Action   : execution paused — waiting for human approval")
+        return None
+
+    # Decision.DENY
+    print("  Action   : execution blocked")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+# We use mcpserver_quickstart to have a reliable server to connect to
+server_params = StdioServerParameters(
+    command="uv",
+    args=["run", "server", "mcpserver_quickstart", "stdio"], 
+    env={"UV_INDEX": os.environ.get("UV_INDEX", "")},
+)
+
+
+async def run():
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            # Discover available tools
+            tools = await session.list_tools()
+            print("Available tools:")
+            for tool in tools.tools:
+                print(f"  - {tool.name}: {tool.description}")
+
+            print("\n--- Running authorization checks ---")
+
+            # Demonstrate: safe tool -> allowed (add is from mcpserver_quickstart)
+            await authorized_call_tool(
+                session,
+                tool_name="add",
+                arguments={"a": 5, "b": 3},
+            )
+
+            # Demonstrate: unknown tool -> approval required
+            await authorized_call_tool(
+                session,
+                tool_name="write_file",
+                arguments={"path": "/tmp/example.txt", "content": "hello"},
+            )
+
+            # Demonstrate: delete tool -> denied
+            await authorized_call_tool(
+                session,
+                tool_name="delete_file",
+                arguments={"path": "/tmp/example.txt"},
+            )
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/examples/snippets/clients/client_with_authorization.py
+++ b/examples/snippets/clients/client_with_authorization.py
@@ -114,7 +114,7 @@ async def authorized_call_tool(
 # We use mcpserver_quickstart to have a reliable server to connect to
 server_params = StdioServerParameters(
     command="uv",
-    args=["run", "server", "mcpserver_quickstart", "stdio"], 
+    args=["--directory", "examples/snippets", "run", "server", "mcpserver_quickstart", "stdio"], 
     env={"UV_INDEX": os.environ.get("UV_INDEX", "")},
 )
 

--- a/examples/snippets/clients/client_with_authorization.py
+++ b/examples/snippets/clients/client_with_authorization.py
@@ -14,9 +14,9 @@ import asyncio
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Callable
 
-from mcp import ClientSession, StdioServerParameters
+from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.stdio import stdio_client
 
 # ---------------------------------------------------------------------------
@@ -69,7 +69,7 @@ async def authorized_call_tool(
     session: ClientSession,
     tool_name: str,
     arguments: dict[str, Any],
-    policy=default_policy,
+    policy: Callable[[AuthRequest], AuthResult] = default_policy,
 ) -> Any:
     """Evaluate the authorization policy before calling a tool.
     Only executes the tool if the decision is ALLOW.
@@ -86,7 +86,11 @@ async def authorized_call_tool(
             tool_result = await session.call_tool(tool_name, arguments)
 
             # Safely extract text output if present
-            output = tool_result.content[0].text if getattr(tool_result, "content", None) else str(tool_result)
+            output = str(tool_result)
+            if hasattr(tool_result, "content") and tool_result.content:
+                first_content = tool_result.content[0]
+                if isinstance(first_content, types.TextContent):
+                    output = first_content.text
             print(f"  Result   : {output}")
             return tool_result
         except Exception as e:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Closes part of #539

Adds a client example demonstrating a pre-execution authorization callback pattern. Shows how to evaluate tool calls against a policy (allow / approval_required / deny) before execution — a common need when connecting agents to MCP servers at scale.

PR #1436 covers sampling examples. This is a complementary example focused on the tool-execution authorization loop.

## Motivation and Context
The original issue requested client examples. Currently, there are no examples demonstrating how to evaluate tool calls against a policy before execution. This pattern is critical for secure agent architecture where some tools are safe to run automatically, but others require human-in-the-loop approval. 

## How Has This Been Tested?
Ran the example locally using `uv run examples/snippets/clients/client_with_authorization.py`. Verified that the client successfully connects to the `mcpserver_quickstart` subprocess, correctly allows the execution of safe tools (like `add`), and properly blocks/flags destructive tools.

## Breaking Changes
None. This is purely an additive documentation/example change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling (N/A - Example script)
- [x] I have added or updated documentation as needed

## Additional context
We ran into the need for this exact pattern while building AgentIAM to manage tool authorizations at scale, and figured a clean, standalone example using dataclasses would be helpful for others trying to implement similar human-in-the-loop policies!