### PR TITLE
fix(auth): add Accept: application/json header to OAuth token requests

### DIFF
--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -92,7 +92,7 @@ class ClientCredentialsOAuthProvider(OAuthClientProvider):
             "grant_type": "client_credentials",
         }
 
-        headers: dict[str, str] = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers: dict[str, str] = {"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"}
 
         # Use standard auth methods (client_secret_basic, client_secret_post, none)
         token_data, headers = self.context.prepare_token_auth(token_data, headers)
@@ -320,7 +320,7 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
             "grant_type": "client_credentials",
         }
 
-        headers: dict[str, str] = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers: dict[str, str] = {"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"}
 
         # Add JWT client authentication (RFC 7523 Section 2.2)
         await self._add_client_authentication_jwt(token_data=token_data)
@@ -481,5 +481,8 @@ class RFC7523OAuthClientProvider(OAuthClientProvider):
 
         token_url = self._get_token_endpoint()
         return httpx.Request(
-            "POST", token_url, data=token_data, headers={"Content-Type": "application/x-www-form-urlencoded"}
+            "POST",
+            token_url,
+            data=token_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
         )

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -402,7 +402,7 @@ class OAuthClientProvider(httpx.Auth):
             token_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"}
         token_data, headers = self.context.prepare_token_auth(token_data, headers)
 
         return httpx.Request("POST", token_url, data=token_data, headers=headers)
@@ -447,7 +447,7 @@ class OAuthClientProvider(httpx.Auth):
             refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"}
         refresh_data, headers = self.context.prepare_token_auth(refresh_data, headers)
 
         return httpx.Request("POST", token_url, data=refresh_data, headers=headers)


### PR DESCRIPTION
## Summary

Adds `Accept: application/json` header to all OAuth token endpoint requests. Some providers (notably GitHub) return form-encoded responses by default unless JSON is explicitly requested, causing token exchange failures.

## Problem

As reported in #1523, the SDK's OAuth token requests only set `Content-Type` but not `Accept`. Providers like GitHub's OAuth endpoint return `application/x-www-form-urlencoded` by default, which fails to parse as JSON.

From [GitHub's OAuth docs](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#2-users-are-redirected-back-to-your-site-by-github):
> By default, the response takes the following form: `access_token=...&token_type=bearer`
> You can also receive the response in different formats by providing the `Accept` header.

## Fix

Added `"Accept": "application/json"` to headers in all token request builders:

- `OAuthClientProvider._build_token_request()` — authorization code exchange
- `OAuthClientProvider._refresh_token()` — token refresh
- `ClientCredentialsOAuthProvider._build_token_request()` — client credentials
- `PrivateKeyJWTOAuthProvider._build_token_request()` — private key JWT
- `SignedJWTOAuthProvider._build_token_request()` — signed JWT assertion

## Testing

- All 96 auth tests pass
- All 15 client_credentials tests pass
- No breaking changes (adding Accept header is additive)

## References

- RFC 6749 Section 5.1 specifies JSON for token responses
- GitHub OAuth docs require explicit Accept header for JSON

Fixes #1523