### PR TITLE
FIX Remove duplicate VBLoRAConfig entry from peft.__all__

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import inspect
-import json
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -322,14 +321,6 @@ class MCPServer(Generic[LifespanResultT]):
                 content=list(unstructured_content),  # type: ignore[arg-type]
                 structured_content=structured_content,  # type: ignore[arg-type]
             )
-        if isinstance(result, dict):  # pragma: no cover
-            # TODO: this code path is unreachable — convert_result never returns a raw dict.
-            # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong
-            # and needs to be cleaned up.
-            return CallToolResult(
-                content=[TextContent(type="text", text=json.dumps(result, indent=2))],
-                structured_content=result,
-            )
         return CallToolResult(content=list(result))
 
     async def _handle_list_resources(
@@ -399,8 +390,16 @@ class MCPServer(Generic[LifespanResultT]):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
-        """Call a tool by name with arguments."""
+    ) -> CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]:
+        """Call a tool by name with arguments.
+
+        The return type reflects what ``FuncMetadata.convert_result`` produces:
+
+        - a :class:`CallToolResult` if the tool function returned one directly;
+        - a ``Sequence[ContentBlock]`` for tools without an output schema;
+        - a ``(unstructured_content, structured_content)`` tuple for tools with
+          an output schema.
+        """
         if context is None:
             context = Context(mcp_server=self)
         return await self._tool_manager.call_tool(name, arguments, context, convert_result=True)


### PR DESCRIPTION
## Description

`peft.__all__` listed `"VBLoRAConfig"` twice (lines 272-273 on `main`). Duplicate entries in `__all__` silently confuse documentation tooling, IDE auto-import, and linters that rely on `__all__` to determine the public API surface. It's the only duplicate among the 138 entries — looks like a copy-paste slip from a past edit.

## Changes

1. `src/peft/__init__.py` — remove the duplicate line.
2. `tests/test_public_api.py` — new test file with two regression tests:
   - `test_all_has_no_duplicates` — guards against this kind of regression.
   - `test_all_names_are_importable` — verifies every name in `__all__` is actually accessible on the package, catching stale or mistyped entries that would break `from peft import *`.

## Verifying the regression test catches the bug

Per CONTRIBUTING.md, ideally a bug fix is accompanied by a test that fails on the broken code and passes on the fix. To confirm:

```
# On main, without the __init__.py change:
$ python -m pytest tests/test_public_api.py::TestPublicApi::test_all_has_no_duplicates -v
FAILED — AssertionError: Duplicate names in peft.__all__: {'VBLoRAConfig': 2}

# With the fix applied:
$ python -m pytest tests/test_public_api.py -v
PASSED  test_all_has_no_duplicates
PASSED  test_all_names_are_importable
```

## How to test

```
python -m pytest tests/test_public_api.py -v
make quality
```

Both pass locally.