### PR TITLE
fix(auth): add Accept header to token and refresh requests

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -402,7 +402,10 @@ class OAuthClientProvider(httpx.Auth):
             token_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        }
         token_data, headers = self.context.prepare_token_auth(token_data, headers)
 
         return httpx.Request("POST", token_url, data=token_data, headers=headers)
@@ -447,7 +450,10 @@ class OAuthClientProvider(httpx.Auth):
             refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        }
         refresh_data, headers = self.context.prepare_token_auth(refresh_data, headers)
 
         return httpx.Request("POST", token_url, data=refresh_data, headers=headers)

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -597,6 +597,7 @@ class TestOAuthFallback:
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert request.headers["Accept"] == "application/json"
 
         # Check form data
         content = request.content.decode()
@@ -623,6 +624,7 @@ class TestOAuthFallback:
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert request.headers["Accept"] == "application/json"
 
         # Check form data
         content = request.content.decode()


### PR DESCRIPTION
## Summary

OAuth token and refresh requests do not include an `Accept: application/json` header. Servers that default to form-encoded responses (e.g. GitHub's OAuth token endpoint) will not return JSON, causing `handle_token_response_scopes` to fail with a parse error.

This adds `Accept: application/json` to both `_build_token_request` and `_refresh_token` so servers know to respond with JSON.

Fixes #1523

## Test plan

- Added `Accept` header assertions to existing `test_token_exchange_request_authorization_code` and `test_refresh_token_request` tests
- All 96 existing auth tests pass: `uv run --frozen pytest tests/client/test_auth.py`

## Risk

Minimal — only adds a standard HTTP header to outgoing requests. No behavioral change for servers already returning JSON.