### PR TITLE
fix: correct MCPServer.call_tool return type and remove dead code

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -430,7 +430,11 @@ The internal layers (`ToolManager.call_tool`, `Tool.run`, `Prompt.render`, `Reso
 
 ### `MCPServer.call_tool()` return type corrected
 
-`MCPServer.call_tool()`'s return type signature has been corrected from `Sequence[ContentBlock] | dict[str, Any]` to `CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]` to match what the internal tool manager actually returns when converting tool results.
+`MCPServer.call_tool()`'s return type signature has been corrected from `Sequence[ContentBlock] | dict[str, Any]` to match what the internal tool manager actually returns when converting tool results. The union is now defined once as the `ToolResult` type alias (`mcp.server.mcpserver.server.ToolResult`), so the signature has a single source of truth:
+
+```python
+ToolResult: TypeAlias = CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]
+```
 
 **Before (v1):**
 
@@ -445,7 +449,7 @@ async def call_tool(
 ```python
 async def call_tool(
     self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-) -> CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]:
+) -> ToolResult:
 ```
 
 ### Registering lowlevel handlers on `MCPServer` (workaround)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -428,6 +428,26 @@ async def my_tool(x: int, ctx: Context) -> str:
 
 The internal layers (`ToolManager.call_tool`, `Tool.run`, `Prompt.render`, `ResourceTemplate.create_resource`, etc.) now require `context` as a positional argument.
 
+### `MCPServer.call_tool()` return type corrected
+
+`MCPServer.call_tool()`'s return type signature has been corrected from `Sequence[ContentBlock] | dict[str, Any]` to `CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]` to match what the internal tool manager actually returns when converting tool results.
+
+**Before (v1):**
+
+```python
+async def call_tool(
+    self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
+) -> Sequence[ContentBlock] | dict[str, Any]:
+```
+
+**After (v2):**
+
+```python
+async def call_tool(
+    self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
+) -> CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]:
+```
+
 ### Registering lowlevel handlers on `MCPServer` (workaround)
 
 `MCPServer` does not expose public APIs for `subscribe_resource`, `unsubscribe_resource`, or `set_logging_level` handlers. In v1, the workaround was to reach into the private lowlevel server and use its decorator methods:

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -7,7 +7,7 @@ import inspect
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import Any, Generic, Literal, TypeVar, overload
+from typing import Any, Generic, Literal, TypeAlias, TypeVar, overload
 
 import anyio
 import pydantic_core
@@ -74,6 +74,15 @@ from mcp.types import Tool as MCPTool
 logger = get_logger(__name__)
 
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
+
+ToolResult: TypeAlias = CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]
+"""Result of invoking a tool via `MCPServer.call_tool`. One of:
+
+- `CallToolResult`: the tool returned a `CallToolResult` directly.
+- `Sequence[ContentBlock]`: unstructured content from a tool with no output schema.
+- `tuple[Sequence[ContentBlock], dict[str, Any]]`: unstructured content paired with
+  structured content from a tool that has an output schema.
+"""
 
 
 class Settings(BaseSettings, Generic[LifespanResultT]):
@@ -308,7 +317,7 @@ class MCPServer(Generic[LifespanResultT]):
     ) -> CallToolResult:
         context = Context(request_context=ctx, mcp_server=self)
         try:
-            result = await self.call_tool(params.name, params.arguments or {}, context)
+            result: ToolResult = await self.call_tool(params.name, params.arguments or {}, context)
         except MCPError:
             raise
         except Exception as e:
@@ -390,14 +399,14 @@ class MCPServer(Generic[LifespanResultT]):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-    ) -> CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]:
+    ) -> ToolResult:
         """Call a tool by name with arguments.
 
         Returns:
-            CallToolResult: If the tool returned a CallToolResult directly.
-            Sequence[ContentBlock]: If the tool returned unstructured content and has no output schema.
-            tuple[Sequence[ContentBlock], dict[str, Any]]: If the tool has an output schema,
-                returning both unstructured content and structured content.
+            ToolResult: One of a `CallToolResult` (returned directly by the tool), a
+                `Sequence[ContentBlock]` (unstructured content from a tool with no output schema),
+                or a `tuple[Sequence[ContentBlock], dict[str, Any]]` (unstructured content paired
+                with structured content from a tool that has an output schema).
         """
         if context is None:
             context = Context(mcp_server=self)

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import inspect
-import json
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -322,14 +321,6 @@ class MCPServer(Generic[LifespanResultT]):
                 content=list(unstructured_content),  # type: ignore[arg-type]
                 structured_content=structured_content,  # type: ignore[arg-type]
             )
-        if isinstance(result, dict):  # pragma: no cover
-            # TODO: this code path is unreachable — convert_result never returns a raw dict.
-            # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong
-            # and needs to be cleaned up.
-            return CallToolResult(
-                content=[TextContent(type="text", text=json.dumps(result, indent=2))],
-                structured_content=result,
-            )
         return CallToolResult(content=list(result))
 
     async def _handle_list_resources(
@@ -399,8 +390,15 @@ class MCPServer(Generic[LifespanResultT]):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
-        """Call a tool by name with arguments."""
+    ) -> CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]:
+        """Call a tool by name with arguments.
+
+        Returns:
+            CallToolResult: If the tool returned a CallToolResult directly.
+            Sequence[ContentBlock]: If the tool returned unstructured content and has no output schema.
+            tuple[Sequence[ContentBlock], dict[str, Any]]: If the tool has an output schema,
+                returning both unstructured content and structured content.
+        """
         if context is None:
             context = Context(mcp_server=self)
         return await self._tool_manager.call_tool(name, arguments, context, convert_result=True)

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1556,3 +1556,74 @@ async def test_handle_call_tool_populates_content_and_structured_content():
     assert result.structured_content == {"x": 1, "y": 2}
     assert len(result.content) == 1
     assert isinstance(result.content[0], TextContent)
+
+
+async def test_handle_call_tool_returns_direct_call_tool_result():
+    """A tool that returns `CallToolResult` directly should be returned unchanged.
+
+    This pins the `isinstance(result, CallToolResult)` branch of `_handle_call_tool`.
+    """
+
+    def direct_result_tool() -> CallToolResult:
+        return CallToolResult(
+            content=[TextContent(type="text", text="Direct content")],
+            is_error=False,
+            structured_content={"custom": "metadata"},
+        )
+
+    mcp = MCPServer()
+    mcp.add_tool(direct_result_tool)
+
+    request_context = ServerRequestContext(
+        session=AsyncMock(),
+        lifespan_context=None,
+        experimental=Experimental(),
+    )
+
+    result = await mcp._handle_call_tool(
+        request_context,
+        CallToolRequestParams(name="direct_result_tool", arguments={}),
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is False
+    assert result.structured_content == {"custom": "metadata"}
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "Direct content"
+
+
+async def test_handle_call_tool_returns_unstructured_sequence():
+    """A tool with no output schema returning a sequence of content blocks flows
+
+    through the fallback branch of `_handle_call_tool` and is wrapped in a CallToolResult.
+    """
+
+    def unstructured_tool() -> list[ContentBlock]:
+        return [
+            TextContent(type="text", text="Hello"),
+            ImageContent(type="image", data="abc", mime_type="image/png"),
+        ]
+
+    mcp = MCPServer()
+    mcp.add_tool(unstructured_tool, structured_output=False)
+
+    request_context = ServerRequestContext(
+        session=AsyncMock(),
+        lifespan_context=None,
+        experimental=Experimental(),
+    )
+
+    result = await mcp._handle_call_tool(
+        request_context,
+        CallToolRequestParams(name="unstructured_tool", arguments={}),
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is False
+    assert result.structured_content is None
+    assert len(result.content) == 2
+    assert isinstance(result.content[0], TextContent)
+    assert result.content[0].text == "Hello"
+    assert isinstance(result.content[1], ImageContent)
+    assert result.content[1].data == "abc"

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -22,6 +22,8 @@ from mcp.shared.exceptions import MCPError
 from mcp.types import (
     AudioContent,
     BlobResourceContents,
+    CallToolRequestParams,
+    CallToolResult,
     Completion,
     CompletionArgument,
     CompletionContext,
@@ -1516,3 +1518,41 @@ async def test_report_progress_passes_related_request_id():
         message="halfway",
         related_request_id="req-abc-123",
     )
+
+
+async def test_handle_call_tool_populates_content_and_structured_content():
+    """A tool with an output schema flows through the tuple branch of `_handle_call_tool`.
+
+    The resulting `CallToolResult` must have both `content` and `structured_content`
+    populated. This pins the reachable tuple path: the converter never returns a raw
+    dict, so the `isinstance(result, dict)` branch removed in #2695 is dead. If that
+    dead branch is ever reintroduced and starts intercepting this path, the structured
+    content would be dropped and this test fails.
+    """
+
+    class Point(BaseModel):
+        x: int
+        y: int
+
+    def make_point(x: int, y: int) -> Point:
+        return Point(x=x, y=y)
+
+    mcp = MCPServer()
+    mcp.add_tool(make_point)
+
+    request_context = ServerRequestContext(
+        session=AsyncMock(),
+        lifespan_context=None,
+        experimental=Experimental(),
+    )
+
+    result = await mcp._handle_call_tool(
+        request_context,
+        CallToolRequestParams(name="make_point", arguments={"x": 1, "y": 2}),
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is False
+    assert result.structured_content == {"x": 1, "y": 2}
+    assert len(result.content) == 1
+    assert isinstance(result.content[0], TextContent)


### PR DESCRIPTION
### Description

This PR addresses the dead-code path and incorrect return type annotation on  MCPServer.call_tool()  described in #2695.

  1. Removed Dead Code: In `src/mcp/server/mcpserver/server.py`, the `isinstance(result, dict)` check inside `_handle_call_tool()` is unreachable. As traced in the issue, `self.call_tool()` invokes the tool manager with  `convert_result=True`, which delegates to `FuncMetadata.convert_result`. This converter function never returns a raw dict  (returning `CallToolResult`, `Sequence[ContentBlock]`, or `tuple[Sequence[ContentBlock], dict[str, Any]]`  instead).
  2. Removed Unused Import: Removed the now-unused `import json` from `src/mcp/server/mcpserver/server.py`.
  3. Corrected Type Annotation: Updated `MCPServer.call_tool()`'s return type signature to accurately reflect the actual runtime types:
   `CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]` 
  4. Migration Guide: Added breaking change documentation to `docs/migration.md` to assist developers migrating to v2.

  ### Related Issues

  Closes #2695

  ### Verification

  • Verified that the test suite passes successfully (1,194 passed).
  • Verified type checking passes cleanly with `pyright` (0 errors, 0 warnings).
  • Ran `coverage` and `strict-no-cover` to verify that code coverage remains at `100.00%` and no unused coverage pragmas exist.
