### PR TITLE
fix: normalize oauth redirect uri url types

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
 
@@ -66,6 +66,17 @@ class OAuthClientMetadata(BaseModel):
     jwks: Any | None = None
     software_id: str | None = None
     software_version: str | None = None
+
+    @field_validator(
+        "redirect_uris",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_redirect_uri_types(cls, v: object) -> object:
+        if isinstance(v, list):
+            uris = cast(list[Any], v)
+            return [str(uri) if isinstance(uri, AnyUrl) else uri for uri in uris]
+        return v
 
     @field_validator(
         "client_uri",

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,7 +1,7 @@
 """Tests for OAuth 2.0 shared code."""
 
 import pytest
-from pydantic import ValidationError
+from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
 
@@ -128,6 +128,18 @@ def test_information_full_inherits_coercion():
     assert info.tos_uri is None
     assert info.policy_uri is None
     assert info.jwks_uri is None
+
+
+def test_redirect_uri_url_subtypes_validate_by_canonical_url():
+    info = OAuthClientInformationFull(
+        client_id="abc123",
+        redirect_uris=[AnyHttpUrl("https://example.com/callback")],
+    )
+    incoming = AnyUrl("https://example.com/callback")
+
+    assert info.validate_redirect_uri(incoming) == incoming
+    assert info.redirect_uris == [incoming]
+    assert info.model_dump(mode="json")["redirect_uris"] == ["https://example.com/callback"]
 
 
 def test_invalid_non_empty_url_still_rejected():


### PR DESCRIPTION
## Summary
- normalize OAuth redirect URI URL objects at the client metadata model boundary
- keep validation and serialization unchanged while allowing AnyUrl/AnyHttpUrl subtype round-trips to compare correctly
- add a shared auth regression test for an AnyHttpUrl registration URI checked against an incoming AnyUrl

Fixes #2687

## To verify
- uv run pytest tests/shared/test_auth.py -q
- uv run ruff check src/mcp/shared/auth.py tests/shared/test_auth.py
- uv run ruff format --check src/mcp/shared/auth.py tests/shared/test_auth.py
- uv run pyright src/mcp/shared/auth.py tests/shared/test_auth.py
- git diff --check