### PR TITLE
fix: gracefully close streamable HTTP sessions on shutdown

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -767,9 +767,18 @@ class StreamableHTTPServerTransport:
 
         Once terminated, all requests with this session ID will receive 404 Not Found.
         """
+        if self._terminated:
+            return
 
         self._terminated = True
         logger.info(f"Terminating session: {self.mcp_session_id}")
+
+        # Close active SSE responses so ASGI response tasks can finish before
+        # the session manager cancels the owning task group.
+        sse_stream_writers = list(self._sse_stream_writers.values())
+        self._sse_stream_writers.clear()
+        for writer in sse_stream_writers:
+            writer.close()
 
         # We need a copy of the keys to avoid modification during iteration
         request_stream_keys = list(self._request_streams.keys())

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -133,12 +133,23 @@ class StreamableHTTPSessionManager:
                 yield  # Let the application run
             finally:
                 logger.info("StreamableHTTP session manager shutting down")
-                # Cancel task group to stop all spawned tasks
-                tg.cancel_scope.cancel()
-                self._task_group = None
-                # Clear any remaining server instances
-                self._server_instances.clear()
-                self._session_owners.clear()
+                try:
+                    await self._terminate_active_sessions()
+                finally:
+                    # Cancel task group to stop all spawned tasks
+                    tg.cancel_scope.cancel()
+                    self._task_group = None
+                    # Clear any remaining server instances
+                    self._server_instances.clear()
+                    self._session_owners.clear()
+
+    async def _terminate_active_sessions(self) -> None:
+        """Terminate tracked transports before cancelling their task group."""
+        for transport in list(self._server_instances.values()):
+            try:
+                await transport.terminate()
+            except Exception:
+                logger.exception("Error terminating StreamableHTTP session during shutdown")
 
     async def handle_request(self, scope: Scope, receive: Receive, send: Send) -> None:
         """Process ASGI request with proper session handling and transport setup.

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -2,7 +2,8 @@
 
 import json
 import logging
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import anyio
@@ -62,6 +63,50 @@ async def test_run_prevents_concurrent_calls():
     # One should succeed, one should fail
     assert len(errors) == 1
     assert "StreamableHTTPSessionManager .run() can only be called once per instance" in str(errors[0])
+
+
+@pytest.mark.anyio
+async def test_run_terminates_active_streaming_session_before_shutdown():
+    """run() should close active SSE transports before task cancellation."""
+    app = Server("test-shutdown-cleanup")
+    manager = StreamableHTTPSessionManager(app=app)
+    transport = StreamableHTTPServerTransport(mcp_session_id="session-id")
+    sse_stream_writer, sse_stream_reader = anyio.create_memory_object_stream[dict[str, str]](1)
+
+    try:
+        transport._sse_stream_writers["request-id"] = sse_stream_writer
+
+        async with manager.run():
+            manager._server_instances["session-id"] = transport
+
+        assert transport.is_terminated
+        assert transport._sse_stream_writers == {}
+        assert manager._server_instances == {}
+        with pytest.raises(anyio.ClosedResourceError):
+            await sse_stream_writer.send({"data": "still-open"})
+    finally:
+        await sse_stream_reader.aclose()
+
+
+@pytest.mark.anyio
+async def test_run_terminates_remaining_sessions_if_one_shutdown_fails(caplog: pytest.LogCaptureFixture):
+    """One failed transport shutdown should not skip later active sessions."""
+    app = Server("test-shutdown-cleanup-error")
+    manager = StreamableHTTPSessionManager(app=app)
+    failing_terminate = AsyncMock(side_effect=RuntimeError("terminate failed"))
+    healthy_terminate = AsyncMock()
+    failing_transport = cast(StreamableHTTPServerTransport, SimpleNamespace(terminate=failing_terminate))
+    healthy_transport = cast(StreamableHTTPServerTransport, SimpleNamespace(terminate=healthy_terminate))
+
+    with caplog.at_level(logging.ERROR):
+        async with manager.run():
+            manager._server_instances["bad-session"] = failing_transport
+            manager._server_instances["healthy-session"] = healthy_transport
+
+    failing_terminate.assert_awaited_once_with()
+    healthy_terminate.assert_awaited_once_with()
+    assert "Error terminating StreamableHTTP session during shutdown" in caplog.text
+    assert manager._server_instances == {}
 
 
 @pytest.mark.anyio
@@ -269,6 +314,43 @@ async def test_stateless_requests_memory_cleanup():
 
             # Verify internal state is cleaned up
             assert len(transport._request_streams) == 0, "Transport should have no active request streams"
+
+
+@pytest.mark.anyio
+async def test_transport_terminate_closes_sse_stream_writers():
+    """terminate() should close active SSE writers so streaming responses can finish."""
+    transport = StreamableHTTPServerTransport(mcp_session_id="test-session")
+    sse_stream_writer, sse_stream_reader = anyio.create_memory_object_stream[dict[str, str]](1)
+
+    try:
+        transport._sse_stream_writers["request-id"] = sse_stream_writer
+
+        await transport.terminate()
+
+        assert transport._sse_stream_writers == {}
+        with pytest.raises(anyio.ClosedResourceError):
+            await sse_stream_writer.send({"data": "still-open"})
+
+        await transport.terminate()
+    finally:
+        await sse_stream_reader.aclose()
+
+
+@pytest.mark.anyio
+async def test_transport_connect_cleans_request_streams_on_exit():
+    """connect() should close registered request streams when the transport exits."""
+    transport = StreamableHTTPServerTransport(mcp_session_id="test-session")
+    request_stream_writer, request_stream_reader = anyio.create_memory_object_stream[Any](1)
+
+    transport._request_streams["request-id"] = (request_stream_writer, request_stream_reader)
+
+    async with transport.connect():
+        assert "request-id" in transport._request_streams
+        transport._terminated = True
+
+    assert transport._request_streams == {}
+    with pytest.raises(anyio.ClosedResourceError):
+        await request_stream_writer.send(cast(Any, object()))
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Background

Fixes #2150.

StreamableHTTPSessionManager currently cancels its task group during lifespan shutdown before asking active stateful transports to close. StreamableHTTPServerTransport.terminate() also closes request/session streams, but it does not close active SSE stream writers.

## Problem

When a server shuts down while clients have active Streamable HTTP SSE responses open, those response tasks can be cancelled before the response stream completes. That can surface as Uvicorn logging ASGI callable returned without completing response.

## Solution

- Make StreamableHTTPServerTransport.terminate() idempotent.
- Close active SSE stream writers during terminate() so EventSourceResponse tasks can complete cleanly.
- Have StreamableHTTPSessionManager terminate tracked active transports before cancelling its task group.
- Keep shutdown cleanup resilient: a failure terminating one transport is logged and does not skip later active transports.

## Validation

Ran:

```bash
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen pytest tests/server/test_streamable_http_manager.py -q
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen pytest tests/shared/test_streamable_http.py -q
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen ruff check .
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen ruff format --check .
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen pyright
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen coverage run -m pytest tests/server/test_streamable_http_manager.py -q
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen coverage combine
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache uv run --frozen coverage report --include="src/mcp/server/streamable_http.py,src/mcp/server/streamable_http_manager.py,tests/server/test_streamable_http_manager.py" --fail-under=0
UV_CACHE_DIR=/tmp/mcp-python-sdk-contrib-yaXdqD/.uv-cache XDG_CACHE_HOME=/tmp/mcp-python-sdk-contrib-yaXdqD/.cache UV_FROZEN=1 uv run --frozen strict-no-cover
```

Results:

- manager tests: 14 passed
- shared Streamable HTTP tests: 61 passed
- ruff, format, pyright, coverage, strict-no-cover: passed

## Risk

Low. The behavior change is limited to shutdown/session termination paths. Normal request handling and stateless per-request cleanup are unchanged.

## Breaking Changes

None.

## Reviewer Notes

The main behavior to review is the ordering: active stateful transports are asked to terminate before the session manager cancels the task group, and terminate() now closes SSE stream writers in addition to request/session streams.