### PR TITLE
Fix stdio transport closing sys.stdin.buffer/sys.stdout.buffer on exit

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -21,6 +21,17 @@ import sys
 from contextlib import asynccontextmanager
 from io import TextIOWrapper
 
+
+class _DetachingTextIOWrapper(TextIOWrapper):
+    """TextIOWrapper that detaches from its buffer on close, preventing
+    the underlying buffer (e.g. sys.stdin.buffer) from being closed."""
+
+    def close(self):
+        try:
+            self.detach()
+        except (ValueError, OSError):
+            pass
+
 import anyio
 import anyio.lowlevel
 
@@ -39,9 +50,9 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
+        stdin = anyio.wrap_file(_DetachingTextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout = anyio.wrap_file(_DetachingTextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)


### PR DESCRIPTION
## Description

Fixes #1933

When using `transport="stdio"`, `anyio.wrap_file()` wraps a `TextIOWrapper` around `sys.stdin.buffer`/`sys.stdout.buffer`. When the server exits, the async file close propagates through `TextIOWrapper.close()` and closes the underlying buffer, making subsequent stdio operations fail with `ValueError: underlying buffer has been closed`.

## Root Cause

The code comment at line 37-38 says:

> Purposely not using context managers for these, as we dont want to close standard process handles.

But `anyio.wrap_file()` creates a context manager that calls `close()` on the `TextIOWrapper`, which in turn closes the underlying `sys.stdin.buffer` — exactly what the comment says should not happen.

## Fix

Added `_DetachingTextIOWrapper` — a thin subclass of `TextIOWrapper` that overrides `close()` to detach the underlying buffer first, preventing close propagation. The buffer survives, and subsequent stdio operations work as expected after the server exits.

## Changes

`src/mcp/server/stdio.py` — +13/-2 lines