### PR TITLE
fix: send SEP-2243 streamable HTTP headers

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -43,6 +43,8 @@ StreamReader = ContextReceiveStream[SessionMessage]
 
 MCP_SESSION_ID = "mcp-session-id"
 MCP_PROTOCOL_VERSION = "mcp-protocol-version"
+MCP_METHOD = "mcp-method"
+MCP_NAME = "mcp-name"
 LAST_EVENT_ID = "last-event-id"
 
 # Reconnection defaults
@@ -82,7 +84,7 @@ class StreamableHTTPTransport:
         self.session_id: str | None = None
         self.protocol_version: str | None = None
 
-    def _prepare_headers(self) -> dict[str, str]:
+    def _prepare_headers(self, message: JSONRPCMessage | None = None) -> dict[str, str]:
         """Build MCP-specific request headers.
 
         These headers will be merged with the httpx.AsyncClient's default headers,
@@ -97,7 +99,27 @@ class StreamableHTTPTransport:
             headers[MCP_SESSION_ID] = self.session_id
         if self.protocol_version:
             headers[MCP_PROTOCOL_VERSION] = self.protocol_version
+        if isinstance(message, JSONRPCRequest | JSONRPCNotification):
+            headers[MCP_METHOD] = message.method
+            if mcp_name := self._get_mcp_name(message):
+                headers[MCP_NAME] = mcp_name
         return headers
+
+    def _get_mcp_name(self, message: JSONRPCRequest | JSONRPCNotification) -> str | None:
+        params = message.params
+        if not isinstance(params, dict):
+            return None
+
+        if message.method in {"tools/call", "prompts/get"}:
+            value = params.get("name")
+        elif message.method in {"resources/read", "resources/subscribe", "resources/unsubscribe"}:
+            value = params.get("uri")
+        else:
+            return None
+
+        if value is None:
+            return None
+        return str(value)
 
     def _is_initialization_request(self, message: JSONRPCMessage) -> bool:
         """Check if the message is an initialization request."""
@@ -253,8 +275,8 @@ class StreamableHTTPTransport:
 
     async def _handle_post_request(self, ctx: RequestContext) -> None:
         """Handle a POST request with response processing."""
-        headers = self._prepare_headers()
         message = ctx.session_message.message
+        headers = self._prepare_headers(message)
         is_initialization = self._is_initialization_request(message)
 
         async with ctx.client.stream(

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -1428,6 +1428,35 @@ async def test_client_includes_protocol_version_header_after_init(context_app: S
         assert headers_data[MCP_PROTOCOL_VERSION_HEADER] == negotiated_version
 
 
+@pytest.mark.parametrize(
+    ("method", "params", "expected_name"),
+    [
+        ("tools/call", {"name": "echo_headers"}, "echo_headers"),
+        ("prompts/get", {"name": "summarize"}, "summarize"),
+        ("resources/read", {"uri": "file:///tmp/readme.md"}, "file:///tmp/readme.md"),
+        ("resources/subscribe", {"uri": "file:///tmp/readme.md"}, "file:///tmp/readme.md"),
+        ("resources/unsubscribe", {"uri": "file:///tmp/readme.md"}, "file:///tmp/readme.md"),
+        ("tools/call", {}, None),
+        ("resources/read", {}, None),
+        ("tools/list", {}, None),
+    ],
+)
+def test_streamable_http_client_adds_sep_2243_headers(
+    method: str, params: dict[str, Any], expected_name: str | None
+) -> None:
+    """POST requests include SEP-2243 method/name headers."""
+    transport = StreamableHTTPTransport("https://example.com/mcp")
+    message = JSONRPCRequest(jsonrpc="2.0", id=1, method=method, params=params)
+
+    headers = transport._prepare_headers(message)
+
+    assert headers["mcp-method"] == method
+    if expected_name is None:
+        assert "mcp-name" not in headers
+    else:
+        assert headers["mcp-name"] == expected_name
+
+
 @pytest.mark.anyio
 async def test_server_validates_protocol_version_header(basic_app: Starlette) -> None:
     """An invalid or unsupported protocol version header is rejected with 400; the negotiated one passes."""


### PR DESCRIPTION
## Summary
- add SEP-2243 `mcp-method` headers to streamable HTTP POST requests
- add `mcp-name` for tool calls, prompt gets, and resource read/subscribe/unsubscribe requests
- cover the method/name mapping without changing existing session or protocol-version headers

## To verify
- `uv run pytest tests/shared/test_streamable_http.py -q`
- `uv run ruff check src/mcp/client/streamable_http.py tests/shared/test_streamable_http.py`
- `uv run ruff format --check src/mcp/client/streamable_http.py tests/shared/test_streamable_http.py`
- `git diff --check`