### PR TITLE
Fix typos: requestor -> requester, Implementors -> Implementers

### DIFF
--- a/src/mcp/server/auth/provider.py
+++ b/src/mcp/server/auth/provider.py
@@ -111,7 +111,7 @@ class OAuthAuthorizationServerProvider(Protocol, Generic[AuthorizationCodeT, Ref
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
         """Retrieves client information by client ID.
 
-        Implementors MAY raise NotImplementedError if dynamic client registration is
+        Implementers MAY raise NotImplementedError if dynamic client registration is
         disabled in ClientRegistrationOptions.
 
         Args:
@@ -124,7 +124,7 @@ class OAuthAuthorizationServerProvider(Protocol, Generic[AuthorizationCodeT, Ref
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         """Saves client information as part of registering it.
 
-        Implementors MAY raise NotImplementedError if dynamic client registration is
+        Implementers MAY raise NotImplementedError if dynamic client registration is
         disabled in ClientRegistrationOptions.
 
         Args:

--- a/src/mcp/server/sse.py
+++ b/src/mcp/server/sse.py
@@ -232,8 +232,8 @@ class SseServerTransport:
             return await response(scope, receive, send)
 
         user = scope.get("user")
-        requestor = authorization_context(user) if isinstance(user, AuthenticatedUser) else None
-        if requestor != self._session_owners.get(session_id):
+        requester = authorization_context(user) if isinstance(user, AuthenticatedUser) else None
+        if requester != self._session_owners.get(session_id):
             # A session can only be used with the credential that created it.
             # Respond exactly as if the session did not exist.
             logger.warning("Rejecting message for session %s: credential does not match", session_id)

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -197,12 +197,12 @@ class StreamableHTTPSessionManager:
         request_mcp_session_id = request.headers.get(MCP_SESSION_ID_HEADER)
 
         user = scope.get("user")
-        requestor = authorization_context(user) if isinstance(user, AuthenticatedUser) else None
+        requester = authorization_context(user) if isinstance(user, AuthenticatedUser) else None
 
         # Existing session case
         if request_mcp_session_id is not None and request_mcp_session_id in self._server_instances:
             transport = self._server_instances[request_mcp_session_id]
-            if requestor != self._session_owners.get(request_mcp_session_id):
+            if requester != self._session_owners.get(request_mcp_session_id):
                 # A session can only be used with the credential that created
                 # it. Respond exactly as if the session did not exist.
                 logger.warning(
@@ -240,8 +240,8 @@ class StreamableHTTPSessionManager:
                 )
 
                 assert http_transport.mcp_session_id is not None
-                if requestor is not None:
-                    self._session_owners[http_transport.mcp_session_id] = requestor
+                if requester is not None:
+                    self._session_owners[http_transport.mcp_session_id] = requester
                 self._server_instances[http_transport.mcp_session_id] = http_transport
                 logger.info(f"Created new transport with session ID: {new_session_id}")
 

--- a/src/mcp/types/_types.py
+++ b/src/mcp/types/_types.py
@@ -534,7 +534,7 @@ class TaskStatusNotificationParams(NotificationParams, Task):
 
 
 class TaskStatusNotification(Notification[TaskStatusNotificationParams, Literal["notifications/tasks/status"]]):
-    """An optional notification from the receiver to the requestor, informing them that a task's status has changed.
+    """An optional notification from the receiver to the requester, informing them that a task's status has changed.
     Receivers are not required to send these notifications.
     """
 


### PR DESCRIPTION
Codespell found several typos in src/mcp/:

- `requestor` → `requester` (in sse.py, streamable_http_manager.py, _types.py)
- `Implementors` → `Implementers` (in auth/provider.py)

Fixed with `codespell --write`.