### PR TITLE
fix(client): send same-origin Origin header from streamable HTTP client

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -202,7 +202,7 @@ Invalid Host header
 The fix is the same `transport_security=TransportSecuritySettings(allowed_hosts=[...], allowed_origins=[...])` shown under `Server returned an error response`. Two of its edges are worth naming:
 
 * An `allowed_hosts` entry is an exact string. `"mcp.example.com"` matches a bare `Host` header and `"mcp.example.com:*"` matches any explicit port. List both.
-* A `403` with the body `Invalid Origin header` is the sibling check on the `Origin` header. It only fires for browsers (nothing else sends `Origin`), and `allowed_origins=` is its allowlist.
+* A `403` with the body `Invalid Origin header` is the sibling check on the `Origin` header, and `allowed_origins=` is its allowlist. Browsers send `Origin`, and so does the python `Client`: it stamps a same-origin value (`scheme://host[:port]`) derived from the URL you connect to, so that spec-compliant servers enforcing CSRF / DNS-rebinding protection accept the handshake. That is why the allowlist above names `http://mcp.example.com` alongside the host — the client's own `Origin` has to be on it.
 
 **[Deploy & scale](run/deploy.md)** has the full treatment, including when switching the check off is the honest configuration.
 

--- a/docs_src/troubleshooting/tutorial004.py
+++ b/docs_src/troubleshooting/tutorial004.py
@@ -13,6 +13,6 @@ def forecast(city: str) -> str:
 app = mcp.streamable_http_app(
     transport_security=TransportSecuritySettings(
         allowed_hosts=["mcp.example.com", "mcp.example.com:*"],
-        allowed_origins=["https://app.example.com"],
+        allowed_origins=["http://mcp.example.com", "http://mcp.example.com:*"],
     )
 )

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -7,6 +7,7 @@ import logging
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 import anyio
 import httpx
@@ -108,6 +109,19 @@ class StreamableHTTPTransport:
         # `notifications/cancelled` at 2026 can abort it; see
         # `_consume_modern_cancellation`. Keys are verbatim-typed ("1" is not 1).
         self._in_flight_posts: dict[RequestId, _InFlightPost] = {}
+        self._default_origin = self._derive_origin(url)
+
+    @staticmethod
+    def _derive_origin(url: str) -> str | None:
+        """Derive a same-origin ``Origin`` value (scheme://host[:port]) from a URL.
+
+        Returns ``None`` when the URL has no scheme or host, in which case no
+        ``Origin`` header is added.
+        """
+        parsed = urlsplit(url)
+        if not parsed.scheme or not parsed.netloc:
+            return None
+        return f"{parsed.scheme}://{parsed.netloc}"
 
     def _prepare_headers(self) -> dict[str, str]:
         """Build MCP-specific request headers for any outbound HTTP request.
@@ -123,6 +137,13 @@ class StreamableHTTPTransport:
             "accept": "application/json, text/event-stream",
             "content-type": "application/json",
         }
+        # Send a same-origin Origin header by default so spec-compliant servers
+        # that enforce anti-DNS-rebinding / CSRF protection (e.g. the Go SDK's
+        # http.CrossOriginProtection) accept the handshake instead of returning
+        # 403. Callers needing a different Origin can set one on the underlying
+        # httpx client's default headers.
+        if self._default_origin is not None:
+            headers["origin"] = self._default_origin
         if self.session_id:
             headers[MCP_SESSION_ID] = self.session_id
         if self._protocol_version_header:

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -1608,6 +1608,26 @@ async def test_client_crash_handled(basic_app: Starlette) -> None:
         assert tools.tools
 
 
+def test_prepare_headers_includes_same_origin():
+    """Default Origin header is derived from the target URL (scheme://host[:port]).
+
+    Regression test for #2727: spec-compliant servers enforcing
+    anti-DNS-rebinding / CSRF protection reject requests with no Origin.
+    """
+    transport = StreamableHTTPTransport(url="http://my-go-server:8081/mcp")
+    headers = transport._prepare_headers()
+    assert headers["origin"] == "http://my-go-server:8081"
+
+    https_transport = StreamableHTTPTransport(url="https://example.com/mcp/path?x=1")
+    assert https_transport._prepare_headers()["origin"] == "https://example.com"
+
+
+def test_prepare_headers_omits_origin_for_invalid_url():
+    """No Origin header is added when the URL lacks a scheme or host."""
+    transport = StreamableHTTPTransport(url="not-a-url")
+    assert "origin" not in transport._prepare_headers()
+
+
 @pytest.mark.anyio
 async def test_handle_sse_event_skips_empty_data() -> None:
     """_handle_sse_event skips empty SSE data (keep-alive pings) without writing to the stream."""


### PR DESCRIPTION
## Summary

- The streamable HTTP **client** now sends a same-origin `Origin` header by default.
- This lets the official Python client interoperate with spec-compliant servers (e.g. the Go SDK's `http.CrossOriginProtection`) that otherwise reject the handshake with `403`.

## Motivation

Closes #2727.

The Python `streamablehttp_client` opened its POST handshake **without** an `Origin` header. The official Go SDK (`modelcontextprotocol/go-sdk` v1.4.x) wraps every streamable-HTTP handler with Go 1.25's `http.CrossOriginProtection`, which denies any state-changing request that cannot prove same-origin via `Sec-Fetch-Site`, a matching `Origin`, or an allow-listed origin. A legitimate server-to-server connection from the Python client therefore looks like a CSRF attempt → `HTTP 403 Forbidden` on the first POST, and the client (per #2110) swallows the non-2xx and hangs forever on `session.initialize()`.

The two reference SDKs from the same org were out of sync by one spec revision: the Go server enforces the rule; the Python client never sent the header that satisfies it.

## Fix

`StreamableHTTPTransport._prepare_headers()` now derives a same-origin value (`scheme://host[:port]`) from the target URL and sends it as the `Origin` header on every request. The derivation:

- Uses `urllib.parse.urlsplit` on the configured URL.
- Returns `None` (adds no header) when the URL has no scheme or host, so malformed/relative URLs are unaffected.

Callers needing a different `Origin` (e.g. multi-tenant proxies) can still set one on the underlying `httpx.AsyncClient` default headers.

## Verification

- `uv run pytest tests/shared/test_streamable_http.py` — **63 passed** (includes the existing `test_streamable_http_client_mcp_headers_override_defaults` / custom-header tests, unchanged).
- New tests:
  - `test_prepare_headers_includes_same_origin` — `http://my-go-server:8081/mcp` → `Origin: http://my-go-server:8081`; `https://…/path?x=1` → `https://example.com`.
  - `test_prepare_headers_omits_origin_for_invalid_url` — no `Origin` added for a URL lacking scheme/host.
- `uv run ruff check` / `ruff format --check` — clean.

Diff: 2 files, +41/-0.
