### PR TITLE
docs: add missing docstrings to core client/server session API methods

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -146,6 +146,20 @@ class ClientSession(
         return types.server_notification_adapter
 
     async def initialize(self) -> types.InitializeResult:
+        """Perform the MCP initialization handshake with the server.
+
+        Sends an InitializeRequest with the client's capabilities (sampling,
+        elicitation, roots, tasks) and client_info, waits for the server's
+        InitializeResult, validates the negotiated protocol version, stores
+        the result, and sends an InitializedNotification.
+
+        Returns:
+            The server's InitializeResult containing server_info,
+            capabilities, instructions, and the negotiated protocol_version.
+
+        Raises:
+            RuntimeError: If the server returns an unsupported protocol version.
+        """
         sampling = (
             (self._sampling_capabilities or types.SamplingCapability())
             if self._sampling_callback is not _default_sampling_callback

--- a/src/mcp/client/sse.py
+++ b/src/mcp/client/sse.py
@@ -18,6 +18,11 @@ logger = logging.getLogger(__name__)
 
 
 def remove_request_params(url: str) -> str:
+    """Strip query parameters from a URL, returning only scheme + host + path.
+
+    Used to derive the base endpoint URL from an SSE connection URL that may
+    include session identifiers or other transient query parameters.
+    """
     return urljoin(url, urlparse(url).path)
 
 

--- a/src/mcp/server/session.py
+++ b/src/mcp/server/session.py
@@ -107,6 +107,11 @@ class ServerSession(
 
     @property
     def client_params(self) -> types.InitializeRequestParams | None:
+        """The client's InitializeRequestParams received during handshake.
+
+        Contains client_info, capabilities, and the requested protocol_version.
+        Returns None if the session has not yet been initialized.
+        """
         return self._client_params
 
     @property
@@ -689,4 +694,9 @@ class ServerSession(
 
     @property
     def incoming_messages(self) -> MemoryObjectReceiveStream[ServerRequestResponder]:
+        """Stream of incoming client requests wrapped as ServerRequestResponder objects.
+
+        Each item in the stream pairs the original client request with a
+        responder that the server handler uses to send back a result or error.
+        """
         return self._incoming_message_stream_reader


### PR DESCRIPTION
Add docstrings to undocumented public methods in the client and server session modules:

- ClientSession.initialize(): document handshake flow, return type, and RuntimeError on unsupported protocol version
- ServerSession.client_params: document property returning client's InitializeRequestParams
- ServerSession.incoming_messages: document the ServerRequestResponder stream property
- remove_request_params(): document URL query-stripping utility

These are the most user-facing public methods that currently lack docstrings, making IDE tooltips and help() output incomplete.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
