### PR TITLE
fix: preserve stdio streams in server transport

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -20,7 +20,7 @@ Example:
 import os
 import sys
 from contextlib import asynccontextmanager
-from io import TextIOWrapper
+from io import TextIOWrapper, UnsupportedOperation
 
 import anyio
 import anyio.lowlevel
@@ -28,6 +28,33 @@ import anyio.lowlevel
 from mcp import types
 from mcp.shared._context_streams import create_context_streams
 from mcp.shared.message import SessionMessage
+
+
+def _wrap_stdin() -> tuple[anyio.AsyncFile[str], bool]:
+    """Wrap stdin as UTF-8 text without closing process stdio on exit."""
+    try:
+        stdin_fd = os.dup(sys.stdin.fileno())
+    except (AttributeError, OSError, UnsupportedOperation):
+        # Some tests and embedders replace sys.stdin with fileno-less in-memory
+        # streams. Keep supporting that shape by falling back to the existing
+        # buffer-wrapping behavior.
+        return anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace")), False
+
+    stdin_buffer = os.fdopen(stdin_fd, "rb", closefd=True)
+    return anyio.wrap_file(TextIOWrapper(stdin_buffer, encoding="utf-8", errors="replace")), True
+
+
+def _wrap_stdout() -> tuple[anyio.AsyncFile[str], bool]:
+    """Wrap stdout as UTF-8 text without closing process stdio on exit."""
+    try:
+        stdout_fd = os.dup(sys.stdout.fileno())
+    except (AttributeError, OSError, UnsupportedOperation):
+        # Match the fileno-less stdin fallback for in-memory test streams and
+        # embedders that provide file-like stdout objects.
+        return anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8")), False
+
+    stdout_buffer = os.fdopen(stdout_fd, "wb", closefd=True)
+    return anyio.wrap_file(TextIOWrapper(stdout_buffer, encoding="utf-8")), True
 
 
 @asynccontextmanager
@@ -42,15 +69,9 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     close_stdin = False
     close_stdout = False
     if not stdin:
-        stdin_fd = os.dup(sys.stdin.fileno())
-        stdin_buffer = os.fdopen(stdin_fd, "rb", closefd=True)
-        stdin = anyio.wrap_file(TextIOWrapper(stdin_buffer, encoding="utf-8", errors="replace"))
-        close_stdin = True
+        stdin, close_stdin = _wrap_stdin()
     if not stdout:
-        stdout_fd = os.dup(sys.stdout.fileno())
-        stdout_buffer = os.fdopen(stdout_fd, "wb", closefd=True)
-        stdout = anyio.wrap_file(TextIOWrapper(stdout_buffer, encoding="utf-8"))
-        close_stdout = True
+        stdout, close_stdout = _wrap_stdout()
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)

--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -36,9 +36,9 @@ def _wrap_stdin() -> tuple[anyio.AsyncFile[str], bool]:
         stdin_fd = os.dup(sys.stdin.fileno())
     except (AttributeError, OSError, UnsupportedOperation):
         # Some tests and embedders replace sys.stdin with fileno-less in-memory
-        # streams. Keep supporting that shape by falling back to the existing
-        # buffer-wrapping behavior.
-        return anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace")), False
+        # streams. Reusing the caller-provided wrapper avoids closing it when the
+        # transport exits.
+        return anyio.wrap_file(sys.stdin), False
 
     stdin_buffer = os.fdopen(stdin_fd, "rb", closefd=True)
     return anyio.wrap_file(TextIOWrapper(stdin_buffer, encoding="utf-8", errors="replace")), True
@@ -51,7 +51,7 @@ def _wrap_stdout() -> tuple[anyio.AsyncFile[str], bool]:
     except (AttributeError, OSError, UnsupportedOperation):
         # Match the fileno-less stdin fallback for in-memory test streams and
         # embedders that provide file-like stdout objects.
-        return anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8")), False
+        return anyio.wrap_file(sys.stdout), False
 
     stdout_buffer = os.fdopen(stdout_fd, "wb", closefd=True)
     return anyio.wrap_file(TextIOWrapper(stdout_buffer, encoding="utf-8")), True

--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -17,6 +17,7 @@ Example:
     ```
 """
 
+import os
 import sys
 from contextlib import asynccontextmanager
 from io import TextIOWrapper
@@ -38,10 +39,18 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # standard process handles. Encoding of stdin/stdout as text streams on
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
+    close_stdin = False
+    close_stdout = False
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
+        stdin_fd = os.dup(sys.stdin.fileno())
+        stdin_buffer = os.fdopen(stdin_fd, "rb", closefd=True)
+        stdin = anyio.wrap_file(TextIOWrapper(stdin_buffer, encoding="utf-8", errors="replace"))
+        close_stdin = True
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout_fd = os.dup(sys.stdout.fileno())
+        stdout_buffer = os.fdopen(stdout_fd, "wb", closefd=True)
+        stdout = anyio.wrap_file(TextIOWrapper(stdout_buffer, encoding="utf-8"))
+        close_stdout = True
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)
@@ -71,7 +80,13 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
         except anyio.ClosedResourceError:  # pragma: no cover
             await anyio.lowlevel.checkpoint()
 
-    async with anyio.create_task_group() as tg:
-        tg.start_soon(stdin_reader)
-        tg.start_soon(stdout_writer)
-        yield read_stream, write_stream
+    try:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(stdin_reader)
+            tg.start_soon(stdout_writer)
+            yield read_stream, write_stream
+    finally:
+        if close_stdin:
+            await stdin.aclose()
+        if close_stdout:
+            await stdout.aclose()

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -2,7 +2,7 @@ import io
 import sys
 import tempfile
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from io import TextIOWrapper
 
@@ -65,6 +65,27 @@ async def test_stdio_server_round_trips_messages_over_injected_streams() -> None
     received_responses = [jsonrpc_message_adapter.validate_json(line.strip()) for line in output_lines]
     assert received_responses[0] == JSONRPCRequest(jsonrpc="2.0", id=3, method="ping")
     assert received_responses[1] == JSONRPCResponse(jsonrpc="2.0", id=4, result={})
+
+
+@pytest.mark.anyio
+async def test_stdio_server_supports_fileno_less_standard_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default path supports in-memory stdio replacements without fileno()."""
+    request = JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")
+    raw_stdin = io.BytesIO(request.model_dump_json(by_alias=True, exclude_none=True).encode() + b"\n")
+    raw_stdout = io.BytesIO()
+
+    test_stdin = TextIOWrapper(raw_stdin, encoding="utf-8")
+    test_stdout = TextIOWrapper(raw_stdout, encoding="utf-8")
+    monkeypatch.setattr(sys, "stdin", test_stdin)
+    monkeypatch.setattr(sys, "stdout", test_stdout)
+
+    with anyio.fail_after(5):
+        async with stdio_server() as (read_stream, write_stream):
+            await write_stream.aclose()
+            async with read_stream:  # pragma: no branch
+                message = await read_stream.receive()
+                assert isinstance(message, SessionMessage)
+                assert message.message == request
 
 
 @pytest.mark.anyio
@@ -170,7 +191,7 @@ def test_mcpserver_run_stdio_runs_lifespan_cleanup_after_stdin_closes(monkeypatc
     events: list[str] = []
 
     @asynccontextmanager
-    async def lifespan(server: MCPServer) -> AsyncIterator[None]:
+    async def lifespan(server: MCPServer) -> AsyncGenerator[None, None]:
         events.append("setup")
         try:
             yield

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -1,5 +1,6 @@
 import io
 import sys
+import tempfile
 import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -67,7 +68,7 @@ async def test_stdio_server_round_trips_messages_over_injected_streams() -> None
 
 
 @pytest.mark.anyio
-async def test_stdio_server_invalid_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_stdio_server_invalid_utf8() -> None:
     """Non-UTF-8 stdin bytes surface as an in-stream exception without killing the stream.
 
     Invalid bytes are replaced with U+FFFD, fail JSON parsing, and arrive as an in-stream
@@ -75,25 +76,43 @@ async def test_stdio_server_invalid_utf8(monkeypatch: pytest.MonkeyPatch) -> Non
     """
     # \xff\xfe are invalid UTF-8 start bytes.
     valid = JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")
-    raw_stdin = io.BytesIO(b"\xff\xfe\n" + valid.model_dump_json(by_alias=True, exclude_none=True).encode() + b"\n")
+    raw_stdin = tempfile.TemporaryFile()
+    raw_stdin.write(b"\xff\xfe\n" + valid.model_dump_json(by_alias=True, exclude_none=True).encode() + b"\n")
+    raw_stdin.seek(0)
+    raw_stdout = tempfile.TemporaryFile()
 
-    # Replace sys.stdin with a wrapper whose .buffer is our raw bytes, so that
-    # stdio_server()'s default path wraps it with errors='replace'.
-    monkeypatch.setattr(sys, "stdin", TextIOWrapper(raw_stdin, encoding="utf-8"))
-    monkeypatch.setattr(sys, "stdout", TextIOWrapper(io.BytesIO(), encoding="utf-8"))
+    # Replace sys.stdin/stdout with wrappers backed by real file descriptors so
+    # stdio_server()'s default path can duplicate them without closing the
+    # original process-level streams.
+    original_stdin = sys.stdin
+    original_stdout = sys.stdout
+    test_stdin = TextIOWrapper(raw_stdin, encoding="utf-8")
+    test_stdout = TextIOWrapper(raw_stdout, encoding="utf-8")
+    sys.stdin = test_stdin
+    sys.stdout = test_stdout
 
-    with anyio.fail_after(5):
-        async with stdio_server() as (read_stream, write_stream):
-            await write_stream.aclose()
-            async with read_stream:  # pragma: no branch
-                # First line: \xff\xfe -> U+FFFD U+FFFD -> JSON parse fails -> exception in stream
-                first = await read_stream.receive()
-                assert isinstance(first, Exception)
+    try:
+        with anyio.fail_after(5):
+            async with stdio_server() as (read_stream, write_stream):
+                await write_stream.aclose()
+                async with read_stream:  # pragma: no branch
+                    # First line: \xff\xfe -> U+FFFD U+FFFD -> JSON parse fails -> exception in stream
+                    first = await read_stream.receive()
+                    assert isinstance(first, Exception)
 
-                # Second line: valid message still comes through
-                second = await read_stream.receive()
-                assert isinstance(second, SessionMessage)
-                assert second.message == valid
+                    # Second line: valid message still comes through
+                    second = await read_stream.receive()
+                    assert isinstance(second, SessionMessage)
+                    assert second.message == valid
+
+        assert not sys.stdin.closed
+        assert not sys.stdout.closed
+        sys.stdout.write("stdio still open")
+    finally:
+        sys.stdin = original_stdin
+        sys.stdout = original_stdout
+        test_stdin.close()
+        test_stdout.close()
 
 
 class _KeepOpenBytesIO(io.BytesIO):

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -87,6 +87,13 @@ async def test_stdio_server_supports_fileno_less_standard_streams(monkeypatch: p
                 assert isinstance(message, SessionMessage)
                 assert message.message == request
 
+    assert not test_stdin.closed
+    assert not test_stdout.closed
+    test_stdin.seek(0)
+    assert test_stdin.readline() == request.model_dump_json(by_alias=True, exclude_none=True) + "\n"
+    test_stdout.write("stdio still open")
+    test_stdout.flush()
+
 
 @pytest.mark.anyio
 async def test_stdio_server_invalid_utf8() -> None:


### PR DESCRIPTION
## Summary
- duplicate the process stdin/stdout file descriptors before wrapping them for the stdio server transport
- close only the duplicated wrapper streams on shutdown, preserving the original process-level streams
- extend the stdio regression test to assert the original `sys.stdin`/`sys.stdout` wrappers remain usable after the server exits

Fixes #1933

## Test plan
- `uv run --frozen pytest tests/server/test_stdio.py -q`
- `uv run --frozen ruff check src/mcp/server/stdio.py tests/server/test_stdio.py`
- `uv run --frozen pyright src/mcp/server/stdio.py tests/server/test_stdio.py`
