### PR TITLE
fix: preserve FastMCP tool error results

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -112,7 +112,7 @@ class FuncMetadata(BaseModel):
         the structured output.
         """
         if isinstance(result, CallToolResult):
-            if self.output_schema is not None:
+            if self.output_schema is not None and not result.isError:
                 assert self.output_model is not None, "Output model must be set if output schema is defined"
                 self.output_model.model_validate(result.structuredContent)
             return result

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -13,7 +13,7 @@ from dirty_equals import IsPartialDict
 from pydantic import BaseModel, Field
 
 from mcp.server.fastmcp.utilities.func_metadata import func_metadata
-from mcp.types import CallToolResult
+from mcp.types import CallToolResult, TextContent
 
 
 class SomeInputModelA(BaseModel):
@@ -876,6 +876,24 @@ def test_tool_call_result_annotated_is_structured_and_invalid():
 
     with pytest.raises(ValueError):
         meta.convert_result(func_returning_annotated_tool_call_result())
+
+
+def test_tool_call_result_annotated_error_skips_structured_validation():
+    class PersonClass(BaseModel):
+        name: str
+
+    def func_returning_tool_error() -> Annotated[CallToolResult, PersonClass]:  # pragma: no cover
+        return CallToolResult(content=[TextContent(type="text", text="Division by zero")], isError=True)
+
+    meta = func_metadata(func_returning_tool_error)
+    result = meta.convert_result(func_returning_tool_error())
+
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent is None
+    content = result.content[0]
+    assert isinstance(content, TextContent)
+    assert content.text == "Division by zero"
 
 
 def test_tool_call_result_in_optional_is_rejected():


### PR DESCRIPTION
## Summary
- skip structured-output validation for `CallToolResult(isError=True)` in FastMCP's v1.x result conversion path
- keep validation unchanged for successful `CallToolResult` values with annotated output schemas
- add a regression test for annotated tool error results without `structuredContent`

Fixes #2429.

## To verify
- `python -m pytest tests\server\fastmcp\test_func_metadata.py -q -k "tool_call_result"`
- `python -m pytest tests\server\fastmcp\test_func_metadata.py -q`
- `python -m py_compile src\mcp\server\fastmcp\utilities\func_metadata.py tests\server\fastmcp\test_func_metadata.py`
- `python -m ruff check src\mcp\server\fastmcp\utilities\func_metadata.py tests\server\fastmcp\test_func_metadata.py`
- `git diff --check`