### PR TITLE
fix: omit empty task result fields

### DIFF
--- a/src/mcp/server/experimental/task_result_handler.py
+++ b/src/mcp/server/experimental/task_result_handler.py
@@ -116,7 +116,7 @@ class TaskResultHandler:
                 related_task = RelatedTaskMetadata(task_id=task_id)
                 related_task_meta: dict[str, Any] = {RELATED_TASK_METADATA_KEY: related_task.model_dump(by_alias=True)}
                 if result is not None:
-                    result_data = result.model_dump(by_alias=True)
+                    result_data = result.model_dump(by_alias=True, mode="json", exclude_none=True)
                     existing_meta: dict[str, Any] = result_data.get("_meta") or {}
                     result_data["_meta"] = {**existing_meta, **related_task_meta}
                     return GetTaskPayloadResult.model_validate(result_data)

--- a/tests/experimental/tasks/server/test_task_result_handler.py
+++ b/tests/experimental/tasks/server/test_task_result_handler.py
@@ -65,6 +65,8 @@ async def test_handle_returns_result_for_completed_task(
     assert response is not None
     assert response.meta is not None
     assert "io.modelcontextprotocol/related-task" in response.meta
+    serialized = response.model_dump(by_alias=True, mode="json")
+    assert serialized["content"] == [{"type": "text", "text": "Done!"}]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
﻿## Summary

- serialize completed task results with `exclude_none=True` and JSON mode before adding related-task metadata
- keep empty optional content fields out of the task result payload, matching normal session response serialization
- add a regression assertion for `TextContent` task results so `annotations` and `_meta` are omitted instead of serialized as null

Fixes #2539.

## To verify

- `python -m py_compile src/mcp/server/experimental/task_result_handler.py tests/experimental/tasks/server/test_task_result_handler.py`
- `uv run python -m pytest tests/experimental/tasks/server/test_task_result_handler.py -q`
- `uv run ruff check src/mcp/server/experimental/task_result_handler.py tests/experimental/tasks/server/test_task_result_handler.py`
- `git diff --check`
