### PR TITLE
docs(examples): fix subject-verb agreement in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 # Python SDK Examples
 
-This folders aims to provide simple examples of using the Python SDK. Please refer to the
+This folder aims to provide simple examples of using the Python SDK. Please refer to the
 [servers repository](https://github.com/modelcontextprotocol/servers)
 for real-world servers.


### PR DESCRIPTION
## Summary

`examples/README.md` opens with "This **folders** aims to provide simple examples...", which has a subject-verb agreement error: the plural "folders" disagrees with the singular verb "aims", and the line describes a single directory.

This one-word fix changes it to "This **folder** aims to provide...".

## Change
```diff
-This folders aims to provide simple examples of using the Python SDK. Please refer to the
+This folder aims to provide simple examples of using the Python SDK. Please refer to the
```

Docs-only, no code or behavior change. Note: this edits `examples/README.md`, not the v1-frozen root `README.md`.