### PR TITLE
docs: fix InMemoryTaskStore import path in experimental tasks docs

### DIFF
--- a/docs/experimental/tasks-client.md
+++ b/docs/experimental/tasks-client.md
@@ -211,7 +211,7 @@ from mcp.types import (
     CreateTaskResult, GetTaskResult, GetTaskPayloadResult,
     TaskMetadata, ElicitRequestParams,
 )
-from mcp.shared.experimental.tasks import InMemoryTaskStore
+from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
 
 # Client-side task store
 client_store = InMemoryTaskStore()

--- a/docs/experimental/tasks.md
+++ b/docs/experimental/tasks.md
@@ -114,7 +114,7 @@ The `ttl` (time-to-live) specifies how long the task and result are retained aft
 Servers persist task state in a `TaskStore`. The SDK provides `InMemoryTaskStore` for development:
 
 ```python
-from mcp.shared.experimental.tasks import InMemoryTaskStore
+from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
 
 store = InMemoryTaskStore()
 ```


### PR DESCRIPTION
## Summary

The experimental tasks docs show:

```python
from mcp.shared.experimental.tasks import InMemoryTaskStore
```

but `InMemoryTaskStore` is **not** re-exported from the `mcp.shared.experimental.tasks` package, so copying this line raises `ImportError: cannot import name 'InMemoryTaskStore' from 'mcp.shared.experimental.tasks'`.

The package's own `__init__.py` directs callers to the submodule:

> Import directly from submodules:
> - `mcp.shared.experimental.tasks.in_memory_task_store.InMemoryTaskStore`

and all library code and tests use that path (e.g. `src/mcp/server/experimental/task_support.py`, `src/mcp/server/lowlevel/experimental.py`, `tests/experimental/tasks/test_elicitation_scenarios.py`).

This fixes both doc snippets to the working import:

```diff
-from mcp.shared.experimental.tasks import InMemoryTaskStore
+from mcp.shared.experimental.tasks.in_memory_task_store import InMemoryTaskStore
```

Files: `docs/experimental/tasks.md`, `docs/experimental/tasks-client.md`.

## Verification
`uv sync` then running the old line reproduces the `ImportError`; the new line imports successfully. Docs-only change.