### PR TITLE
fix: normalize OAuth redirect URI URL subtypes

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
 
@@ -83,6 +83,14 @@ class OAuthClientMetadata(BaseModel):
         # registration response. Treat "" as absent.
         if v == "":
             return None
+        return v
+
+    @field_validator("redirect_uris", mode="before")
+    @classmethod
+    def _normalize_redirect_uris(cls, v: object) -> object:
+        if isinstance(v, list | tuple | set | frozenset):
+            redirect_uris = cast(list[Any] | tuple[Any, ...] | set[Any] | frozenset[Any], v)
+            return [str(uri) for uri in redirect_uris]
         return v
 
     def validate_scope(self, requested_scope: str | None) -> list[str] | None:

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,7 +1,9 @@
 """Tests for OAuth 2.0 shared code."""
 
+from typing import Any
+
 import pytest
-from pydantic import ValidationError
+from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
 
@@ -107,6 +109,27 @@ def test_valid_url_passes_through_unchanged():
     }
     metadata = OAuthClientMetadata.model_validate(data)
     assert str(metadata.client_uri) == "https://udemy.com/"
+
+
+@pytest.mark.parametrize(
+    "redirect_uris",
+    [
+        [AnyHttpUrl("https://example.com/callback")],
+        (AnyHttpUrl("https://example.com/callback"),),
+        {AnyHttpUrl("https://example.com/callback")},
+        frozenset({AnyHttpUrl("https://example.com/callback")}),
+    ],
+)
+def test_redirect_uri_url_subtypes_are_normalized(redirect_uris: Any):
+    info = OAuthClientInformationFull(
+        client_id="abc123",
+        redirect_uris=redirect_uris,
+    )
+
+    incoming = AnyUrl("https://example.com/callback")
+
+    assert info.validate_redirect_uri(incoming) == incoming
+    assert info.model_dump(mode="json")["redirect_uris"] == ["https://example.com/callback"]
 
 
 def test_information_full_inherits_coercion():


### PR DESCRIPTION
﻿## Summary
- normalize `redirect_uris` values at the OAuth client metadata boundary
- keep raw string, `AnyUrl`, and URL subtype inputs serializing the same way
- add a regression test for `AnyHttpUrl` registration followed by `AnyUrl` redirect validation

## To verify
- `.\.venv\Scripts\python.exe -m pytest tests\shared\test_auth.py -q`
- `.\.venv\Scripts\python.exe -m ruff check src\mcp\shared\auth.py tests\shared\test_auth.py`
- `.\.venv\Scripts\python.exe -m ruff format --check src\mcp\shared\auth.py tests\shared\test_auth.py`
- `git diff --check`

Refs #2687
