### PR TITLE
test: add regression test for issue #2001 (progress related_request_id)

### DIFF
--- a/tests/issues/test_2001_progress_related_request_id.py
+++ b/tests/issues/test_2001_progress_related_request_id.py
@@ -13,75 +13,75 @@ from mcp.server.mcpserver import Context
 pytestmark = pytest.mark.anyio
 
 async def test_report_progress_passes_related_request_id() -> None:
-      """report_progress must forward request_id as related_request_id."""
-      mock_session = AsyncMock()
-      mock_session.send_progress_notification = AsyncMock()
-      request_context = ServerRequestContext(
-      request_id="req-2001",
-      session=mock_session,
-      meta={"progress_token": "tok-progress"},
-      lifespan_context=None,
-      experimental=Experimental(),
-      )
-      ctx = Context(request_context=request_context, mcp_server=MagicMock())
-      await ctx.report_progress(25, 100, message="quarter done")
-      await ctx.report_progress(50, 100)
-      await ctx.report_progress(100, 100, message="complete")
-      assert mock_session.send_progress_notification.call_count == 3
-      mock_session.send_progress_notification.assert_any_call(
-      progress_token="tok-progress",
-      progress=25.0,
-      total=100.0,
-      message="quarter done",
-      related_request_id="req-2001",
-      )
-      mock_session.send_progress_notification.assert_any_call(
-      progress_token="tok-progress",
-      progress=50.0,
-      total=100.0,
-      message=None,
-      related_request_id="req-2001",
-      )
-      mock_session.send_progress_notification.assert_any_call(
-      progress_token="tok-progress",
-      progress=100.0,
-      total=100.0,
-      message="complete",
-      related_request_id="req-2001",
-      )
+    """report_progress must forward request_id as related_request_id."""
+    mock_session = AsyncMock()
+    mock_session.send_progress_notification = AsyncMock()
+    request_context = ServerRequestContext(
+    request_id="req-2001",
+    session=mock_session,
+    meta={"progress_token": "tok-progress"},
+    lifespan_context=None,
+    experimental=Experimental(),
+    )
+    ctx = Context(request_context=request_context, mcp_server=MagicMock())
+    await ctx.report_progress(25, 100, message="quarter done")
+    await ctx.report_progress(50, 100)
+    await ctx.report_progress(100, 100, message="complete")
+    assert mock_session.send_progress_notification.call_count == 3
+    mock_session.send_progress_notification.assert_any_call(
+    progress_token="tok-progress",
+    progress=25.0,
+    total=100.0,
+    message="quarter done",
+    related_request_id="req-2001",
+    )
+    mock_session.send_progress_notification.assert_any_call(
+    progress_token="tok-progress",
+    progress=50.0,
+    total=100.0,
+    message=None,
+    related_request_id="req-2001",
+    )
+    mock_session.send_progress_notification.assert_any_call(
+    progress_token="tok-progress",
+    progress=100.0,
+    total=100.0,
+    message="complete",
+    related_request_id="req-2001",
+    )
 
 async def test_report_progress_no_token_skips_notification() -> None:
-      """report_progress is a no-op when no progress_token is present."""
-      mock_session = AsyncMock()
-      mock_session.send_progress_notification = AsyncMock()
-      request_context = ServerRequestContext(
-      request_id="req-no-token",
-      session=mock_session,
-      meta={},
-      lifespan_context=None,
-      experimental=Experimental(),
-      )
-      ctx = Context(request_context=request_context, mcp_server=MagicMock())
-      await ctx.report_progress(50, 100)
+    """report_progress is a no-op when no progress_token is present."""
+    mock_session = AsyncMock()
+    mock_session.send_progress_notification = AsyncMock()
+    request_context = ServerRequestContext(
+    request_id="req-no-token",
+    session=mock_session,
+    meta={},
+    lifespan_context=None,
+    experimental=Experimental(),
+    )
+    ctx = Context(request_context=request_context, mcp_server=MagicMock())
+    await ctx.report_progress(50, 100)
 mock_session.send_progress_notification.assert_not_called()
 
 async def test_report_progress_integer_token() -> None:
-      """report_progress works when progress_token is an integer (e.g. 0)."""
-      mock_session = AsyncMock()
-      mock_session.send_progress_notification = AsyncMock()
-      request_context = ServerRequestContext(
-      request_id="req-int-token",
-      session=mock_session,
-      meta={"progress_token": 0},
-      lifespan_context=None,
-      experimental=Experimental(),
-      )
-      ctx = Context(request_context=request_context, mcp_server=MagicMock())
-      await ctx.report_progress(1, 10)
-      mock_session.send_progress_notification.assert_awaited_once_with(
-      progress_token=0,
-      progress=1.0,
-      total=10.0,
-      message=None,
-      related_request_id="req-int-token",
-      )
+    """report_progress works when progress_token is an integer (e.g. 0)."""
+    mock_session = AsyncMock()
+    mock_session.send_progress_notification = AsyncMock()
+    request_context = ServerRequestContext(
+    request_id="req-int-token",
+    session=mock_session,
+    meta={"progress_token": 0},
+    lifespan_context=None,
+    experimental=Experimental(),
+    )
+    ctx = Context(request_context=request_context, mcp_server=MagicMock())
+    await ctx.report_progress(1, 10)
+    mock_session.send_progress_notification.assert_awaited_once_with(
+    progress_token=0,
+    progress=1.0,
+    total=10.0,
+    message=None,
+    related_request_id="req-int-token",
+    )

--- a/tests/issues/test_2001_progress_related_request_id.py
+++ b/tests/issues/test_2001_progress_related_request_id.py
@@ -1,15 +1,6 @@
-"""Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2001.
-
-Progress notifications not delivered via SSE in stateless HTTP mode.
-
-Root cause: Context.report_progress() was calling send_progress_notification()
-without passing related_request_id.  The SSE / streamable-HTTP transport uses
-that field to route server-initiated messages back to the correct client stream;
-without it notifications are silently dropped.
-
-Fix: pass related_request_id=self.request_id in send_progress_notification(),
-consistent with how send_log_message() already works.
-"""
+# Regression test for issue #2001 - progress notifications via SSE in stateless HTTP
+# Root cause: send_progress_notification() called without related_request_id.
+# Fix: pass related_request_id=self.request_id - see mcpserver/context.py
 
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,97 +12,76 @@ from mcp.server.mcpserver import Context
 
 pytestmark = pytest.mark.anyio
 
-
 async def test_report_progress_passes_related_request_id() -> None:
-      """report_progress must forward request_id as related_request_id.
-
-          Without related_request_id the streamable-HTTP transport cannot route
-              progress notifications to the correct SSE stream; they are silently
-                  dropped.  Regression test for issue #2001.
-                      """
+      """report_progress must forward request_id as related_request_id."""
       mock_session = AsyncMock()
       mock_session.send_progress_notification = AsyncMock()
-
-    request_context = ServerRequestContext(
-              request_id="req-2001",
-              session=mock_session,
-              meta={"progress_token": "tok-progress"},
-              lifespan_context=None,
-              experimental=Experimental(),
-    )
-
-    ctx = Context(request_context=request_context, mcp_server=MagicMock())
-
-    await ctx.report_progress(25, 100, message="quarter done")
-    await ctx.report_progress(50, 100)
-    await ctx.report_progress(100, 100, message="complete")
-
-    assert mock_session.send_progress_notification.call_count == 3
-
-    mock_session.send_progress_notification.assert_any_call(
-              progress_token="tok-progress",
-              progress=25.0,
-              total=100.0,
-              message="quarter done",
-              related_request_id="req-2001",
-    )
-    mock_session.send_progress_notification.assert_any_call(
-              progress_token="tok-progress",
-              progress=50.0,
-              total=100.0,
-              message=None,
-              related_request_id="req-2001",
-    )
-    mock_session.send_progress_notification.assert_any_call(
-              progress_token="tok-progress",
-              progress=100.0,
-              total=100.0,
-              message="complete",
-              related_request_id="req-2001",
-    )
-
+      request_context = ServerRequestContext(
+      request_id="req-2001",
+      session=mock_session,
+      meta={"progress_token": "tok-progress"},
+      lifespan_context=None,
+      experimental=Experimental(),
+      )
+      ctx = Context(request_context=request_context, mcp_server=MagicMock())
+      await ctx.report_progress(25, 100, message="quarter done")
+      await ctx.report_progress(50, 100)
+      await ctx.report_progress(100, 100, message="complete")
+      assert mock_session.send_progress_notification.call_count == 3
+      mock_session.send_progress_notification.assert_any_call(
+      progress_token="tok-progress",
+      progress=25.0,
+      total=100.0,
+      message="quarter done",
+      related_request_id="req-2001",
+      )
+      mock_session.send_progress_notification.assert_any_call(
+      progress_token="tok-progress",
+      progress=50.0,
+      total=100.0,
+      message=None,
+      related_request_id="req-2001",
+      )
+      mock_session.send_progress_notification.assert_any_call(
+      progress_token="tok-progress",
+      progress=100.0,
+      total=100.0,
+      message="complete",
+      related_request_id="req-2001",
+      )
 
 async def test_report_progress_no_token_skips_notification() -> None:
       """report_progress is a no-op when no progress_token is present."""
       mock_session = AsyncMock()
       mock_session.send_progress_notification = AsyncMock()
-
-    request_context = ServerRequestContext(
-              request_id="req-no-token",
-              session=mock_session,
-              meta={},
-              lifespan_context=None,
-              experimental=Experimental(),
-    )
-
-    ctx = Context(request_context=request_context, mcp_server=MagicMock())
-
-    await ctx.report_progress(50, 100)
-
-    mock_session.send_progress_notification.assert_not_called()
-
+      request_context = ServerRequestContext(
+      request_id="req-no-token",
+      session=mock_session,
+      meta={},
+      lifespan_context=None,
+      experimental=Experimental(),
+      )
+      ctx = Context(request_context=request_context, mcp_server=MagicMock())
+      await ctx.report_progress(50, 100)
+mock_session.send_progress_notification.assert_not_called()
 
 async def test_report_progress_integer_token() -> None:
       """report_progress works when progress_token is an integer (e.g. 0)."""
       mock_session = AsyncMock()
       mock_session.send_progress_notification = AsyncMock()
-
-    request_context = ServerRequestContext(
-              request_id="req-int-token",
-              session=mock_session,
-              meta={"progress_token": 0},
-              lifespan_context=None,
-              experimental=Experimental(),
-    )
-
-    ctx = Context(request_context=request_context, mcp_server=MagicMock())
-
-    await ctx.report_progress(1, 10)
-
-    mock_session.send_progress_notification.assert_awaited_once_with(
-              progress_token=0,
-              progress=1.0,
-              total=10.0,
-              message=None,
-              related_request_id="req-int-token",
-    )
+      request_context = ServerRequestContext(
+      request_id="req-int-token",
+      session=mock_session,
+      meta={"progress_token": 0},
+      lifespan_context=None,
+      experimental=Experimental(),
+      )
+      ctx = Context(request_context=request_context, mcp_server=MagicMock())
+      await ctx.report_progress(1, 10)
+      mock_session.send_progress_notification.assert_awaited_once_with(
+      progress_token=0,
+      progress=1.0,
+      total=10.0,
+      message=None,
+      related_request_id="req-int-token",
+      )

--- a/tests/issues/test_2001_progress_related_request_id.py
+++ b/tests/issues/test_2001_progress_related_request_id.py
@@ -1,0 +1,117 @@
+"""Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2001.
+
+Progress notifications not delivered via SSE in stateless HTTP mode.
+
+Root cause: Context.report_progress() was calling send_progress_notification()
+without passing related_request_id.  The SSE / streamable-HTTP transport uses
+that field to route server-initiated messages back to the correct client stream;
+without it notifications are silently dropped.
+
+Fix: pass related_request_id=self.request_id in send_progress_notification(),
+consistent with how send_log_message() already works.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mcp.server.context import ServerRequestContext
+from mcp.server.experimental.request_context import Experimental
+from mcp.server.mcpserver import Context
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_report_progress_passes_related_request_id() -> None:
+      """report_progress must forward request_id as related_request_id.
+
+          Without related_request_id the streamable-HTTP transport cannot route
+              progress notifications to the correct SSE stream; they are silently
+                  dropped.  Regression test for issue #2001.
+                      """
+      mock_session = AsyncMock()
+      mock_session.send_progress_notification = AsyncMock()
+
+    request_context = ServerRequestContext(
+              request_id="req-2001",
+              session=mock_session,
+              meta={"progress_token": "tok-progress"},
+              lifespan_context=None,
+              experimental=Experimental(),
+    )
+
+    ctx = Context(request_context=request_context, mcp_server=MagicMock())
+
+    await ctx.report_progress(25, 100, message="quarter done")
+    await ctx.report_progress(50, 100)
+    await ctx.report_progress(100, 100, message="complete")
+
+    assert mock_session.send_progress_notification.call_count == 3
+
+    mock_session.send_progress_notification.assert_any_call(
+              progress_token="tok-progress",
+              progress=25.0,
+              total=100.0,
+              message="quarter done",
+              related_request_id="req-2001",
+    )
+    mock_session.send_progress_notification.assert_any_call(
+              progress_token="tok-progress",
+              progress=50.0,
+              total=100.0,
+              message=None,
+              related_request_id="req-2001",
+    )
+    mock_session.send_progress_notification.assert_any_call(
+              progress_token="tok-progress",
+              progress=100.0,
+              total=100.0,
+              message="complete",
+              related_request_id="req-2001",
+    )
+
+
+async def test_report_progress_no_token_skips_notification() -> None:
+      """report_progress is a no-op when no progress_token is present."""
+      mock_session = AsyncMock()
+      mock_session.send_progress_notification = AsyncMock()
+
+    request_context = ServerRequestContext(
+              request_id="req-no-token",
+              session=mock_session,
+              meta={},
+              lifespan_context=None,
+              experimental=Experimental(),
+    )
+
+    ctx = Context(request_context=request_context, mcp_server=MagicMock())
+
+    await ctx.report_progress(50, 100)
+
+    mock_session.send_progress_notification.assert_not_called()
+
+
+async def test_report_progress_integer_token() -> None:
+      """report_progress works when progress_token is an integer (e.g. 0)."""
+      mock_session = AsyncMock()
+      mock_session.send_progress_notification = AsyncMock()
+
+    request_context = ServerRequestContext(
+              request_id="req-int-token",
+              session=mock_session,
+              meta={"progress_token": 0},
+              lifespan_context=None,
+              experimental=Experimental(),
+    )
+
+    ctx = Context(request_context=request_context, mcp_server=MagicMock())
+
+    await ctx.report_progress(1, 10)
+
+    mock_session.send_progress_notification.assert_awaited_once_with(
+              progress_token=0,
+              progress=1.0,
+              total=10.0,
+              message=None,
+              related_request_id="req-int-token",
+    )

--- a/tests/issues/test_2001_progress_related_request_id.py
+++ b/tests/issues/test_2001_progress_related_request_id.py
@@ -12,76 +12,92 @@ from mcp.server.mcpserver import Context
 
 pytestmark = pytest.mark.anyio
 
+
 async def test_report_progress_passes_related_request_id() -> None:
     """report_progress must forward request_id as related_request_id."""
     mock_session = AsyncMock()
     mock_session.send_progress_notification = AsyncMock()
+
     request_context = ServerRequestContext(
-    request_id="req-2001",
-    session=mock_session,
-    meta={"progress_token": "tok-progress"},
-    lifespan_context=None,
-    experimental=Experimental(),
+        request_id="req-2001",
+        session=mock_session,
+        meta={"progress_token": "tok-progress"},
+        lifespan_context=None,
+        experimental=Experimental(),
     )
+
     ctx = Context(request_context=request_context, mcp_server=MagicMock())
+
     await ctx.report_progress(25, 100, message="quarter done")
     await ctx.report_progress(50, 100)
     await ctx.report_progress(100, 100, message="complete")
+
     assert mock_session.send_progress_notification.call_count == 3
+
     mock_session.send_progress_notification.assert_any_call(
-    progress_token="tok-progress",
-    progress=25.0,
-    total=100.0,
-    message="quarter done",
-    related_request_id="req-2001",
+        progress_token="tok-progress",
+        progress=25.0,
+        total=100.0,
+        message="quarter done",
+        related_request_id="req-2001",
     )
     mock_session.send_progress_notification.assert_any_call(
-    progress_token="tok-progress",
-    progress=50.0,
-    total=100.0,
-    message=None,
-    related_request_id="req-2001",
+        progress_token="tok-progress",
+        progress=50.0,
+        total=100.0,
+        message=None,
+        related_request_id="req-2001",
     )
     mock_session.send_progress_notification.assert_any_call(
-    progress_token="tok-progress",
-    progress=100.0,
-    total=100.0,
-    message="complete",
-    related_request_id="req-2001",
+        progress_token="tok-progress",
+        progress=100.0,
+        total=100.0,
+        message="complete",
+        related_request_id="req-2001",
     )
+
 
 async def test_report_progress_no_token_skips_notification() -> None:
     """report_progress is a no-op when no progress_token is present."""
     mock_session = AsyncMock()
     mock_session.send_progress_notification = AsyncMock()
+
     request_context = ServerRequestContext(
-    request_id="req-no-token",
-    session=mock_session,
-    meta={},
-    lifespan_context=None,
-    experimental=Experimental(),
+        request_id="req-no-token",
+        session=mock_session,
+        meta={},
+        lifespan_context=None,
+        experimental=Experimental(),
     )
+
     ctx = Context(request_context=request_context, mcp_server=MagicMock())
+
     await ctx.report_progress(50, 100)
-mock_session.send_progress_notification.assert_not_called()
+
+    mock_session.send_progress_notification.assert_not_called()
+
 
 async def test_report_progress_integer_token() -> None:
     """report_progress works when progress_token is an integer (e.g. 0)."""
     mock_session = AsyncMock()
     mock_session.send_progress_notification = AsyncMock()
+
     request_context = ServerRequestContext(
-    request_id="req-int-token",
-    session=mock_session,
-    meta={"progress_token": 0},
-    lifespan_context=None,
-    experimental=Experimental(),
+        request_id="req-int-token",
+        session=mock_session,
+        meta={"progress_token": 0},
+        lifespan_context=None,
+        experimental=Experimental(),
     )
+
     ctx = Context(request_context=request_context, mcp_server=MagicMock())
+
     await ctx.report_progress(1, 10)
+
     mock_session.send_progress_notification.assert_awaited_once_with(
-    progress_token=0,
-    progress=1.0,
-    total=10.0,
-    message=None,
-    related_request_id="req-int-token",
+        progress_token=0,
+        progress=1.0,
+        total=10.0,
+        message=None,
+        related_request_id="req-int-token",
     )


### PR DESCRIPTION
Adds a dedicated regression test file for issue #2001.

Context.report_progress() was silently dropping progress notifications in stateless HTTP / SSE transports because send_progress_notification() was called without related_request_id. The fix (already in main via mcpserver/context.py) passes related_request_id=self.request_id, consistent with send_log_message().

This test file covers:
- The primary regression: related_request_id is forwarded on every call
- Edge case: no progress_token -> notification is skipped (no-op)
- Edge case: integer progress_token (e.g. 0) works correctly

Closes #2001

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
