### PR TITLE
fix(server): send JSON-RPC parse error when stdio transport fails to parse message

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -21,6 +21,7 @@ from mcp.shared.response_router import ResponseRouter
 from mcp.types import (
     CONNECTION_CLOSED,
     INVALID_PARAMS,
+    PARSE_ERROR,
     REQUEST_TIMEOUT,
     CancelledNotification,
     ClientNotification,
@@ -427,6 +428,21 @@ class BaseSession(
 
                 async for message in self._read_stream:
                     if isinstance(message, Exception):
+                        # The transport couldn't parse the incoming message
+                        # (e.g. deeply-nested JSON exceeding the recursion
+                        # limit on stdio).  Per JSON-RPC spec §5, send a
+                        # Parse error with id=null so the client doesn't
+                        # hang waiting for a response that will never come.
+                        error_response = JSONRPCError(
+                            jsonrpc="2.0",
+                            id=None,
+                            error=ErrorData(
+                                code=PARSE_ERROR,
+                                message="Parse error",
+                                data=str(message),
+                            ),
+                        )
+                        await self._write_stream.send(SessionMessage(message=error_response))
                         await self._handle_incoming(message)
                         continue
 


### PR DESCRIPTION
## Description

When the stdio transport cannot parse an incoming JSON-RPC message (e.g. a deeply-nested `ping` request that exceeds pydantic`'s recursion limit during `validate_json`), `stdin_reader` sends a raw `Exception` through the read stream.

Previously, `BaseSession._receive_loop()` only forwarded this `Exception` to the application layer via `_handle_incoming()` without sending a JSON-RPC error response through the write stream. This left the client`'s request permanently pending until a client-side timeout.

## Root Cause

The flow for deeply-nested JSON on stdio:

1. `stdin_reader` calls `jsonrpc_message_adapter.validate_json(line)` → `ValidationError("recursion limit exceeded")`
2. The exception is caught and sent as a raw `Exception` through `read_stream_writer.send(exc)`
3. `BaseSession._receive_loop()` receives the `Exception`, calls `_handle_incoming(exc)`, but never sends a JSON-RPC response
4. Client waits forever for a response that will never arrive

## Fix

Catch the transport-level `Exception` in `BaseSession._receive_loop()` and send a proper JSON-RPC parse error (`code: -32700`) with `id: null` through the write stream, matching JSON-RPC spec §5 and the existing Streamable HTTP transport behaviour.

**Before (broken):**
```
Client sends deeply-nested JSON → server logs error internally → no response → client hangs
```

**After (fixed):**
```
Client sends deeply-nested JSON → server sends {"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"Parse error"}} → client can handle error
```

## Changes

- `src/mcp/shared/session.py`: Added `PARSE_ERROR` import; added JSON-RPC error response emission in the `isinstance(message, Exception)` branch of `_receive_loop()`

The `_handle_incoming(message)` call is preserved so the application layer can still observe transport-level failures.

Fixes #2751