### PR TITLE
Fix stdio server newline translation on Windows

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -39,9 +39,9 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     # python is platform-dependent (Windows is particularly problematic), so we
     # re-wrap the underlying binary stream to ensure UTF-8.
     if not stdin:
-        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
+        stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace", newline=""))
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8", newline=""))
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -64,6 +64,29 @@ async def test_stdio_server():
 
 
 @pytest.mark.anyio
+async def test_stdio_server_uses_lf_newlines_with_default_stdout(monkeypatch: pytest.MonkeyPatch):
+    class UnclosableBytesIO(io.BytesIO):
+        def close(self) -> None:
+            pass
+
+    raw_stdout = UnclosableBytesIO()
+    monkeypatch.setattr(sys, "stdin", TextIOWrapper(io.BytesIO(b""), encoding="utf-8"))
+    monkeypatch.setattr(sys, "stdout", TextIOWrapper(raw_stdout, encoding="utf-8"))
+
+    response = JSONRPCRequest(jsonrpc="2.0", id=3, method="ping")
+
+    with anyio.fail_after(5):
+        async with stdio_server() as (read_stream, write_stream):
+            await read_stream.aclose()
+            async with write_stream:  # pragma: no branch
+                await write_stream.send(SessionMessage(response))
+
+    raw_bytes = raw_stdout.getvalue()
+    assert raw_bytes.endswith(b"\n")
+    assert b"\r\n" not in raw_bytes
+
+
+@pytest.mark.anyio
 async def test_stdio_server_invalid_utf8(monkeypatch: pytest.MonkeyPatch):
     """Non-UTF-8 bytes on stdin must not crash the server.
 


### PR DESCRIPTION
## Summary

- Disable Windows CRLF translation in `stdio_server()` by setting `newline=""` on the default stdio wrappers.
- Add a regression test for the default stdout path so JSON-RPC frames stay LF-only.

Fixes #2433.

## Verification

Windows 11, Python 3.13.13:

```text
tests/server/test_stdio.py::test_stdio_server PASSED
tests/server/test_stdio.py::test_stdio_server_uses_lf_newlines_with_default_stdout PASSED
tests/server/test_stdio.py::test_stdio_server_invalid_utf8 PASSED
3 passed

b'{"jsonrpc":"2.0","id":3,"method":"ping"}\n'
```

Branch coverage for `tests/server/test_stdio.py`: `100.00%`.

Codex review passed before commit.
