### PR TITLE
fix: add invalid_target to AuthorizationErrorCode per RFC 8707 §2

### DIFF
--- a/src/mcp/server/auth/provider.py
+++ b/src/mcp/server/auth/provider.py
@@ -68,6 +68,7 @@ AuthorizationErrorCode = Literal[
     "invalid_scope",
     "server_error",
     "temporarily_unavailable",
+    "invalid_target",  # RFC 8707 §2
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `"invalid_target"` to `AuthorizationErrorCode` Literal per [RFC 8707 §2](https://www.rfc-editor.org/rfc/rfc8707#section-2).

## Problem

`mcp/server/auth/provider.py` `AuthorizationErrorCode` is missing `invalid_target`, the OAuth 2.0 error code for resource-indicator mismatches. When downstream clients (e.g. FastMCP OAuthProxy) raise `AuthorizeError(error="invalid_target", ...)`, pydantic rejects it with `ValidationError` instead of returning the proper OAuth-compliant error response.

## Fix

Added `"invalid_target"` to the `Literal` type in `provider.py` (one line).

## Verification

```python
from mcp.server.auth.provider import AuthorizationErrorCode, AuthorizeError
from mcp.server.auth.handlers.authorize import AuthorizationErrorResponse

# invalid_target is now accepted
assert "invalid_target" in AuthorizationErrorCode.__args__
AuthorizationErrorResponse(error="invalid_target", error_description="test")
AuthorizeError(error="invalid_target", error_description="test")
```

Closes #2641