### PR TITLE
docs: require a passing conformance test for new 2026-07-28 spec features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,11 @@
   tests. Don't silence warnings from your own code; fix the underlying cause.
   Scoped `ignore::` entries for upstream libraries are acceptable in
   `pyproject.toml` with a comment explaining why.
+- New features from the 2026-07-28 spec must have a matching test in the
+  [conformance suite](https://github.com/modelcontextprotocol/conformance)
+  that passes against this SDK (CI runs it via
+  `.github/workflows/conformance.yml`). If no matching test exists, stop and
+  tell the user so they can raise an issue on the conformance repo.
 
 ### Coverage
 


### PR DESCRIPTION
Adds a bullet to the AGENTS.md Testing section requiring that new features from the 2026-07-28 spec have a matching, passing test in the [conformance suite](https://github.com/modelcontextprotocol/conformance) — and that coding agents stop and surface a gap to the user (so it can be raised on the conformance repo) instead of skipping the check silently.

## Motivation and Context
As spec features land for the 2026-07-28 version, the conformance suite is how we verify cross-SDK behavior. Without a written rule, agent-driven contributions tend to treat unit tests as sufficient and never check conformance coverage. This makes the conformance check part of the documented definition of done and gives a clear escalation path (file an issue on modelcontextprotocol/conformance) when the suite has no scenario for a feature.

## How Has This Been Tested?
Docs-only change; markdownlint passes via pre-commit.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
CI already runs the suite both ways (server via the everything-server, client via the conformance client harness) in `.github/workflows/conformance.yml`; the new bullet points there for the wire-up.