### PR TITLE
Require protocol_version to be a string

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -120,7 +120,7 @@ class StreamableHTTPTransport:
             try:
                 # Parse the result as InitializeResult for type safety
                 init_result = InitializeResult.model_validate(message.result, by_name=False)
-                self.protocol_version = str(init_result.protocol_version)
+                self.protocol_version = init_result.protocol_version
                 logger.info(f"Negotiated protocol version: {self.protocol_version}")
             except Exception:  # pragma: no cover
                 logger.warning("Failed to parse initialization response as InitializeResult", exc_info=True)

--- a/src/mcp/types/_types.py
+++ b/src/mcp/types/_types.py
@@ -545,7 +545,7 @@ class TaskStatusNotification(Notification[TaskStatusNotificationParams, Literal[
 class InitializeRequestParams(RequestParams):
     """Parameters for the initialize request."""
 
-    protocol_version: str | int
+    protocol_version: str
     """The latest version of the Model Context Protocol that the client supports."""
     capabilities: ClientCapabilities
     client_info: Implementation
@@ -563,7 +563,7 @@ class InitializeRequest(Request[InitializeRequestParams, Literal["initialize"]])
 class InitializeResult(Result):
     """After receiving an initialize request from the client, the server sends this."""
 
-    protocol_version: str | int
+    protocol_version: str
     """The version of the Model Context Protocol that the server wants to use."""
     capabilities: ServerCapabilities
     server_info: Implementation


### PR DESCRIPTION
`InitializeRequestParams.protocol_version` and `InitializeResult.protocol_version` were typed `str | int`; this narrows both to `str`, and drops a now-redundant `str(...)` coercion in the streamable HTTP client transport.

## Motivation and Context

The [spec schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts) defines `protocolVersion` as a plain `string`. The `int` variant dates back to the pre-release protocol, where the handshake used the literal integer `1` — when versioning moved to date strings in 2024-10-07, the union was kept so old peers wouldn't fail validation. The TypeScript SDK removed its equivalent (`z.string().or(z.number().int())` → `z.string()`) in November 2024 (modelcontextprotocol/typescript-sdk@0bf7e66e98209dd5fd97dff09e8a3435e31f54aa); the Python SDK never followed.

The `int` arm is dead in practice: an integer version can never match `SUPPORTED_PROTOCOL_VERSIONS` (a `list[str]`), so on the server it always fell into the version-mismatch fallback, and on the client it always raised `RuntimeError`. Accepting integers only changed the failure mode for peers that haven't been able to negotiate since 2024.

## How Has This Been Tested?

Full test suite passes locally with 100% coverage (`./scripts/test`). No tests exercised integer versions.

## Breaking Changes

Peers that send an integer `protocolVersion` now get a validation error instead of a version-mismatch response; they could not complete negotiation before either. Type annotations referencing the union (`str | int`) on these fields will need updating.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The field's pre-history in this repo: `protocolVersion: Literal[1]` → `str | int` in 2d55eab ("Update types for protocol version 2024-10-07").