### PR TITLE
[v1.x] Add Python 3.14 trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "anyio>=4.5",


### PR DESCRIPTION
Adds the `Programming Language :: Python :: 3.14` trove classifier on the v1.x branch.

## Motivation and Context

The README's supported-Python-versions badge (`img.shields.io/pypi/pyversions/mcp.svg`) renders the classifiers of the latest PyPI release, which currently stop at 3.13 — so the badge says 3.10–3.13 even though the SDK installs and works on 3.14. References #2537, where the direction was to add the classifier on v1; the badge updates once the next v1.x release is published with this classifier.

This mirrors the approach used when 3.11–3.13 were added (9bdb8a2). A follow-up PR adds 3.14 to the v1.x CI test matrix so the advertised support is exercised: #2769

## How Has This Been Tested?

- Built the package and verified the wheel METADATA carries `Classifier: Programming Language :: Python :: 3.14`.
- Full v1.x test suite passes locally on 3.14 with 100% coverage (both lowest-direct and highest resolutions) — see the follow-up PR for the matrix change.
- Classifiers aren't resolution inputs, so `uv lock --check` passes without a lockfile change.

## Breaking Changes

None.

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The badge has shown 3.10–3.13 since 3.14.0 was released (2025-10). Once this merges, cutting a release (e.g. v1.27.3) makes it the latest version on PyPI and the badge updates automatically — no README edits needed on either branch.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>