### PR TITLE
fix: propagate McpError from tool handlers as JSON-RPC error

### DIFF
--- a/src/mcp/server/fastmcp/tools/base.py
+++ b/src/mcp/server/fastmcp/tools/base.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.server.fastmcp.utilities.context_injection import find_context_parameter
 from mcp.server.fastmcp.utilities.func_metadata import FuncMetadata, func_metadata
-from mcp.shared.exceptions import UrlElicitationRequiredError
+from mcp.shared.exceptions import McpError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
 from mcp.types import Icon, ToolAnnotations
 
@@ -109,9 +109,7 @@ class Tool(BaseModel):
                 result = self.fn_metadata.convert_result(result)
 
             return result
-        except UrlElicitationRequiredError:
-            # Re-raise UrlElicitationRequiredError so it can be properly handled
-            # as an MCP error response with code -32042
+        except McpError:
             raise
         except Exception as e:
             raise ToolError(f"Error executing tool {self.name}: {e}") from e

--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -90,7 +90,7 @@ from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.models import InitializationOptions
 from mcp.server.session import ServerSession
 from mcp.shared.context import RequestContext
-from mcp.shared.exceptions import McpError, UrlElicitationRequiredError
+from mcp.shared.exceptions import McpError
 from mcp.shared.message import ServerMessageMetadata, SessionMessage
 from mcp.shared.session import RequestResponder
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
@@ -576,9 +576,7 @@ class Server(Generic[LifespanResultT, RequestT]):
                             isError=False,
                         )
                     )
-                except UrlElicitationRequiredError:
-                    # Re-raise UrlElicitationRequiredError so it can be properly handled
-                    # by _handle_request, which converts it to an error response with code -32042
+                except McpError:
                     raise
                 except Exception as e:
                     return self._make_error_result(str(e))

--- a/tests/client/test_list_roots_callback.py
+++ b/tests/client/test_list_roots_callback.py
@@ -52,7 +52,9 @@ async def test_list_roots_callback():
     # Test without list_roots callback
     async with create_session(server._mcp_server) as client_session:
         # Make a request to trigger sampling callback
-        result = await client_session.call_tool("test_list_roots", {"message": "test message"})
-        assert result.isError is True
-        assert isinstance(result.content[0], TextContent)
-        assert result.content[0].text == "Error executing tool test_list_roots: List roots not supported"
+        # McpError propagates as a JSON-RPC error, not CallToolResult(isError=True)
+        from mcp.shared.exceptions import McpError
+
+        with pytest.raises(McpError) as exc_info:
+            await client_session.call_tool("test_list_roots", {"message": "test message"})
+        assert "List roots not supported" in exc_info.value.error.message

--- a/tests/client/test_sampling_callback.py
+++ b/tests/client/test_sampling_callback.py
@@ -54,10 +54,12 @@ async def test_sampling_callback():
     # Test without sampling callback
     async with create_session(server._mcp_server) as client_session:
         # Make a request to trigger sampling callback
-        result = await client_session.call_tool("test_sampling", {"message": "Test message for sampling"})
-        assert result.isError is True
-        assert isinstance(result.content[0], TextContent)
-        assert result.content[0].text == "Error executing tool test_sampling: Sampling not supported"
+        # McpError propagates as a JSON-RPC error, not CallToolResult(isError=True)
+        from mcp.shared.exceptions import McpError
+
+        with pytest.raises(McpError) as exc_info:
+            await client_session.call_tool("test_sampling", {"message": "Test message for sampling"})
+        assert "Sampling not supported" in exc_info.value.error.message
 
 
 @pytest.mark.anyio

--- a/tests/server/fastmcp/test_url_elicitation_error_throw.py
+++ b/tests/server/fastmcp/test_url_elicitation_error_throw.py
@@ -111,3 +111,24 @@ async def test_normal_exceptions_still_return_error_result():
         assert len(result.content) == 1
         assert isinstance(result.content[0], types.TextContent)
         assert "Something went wrong" in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_mcp_error_in_tool_handler_propagates_as_jsonrpc_error():
+    """Test that McpError raised from a tool is received as a JSON-RPC error, not isError:true."""
+    mcp = FastMCP(name="McpErrorServer")
+
+    @mcp.tool(description="A tool that raises McpError")
+    async def server_fault_tool(ctx: Context[ServerSession, None]) -> str:
+        raise McpError(types.ErrorData(code=-32000, message="server fault"))
+
+    async with create_connected_server_and_client_session(mcp._mcp_server) as client_session:
+        await client_session.initialize()
+
+        # McpError should propagate as a JSON-RPC error, not CallToolResult(isError=True)
+        with pytest.raises(McpError) as exc_info:
+            await client_session.call_tool("server_fault_tool", {})
+
+        error = exc_info.value.error
+        assert error.code == -32000
+        assert error.message == "server fault"


### PR DESCRIPTION
## Motivation and Context
  
  When a tool handler raises `McpError`, both the lowlevel server's `call_tool` decorator and FastMCP's `Tool.run()` catch it via  `except Exception` and wrap it as `CallToolResult(isError=True)`. This loses the structured error code on the wire — clients cannot distinguish error types without parsing the message string.
  
  The existing `UrlElicitationRequiredError` (a subclass of `McpError`) already had a re-raise bypass, but the parent `McpError` class did not. The v2 `McpServer` on `main` already handles this correctly with `except MCPError: raise`.
  
  Fixes #2770
  
  ## How Has This Been Tested?
  
  - Added `test_mcp_error_in_tool_handler_propagates_as_jsonrpc_error` — verifies McpError propagates as JSON-RPC error with code  preserved
  - Existing `test_url_elicitation_error_thrown_from_tool` — confirms UrlElicitationRequiredError still works (subclass of McpError)
  - Existing `test_normal_exceptions_still_return_error_result` — confirms regular exceptions still become isError:true
  - Full `tests/server/` suite passes (503 tests)
  
  ## Breaking Changes
  
  Servers that intentionally raise `McpError` in tool handlers expecting it to be wrapped as `isError:true` will now get a JSON-RPC error response instead. This is the correct behavior per MCP spec — `McpError` represents protocol-level errors, not tool execution failures.
  
  ## Types of changes
  
  - [x] Bug fix (non-breaking change which fixes an issue)
  
  ## Checklist
  
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
  - [x] My code follows the repository's style guidelines
  - [x] New and existing tests pass locally
  - [x] I have added appropriate error handling
  - [x] I have added or updated documentation as needed
  
  ## Additional context
  
  Two locations fixed:
  1. `src/mcp/server/lowlevel/server.py` — the `call_tool` decorator handler
  2. `src/mcp/server/fastmcp/tools/base.py` — the `Tool.run()` method
  
  Both now use `except McpError: raise` which subsumes the previous `except UrlElicitationRequiredError: raise` since it's a subclass.