### PR TITLE
fix: add raise ... from e in all except handlers

### DIFF
--- a/src/mcp/client/auth/utils.py
+++ b/src/mcp/client/auth/utils.py
@@ -241,7 +241,7 @@ async def handle_registration_response(response: Response) -> OAuthClientInforma
         client_info = OAuthClientInformationFull.model_validate_json(content)
         return client_info
     except ValidationError as e:  # pragma: no cover
-        raise OAuthRegistrationError(f"Invalid registration response: {e}")
+        raise OAuthRegistrationError(f"Invalid registration response: {e}") from e
 
 
 def is_valid_client_metadata_url(url: str | None) -> bool:
@@ -334,4 +334,4 @@ async def handle_token_response_scopes(
         token_response = OAuthToken.model_validate_json(content)
         return token_response
     except ValidationError as e:  # pragma: no cover
-        raise OAuthTokenError(f"Invalid token response: {e}")
+        raise OAuthTokenError(f"Invalid token response: {e}") from e

--- a/src/mcp/client/auth/utils.py
+++ b/src/mcp/client/auth/utils.py
@@ -241,7 +241,7 @@ async def handle_registration_response(response: Response) -> OAuthClientInforma
         client_info = OAuthClientInformationFull.model_validate_json(content)
         return client_info
     except ValidationError as e:  # pragma: no cover
-        raise OAuthRegistrationError(f"Invalid registration response: {e}") from e
+        raise OAuthRegistrationError("Invalid registration response") from e
 
 
 def is_valid_client_metadata_url(url: str | None) -> bool:
@@ -334,4 +334,4 @@ async def handle_token_response_scopes(
         token_response = OAuthToken.model_validate_json(content)
         return token_response
     except ValidationError as e:  # pragma: no cover
-        raise OAuthTokenError(f"Invalid token response: {e}") from e
+        raise OAuthTokenError("Invalid token response") from e

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -318,7 +318,7 @@ class ClientSession(
             except ValidationError as e:
                 raise RuntimeError(f"Invalid structured content returned by tool {name}: {e}") from e
             except SchemaError as e:  # pragma: no cover
-                raise RuntimeError(f"Invalid schema for tool {name}: {e}") from e  # pragma: no cover
+                raise RuntimeError(f"Invalid schema for tool {name}: {e}") from e
 
     async def list_prompts(self, *, params: types.PaginatedRequestParams | None = None) -> types.ListPromptsResult:
         """Send a prompts/list request.

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -316,9 +316,9 @@ class ClientSession(
             try:
                 validate(result.structured_content, output_schema)
             except ValidationError as e:
-                raise RuntimeError(f"Invalid structured content returned by tool {name}: {e}")
+                raise RuntimeError(f"Invalid structured content returned by tool {name}: {e}") from e
             except SchemaError as e:  # pragma: no cover
-                raise RuntimeError(f"Invalid schema for tool {name}: {e}")  # pragma: no cover
+                raise RuntimeError(f"Invalid schema for tool {name}: {e}") from e  # pragma: no cover
 
     async def list_prompts(self, *, params: types.PaginatedRequestParams | None = None) -> types.ListPromptsResult:
         """Send a prompts/list request.

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -186,4 +186,4 @@ class Prompt(BaseModel):
 
             return messages
         except Exception as e:
-            raise ValueError(f"Error rendering prompt {self.name}: {e}")
+            raise ValueError(f"Error rendering prompt {self.name}: {e}") from e

--- a/src/mcp/server/mcpserver/resources/resource_manager.py
+++ b/src/mcp/server/mcpserver/resources/resource_manager.py
@@ -93,7 +93,7 @@ class ResourceManager:
                 try:
                     return await template.create_resource(uri_str, params, context=context)
                 except Exception as e:  # pragma: no cover
-                    raise ValueError(f"Error creating resource from template: {e}")
+                    raise ValueError(f"Error creating resource from template: {e}") from e
 
         raise ValueError(f"Unknown resource: {uri}")
 

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -130,4 +130,4 @@ class ResourceTemplate(BaseModel):
                 fn=lambda: result,  # Capture result in closure
             )
         except Exception as e:
-            raise ValueError(f"Error creating resource from template: {e}")
+            raise ValueError(f"Error creating resource from template: {e}") from e

--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -72,7 +72,7 @@ class FunctionResource(Resource):
             else:
                 return pydantic_core.to_json(result, fallback=str, indent=2).decode()
         except Exception as e:
-            raise ValueError(f"Error reading resource {self.uri}: {e}")
+            raise ValueError(f"Error reading resource {self.uri}: {e}") from e
 
     @classmethod
     def from_function(
@@ -148,7 +148,7 @@ class FileResource(Resource):
                 return await anyio.to_thread.run_sync(self.path.read_bytes)
             return await anyio.to_thread.run_sync(self.path.read_text)
         except Exception as e:
-            raise ValueError(f"Error reading file {self.path}: {e}")
+            raise ValueError(f"Error reading file {self.path}: {e}") from e
 
 
 class HttpResource(Resource):
@@ -193,7 +193,7 @@ class DirectoryResource(Resource):
                 return list(self.path.glob(self.pattern)) if not self.recursive else list(self.path.rglob(self.pattern))
             return list(self.path.glob("*")) if not self.recursive else list(self.path.rglob("*"))
         except Exception as e:
-            raise ValueError(f"Error listing directory {self.path}: {e}")
+            raise ValueError(f"Error listing directory {self.path}: {e}") from e
 
     async def read(self) -> str:  # Always returns JSON string  # pragma: no cover
         """Read the directory listing."""
@@ -202,4 +202,4 @@ class DirectoryResource(Resource):
             file_list = [str(f.relative_to(self.path)) for f in files if f.is_file()]
             return json.dumps({"files": file_list}, indent=2)
         except Exception as e:
-            raise ValueError(f"Error reading directory {self.path}: {e}")
+            raise ValueError(f"Error reading directory {self.path}: {e}") from e


### PR DESCRIPTION
Follow-up to #2542.

Adds `from e` to all remaining `raise` statements inside `except ... as e:` blocks that were missing exception chaining. This ensures the original traceback is preserved when exceptions are re-raised, making debugging significantly easier.

**Files changed (11 sites across 6 files):**
- `src/mcp/client/session.py` (2)
- `src/mcp/client/auth/utils.py` (2)
- `src/mcp/server/mcpserver/resources/types.py` (4)
- `src/mcp/server/mcpserver/resources/resource_manager.py` (1)
- `src/mcp/server/mcpserver/resources/templates.py` (1)
- `src/mcp/server/mcpserver/prompts/base.py` (1)