### PR TITLE
feat(client): send a same-origin Origin header by default (streamable HTTP)

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -66,6 +66,27 @@ def _encode_header_value(value: str) -> str:
     return f"=?base64?{base64.b64encode(value.encode('utf-8')).decode('ascii')}?="
 
 
+def _get_default_origin(url: str) -> str | None:
+    """Derive a same-origin ``Origin`` value for *url*.
+
+    Browsers always send an ``Origin`` on cross-origin-capable requests; a server-to-server
+    client sends none. Emitting a correct same-origin value matches browser behavior and
+    satisfies servers that gate state-changing requests on a present, same-origin ``Origin``
+    (defense-in-depth against DNS-rebinding/CSRF), without weakening any server's posture.
+
+    The value is built from ``httpx.URL`` so it uses the exact scheme/host/port normalization
+    httpx applies to the ``Host`` header (default ports dropped, IPv6 hosts bracketed, userinfo
+    stripped). That keeps ``Origin`` and ``Host`` byte-for-byte consistent even for inputs like
+    ``https://host:443/mcp``, where naive parsing keeps a redundant ``:443`` that would *not*
+    match the ``Host`` httpx sends. Returns ``None`` for non-HTTP(S) URLs or URLs without an
+    authority, where no meaningful web origin exists.
+    """
+    parsed = httpx.URL(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc.decode('ascii')}"
+
+
 class StreamableHTTPError(Exception):
     """Base exception for StreamableHTTP transport errors."""
 
@@ -88,17 +109,22 @@ class RequestContext:
 class StreamableHTTPTransport:
     """StreamableHTTP client transport implementation."""
 
-    def __init__(self, url: str, protocol_version: str | None = None) -> None:
+    def __init__(
+        self, url: str, default_origin: str | None = None, protocol_version: str | None = None
+    ) -> None:
         """Initialize the StreamableHTTP transport.
 
         Args:
             url: The endpoint URL.
+            default_origin: ``Origin`` header to send when the caller has not configured one
+                on the HTTP client. See ``_get_default_origin``.
             protocol_version: Pin the MCP-Protocol-Version header from the first request.
                 Only honoured for stateless 2026-07-28+ sessions that never send
                 initialize; for earlier (stateful) versions the header is populated
                 from the negotiated InitializeResult, so a pre-2026 value is ignored.
         """
         self.url = url
+        self.default_origin = default_origin
         self.session_id: str | None = None
         self.protocol_version: str | None = protocol_version if protocol_version in MODERN_PROTOCOL_VERSIONS else None
 
@@ -134,6 +160,9 @@ class StreamableHTTPTransport:
             "accept": "application/json, text/event-stream",
             "content-type": "application/json",
         }
+        # Same-origin Origin for servers that gate on it; only when the caller set none.
+        if self.default_origin:
+            headers["origin"] = self.default_origin
         # Add session headers if available
         if self.session_id:
             headers[MCP_SESSION_ID] = self.session_id
@@ -597,7 +626,10 @@ async def streamable_http_client(
         # Create default client with recommended MCP timeouts
         client = create_mcp_http_client()
 
-    transport = StreamableHTTPTransport(url, protocol_version=protocol_version)
+    # Only supply a default Origin when the caller hasn't set one, so an explicit Origin
+    # (e.g. a multi-tenant proxy's) always wins. The client's own headers are left untouched.
+    default_origin = None if "origin" in client.headers else _get_default_origin(url)
+    transport = StreamableHTTPTransport(url, default_origin=default_origin, protocol_version=protocol_version)
 
     logger.debug(f"Connecting to StreamableHTTP endpoint: {url}")
 

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -22,13 +22,14 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from httpx_sse import ServerSentEvent
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.routing import Mount
+from starlette.responses import Response
+from starlette.routing import Mount, Route
 from starlette.types import Message, Scope
 
 from mcp import MCPError, types
 from mcp.client import ClientRequestContext
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import StreamableHTTPTransport, streamable_http_client
+from mcp.client.streamable_http import StreamableHTTPTransport, _get_default_origin, streamable_http_client
 from mcp.server import Server, ServerRequestContext
 from mcp.server.streamable_http import (
     GET_STREAM_KEY,
@@ -362,6 +363,65 @@ def make_client(app: Starlette, headers: dict[str, str] | None = None) -> httpx.
     return httpx.AsyncClient(
         transport=StreamingASGITransport(app), base_url=BASE_URL, headers=headers, follow_redirects=True
     )
+
+
+def test_get_default_origin_normalizes_authority() -> None:
+    """The default Origin matches the Host header httpx emits for the same URL."""
+    # Default ports are dropped, so Origin "https://h:443" can't mismatch the Host "h".
+    assert _get_default_origin("https://example.com:443/mcp?token=abc") == "https://example.com"
+    assert _get_default_origin("http://example.com:80/mcp") == "http://example.com"
+    # Non-default ports kept; IPv6 hosts bracketed; userinfo stripped.
+    assert _get_default_origin("https://example.com:8443/mcp") == "https://example.com:8443"
+    assert _get_default_origin("http://user:pass@[::1]:8080/mcp") == "http://[::1]:8080"
+
+
+def test_get_default_origin_returns_none_without_web_origin() -> None:
+    """URLs with no meaningful web origin yield no Origin header."""
+    assert _get_default_origin("ws://example.com/mcp") is None  # non-HTTP scheme
+    assert _get_default_origin("http:///mcp") is None  # no authority
+
+
+def _make_origin_recording_app(seen: anyio.Event, recorded: dict[str, str | None]) -> Starlette:
+    async def mcp_endpoint(request: Request) -> Response:
+        recorded["origin"] = request.headers.get("origin")
+        recorded["host"] = request.headers.get("host")
+        seen.set()
+        return Response(status_code=202)
+
+    return Starlette(routes=[Route("/mcp", endpoint=mcp_endpoint, methods=["POST"])])
+
+
+@pytest.mark.anyio
+async def test_streamable_http_client_sends_same_origin_by_default() -> None:
+    """The client sends a same-origin Origin derived from the URL, matching the Host it emits."""
+    seen = anyio.Event()
+    recorded: dict[str, str | None] = {}
+    async with make_client(_make_origin_recording_app(seen, recorded)) as client:
+        async with streamable_http_client(f"{BASE_URL}/mcp", http_client=client) as (_read_stream, write_stream):
+            await write_stream.send(SessionMessage(JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")))
+            with anyio.fail_after(5):
+                await seen.wait()
+
+    assert recorded["origin"] == BASE_URL
+    assert recorded["origin"] is not None
+    assert recorded["origin"].split("://", 1)[1] == recorded["host"]  # Origin host == Host header
+    assert "origin" not in client.headers  # caller's client is left untouched
+
+
+@pytest.mark.anyio
+async def test_streamable_http_client_preserves_custom_origin() -> None:
+    """A caller-configured Origin always wins over the derived default."""
+    seen = anyio.Event()
+    recorded: dict[str, str | None] = {}
+    app = _make_origin_recording_app(seen, recorded)
+    async with make_client(app, headers={"Origin": "https://proxy.example"}) as client:
+        async with streamable_http_client(f"{BASE_URL}/mcp", http_client=client) as (_read_stream, write_stream):
+            await write_stream.send(SessionMessage(JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")))
+            with anyio.fail_after(5):
+                await seen.wait()
+
+    assert recorded["origin"] == "https://proxy.example"
+    assert client.headers["origin"] == "https://proxy.example"
 
 
 # Test fixtures


### PR DESCRIPTION
## Summary

The streamable HTTP client opens its handshake with **no `Origin` header**. This PR makes it send a **same-origin `Origin`** derived from the target URL by default, matching browser behavior and satisfying servers that gate state-changing requests on a present, same-origin `Origin` (defense-in-depth against DNS-rebinding / CSRF) — without weakening any server's posture.

Refs #2727.

## Honest scoping (please read)

While preparing this I verified the motivating claim in #2727 — that go-sdk's `http.CrossOriginProtection` rejects the Python client with `403` *because* it sends no `Origin`. **It does not.** I built a Go 1.25 server with the real `http.NewCrossOriginProtection()` (the exact type go-sdk calls) and tested it:

| Request (POST) | Result |
|---|---|
| **no `Origin`** (client today) | **`200` — accepted** |
| `Origin` mismatching `Host` | `403` |
| `Origin` matching `Host` (this PR) | `200` |

The stdlib `Check()` has `if origin == "" { return nil }` — it *fails open* for non-browser clients. So this change is **not** a fix for that `403`; I don't want to oversell it. It's worthwhile as **browser-parity + defense-in-depth**, and for interop with any server that *does* require a present same-origin `Origin`. If maintainers feel the client should keep sending nothing, that's a reasonable call and I'll close this.

## Why derive from `httpx.URL` (the one real correctness point)

```python
parsed = httpx.URL(url)
if parsed.scheme not in ("http", "https") or not parsed.netloc:
    return None
return f"{parsed.scheme}://{parsed.netloc.decode('ascii')}"
```

The server compares the `Origin` host against the `Host` header. Building the origin from `httpx.URL` reuses the exact normalization httpx applies to `Host` (default ports dropped, IPv6 bracketed, userinfo stripped), so the two always agree. This matters for an explicit default port:

| URL | `Host` httpx sends | naive `urlsplit` origin | matches? | `httpx.URL` origin (this PR) | matches? |
|---|---|---|---|---|---|
| `https://h:443/mcp` | `h` | `https://h:443` | ❌ would `403` | `https://h` | ✅ |

So a careless derivation can turn a working `200` into a `403`; this one can't.

## Behavior

- A caller-provided `Origin` (on their `httpx.AsyncClient`) always wins; the default only fills the gap.
- The caller's client headers are never mutated.
- Non-HTTP(S) / authority-less URLs add no header.

## Tests & checks

- `test_get_default_origin_normalizes_authority` / `..._returns_none_without_web_origin` — derivation incl. default-port drop, IPv6, userinfo, non-HTTP.
- `test_streamable_http_client_sends_same_origin_by_default` — in-process (#2767 harness); asserts the sent `Origin` equals the `Host` and the caller's client is untouched.
- `test_streamable_http_client_preserves_custom_origin` — caller `Origin` wins.
- `./scripts/test`: full suite green, **100.00%** branch coverage, `strict-no-cover` clean; `ruff` + `pyright` clean.

## Relationship to existing PRs

#2729, #2731, #2752, #2759 already propose an Origin header for #2727. This one differs by deriving from `httpx.URL` so the `Origin`/`Host` match holds for explicit default ports (the cases the `urlsplit`-based versions get wrong). Happy to consolidate into whichever the maintainers prefer rather than add a fifth — flagging so this isn't duplicate noise.
