### PR TITLE
feat(auth): specify OIDC application_type during dynamic client registration (SEP-837)

### DIFF
--- a/src/mcp/client/auth/utils.py
+++ b/src/mcp/client/auth/utils.py
@@ -1,4 +1,6 @@
+import ipaddress
 import re
+from typing import Literal
 from urllib.parse import urljoin, urlparse
 
 from httpx import Request, Response
@@ -215,6 +217,41 @@ def create_oauth_metadata_request(url: str) -> Request:
     return Request("GET", url, headers={MCP_PROTOCOL_VERSION: LATEST_PROTOCOL_VERSION})
 
 
+def _is_loopback_host(host: str) -> bool:
+    """Return True if host is a loopback address (localhost, 127.0.0.0/8, or ::1)."""
+    if host == "localhost":
+        return True
+    try:
+        # pydantic keeps IPv6 hosts bracketed (e.g. "[::1]"); ipaddress wants them bare.
+        return ipaddress.ip_address(host.strip("[]")).is_loopback
+    except ValueError:
+        return False
+
+
+def infer_application_type(redirect_uris: list[AnyUrl] | None) -> Literal["native", "web"] | None:
+    """Infer the OIDC application_type from a client's redirect URIs (SEP-837).
+
+    Loopback redirect URIs (localhost, 127.0.0.0/8, ::1) and private-use URI schemes
+    identify a native application; an http(s) URL with a non-loopback host identifies
+    a web application. A mix of both is ambiguous, so the type is left unset for the
+    authorization server to decide.
+    """
+    if not redirect_uris:
+        return None
+
+    has_native = False
+    has_web = False
+    for uri in redirect_uris:
+        if uri.scheme in ("http", "https") and not _is_loopback_host(uri.host or ""):
+            has_web = True
+        else:
+            has_native = True
+
+    if has_native and has_web:
+        return None
+    return "native" if has_native else "web"
+
+
 def create_client_registration_request(
     auth_server_metadata: OAuthMetadata | None, client_metadata: OAuthClientMetadata, auth_base_url: str
 ) -> Request:
@@ -226,6 +263,14 @@ def create_client_registration_request(
         registration_url = urljoin(auth_base_url, "/register")
 
     registration_data = client_metadata.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+    # SEP-837: OIDC servers assume application_type "web" when it is omitted, which can
+    # reject the loopback redirect URIs native clients use. Send a type inferred from
+    # the redirect URIs when the caller did not set one explicitly.
+    if "application_type" not in registration_data:
+        application_type = infer_application_type(client_metadata.redirect_uris)
+        if application_type is not None:
+            registration_data["application_type"] = application_type
 
     return Request("POST", registration_url, json=registration_data, headers={"Content-Type": "application/json"})
 

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -54,6 +54,12 @@ class OAuthClientMetadata(BaseModel):
     response_types: list[str] = ["code"]
     scope: str | None = None
 
+    # OpenID Connect application type (OIDC Dynamic Client Registration 1.0 §2).
+    # OIDC servers assume "web" when this is omitted (SEP-837), which can reject the
+    # loopback redirect URIs native clients rely on. Left None here; the client
+    # infers it from redirect_uris at registration time when no value is set.
+    application_type: Literal["native", "web"] | None = None
+
     # these fields are currently unused, but we support & store them for potential
     # future use
     client_name: str | None = None

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1,6 +1,7 @@
 """Tests for refactored OAuth client authentication implementation."""
 
 import base64
+import json
 import time
 from unittest import mock
 from urllib.parse import parse_qs, quote, unquote, urlparse
@@ -23,6 +24,7 @@ from mcp.client.auth.utils import (
     extract_scope_from_www_auth,
     get_client_metadata_scopes,
     handle_registration_response,
+    infer_application_type,
     is_valid_client_metadata_url,
     should_use_client_metadata_url,
 )
@@ -1026,6 +1028,61 @@ class TestCreateClientRegistrationRequest:
 
         assert str(request.url) == "https://auth.example.com/register"
         assert request.method == "POST"
+
+
+@pytest.mark.parametrize(
+    ("redirect_uris", "expected"),
+    [
+        (["http://localhost:3030/callback"], "native"),
+        (["http://127.0.0.1:3030/callback"], "native"),
+        (["http://[::1]:3030/callback"], "native"),
+        (["com.example.app:/oauth2redirect"], "native"),
+        (["https://app.example.com/callback"], "web"),
+        (["http://localhost:3030/callback", "https://app.example.com/callback"], None),
+    ],
+)
+def test_infer_application_type(redirect_uris: list[str], expected: str | None):
+    """SEP-837: native for loopback or private-use redirect URIs, web for remote hosts."""
+    assert infer_application_type([AnyUrl(uri) for uri in redirect_uris]) == expected
+
+
+def test_infer_application_type_without_redirect_uris():
+    assert infer_application_type([]) is None
+    assert infer_application_type(None) is None
+
+
+def test_create_client_registration_request_infers_native_application_type():
+    """A loopback redirect URI registers the client as a native application (SEP-837)."""
+    client_metadata = OAuthClientMetadata(redirect_uris=[AnyUrl("http://localhost:3030/callback")])
+
+    request = create_client_registration_request(None, client_metadata, "https://auth.example.com")
+
+    assert json.loads(request.content)["application_type"] == "native"
+
+
+def test_create_client_registration_request_preserves_explicit_application_type():
+    """An explicit application_type is sent as-is, without inference overriding it."""
+    client_metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://localhost:3030/callback")], application_type="web"
+    )
+
+    request = create_client_registration_request(None, client_metadata, "https://auth.example.com")
+
+    assert json.loads(request.content)["application_type"] == "web"
+
+
+def test_create_client_registration_request_omits_ambiguous_application_type():
+    """Redirect URIs that mix native and web styles leave application_type unset."""
+    client_metadata = OAuthClientMetadata(
+        redirect_uris=[
+            AnyUrl("http://localhost:3030/callback"),
+            AnyUrl("https://app.example.com/callback"),
+        ]
+    )
+
+    request = create_client_registration_request(None, client_metadata, "https://auth.example.com")
+
+    assert "application_type" not in json.loads(request.content)
 
 
 class TestAuthFlow:

--- a/tests/interaction/auth/test_flow.py
+++ b/tests/interaction/auth/test_flow.py
@@ -205,6 +205,7 @@ async def test_the_dcr_request_carries_the_client_metadata() -> None:
             "scope": "mcp",
             "client_name": "interaction-suite",
             "software_id": "interaction-test-suite",
+            "application_type": "native",
         }
     )
 

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -138,3 +138,24 @@ def test_invalid_non_empty_url_still_rejected():
     }
     with pytest.raises(ValidationError):
         OAuthClientMetadata.model_validate(data)
+
+
+def test_application_type_defaults_to_none():
+    """SEP-837 application_type is optional; the client infers it when unset."""
+    metadata = OAuthClientMetadata.model_validate({"redirect_uris": ["http://localhost:3030/callback"]})
+    assert metadata.application_type is None
+
+
+@pytest.mark.parametrize("application_type", ["native", "web"])
+def test_application_type_accepts_valid_values(application_type: str):
+    metadata = OAuthClientMetadata.model_validate(
+        {"redirect_uris": ["http://localhost:3030/callback"], "application_type": application_type}
+    )
+    assert metadata.application_type == application_type
+
+
+def test_application_type_rejects_invalid_value():
+    with pytest.raises(ValidationError):
+        OAuthClientMetadata.model_validate(
+            {"redirect_uris": ["http://localhost:3030/callback"], "application_type": "desktop"}
+        )


### PR DESCRIPTION
Adds an `application_type` field to `OAuthClientMetadata` and sends it during OAuth Dynamic Client Registration, inferring the value from the client's redirect URIs when the caller does not set one.

Closes #2783.

## Motivation and Context

[SEP-837](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/837) requires MCP clients to send an `application_type` during OIDC Dynamic Client Registration. Omitting it defaults the client to `"web"`, which conflicts with the loopback redirect URIs (`localhost`, `127.0.0.1`, `::1`) that native clients (CLI and desktop apps) use, so the server can reject the registration.

Currently `OAuthClientMetadata` has no such field and `create_client_registration_request` never sends one, so the client hits that default. This PR adds the field and infers a value from the redirect URIs at registration time: loopback and private-use schemes register as `"native"`, a remote `https` host as `"web"`, and a mix is left unset for the authorization server to decide. An explicit value is always sent as-is, and non-OIDC servers ignore the parameter. This follows the spec's guidance [1] and mirrors the approach already merged in the Go SDK (modelcontextprotocol/go-sdk#904) and Rust SDK (modelcontextprotocol/rust-sdk#883).

## How Has This Been Tested?

The full suite passes locally with 100% coverage ([`./scripts/test`](https://github.com/modelcontextprotocol/python-sdk/blob/db06b5f7b3d26001c1dd08bf13abf57637177dd5/scripts/test)); `ruff`, `ruff format`, and `pyright` are clean.

New unit tests cover the [`application_type`](https://github.com/modelcontextprotocol/python-sdk/blob/db06b5f7b3d26001c1dd08bf13abf57637177dd5/src/mcp/shared/auth.py#L61) model field, the [redirect-URI inference](https://github.com/modelcontextprotocol/python-sdk/blob/db06b5f7b3d26001c1dd08bf13abf57637177dd5/src/mcp/client/auth/utils.py#L231) (loopback, IPv4/IPv6 loopback, private-use scheme, remote host, and ambiguous mixes), and that [`create_client_registration_request`](https://github.com/modelcontextprotocol/python-sdk/blob/db06b5f7b3d26001c1dd08bf13abf57637177dd5/src/mcp/client/auth/utils.py#L255) sends the inferred type, preserves an explicit one, and omits an ambiguous one. The auth interaction suite's registration snapshot was updated to include `application_type: "native"` for its loopback redirect. The conformance suite already covers SEP-837 ([`src/seps/sep-837.yaml`](https://github.com/modelcontextprotocol/conformance/blob/25fd44323ff3fe28967b95ea8105de47f674b7d8/src/seps/sep-837.yaml)), so [`conformance.yml`](https://github.com/modelcontextprotocol/python-sdk/blob/db06b5f7b3d26001c1dd08bf13abf57637177dd5/.github/workflows/conformance.yml) exercises this against the SDK.

## Breaking Changes

None. `application_type` is optional and defaults to `None`; existing callers are unaffected, and registration requests only gain a parameter that OIDC servers expect and non-OIDC servers ignore.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The registration failure SEP-837 describes is already surfaced by `handle_registration_response` as an `OAuthRegistrationError`, so no new error handling was needed; this PR only ensures the client declares the correct type up front.

[1]: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/7df71535a0c9b2057d73966bb6b123e684a940cd/docs/specification/draft/basic/authorization/client-registration.mdx#L152-L179
