### PR TITLE
fix: preserve OAuth authorization endpoint query params

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -12,7 +12,7 @@ import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any, Protocol
-from urllib.parse import quote, urlencode, urljoin, urlparse
+from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlunparse
 
 import anyio
 import httpx
@@ -51,6 +51,12 @@ from mcp.shared.auth_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _url_with_query_params(url: str, params: dict[str, str]) -> str:
+    parsed = urlparse(url)
+    query = urlencode([*parse_qsl(parsed.query, keep_blank_values=True), *params.items()])
+    return urlunparse(parsed._replace(query=query))
 
 
 class PKCEParameters(BaseModel):
@@ -325,14 +331,14 @@ class OAuthClientProvider(httpx.Auth):
             auth_base_url = self.context.get_authorization_base_url(self.context.server_url)
             auth_endpoint = urljoin(auth_base_url, "/authorize")
 
-        if not self.context.client_info:
+        if not self.context.client_info or not self.context.client_info.client_id:
             raise OAuthFlowError("No client info available for authorization")  # pragma: no cover
 
         # Generate PKCE parameters
         pkce_params = PKCEParameters.generate()
         state = secrets.token_urlsafe(32)
 
-        auth_params = {
+        auth_params: dict[str, str] = {
             "response_type": "code",
             "client_id": self.context.client_info.client_id,
             "redirect_uri": str(self.context.client_metadata.redirect_uris[0]),
@@ -353,7 +359,7 @@ class OAuthClientProvider(httpx.Auth):
             if "offline_access" in self.context.client_metadata.scope.split():
                 auth_params["prompt"] = "consent"
 
-        authorization_url = f"{auth_endpoint}?{urlencode(auth_params)}"
+        authorization_url = _url_with_query_params(auth_endpoint, auth_params)
         await self.context.redirect_handler(authorization_url)
 
         # Wait for callback

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1168,6 +1168,47 @@ class TestAuthFlow:
         assert oauth_provider.context.token_expiry_time is not None
 
     @pytest.mark.anyio
+    async def test_authorization_endpoint_preserves_existing_query(self, oauth_provider: OAuthClientProvider):
+        captured_auth_url: str | None = None
+        captured_state: str | None = None
+
+        async def redirect_handler(url: str) -> None:
+            nonlocal captured_auth_url, captured_state
+            captured_auth_url = url
+            captured_state = parse_qs(urlparse(url).query)["state"][0]
+
+        async def callback_handler() -> tuple[str, str | None]:
+            return "test_auth_code", captured_state
+
+        oauth_provider.context.redirect_handler = redirect_handler
+        oauth_provider.context.callback_handler = callback_handler
+        oauth_provider.context.oauth_metadata = OAuthMetadata(
+            issuer=AnyHttpUrl("https://test.salesforce.com"),
+            authorization_endpoint=AnyHttpUrl(
+                "https://test.salesforce.com/services/oauth2/authorize?prompt=select_account"
+            ),
+            token_endpoint=AnyHttpUrl("https://test.salesforce.com/services/oauth2/token"),
+        )
+        oauth_provider.context.client_info = OAuthClientInformationFull(
+            client_id="test_client",
+            client_secret="test_secret",
+            redirect_uris=[AnyUrl("http://localhost:3030/callback")],
+        )
+
+        auth_code, _ = await oauth_provider._perform_authorization_code_grant()
+
+        assert auth_code == "test_auth_code"
+        assert captured_auth_url is not None
+        parsed = urlparse(captured_auth_url)
+        params = parse_qs(parsed.query)
+        assert parsed.path == "/services/oauth2/authorize"
+        assert "?" not in parsed.query
+        assert params["prompt"] == ["select_account"]
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["test_client"]
+        assert params["redirect_uri"] == ["http://localhost:3030/callback"]
+
+    @pytest.mark.anyio
     async def test_auth_flow_no_unnecessary_retry_after_oauth(
         self, oauth_provider: OAuthClientProvider, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
     ):


### PR DESCRIPTION
Fixes #2776.

## Summary

The OAuth authorization URL builder always appended SDK parameters with a literal `?`:

```python
f"{auth_endpoint}?{urlencode(auth_params)}"
```

That breaks authorization servers whose metadata already includes endpoint-level query parameters. Salesforce sandbox auth endpoints are one example:

```text
https://test.salesforce.com/services/oauth2/authorize?prompt=select_account
```

The generated URL became `...?prompt=select_account?response_type=...`, so the OAuth parameters were folded into the existing `prompt` value instead of being sent as query parameters.

This change parses the endpoint query first, preserves existing parameters, and appends the SDK-generated OAuth parameters with normal form encoding.

## Validation

- `PYTHONPATH=src python -m pytest tests/client/test_auth.py -q -k authorization_endpoint_preserves_existing_query`
- `PYTHONPATH=src python -m pytest tests/client/test_auth.py -q`
- `python -m py_compile src/mcp/client/auth/oauth2.py tests/client/test_auth.py`
- `python -m ruff check src/mcp/client/auth/oauth2.py tests/client/test_auth.py`
- `git diff --check upstream/main..HEAD`

I also tried `python -m pyright src/mcp/client/auth/oauth2.py tests/client/test_auth.py`, but the local run failed on pre-existing environment/type-resolution issues in `tests/client/test_auth.py` before isolating this patch.
