### PR TITLE
Deflake the session-level timeout test with trio's virtual clock

### DIFF
--- a/tests/interaction/lowlevel/test_timeouts.py
+++ b/tests/interaction/lowlevel/test_timeouts.py
@@ -1,14 +1,16 @@
 """Request timeouts against the low-level Server, driven through the public Client API.
 
 The handler blocks on an event that is never set, so the awaited response can never arrive and
-any positive timeout fires deterministically on the next event-loop pass. The timeout is therefore
-set to an effectively-zero duration: the tests add no wall-clock time to the suite. (Zero itself
+any positive timeout fires deterministically on the next event-loop pass. Per-request timeouts are
+set to an effectively-zero duration; the session-level test runs on trio's virtual clock instead
+(see the comment there). Either way the tests add no wall-clock time to the suite. (Zero itself
 cannot be used: a falsy read_timeout_seconds is silently treated as "no timeout".)
 """
 
 import anyio
 import pytest
 from inline_snapshot import snapshot
+from trio.testing import MockClock
 
 from mcp import MCPError, types
 from mcp.client.client import Client
@@ -85,7 +87,19 @@ async def test_session_serves_requests_after_timeout() -> None:
     assert result == snapshot(CallToolResult(content=[TextContent(text="still alive")]))
 
 
+# A session-level timeout cannot use the effectively-zero pattern above: it also governs the
+# initialize handshake, which must complete before the blocked tool call can wait the timeout
+# out in full. Any real-clock margin is a bet against CI scheduler stalls (a 50ms value lost
+# that bet in CI; the in-process handshake tail reaches ~190ms on a loaded windows runner), so
+# this test runs on trio's virtual clock instead. With autojump, time advances only when every
+# task is blocked: the handshake always has a runnable task and therefore cannot time out no
+# matter how slow the runner, and once the tool call blocks on the never-answered request the
+# run goes idle and the clock jumps straight to the deadline — deterministic, with no real wait.
 @requirement("protocol:timeout:session-default")
+@pytest.mark.parametrize(
+    "anyio_backend",
+    [pytest.param(("trio", {"clock": MockClock(autojump_threshold=0)}), id="trio-mockclock")],
+)
 async def test_session_level_timeout_applies_to_every_request() -> None:
     """A read timeout configured on the client applies to requests that do not set their own."""
 
@@ -96,12 +110,6 @@ async def test_session_level_timeout_applies_to_every_request() -> None:
 
     server = Server("blocker", on_call_tool=call_tool)
 
-    # The one real wall-clock wait in the suite, and it cannot be made effectively zero like the
-    # per-request timeouts: a session-level timeout also governs the initialize handshake, so the
-    # value must be long enough for the in-process handshake to complete before the blocked tool
-    # call waits it out in full. 50ms buys a ~50x safety margin over the handshake's actual
-    # latency; lowering it only erodes the margin against CI scheduler jitter without saving
-    # anything perceptible.
     async with Client(server, read_timeout_seconds=0.05) as client:
         with pytest.raises(MCPError) as exc_info:
             await client.call_tool("block", {})


### PR DESCRIPTION
`test_session_level_timeout_applies_to_every_request` flaked three times in its first week. This switches it to trio's virtual clock so it is deterministic by construction, with no real waiting.

## Motivation and Context

The test sets `Client(server, read_timeout_seconds=0.05)`. A session-level read timeout applies to every request that doesn't set its own — including the `InitializeRequest` sent inside `Client.__aenter__` — so the in-process handshake had to beat 50ms of real clock before the test body even ran. Under CI load it sometimes didn't, and the test died in `__aenter__` with `Timed out while waiting for response to InitializeRequest`:

- [3.12, locked, ubuntu-latest](https://github.com/modelcontextprotocol/python-sdk/actions/runs/26672595278/job/78618483431) (May 30)
- [3.12, locked, windows-latest](https://github.com/modelcontextprotocol/python-sdk/actions/runs/26946169777/job/79499573050) (Jun 4)
- [3.12, locked, windows-latest](https://github.com/modelcontextprotocol/python-sdk/actions/runs/27031698828/job/79785389546) (Jun 5)

Looping the in-memory handshake on a CPU-saturated `windows-latest` runner (3.12, locked) puts its tail at p99 ≈ 70ms and max ≈ 190ms — 4.3% of handshakes exceeded 50ms; even idle, the max was 26ms. So the existing value was a standing bet against scheduler stalls, and any wider real-clock margin pays for itself in wall-clock time on every run.

The file's other tests are deterministic because the timed request can never be answered (the handler blocks forever), so an effectively-zero timeout always wins. The session-default test can't use that trick: the same knob governs the handshake, which must *succeed* first.

Running this one test on trio's `MockClock(autojump_threshold=0)` removes the bet instead of widening it. Virtual time only advances when every task is blocked: during the handshake some task is always runnable, so the handshake cannot time out no matter how slow the runner, and once the tool call blocks on the never-answered request the run goes idle and the clock jumps straight to the deadline. The timeout value and snapshot stay as they were; the file now runs in milliseconds. trio is already a dev dependency, and the per-test `anyio_backend` parametrization keeps the rest of the suite on asyncio.

## How Has This Been Tested?

- 500 iterations of the test shape under the MockClock via the pytest plugin path: identical outcome every time, ~1.1s of real time for 25s of virtual timeouts.
- 30 consecutive runs of the file, all green; full `tests/interaction/` suite passes (529 tests, ~5s).
- Sanity-checked the failure mode is unchanged: a tiny real-clock timeout racing the handshake is not a viable alternative — on Windows 3.12, `time.monotonic` has 15.625ms granularity, so `fail_after(1e-6)` actually lets the handshake win most races (and 3.13+ switched to QPC, flipping the behavior). Virtual time sidesteps clock granularity entirely.

## Breaking Changes

None — test-only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

All three flakes hit the 3.12/locked matrix cell. For the two Windows hits there's a plausible amplifier: on 3.12, asyncio's clock is `GetTickCount64`-based, so a 50ms deadline computed from a floor-quantized clock can fire up to ~15.6ms early in real time.

The CI tracebacks above are also a live reproduction of #2114: the `MCPError` from the failed initialize surfaces from `Client.__aenter__` double-wrapped in `ExceptionGroup`s.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
