### PR TITLE
fix(auth): normalize redirect URI URL subclasses

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
 
@@ -74,7 +74,8 @@ class OAuthClientMetadata(BaseModel):
         # AnyUrl equality is type-strict. Store the declared base type so later
         # redirect_uri membership checks compare URLs, not URL wrapper classes.
         if isinstance(v, list | tuple):
-            return [str(item) if isinstance(item, AnyUrl) else item for item in v]
+            items = cast("list[object] | tuple[object, ...]", v)
+            return [str(item) if isinstance(item, AnyUrl) else item for item in items]
         return v
 
     @field_validator(

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -67,6 +67,16 @@ class OAuthClientMetadata(BaseModel):
     software_id: str | None = None
     software_version: str | None = None
 
+    @field_validator("redirect_uris", mode="before")
+    @classmethod
+    def _coerce_redirect_uris_to_any_url(cls, v: object) -> object:
+        # Pydantic v2 keeps AnyUrl subclasses such as AnyHttpUrl as-is, while
+        # AnyUrl equality is type-strict. Store the declared base type so later
+        # redirect_uri membership checks compare URLs, not URL wrapper classes.
+        if isinstance(v, list | tuple):
+            return [str(item) if isinstance(item, AnyUrl) else item for item in v]
+        return v
+
     @field_validator(
         "client_uri",
         "logo_uri",

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -73,8 +73,8 @@ class OAuthClientMetadata(BaseModel):
         # Pydantic v2 keeps AnyUrl subclasses such as AnyHttpUrl as-is, while
         # AnyUrl equality is type-strict. Store the declared base type so later
         # redirect_uri membership checks compare URLs, not URL wrapper classes.
-        if isinstance(v, list | tuple):
-            items = cast("list[object] | tuple[object, ...]", v)
+        if isinstance(v, list | tuple | set | frozenset):
+            items = cast("list[object] | tuple[object, ...] | set[object] | frozenset[object]", v)
             return [str(item) if isinstance(item, AnyUrl) else item for item in items]
         return v
 

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,5 +1,7 @@
 """Tests for OAuth 2.0 shared code."""
 
+from typing import Any
+
 import pytest
 from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
@@ -130,10 +132,19 @@ def test_information_full_inherits_coercion():
     assert info.jwks_uri is None
 
 
-def test_redirect_uris_normalize_any_url_subtypes():
+@pytest.mark.parametrize(
+    "redirect_uris",
+    [
+        [AnyHttpUrl("https://example.com/callback")],
+        (AnyHttpUrl("https://example.com/callback"),),
+        {AnyHttpUrl("https://example.com/callback")},
+        frozenset({AnyHttpUrl("https://example.com/callback")}),
+    ],
+)
+def test_redirect_uris_normalize_any_url_subtypes(redirect_uris: Any):
     info = OAuthClientInformationFull(
         client_id="abc123",
-        redirect_uris=[AnyHttpUrl("https://example.com/callback")],
+        redirect_uris=redirect_uris,
     )
 
     assert info.validate_redirect_uri(AnyUrl("https://example.com/callback")) == AnyUrl("https://example.com/callback")

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,9 +1,9 @@
 """Tests for OAuth 2.0 shared code."""
 
 import pytest
-from pydantic import ValidationError
+from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
-from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
+from mcp.shared.auth import InvalidRedirectUriError, OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
 
 
 def test_oauth():
@@ -128,6 +128,19 @@ def test_information_full_inherits_coercion():
     assert info.tos_uri is None
     assert info.policy_uri is None
     assert info.jwks_uri is None
+
+
+def test_redirect_uris_normalize_any_url_subtypes():
+    info = OAuthClientInformationFull(
+        client_id="abc123",
+        redirect_uris=[AnyHttpUrl("https://example.com/callback")],
+    )
+
+    assert info.validate_redirect_uri(AnyUrl("https://example.com/callback")) == AnyUrl("https://example.com/callback")
+    assert info.model_dump(mode="json")["redirect_uris"] == ["https://example.com/callback"]
+
+    with pytest.raises(InvalidRedirectUriError):
+        info.validate_redirect_uri(AnyUrl("https://example.com/other"))
 
 
 def test_invalid_non_empty_url_still_rejected():


### PR DESCRIPTION
## Summary

Fixes #2687.

`OAuthClientInformationFull.redirect_uris` is declared as `list[AnyUrl]`, but Pydantic v2 preserves already-validated URL subclasses such as `AnyHttpUrl`. That makes a stored `AnyHttpUrl("https://...")` fail membership checks against an incoming `AnyUrl("https://...")`, even when the URL text is identical.

This normalizes URL subclass instances back through strings at the model boundary, so redirect URI validation compares the declared `AnyUrl` values rather than the wrapper subclass type.

## Validation

```text
uv run pytest tests/shared/test_auth.py -q
uv run ruff check src/mcp/shared/auth.py tests/shared/test_auth.py
uv run ruff format --check src/mcp/shared/auth.py tests/shared/test_auth.py
python -m py_compile src/mcp/shared/auth.py tests/shared/test_auth.py
git diff --check
```
