### PR TITLE
fix: omit null optional fields from task result payloads

### DIFF
--- a/src/mcp/server/experimental/task_result_handler.py
+++ b/src/mcp/server/experimental/task_result_handler.py
@@ -129,9 +129,15 @@ class TaskResultHandler:
                 # The stored result contains the actual payload data
                 # Per spec: tasks/result MUST include _meta with related-task metadata
                 related_task = RelatedTaskMetadata(taskId=task_id)
-                related_task_meta: dict[str, Any] = {RELATED_TASK_METADATA_KEY: related_task.model_dump(by_alias=True)}
+                related_task_meta: dict[str, Any] = {
+                    RELATED_TASK_METADATA_KEY: related_task.model_dump(
+                        by_alias=True,
+                        mode="json",
+                        exclude_none=True,
+                    )
+                }
                 if result is not None:
-                    result_data = result.model_dump(by_alias=True)
+                    result_data = result.model_dump(by_alias=True, mode="json", exclude_none=True)
                     existing_meta: dict[str, Any] = result_data.get("_meta") or {}
                     result_data["_meta"] = {**existing_meta, **related_task_meta}
                     return GetTaskPayloadResult.model_validate(result_data)

--- a/tests/experimental/tasks/server/test_task_result_handler.py
+++ b/tests/experimental/tasks/server/test_task_result_handler.py
@@ -68,6 +68,29 @@ async def test_handle_returns_result_for_completed_task(
 
 
 @pytest.mark.anyio
+async def test_handle_omits_none_fields_from_completed_task_payload(
+    store: InMemoryTaskStore, queue: InMemoryTaskMessageQueue, handler: TaskResultHandler
+) -> None:
+    """Test task result payloads omit optional None fields instead of serializing null."""
+    task = await store.create_task(TaskMetadata(ttl=60000), task_id="test-task")
+    result = CallToolResult(content=[TextContent(type="text", text="Done!")])
+    await store.store_result(task.taskId, result)
+    await store.update_task(task.taskId, status="completed")
+
+    mock_session = Mock()
+    mock_session.send_message = AsyncMock()
+
+    request = GetTaskPayloadRequest(params=GetTaskPayloadRequestParams(taskId=task.taskId))
+    response = await handler.handle(request, mock_session, "req-1")
+
+    payload = response.model_dump(by_alias=True, mode="json")
+    assert payload["content"] == [{"type": "text", "text": "Done!"}]
+    assert "annotations" not in payload["content"][0]
+    assert "_meta" not in payload["content"][0]
+    assert "io.modelcontextprotocol/related-task" in payload["_meta"]
+
+
+@pytest.mark.anyio
 async def test_handle_raises_for_nonexistent_task(
     store: InMemoryTaskStore, queue: InMemoryTaskMessageQueue, handler: TaskResultHandler
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #2539.

Task result delivery was serializing completed task payloads with `model_dump(by_alias=True)`, which preserved optional `None` fields as JSON `null` inside nested content blocks. This can make `tasks/result` responses fail clients that treat those fields as optional-but-not-null.

This updates the task result handler to dump payloads with `mode="json"` and `exclude_none=True`, matching the session serialization path, while still adding the required related-task metadata.

## Tests

- `.venv/bin/python -m pytest -q tests/experimental/tasks/server/test_task_result_handler.py::test_handle_omits_none_fields_from_completed_task_payload`
- `.venv/bin/python -m compileall -q src/mcp/server/experimental/task_result_handler.py tests/experimental/tasks/server/test_task_result_handler.py && git diff --check`
- `.venv/bin/python -m pytest -q tests/experimental/tasks/server/test_task_result_handler.py`
- `.venv/bin/python -m pytest -q tests/experimental/tasks/server`
- `.venv/bin/ruff check src/mcp/server/experimental/task_result_handler.py tests/experimental/tasks/server/test_task_result_handler.py && .venv/bin/ruff format --check src/mcp/server/experimental/task_result_handler.py tests/experimental/tasks/server/test_task_result_handler.py`
