### PR TITLE
fix(client): skip unsupported capability requests in ClientSessionGroup

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -345,11 +345,7 @@ class ClientSessionGroup:
         tool_to_session_temp: dict[str, mcp.ClientSession] = {}
 
         # Query capabilities negotiated during initialize().
-        capabilities = (
-            session.initialize_result.capabilities
-            if session.initialize_result is not None
-            else None
-        )
+        capabilities = session.initialize_result.capabilities if session.initialize_result is not None else None
         # Query the server for its prompts and aggregate to list.
         if capabilities is None or capabilities.prompts is not None:
             try:

--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -344,39 +344,45 @@ class ClientSessionGroup:
         tools_temp: dict[str, types.Tool] = {}
         tool_to_session_temp: dict[str, mcp.ClientSession] = {}
 
+        # Query capabilities negotiated during initialize().
+        capabilities = (
+            session.initialize_result.capabilities
+            if session.initialize_result is not None
+            else None
+        )
         # Query the server for its prompts and aggregate to list.
-        try:
-            prompts = (await session.list_prompts()).prompts
-            for prompt in prompts:
-                name = self._component_name(prompt.name, server_info)
-                prompts_temp[name] = prompt
-                component_names.prompts.add(name)
-        except MCPError as err:  # pragma: no cover
-            logging.warning(f"Could not fetch prompts: {err}")
+        if capabilities is None or capabilities.prompts is not None:
+            try:
+                prompts = (await session.list_prompts()).prompts
+                for prompt in prompts:
+                    name = self._component_name(prompt.name, server_info)
+                    prompts_temp[name] = prompt
+                    component_names.prompts.add(name)
+            except MCPError as err:  # pragma: no cover
+                logging.warning(f"Could not fetch prompts: {err}")
 
         # Query the server for its resources and aggregate to list.
-        try:
-            resources = (await session.list_resources()).resources
-            for resource in resources:
-                name = self._component_name(resource.name, server_info)
-                resources_temp[name] = resource
-                component_names.resources.add(name)
-        except MCPError as err:  # pragma: no cover
-            logging.warning(f"Could not fetch resources: {err}")
+        if capabilities is None or capabilities.resources is not None:
+            try:
+                resources = (await session.list_resources()).resources
+                for resource in resources:
+                    name = self._component_name(resource.name, server_info)
+                    resources_temp[name] = resource
+                    component_names.resources.add(name)
+            except MCPError as err:  # pragma: no cover
+                logging.warning(f"Could not fetch resources: {err}")
 
         # Query the server for its tools and aggregate to list.
-        try:
-            tools = (await session.list_tools()).tools
-            for tool in tools:
-                name = self._component_name(tool.name, server_info)
-                tools_temp[name] = tool
-                tool_to_session_temp[name] = session
-                component_names.tools.add(name)
-        except MCPError as err:  # pragma: no cover
-            logging.warning(f"Could not fetch tools: {err}")
-
-        # Clean up exit stack for session if we couldn't retrieve anything
-        # from the server.
+        if capabilities is None or capabilities.tools is not None:
+            try:
+                tools = (await session.list_tools()).tools
+                for tool in tools:
+                    name = self._component_name(tool.name, server_info)
+                    tools_temp[name] = tool
+                    tool_to_session_temp[name] = session
+                    component_names.tools.add(name)
+            except MCPError as err:  # pragma: no cover
+                logging.warning(f"Could not fetch tools: {err}")
         if not any((prompts_temp, resources_temp, tools_temp)):
             del self._session_exit_stacks[session]  # pragma: no cover
 

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -169,6 +169,50 @@ async def test_client_session_group_skips_unsupported_capabilities(
 
 
 @pytest.mark.anyio
+@pytest.mark.anyio
+async def test_client_session_group_skips_unsupported_tools(
+    mock_exit_stack: contextlib.AsyncExitStack,
+):
+    mock_server_info = mock.Mock(spec=types.Implementation)
+    mock_server_info.name = "TestServer"
+
+    mock_session = mock.AsyncMock(spec=mcp.ClientSession)
+
+    mock_prompt = mock.Mock(spec=types.Prompt)
+    mock_prompt.name = "prompt"
+
+    mock_resource = mock.Mock(spec=types.Resource)
+    mock_resource.name = "resource"
+
+    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[mock_prompt])
+    mock_session.list_resources.return_value = mock.AsyncMock(resources=[mock_resource])
+    mock_session.list_tools.return_value = mock.AsyncMock(tools=[])
+
+    capabilities = mock.Mock()
+    capabilities.tools = None
+    capabilities.prompts = object()
+    capabilities.resources = object()
+
+    initialize_result = mock.Mock()
+    initialize_result.capabilities = capabilities
+    mock_session.initialize_result = initialize_result
+
+    group = ClientSessionGroup(exit_stack=mock_exit_stack)
+
+    await group._aggregate_components(
+        mock_server_info,
+        mock_session,
+    )
+
+    mock_session.list_tools.assert_not_awaited()
+    mock_session.list_prompts.assert_awaited_once()
+    mock_session.list_resources.assert_awaited_once()
+
+    assert "prompt" in group.prompts
+    assert "resource" in group.resources
+
+
+@pytest.mark.anyio
 async def test_client_session_group_connect_to_server_with_name_hook(mock_exit_stack: contextlib.AsyncExitStack):
     """Test connecting with a component name hook."""
     # --- Mock Dependencies ---

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -126,6 +126,49 @@ async def test_client_session_group_connect_to_server(mock_exit_stack: contextli
 
 
 @pytest.mark.anyio
+
+@pytest.mark.anyio
+async def test_client_session_group_skips_unsupported_capabilities(
+    mock_exit_stack: contextlib.AsyncExitStack,
+):
+    """Only query capabilities advertised by the server."""
+
+    mock_server_info = mock.Mock(spec=types.Implementation)
+    mock_server_info.name = "ToolsOnlyServer"
+
+    mock_session = mock.AsyncMock(spec=mcp.ClientSession)
+
+    mock_tool = mock.Mock(spec=types.Tool)
+    mock_tool.name = "ping"
+
+    mock_session.list_tools.return_value = mock.AsyncMock(tools=[mock_tool])
+    mock_session.list_resources.return_value = mock.AsyncMock(resources=[])
+    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[])
+
+    capabilities = mock.Mock()
+    capabilities.tools = object()
+    capabilities.prompts = None
+    capabilities.resources = None
+
+    initialize_result = mock.Mock()
+    initialize_result.capabilities = capabilities
+
+    mock_session.initialize_result = initialize_result
+
+    group = ClientSessionGroup(exit_stack=mock_exit_stack)
+
+    await group._aggregate_components(
+        mock_server_info,
+        mock_session,
+    )
+
+    mock_session.list_tools.assert_awaited_once()
+    mock_session.list_prompts.assert_not_awaited()
+    mock_session.list_resources.assert_not_awaited()
+
+    assert "ping" in group.tools
+
+@pytest.mark.anyio
 async def test_client_session_group_connect_to_server_with_name_hook(mock_exit_stack: contextlib.AsyncExitStack):
     """Test connecting with a component name hook."""
     # --- Mock Dependencies ---

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -126,7 +126,6 @@ async def test_client_session_group_connect_to_server(mock_exit_stack: contextli
 
 
 @pytest.mark.anyio
-
 @pytest.mark.anyio
 async def test_client_session_group_skips_unsupported_capabilities(
     mock_exit_stack: contextlib.AsyncExitStack,
@@ -167,6 +166,7 @@ async def test_client_session_group_skips_unsupported_capabilities(
     mock_session.list_resources.assert_not_awaited()
 
     assert "ping" in group.tools
+
 
 @pytest.mark.anyio
 async def test_client_session_group_connect_to_server_with_name_hook(mock_exit_stack: contextlib.AsyncExitStack):


### PR DESCRIPTION
# MCP Python SDK Contribution – Issue #2689

## Respect Negotiated Capabilities in ClientSessionGroup

### Overview

This contribution improves capability negotiation behavior in the MCP Python SDK.

Previously, `ClientSessionGroup._aggregate_components()` attempted to retrieve prompts, resources, and tools from every connected server regardless of the capabilities negotiated during initialization.

### Problem

During server initialization, MCP servers advertise their supported capabilities. However, the existing implementation attempted to call:

* `list_prompts()`
* `list_resources()`
* `list_tools()`

without verifying whether those capabilities were available.

### Solution

The implementation now checks the negotiated capabilities before requesting server components.

#### New Behavior

* Query prompts only when prompt capabilities are advertised.
* Query resources only when resource capabilities are advertised.
* Query tools only when tool capabilities are advertised.

This ensures that `ClientSessionGroup` interacts only with features explicitly supported by the connected server.

### Testing

Added regression test:

`test_client_session_group_skips_unsupported_capabilities`

#### Validation

```bash
uv run pytest tests/client/test_session_group.py -v
```

Output:

```text
12 passed
```

### Files Modified

* `src/mcp/client/session_group.py`
* `tests/client/test_session_group.py`

### Benefits

* Better protocol compliance
* Reduced unnecessary RPC requests
* Improved compatibility with capability-limited MCP servers
* More predictable client behavior

### Related Issue

Fixes #2689

### Author

**Bobby Nandigam**

