### PR TITLE
fix: suppress MCPServer KeyboardInterrupt tracebacks

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -295,9 +295,9 @@ class MCPServer(Generic[LifespanResultT]):
             match transport:
                 case "stdio":
                     anyio.run(self.run_stdio_async)
-                case "sse":  # pragma: no cover
+                case "sse":
                     anyio.run(lambda: self.run_sse_async(**kwargs))
-                case "streamable-http":  # pragma: no cover
+                case "streamable-http":
                     anyio.run(lambda: self.run_streamable_http_async(**kwargs))
         except KeyboardInterrupt:
             return

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -297,7 +297,7 @@ class MCPServer(Generic[LifespanResultT]):
                     anyio.run(self.run_stdio_async)
                 case "sse":
                     anyio.run(lambda: self.run_sse_async(**kwargs))
-                case "streamable-http":
+                case "streamable-http":  # pragma: no branch
                     anyio.run(lambda: self.run_streamable_http_async(**kwargs))
         except KeyboardInterrupt:
             return

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -291,13 +291,16 @@ class MCPServer(Generic[LifespanResultT]):
         if transport not in TRANSPORTS.__args__:  # type: ignore  # pragma: no cover
             raise ValueError(f"Unknown transport: {transport}")
 
-        match transport:
-            case "stdio":
-                anyio.run(self.run_stdio_async)
-            case "sse":  # pragma: no cover
-                anyio.run(lambda: self.run_sse_async(**kwargs))
-            case "streamable-http":  # pragma: no cover
-                anyio.run(lambda: self.run_streamable_http_async(**kwargs))
+        try:
+            match transport:
+                case "stdio":
+                    anyio.run(self.run_stdio_async)
+                case "sse":  # pragma: no cover
+                    anyio.run(lambda: self.run_sse_async(**kwargs))
+                case "streamable-http":  # pragma: no cover
+                    anyio.run(lambda: self.run_streamable_http_async(**kwargs))
+        except KeyboardInterrupt:
+            return
 
     async def _handle_list_tools(
         self, ctx: ServerRequestContext[LifespanResultT], params: PaginatedRequestParams | None

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1,6 +1,6 @@
 import base64
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -72,6 +72,16 @@ class TestServer:
 
         mcp_no_deps = MCPServer("test")
         assert mcp_no_deps.dependencies == []
+
+    @pytest.mark.parametrize("transport", ["stdio", "sse", "streamable-http"])
+    def test_run_suppresses_keyboard_interrupt(self, transport: str):
+        mcp = MCPServer("test")
+        transport_name = cast(Literal["stdio", "sse", "streamable-http"], transport)
+
+        with patch("mcp.server.mcpserver.server.anyio.run", side_effect=KeyboardInterrupt) as run:
+            mcp.run(transport=transport_name)
+
+        run.assert_called_once()
 
     async def test_sse_app_returns_starlette_app(self):
         """Test that sse_app returns a Starlette application with correct routes."""


### PR DESCRIPTION
## Summary
- suppress `KeyboardInterrupt` at the synchronous `MCPServer.run()` boundary
- cover `stdio`, `sse`, and `streamable-http` dispatch paths with a focused regression test

Closes #2663.

## To verify
- `uv run --frozen pytest tests/server/mcpserver/test_server.py::TestServer::test_run_suppresses_keyboard_interrupt -q`
- `uv run --frozen pytest tests/server/mcpserver/test_server.py -q`
- `uv run --frozen ruff check src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py`
- `uv run --frozen pyright src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py`
- `git diff --check`