### PR TITLE
fix: detect context on callable tool objects

### DIFF
--- a/src/mcp/server/mcpserver/utilities/context_injection.py
+++ b/src/mcp/server/mcpserver/utilities/context_injection.py
@@ -22,9 +22,13 @@ def find_context_parameter(fn: Callable[..., Any]) -> str | None:
     Returns:
         The name of the context parameter, or None if not found
     """
+    target = fn
+    if not inspect.isfunction(fn) and not inspect.ismethod(fn):
+        target = fn.__call__
+
     # Get type hints to properly resolve string annotations
     try:
-        hints = typing.get_type_hints(fn)
+        hints = typing.get_type_hints(target)
     except Exception:  # pragma: lax no cover
         # If we can't resolve type hints, we can't find the context parameter
         return None

--- a/tests/server/mcpserver/test_tool_manager.py
+++ b/tests/server/mcpserver/test_tool_manager.py
@@ -328,6 +328,40 @@ class TestToolSchema:
         assert "ctx" not in tool.fn_metadata.arg_model.model_fields
 
 
+def test_context_arg_excluded_from_callable_object_schema():
+    class MyTool:
+        def __init__(self):
+            self.__name__ = "MyTool"
+
+        async def __call__(self, query: str, ctx: Context) -> str:  # pragma: no cover
+            return query
+
+    manager = ToolManager()
+    tool = manager.add_tool(MyTool())
+
+    assert tool.context_kwarg == "ctx"
+    assert "ctx" not in json.dumps(tool.parameters)
+    assert "Context" not in json.dumps(tool.parameters)
+    assert "ctx" not in tool.fn_metadata.arg_model.model_fields
+
+
+@pytest.mark.anyio
+async def test_context_injected_into_callable_object():
+    class MyTool:
+        def __init__(self):
+            self.__name__ = "MyTool"
+
+        async def __call__(self, query: str, ctx: Context) -> str:
+            assert isinstance(ctx, Context)
+            return query
+
+    manager = ToolManager()
+    manager.add_tool(MyTool())
+
+    result = await manager.call_tool("MyTool", {"query": "hello"}, context=Context())
+    assert result == "hello"
+
+
 class TestContextHandling:
     """Test context handling in the tool manager."""
 


### PR DESCRIPTION
Fixes #1974.

## Summary

`find_context_parameter()` previously inspected callable object instances directly with `typing.get_type_hints()`. For instances that implement `__call__`, those type hints live on the bound `__call__` method, so a `ctx: Context` parameter was not detected. That meant callable-object tools exposed `ctx` as a required external tool argument instead of letting the framework inject it.

This updates context detection to inspect `fn.__call__` for callable objects while preserving the existing path for regular functions and methods. It also adds regression coverage for both schema generation and runtime context injection on callable-object tools.

## Validation

- `uv run --frozen pytest tests/server/mcpserver/test_tool_manager.py -q`
- `uv run --frozen ruff check src/mcp/server/mcpserver/utilities/context_injection.py tests/server/mcpserver/test_tool_manager.py`
- `uv run --frozen ruff format --check src/mcp/server/mcpserver/utilities/context_injection.py tests/server/mcpserver/test_tool_manager.py`
- `uv run --frozen pyright`
- `env -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY -u all_proxy -u http_proxy -u https_proxy ./scripts/test`
- `git diff --check`

This PR was prepared with AI assistance and manually validated with the checks above.