### PR TITLE
Clarify AGENTS.md policy on compat shims for breaking changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,12 @@
 
 <!-- TODO: drop this section once v2 ships and main becomes the stable line -->
 
-- `main` is currently the V2 rework. Breaking changes are expected here — when removing or
-  replacing an API, delete it outright and document the change in
-  `docs/migration.md`. Do not add `@deprecated` shims or backward-compat layers
-  on `main`.
+- `main` is currently the V2 rework.
+- Breaking changes are expected here — removing or replacing an API must be
+  intentional. Adding a replacement API or `@deprecated` shim must likewise be
+  a deliberate design choice, not bolted on for free.
+- Breaking changes (including those softened by a backwards-compatibility
+  shim) must be documented in `docs/migration.md`.
 - `v1.x` is the release branch for the current stable line. Backport PRs target
   this branch and use a `[v1.x]` title prefix.
 - `README.md` is frozen at v1 (a pre-commit hook rejects edits). Edit
@@ -117,7 +119,8 @@ What the existing pragmas mean:
 
 ## Breaking Changes
 
-When making breaking changes, document them in `docs/migration.md`. Include:
+When making breaking changes, document them in `docs/migration.md` — including
+changes softened by a backwards-compatibility shim. Include:
 
 - What changed
 - Why it changed


### PR DESCRIPTION
Reword the branching-model section of AGENTS.md: instead of banning `@deprecated` shims and backward-compat layers outright on `main`, state that removing or replacing an API must be intentional, and that adding a replacement API or `@deprecated` shim must likewise be a deliberate design choice rather than something bolted on by default.

## Motivation and Context

The old wording read as an absolute rule, but sometimes a shim *is* the right call during the v2 rework — it just has to be a conscious decision. This also makes explicit that a breaking change still needs a `docs/migration.md` entry even when a compat shim softens it, and echoes that in the Breaking Changes section so it's visible to readers who jump straight there.

## How Has This Been Tested?

Docs-only change; pre-commit (markdownlint) passes.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
