### PR TITLE
fix(server): align call_tool result shapes

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import inspect
-import json
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -75,6 +74,7 @@ from mcp.types import Tool as MCPTool
 logger = get_logger(__name__)
 
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
+ToolResult = CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]
 
 
 class Settings(BaseSettings, Generic[LifespanResultT]):
@@ -322,14 +322,6 @@ class MCPServer(Generic[LifespanResultT]):
                 content=list(unstructured_content),  # type: ignore[arg-type]
                 structured_content=structured_content,  # type: ignore[arg-type]
             )
-        if isinstance(result, dict):  # pragma: no cover
-            # TODO: this code path is unreachable — convert_result never returns a raw dict.
-            # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong
-            # and needs to be cleaned up.
-            return CallToolResult(
-                content=[TextContent(type="text", text=json.dumps(result, indent=2))],
-                structured_content=result,
-            )
         return CallToolResult(content=list(result))
 
     async def _handle_list_resources(
@@ -399,8 +391,12 @@ class MCPServer(Generic[LifespanResultT]):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
-        """Call a tool by name with arguments."""
+    ) -> ToolResult:
+        """Call a tool by name with arguments.
+
+        Returns either a ready-made CallToolResult, unstructured content blocks,
+        or unstructured content paired with structured content.
+        """
         if context is None:
             context = Context(mcp_server=self)
         return await self._tool_manager.call_tool(name, arguments, context, convert_result=True)

--- a/tests/interaction/_requirements.py
+++ b/tests/interaction/_requirements.py
@@ -681,6 +681,10 @@ REQUIREMENTS: dict[str, Requirement] = {
             "tool result with isError true and the failure text in content; it does not become a JSON-RPC error."
         ),
     ),
+    "mcpserver:tool:call-tool-result-direct": Requirement(
+        source="issue:#2695",
+        behavior="A tool function may return a ready-made CallToolResult and have it passed through.",
+    ),
     "mcpserver:tool:input-validation": Requirement(
         source=f"{SPEC_BASE_URL}/server/tools#error-handling",
         behavior=(
@@ -725,6 +729,13 @@ REQUIREMENTS: dict[str, Requirement] = {
                 "params); MCPServer reports a tool execution error (isError true) instead. The low-level "
                 "path follows the spec example (see tools:call:unknown-name)."
             ),
+        ),
+    ),
+    "mcpserver:tool:unstructured-content": Requirement(
+        source="issue:#2695",
+        behavior=(
+            "A tool function that returns unstructured content blocks without an output schema is returned as "
+            "ordinary result content, not structured content."
         ),
     ),
     "mcpserver:tool:url-elicitation-error": Requirement(

--- a/tests/interaction/mcpserver/test_tools.py
+++ b/tests/interaction/mcpserver/test_tools.py
@@ -212,6 +212,38 @@ async def test_call_tool_list_return_is_wrapped_in_result_key(connect: Connect) 
     )
 
 
+@requirement("mcpserver:tool:call-tool-result-direct")
+async def test_tool_returning_call_tool_result_passes_through(connect: Connect) -> None:
+    """A tool may return a fully formed CallToolResult when it needs to control the wire result."""
+    mcp = MCPServer("direct")
+
+    @mcp.tool()
+    def report() -> CallToolResult:
+        return CallToolResult(content=[TextContent(text="ready")], structured_content={"status": "ready"})
+
+    async with connect(mcp) as client:
+        result = await client.call_tool("report", {})
+
+    assert result == snapshot(
+        CallToolResult(content=[TextContent(text="ready")], structured_content={"status": "ready"})
+    )
+
+
+@requirement("mcpserver:tool:unstructured-content")
+async def test_tool_without_output_schema_returns_unstructured_content(connect: Connect) -> None:
+    """Without an output schema, MCPServer wraps content blocks as unstructured result content."""
+    mcp = MCPServer("raw-content")
+
+    @mcp.tool()
+    def raw_blocks():
+        return [TextContent(text="raw")]
+
+    async with connect(mcp) as client:
+        result = await client.call_tool("raw_blocks", {})
+
+    assert result == snapshot(CallToolResult(content=[TextContent(text="raw")]))
+
+
 @requirement("mcpserver:tool:input-validation")
 async def test_call_tool_invalid_arguments_become_error_result(connect: Connect) -> None:
     """Arguments that fail validation against the tool's signature are reported as an is_error

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1,6 +1,6 @@
 import base64
 from pathlib import Path
-from typing import Any
+from typing import Any, get_type_hints
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,6 +15,7 @@ from mcp.server.mcpserver import Context, MCPServer
 from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.prompts.base import Message, UserMessage
 from mcp.server.mcpserver.resources import FileResource, FunctionResource
+from mcp.server.mcpserver.server import ToolResult
 from mcp.server.mcpserver.utilities.types import Audio, Image
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import MCPError
@@ -72,6 +73,9 @@ class TestServer:
 
         mcp_no_deps = MCPServer("test")
         assert mcp_no_deps.dependencies == []
+
+    def test_call_tool_return_annotation_lists_reachable_shapes(self):
+        assert get_type_hints(MCPServer.call_tool)["return"] == ToolResult
 
     async def test_sse_app_returns_starlette_app(self):
         """Test that sse_app returns a Starlette application with correct routes."""


### PR DESCRIPTION
## Summary
- remove the unreachable raw-dict branch in `MCPServer._handle_call_tool`
- align `MCPServer.call_tool` with the result shapes actually returned by the tool manager
- add regression coverage for direct `CallToolResult` returns and unstructured content-block returns

Fixes #2695

## To verify
- `uv run --frozen pytest tests\interaction\mcpserver\test_tools.py::test_tool_returning_call_tool_result_passes_through tests\interaction\mcpserver\test_tools.py::test_tool_without_output_schema_returns_unstructured_content tests\interaction\mcpserver\test_tools.py::test_call_tool_model_return_becomes_structured_content tests\server\mcpserver\test_server.py::TestServer::test_call_tool_return_annotation_lists_reachable_shapes -q`
- `uv run --frozen pytest tests\interaction\test_coverage.py -q`
- `uv run --frozen ruff check src\mcp\server\mcpserver\server.py tests\interaction\mcpserver\test_tools.py tests\interaction\_requirements.py tests\server\mcpserver\test_server.py`
- `uv run --frozen pyright src\mcp\server\mcpserver\server.py tests\interaction\mcpserver\test_tools.py tests\interaction\_requirements.py tests\server\mcpserver\test_server.py`
- `git diff --check`
