### PR TITLE
[v1.x] Add a v2 status banner to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
 
 </div>
 
+> **This documents v1.x, the stable release line of the MCP Python SDK. v2 is in alpha.**
+>
+> v2 pre-releases are published to PyPI as `2.0.0aN`. Installers never select a pre-release unless you opt in (for example `pip install mcp==2.0.0a1`), so v1.x users are unaffected. **If your package depends on `mcp`, add a `<2` upper bound to your version constraint (for example `mcp>=1.27,<2`) before the stable v2 release lands.** See the [v2 documentation](https://github.com/modelcontextprotocol/python-sdk/blob/main/README.v2.md) and the [migration guide](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md) for what's changing.
+>
+> v1.x remains recommended for production use. It is in maintenance mode and continues to receive critical bug fixes and security patches.
+
 <!-- omit in toc -->
 ## Table of Contents
 


### PR DESCRIPTION
Adds a short banner to the v1.x README announcing the v2 alpha.

## Motivation and Context

v2 pre-releases are about to be published to PyPI as `2.0.0aN`. This branch's README is both the repository documentation for the stable line and the PyPI project description for every stable release, so it is the highest-traffic place to tell users three things: v2 is coming and is currently in alpha, installers will not give anyone a pre-release without an explicit opt-in, and packages that depend on `mcp` should add a `<2` upper bound before the stable v2 release lands. It also states v1.x's maintenance-mode status.

The banner uses plain blockquote markup and absolute URLs so it renders correctly on PyPI (no GitHub-only alert syntax, no relative links).

A companion PR on `main` (#2834) updates that branch's README banner to match.

## How Has This Been Tested?

markdownlint and pre-commit pass; docs-only change.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>