### PR TITLE
test: lock in CallToolResult(is_error=True) with non-text content (#348)

### DIFF
--- a/tests/interaction/_requirements.py
+++ b/tests/interaction/_requirements.py
@@ -528,6 +528,14 @@ REQUIREMENTS: dict[str, Requirement] = {
             "in content, not as a JSON-RPC error."
         ),
     ),
+    "tools:call:is-error-with-content": Requirement(
+        source="issue:#348",
+        behavior=(
+            "A tool can return a hand-built CallToolResult with isError true that carries arbitrary "
+            "content (e.g. an image), not just text; the content blocks and the isError flag reach the "
+            "caller intact."
+        ),
+    ),
     "tools:call:logging-mid-execution": Requirement(
         source=f"{SPEC_BASE_URL}/server/utilities/logging#log-message-notifications",
         behavior=(

--- a/tests/interaction/mcpserver/test_tools.py
+++ b/tests/interaction/mcpserver/test_tools.py
@@ -16,6 +16,7 @@ from mcp.types import (
     CallToolResult,
     ElicitRequestURLParams,
     ErrorData,
+    ImageContent,
     LoggingMessageNotification,
     LoggingMessageNotificationParams,
     TextContent,
@@ -131,6 +132,30 @@ async def test_call_tool_unknown_name_returns_error_result(connect: Connect) -> 
         result = await client.call_tool("nope", {})
 
     assert result == snapshot(CallToolResult(content=[TextContent(text="Unknown tool: nope")], is_error=True))
+
+
+@requirement("tools:call:is-error-with-content")
+async def test_tool_returning_call_tool_result_can_flag_is_error_on_non_text_content(connect: Connect) -> None:
+    """A tool may hand back a CallToolResult with is_error=True carrying non-text content.
+
+    Raising an exception is the usual way to produce an is_error result, but that only yields a
+    text message. A tool that wants to report failure while returning richer content (here, an
+    image) can return a CallToolResult directly; MCPServer passes it through unchanged, so both the
+    image block and the is_error flag reach the caller. Regression lock-in for issue #348.
+    """
+    mcp = MCPServer("imager")
+
+    @mcp.tool()
+    def render() -> CallToolResult:
+        return CallToolResult(
+            content=[ImageContent(data="aW1n", mime_type="image/png")],
+            is_error=True,
+        )
+
+    async with connect(mcp) as client:
+        result = await client.call_tool("render", {})
+
+    assert result == snapshot(CallToolResult(content=[ImageContent(data="aW1n", mime_type="image/png")], is_error=True))
 
 
 @requirement("mcpserver:tool:output-schema:model")


### PR DESCRIPTION
## What

Adds a regression test proving a FastMCP tool can return a `CallToolResult` with `is_error=True` carrying **non-text** content (an image), and a matching requirements-manifest entry.

## Why

Issue #348 (good first issue, ready for work) reports that there's "no way to set `isError=True` for arbitrary tool result content" — e.g. returning an image with `isError=True`.

While looking into it, the capability actually already exists on `main`: `_handle_call_tool` and `func_metadata.convert_result` pass a tool-returned `CallToolResult` through unchanged, so a tool can return `CallToolResult(content=[ImageContent(...)], is_error=True)` directly. The existing tests only cover this for **text** content and for the validation/exception paths — the non-text + `is_error` case from #348 wasn't pinned anywhere.

This PR locks that behaviour in so it can't silently regress, and documents the pattern in the test docstring. **Test-only — no library change.**

## Verification

- New test passes across all three transports (in-memory, SSE, streamable-HTTP)
- `tests/interaction/test_coverage.py` requirements gate passes (new requirement is exercised; test carries a requirement)
- `ruff format --check`, `ruff check`, and `pyright` all clean
- Full `tests/interaction/mcpserver/test_tools.py` (42 tests) passes

If maintainers would rather close #348 with a dedicated convenience API instead of documenting the `CallToolResult` passthrough, happy to adjust — this seemed like the lowest-risk way to resolve it.

Closes #348.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)