### PR TITLE
fix: propagate MCPError from tool handlers as JSON-RPC error

### DIFF
--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -10,7 +10,7 @@ from mcp.server.mcpserver.exceptions import ToolError
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
 from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
 from mcp.shared._callable_inspection import is_async_callable
-from mcp.shared.exceptions import UrlElicitationRequiredError
+from mcp.shared.exceptions import MCPError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
 from mcp.types import Icon, ToolAnnotations
 
@@ -111,9 +111,7 @@ class Tool(BaseModel):
                 result = self.fn_metadata.convert_result(result)
 
             return result
-        except UrlElicitationRequiredError:
-            # Re-raise UrlElicitationRequiredError so it can be properly handled
-            # as an MCP error response with code -32042
+        except MCPError:
             raise
         except Exception as e:
             raise ToolError(f"Error executing tool {self.name}: {e}") from e

--- a/tests/server/mcpserver/test_url_elicitation_error_throw.py
+++ b/tests/server/mcpserver/test_url_elicitation_error_throw.py
@@ -91,6 +91,23 @@ async def test_url_elicitation_error_from_error():
 
 
 @pytest.mark.anyio
+async def test_mcp_error_propagates_as_json_rpc_error():
+    """Test that MCPError raised from a tool propagates as a JSON-RPC error, not isError result."""
+    mcp = MCPServer(name="McpErrorServer")
+
+    @mcp.tool(description="A tool that raises a plain MCPError")
+    async def failing_tool(ctx: Context) -> str:
+        raise MCPError(-32000, "custom MCP error")
+
+    async with Client(mcp) as client:
+        with pytest.raises(MCPError) as exc_info:
+            await client.call_tool("failing_tool", {})
+
+        assert exc_info.value.error.code == -32000
+        assert exc_info.value.error.message == "custom MCP error"
+
+
+@pytest.mark.anyio
 async def test_normal_exceptions_still_return_error_result():
     """Test that normal exceptions still return CallToolResult with is_error=True."""
     mcp = MCPServer(name="NormalErrorServer")


### PR DESCRIPTION
Fixes #2770

## Root cause

`tools/base.py` only re-raised `UrlElicitationRequiredError`; any other `MCPError` raised inside a tool function fell through to the bare `except Exception` clause, got wrapped into `ToolError`, and surfaced as `CallToolResult(isError=True)` instead of a structured JSON-RPC error response.

## Fix

Broaden the guard from `except UrlElicitationRequiredError` to `except MCPError`. Since `UrlElicitationRequiredError` is a subclass of `MCPError`, the existing behaviour for that case is unchanged.

## Changes

- `src/mcp/server/mcpserver/tools/base.py`: widen re-raise guard (1 line)
- `tests/server/mcpserver/test_url_elicitation_error_throw.py`: regression test covering the plain `MCPError` propagation path

## Testing

```
uv run --frozen pytest tests/server/mcpserver/test_url_elicitation_error_throw.py tests/interaction/mcpserver/test_tools.py
# 438 passed
```