### PR TITLE
Fix/simple auth example

### DIFF
--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -31,7 +31,7 @@ class ResourceServerSettings(BaseSettings):
     # Server settings
     host: str = "localhost"
     port: int = 8001
-    server_url: AnyHttpUrl = AnyHttpUrl("http://localhost:8001/mcp")
+    server_url: AnyHttpUrl = AnyHttpUrl("http://localhost:8001")
 
     # Authorization Server settings
     auth_server_url: AnyHttpUrl = AnyHttpUrl("http://localhost:9000")
@@ -128,7 +128,7 @@ def main(port: int, auth_server: str, transport: Literal["sse", "streamable-http
 
         # Create settings
         host = "localhost"
-        server_url = f"http://{host}:{port}/mcp"
+        server_url = f"http://{host}:{port}"
         settings = ResourceServerSettings(
             host=host,
             port=port,

--- a/examples/servers/simple-auth/mcp_simple_auth/simple_auth_provider.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/simple_auth_provider.py
@@ -265,8 +265,7 @@ class SimpleOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Re
         """Exchange refresh token - not supported in this example."""
         raise NotImplementedError("Refresh tokens not supported")
 
-    # TODO(Marcelo): The type hint is wrong. We need to fix, and test to check if it works.
-    async def revoke_token(self, token: str, token_type_hint: str | None = None) -> None:  # type: ignore
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
         """Revoke a token."""
-        if token in self.tokens:
-            del self.tokens[token]
+        if token.token in self.tokens:
+            del self.tokens[token.token]


### PR DESCRIPTION
Fixes #2826 .

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Fixes an error in the simple-auth example:
- Fix `server_url` link
- Fix the TODO related to the type hint with revoke_token method

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
In addition to the tests, type checking and linting provided in the repo, I have tried to recreate the issue described in #2826 and it is now working fine.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
