### PR TITLE
docs: fix sentence fragment in testing guide

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,7 +37,7 @@ To run the below test, you'll need to install the following dependencies:
     so I won't go into details here.
 
     The [`inline-snapshot`](https://15r10nk.github.io/inline-snapshot/latest/) is a library that allows
-    you to take snapshots of the output of your tests. Which makes it easier to create tests for your
+    you to take snapshots of the output of your tests, which makes it easier to create tests for your
     server - you don't need to use it, but we are spreading the word for best practices.
 
 ```python title="test_server.py"


### PR DESCRIPTION
Joins a sentence fragment in `docs/testing.md` ("…snapshots of the output of your tests. Which makes it easier…") into a single sentence.

## Motivation and Context
Small grammar fix in the testing guide.

## How Has This Been Tested?
Docs-only change; rendered output unaffected beyond the wording fix.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None.