### PR TITLE
fix: correlate invalid JSON-RPC envelope errors with the original request id

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -24,9 +24,36 @@ from io import TextIOWrapper
 import anyio
 import anyio.lowlevel
 import mcp_types as types
+import pydantic_core
 
 from mcp.shared._context_streams import create_context_streams
-from mcp.shared.message import SessionMessage
+from mcp.shared.message import SessionMessage, extract_raw_request_id
+
+
+def _error_response_for_invalid_line(line: str) -> SessionMessage:
+    """Build the JSON-RPC error response for a stdin line that failed message validation.
+
+    Correlates the error with the originating request where possible: for lines that
+    are valid JSON but an invalid JSON-RPC envelope, the request id is extracted
+    best-effort from the raw payload (Invalid Request, -32600); for lines that are
+    not valid JSON, a null id is used (Parse error, -32700), per the JSON-RPC 2.0
+    specification.
+
+    Args:
+        line: The raw stdin line that failed to validate as a JSON-RPC message.
+
+    Returns:
+        A `SessionMessage` wrapping the `JSONRPCError` to write back to the client.
+    """
+    try:
+        raw_message = pydantic_core.from_json(line)
+    except ValueError:
+        request_id = None
+        error = types.ErrorData(code=types.PARSE_ERROR, message="Parse error")
+    else:
+        request_id = extract_raw_request_id(raw_message)
+        error = types.ErrorData(code=types.INVALID_REQUEST, message="Invalid Request")
+    return SessionMessage(types.JSONRPCError(jsonrpc="2.0", id=request_id, error=error))
 
 
 @asynccontextmanager
@@ -53,6 +80,13 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
                     try:
                         message = types.jsonrpc_message_adapter.validate_json(line, by_name=False)
                     except Exception as exc:
+                        try:
+                            await write_stream.send(_error_response_for_invalid_line(line))
+                        except anyio.ClosedResourceError:
+                            # The server side already closed the write stream; the
+                            # error response cannot be delivered, but the exception
+                            # below still surfaces the bad line in-stream.
+                            await anyio.lowlevel.checkpoint()
                         await read_stream_writer.send(exc)
                         continue
 

--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -23,10 +23,38 @@ from typing import BinaryIO, Literal, TextIO
 import anyio
 import anyio.lowlevel
 import mcp_types as types
+import pydantic_core
 
 from mcp.os.win32.utilities import rebind_std_handle_to_fd
 from mcp.shared._context_streams import create_context_streams
-from mcp.shared.message import SessionMessage
+from mcp.shared.message import SessionMessage, extract_raw_request_id
+
+
+def _error_response_for_invalid_line(line: str) -> SessionMessage:
+    """Build the JSON-RPC error response for a stdin line that failed message validation.
+
+    Correlates the error with the originating request where possible: for lines that
+    are valid JSON but an invalid JSON-RPC envelope, the request id is extracted
+    best-effort from the raw payload (Invalid Request, -32600); for lines that are
+    not valid JSON, a null id is used (Parse error, -32700), per the JSON-RPC 2.0
+    specification.
+
+    Args:
+        line: The raw stdin line that failed to validate as a JSON-RPC message.
+
+    Returns:
+        A `SessionMessage` wrapping the `JSONRPCError` to write back to the client.
+    """
+    try:
+        raw_message = pydantic_core.from_json(line)
+    except ValueError:
+        request_id = None
+        error = types.ErrorData(code=types.PARSE_ERROR, message="Parse error")
+    else:
+        request_id = extract_raw_request_id(raw_message)
+        error = types.ErrorData(code=types.INVALID_REQUEST, message="Invalid Request")
+    return SessionMessage(types.JSONRPCError(jsonrpc="2.0", id=request_id, error=error))
+
 
 if sys.platform != "win32":  # pragma: no branch
     import fcntl  # pragma: lax no cover - POSIX-only line, uncovered on Windows runners
@@ -188,6 +216,13 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
                         try:
                             message = types.jsonrpc_message_adapter.validate_json(line, by_name=False)
                         except Exception as exc:
+                            try:
+                                await write_stream.send(_error_response_for_invalid_line(line))
+                            except anyio.ClosedResourceError:
+                                # The server side already closed the write stream; the
+                                # error response cannot be delivered, but the exception
+                                # below still surfaces the bad line in-stream.
+                                await anyio.lowlevel.checkpoint()
                             await read_stream_writer.send(exc)
                             continue
 

--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -22,7 +22,6 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from mcp_types import (
     DEFAULT_NEGOTIATED_VERSION,
     INTERNAL_ERROR,
-    INVALID_PARAMS,
     INVALID_REQUEST,
     PARSE_ERROR,
     ErrorData,
@@ -44,7 +43,7 @@ from mcp.server.transport_security import TransportSecurityMiddleware, Transport
 from mcp.shared._context_streams import ContextReceiveStream, ContextSendStream, create_context_streams
 from mcp.shared._stream_protocols import ReadStream, WriteStream
 from mcp.shared.inbound import MCP_PROTOCOL_VERSION_HEADER
-from mcp.shared.message import ServerMessageMetadata, SessionMessage
+from mcp.shared.message import ServerMessageMetadata, SessionMessage, extract_raw_request_id
 
 logger = logging.getLogger(__name__)
 
@@ -331,8 +330,14 @@ class StreamableHTTPServerTransport:
         status_code: HTTPStatus,
         error_code: int = INVALID_REQUEST,
         headers: dict[str, str] | None = None,
+        request_id: RequestId | None = None,
     ) -> Response:
-        """Create an error response with a simple string message."""
+        """Create an error response with a simple string message.
+
+        ``request_id`` correlates the error with the originating request when it
+        could be extracted from the (possibly invalid) request body; it defaults
+        to ``None`` (a null id) per the JSON-RPC 2.0 specification.
+        """
         response_headers = {"Content-Type": CONTENT_TYPE_JSON}
         if headers:
             response_headers.update(headers)
@@ -343,7 +348,7 @@ class StreamableHTTPServerTransport:
         # Return a properly formatted JSON error response
         error_response = JSONRPCError(
             jsonrpc="2.0",
-            id=None,
+            id=request_id,
             error=ErrorData(code=error_code, message=error_message),
         )
 
@@ -494,10 +499,14 @@ class StreamableHTTPServerTransport:
             try:
                 message = jsonrpc_message_adapter.validate_python(raw_message, by_name=False)
             except ValidationError as e:
+                # Correlate the error with the originating request: even though the
+                # envelope is invalid, the id is often still extractable from the raw
+                # payload (falls back to a null id per the JSON-RPC 2.0 spec).
                 response = self._create_error_response(
                     f"Validation error: {str(e)}",
                     HTTPStatus.BAD_REQUEST,
-                    INVALID_PARAMS,
+                    INVALID_REQUEST,
+                    request_id=extract_raw_request_id(raw_message),
                 )
                 await response(scope, receive, send)
                 return

--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -22,7 +22,6 @@ from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStre
 from mcp_types import (
     DEFAULT_NEGOTIATED_VERSION,
     INTERNAL_ERROR,
-    INVALID_PARAMS,
     INVALID_REQUEST,
     PARSE_ERROR,
     ErrorData,
@@ -44,7 +43,7 @@ from mcp.server.transport_security import TransportSecurityMiddleware, Transport
 from mcp.shared._context_streams import ContextReceiveStream, ContextSendStream, create_context_streams
 from mcp.shared._stream_protocols import ReadStream, WriteStream
 from mcp.shared.inbound import MCP_PROTOCOL_VERSION_HEADER
-from mcp.shared.message import CloseSSEStreamCallback, ServerMessageMetadata, SessionMessage
+from mcp.shared.message import CloseSSEStreamCallback, ServerMessageMetadata, SessionMessage, extract_raw_request_id
 
 logger = logging.getLogger(__name__)
 
@@ -369,8 +368,14 @@ class StreamableHTTPServerTransport:
         status_code: HTTPStatus,
         error_code: int = INVALID_REQUEST,
         headers: dict[str, str] | None = None,
+        request_id: RequestId | None = None,
     ) -> Response:
-        """Create an error response with a simple string message."""
+        """Create an error response with a simple string message.
+
+        ``request_id`` correlates the error with the originating request when it
+        could be extracted from the (possibly invalid) request body; it defaults
+        to ``None`` (a null id) per the JSON-RPC 2.0 specification.
+        """
         response_headers = {"Content-Type": CONTENT_TYPE_JSON}
         if headers:
             response_headers.update(headers)
@@ -381,7 +386,7 @@ class StreamableHTTPServerTransport:
         # Return a properly formatted JSON error response
         error_response = JSONRPCError(
             jsonrpc="2.0",
-            id=None,
+            id=request_id,
             error=ErrorData(code=error_code, message=error_message),
         )
 
@@ -546,10 +551,14 @@ class StreamableHTTPServerTransport:
             try:
                 message = jsonrpc_message_adapter.validate_python(raw_message, by_name=False)
             except ValidationError as e:
+                # Correlate the error with the originating request: even though the
+                # envelope is invalid, the id is often still extractable from the raw
+                # payload (falls back to a null id per the JSON-RPC 2.0 spec).
                 response = self._create_error_response(
                     f"Validation error: {str(e)}",
                     HTTPStatus.BAD_REQUEST,
-                    INVALID_PARAMS,
+                    INVALID_REQUEST,
+                    request_id=extract_raw_request_id(raw_message),
                 )
                 await response(scope, receive, send)
                 return

--- a/src/mcp/shared/message.py
+++ b/src/mcp/shared/message.py
@@ -6,13 +6,36 @@ to support transport-specific features like resumability.
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from mcp_types import JSONRPCMessage, RequestId
 
 ResumptionToken = str
 
 ResumptionTokenUpdateCallback = Callable[[ResumptionToken], Awaitable[None]]
+
+
+def extract_raw_request_id(raw_message: Any) -> RequestId | None:
+    """Best-effort extraction of a JSON-RPC request id from an unvalidated payload.
+
+    Used to correlate error responses with the originating request when an incoming
+    message fails JSON-RPC envelope validation: even though the envelope is invalid,
+    the ``id`` member is often still present in the raw parsed JSON.
+
+    Args:
+        raw_message: The parsed JSON payload, before any envelope validation.
+
+    Returns:
+        The request id when it is a valid JSON-RPC id type (a string, or an integer
+        that is not a bool — ``bool`` subclasses ``int`` but is not a valid id),
+        otherwise ``None``.
+    """
+    if isinstance(raw_message, dict):
+        raw_id = cast("dict[Any, Any]", raw_message).get("id")
+        if isinstance(raw_id, str) or (isinstance(raw_id, int) and not isinstance(raw_id, bool)):
+            return raw_id
+    return None
+
 
 # Callback type for closing SSE streams without terminating
 CloseSSEStreamCallback = Callable[[], Awaitable[None]]

--- a/tests/interaction/transports/test_hosting_http.py
+++ b/tests/interaction/transports/test_hosting_http.py
@@ -15,6 +15,7 @@ from mcp_types import (
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
     INVALID_PARAMS,
+    INVALID_REQUEST,
     PARSE_ERROR,
     PROTOCOL_VERSION_META_KEY,
     UNSUPPORTED_PROTOCOL_VERSION,
@@ -134,7 +135,7 @@ async def test_non_json_content_type_is_rejected() -> None:
 @requirement("hosting:http:parse-error-400")
 @requirement("hosting:http:batch")
 async def test_malformed_and_batched_bodies_return_400() -> None:
-    """A non-JSON body returns 400 Parse error; a JSON array of requests returns 400 Invalid params."""
+    """A non-JSON body returns 400 Parse error; a JSON array of requests returns 400 Invalid Request."""
     async with mounted_app(_server()) as (http, _):
         session_id = await initialize_via_http(http)
         not_json = await http.post(
@@ -154,7 +155,7 @@ async def test_malformed_and_batched_bodies_return_400() -> None:
     assert not_json.status_code == 400
     assert JSONRPCError.model_validate_json(not_json.text).error.code == PARSE_ERROR
     assert batched.status_code == 400
-    assert JSONRPCError.model_validate_json(batched.text).error.code == INVALID_PARAMS
+    assert JSONRPCError.model_validate_json(batched.text).error.code == INVALID_REQUEST
 
 
 @requirement("hosting:http:protocol-version-400")

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -10,7 +10,10 @@ import pytest
 from mcp_types import (
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
+    INVALID_REQUEST,
+    PARSE_ERROR,
     PROTOCOL_VERSION_META_KEY,
+    JSONRPCError,
     JSONRPCMessage,
     JSONRPCRequest,
     JSONRPCResponse,
@@ -103,6 +106,46 @@ async def test_stdio_server_invalid_utf8(monkeypatch: pytest.MonkeyPatch) -> Non
                 second = await read_stream.receive()
                 assert isinstance(second, SessionMessage)
                 assert second.message == valid
+
+
+@pytest.mark.anyio
+async def test_stdio_server_replies_to_invalid_messages_with_correlated_errors() -> None:
+    """Invalid stdin lines are answered with a JSON-RPC error carrying the original id.
+
+    Lines that are valid JSON but invalid JSON-RPC envelopes get an Invalid Request
+    error with the id extracted best-effort from the raw payload; lines that are not
+    valid JSON get a Parse error with a null id, per the JSON-RPC 2.0 specification.
+    The exception is still surfaced in-stream for each bad line.
+    """
+    invalid_lines = [
+        '{"jsonrpc": "1.0", "id": 3, "method": "ping", "params": {}}',
+        '{"id": 4, "method": "ping", "params": {}}',
+        '{"jsonrpc": "2.0", "id": 8, "method": 12345, "params": {}}',
+        "this is not valid json",
+    ]
+    stdin = io.StringIO("".join(line + "\n" for line in invalid_lines))
+    stdout = io.StringIO()
+
+    with anyio.fail_after(5):
+        async with stdio_server(stdin=anyio.AsyncFile(stdin), stdout=anyio.AsyncFile(stdout)) as (
+            read_stream,
+            write_stream,
+        ):
+            async with read_stream:
+                for _ in invalid_lines:
+                    received = await read_stream.receive()
+                    assert isinstance(received, Exception)
+            await write_stream.aclose()
+
+    stdout.seek(0)
+    error_responses = [JSONRPCError.model_validate_json(line.strip()) for line in stdout.readlines()]
+    assert [error_response.id for error_response in error_responses] == [3, 4, 8, None]
+    assert [error_response.error.code for error_response in error_responses] == [
+        INVALID_REQUEST,
+        INVALID_REQUEST,
+        INVALID_REQUEST,
+        PARSE_ERROR,
+    ]
 
 
 class _GatedStdin(io.RawIOBase):

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -13,8 +13,11 @@ import pytest
 from mcp_types import (
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
+    INVALID_REQUEST,
+    PARSE_ERROR,
     PROTOCOL_VERSION_META_KEY,
     SERVER_INFO_META_KEY,
+    JSONRPCError,
     JSONRPCMessage,
     JSONRPCRequest,
     JSONRPCResponse,
@@ -538,6 +541,46 @@ async def test_a_degraded_session_does_not_close_the_sys_stream_it_served(
         gc.collect()
         assert not sys.stdin.buffer.closed
         assert not sys.stdout.buffer.closed
+
+
+@pytest.mark.anyio
+async def test_stdio_server_replies_to_invalid_messages_with_correlated_errors() -> None:
+    """Invalid stdin lines are answered with a JSON-RPC error carrying the original id.
+
+    Lines that are valid JSON but invalid JSON-RPC envelopes get an Invalid Request
+    error with the id extracted best-effort from the raw payload; lines that are not
+    valid JSON get a Parse error with a null id, per the JSON-RPC 2.0 specification.
+    The exception is still surfaced in-stream for each bad line.
+    """
+    invalid_lines = [
+        '{"jsonrpc": "1.0", "id": 3, "method": "ping", "params": {}}',
+        '{"id": 4, "method": "ping", "params": {}}',
+        '{"jsonrpc": "2.0", "id": 8, "method": 12345, "params": {}}',
+        "this is not valid json",
+    ]
+    stdin = io.StringIO("".join(line + "\n" for line in invalid_lines))
+    stdout = io.StringIO()
+
+    with anyio.fail_after(5):
+        async with stdio_server(stdin=anyio.AsyncFile(stdin), stdout=anyio.AsyncFile(stdout)) as (
+            read_stream,
+            write_stream,
+        ):
+            async with read_stream:
+                for _ in invalid_lines:
+                    received = await read_stream.receive()
+                    assert isinstance(received, Exception)
+            await write_stream.aclose()
+
+    stdout.seek(0)
+    error_responses = [JSONRPCError.model_validate_json(line.strip()) for line in stdout.readlines()]
+    assert [error_response.id for error_response in error_responses] == [3, 4, 8, None]
+    assert [error_response.error.code for error_response in error_responses] == [
+        INVALID_REQUEST,
+        INVALID_REQUEST,
+        INVALID_REQUEST,
+        PARSE_ERROR,
+    ]
 
 
 class _GatedStdin(io.RawIOBase):

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -511,6 +511,40 @@ async def test_json_parsing(basic_app: Starlette) -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("body", "expected_id"),
+    [
+        pytest.param({"jsonrpc": "1.0", "id": 3, "method": "ping", "params": {}}, 3, id="wrong-jsonrpc-version"),
+        pytest.param({"id": 4, "method": "ping", "params": {}}, 4, id="missing-jsonrpc-field"),
+        pytest.param({"jsonrpc": "2.0", "id": 8, "method": 12345, "params": {}}, 8, id="method-not-a-string"),
+        pytest.param({"jsonrpc": "2.0", "id": 2.5, "method": 12345, "params": {}}, None, id="id-not-a-valid-type"),
+    ],
+)
+async def test_validation_error_preserves_request_id(
+    basic_app: Starlette, body: dict[str, Any], expected_id: int | None
+) -> None:
+    """An envelope-invalid message is answered with an error carrying the original request id.
+
+    The id is extracted best-effort from the raw payload so the client can correlate the
+    error response with its request; when no valid id can be extracted, the error falls
+    back to a null id per the JSON-RPC 2.0 specification.
+    """
+    async with make_client(basic_app) as client:
+        response = await client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json=body,
+        )
+        assert response.status_code == 400
+        error = types.JSONRPCError.model_validate_json(response.text)
+        assert error.id == expected_id
+        assert error.error.code == types.INVALID_REQUEST
+
+
+@pytest.mark.anyio
 async def test_method_not_allowed(basic_app: Starlette) -> None:
     """Unsupported HTTP methods are rejected with 405."""
     async with make_client(basic_app) as client:

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -510,6 +510,40 @@ async def test_json_parsing(basic_app: Starlette) -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("body", "expected_id"),
+    [
+        pytest.param({"jsonrpc": "1.0", "id": 3, "method": "ping", "params": {}}, 3, id="wrong-jsonrpc-version"),
+        pytest.param({"id": 4, "method": "ping", "params": {}}, 4, id="missing-jsonrpc-field"),
+        pytest.param({"jsonrpc": "2.0", "id": 8, "method": 12345, "params": {}}, 8, id="method-not-a-string"),
+        pytest.param({"jsonrpc": "2.0", "id": 2.5, "method": 12345, "params": {}}, None, id="id-not-a-valid-type"),
+    ],
+)
+async def test_validation_error_preserves_request_id(
+    basic_app: Starlette, body: dict[str, Any], expected_id: int | None
+) -> None:
+    """An envelope-invalid message is answered with an error carrying the original request id.
+
+    The id is extracted best-effort from the raw payload so the client can correlate the
+    error response with its request; when no valid id can be extracted, the error falls
+    back to a null id per the JSON-RPC 2.0 specification.
+    """
+    async with make_client(basic_app) as client:
+        response = await client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json=body,
+        )
+        assert response.status_code == 400
+        error = types.JSONRPCError.model_validate_json(response.text)
+        assert error.id == expected_id
+        assert error.error.code == types.INVALID_REQUEST
+
+
+@pytest.mark.anyio
 async def test_method_not_allowed(basic_app: Starlette) -> None:
     """Unsupported HTTP methods are rejected with 405."""
     async with make_client(basic_app) as client:


### PR DESCRIPTION
Fixes #2848

When an incoming message is valid JSON but fails JSON-RPC envelope validation (e.g. `"jsonrpc": "1.0"`, a missing `jsonrpc` field, or a non-string `method`), the error response could not be correlated with the originating request:

- **stdio**: the server transport forwarded the exception in-stream and never answered, so the client got no response for its request id.
- **Streamable HTTP**: the server replied 400 with a JSON-RPC error using a null id (`"server-error"` on v1.x), breaking client-side request/response correlation.

This PR extracts the request id best-effort from the raw parsed payload (shared helper `extract_raw_request_id`; only spec-valid id types are accepted — strings and non-bool integers) and preserves it in the error response on both transports, falling back to a null id per the JSON-RPC 2.0 spec when no valid id can be extracted. The stdio transport now also answers unparseable lines with `-32700 Parse error` (null id), matching the HTTP transport's existing parse-error behavior. Envelope-invalid messages are now reported as `-32600 Invalid Request` instead of `-32602 Invalid params`, matching JSON-RPC 2.0 error code semantics (the issue's three repro cases are envelope violations, not parameter errors).

Tests cover all three repro cases from the issue on both transports, plus the null-id fallback (unextractable id and unparseable body). Full suite, `ruff`, and `pyright` pass.
