### PR TITLE
fix: retry token refresh without RFC 8707 resource param when the AS rejects it

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -54,6 +54,18 @@ from mcp.shared.version import is_version_at_least
 logger = logging.getLogger(__name__)
 
 
+def _normalize_resource_url(resource: str) -> str:
+    """Undo the trailing slash URL parsers add to bare-domain URLs (e.g. pydantic's AnyHttpUrl).
+
+    RFC 9728 requires exact-string identity on the resource identifier, so only a root path
+    with no query or fragment is stripped; trailing slashes on deeper paths are preserved.
+    """
+    parsed = urlparse(resource)
+    if parsed.path == "/" and not parsed.params and not parsed.query and not parsed.fragment:
+        return f"{parsed.scheme}://{parsed.netloc}"
+    return resource
+
+
 class PKCEParameters(BaseModel):
     """PKCE (Proof Key for Code Exchange) parameters."""
 
@@ -152,7 +164,7 @@ class OAuthContext:
 
         # If PRM provides a resource that's a valid parent, use it
         if self.protected_resource_metadata and self.protected_resource_metadata.resource:
-            prm_resource = str(self.protected_resource_metadata.resource)
+            prm_resource = _normalize_resource_url(str(self.protected_resource_metadata.resource))
             if check_resource_allowed(requested_resource=resource, configured_resource=prm_resource):
                 resource = prm_resource
 
@@ -441,9 +453,8 @@ class OAuthClientProvider(httpx.Auth):
             "client_id": self.context.client_info.client_id,
         }
 
-        # Only include resource param if conditions are met
-        if self.context.should_include_resource_param(self.context.protocol_version):
-            refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
+        # The RFC 8707 resource param is deliberately omitted: some providers
+        # (e.g. Entra ID v2.0) reject it on refresh_token grants.
 
         # Prepare authentication based on preferred method
         headers = {"Content-Type": "application/x-www-form-urlencoded"}

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -5,6 +5,7 @@ Implements authorization code flow with PKCE and automatic token refresh.
 
 import base64
 import hashlib
+import json
 import logging
 import secrets
 import string
@@ -79,6 +80,15 @@ _SECRET_TOKEN_ENDPOINT_AUTH_METHODS = ("client_secret_post", "client_secret_basi
 _REGISTRATION_USABLE_TOKEN_ENDPOINT_AUTH_METHODS: tuple[str | None, ...] = tuple(
     method for method in _KNOWN_TOKEN_ENDPOINT_AUTH_METHODS if method != "private_key_jwt"
 )
+
+
+def _refresh_error_code(body: bytes) -> str | None:
+    """Extract the RFC 6749 ``error`` code from a failed token response, if any."""
+    try:
+        error = json.loads(body).get("error")
+    except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+        return None
+    return error if isinstance(error, str) else None
 
 
 def check_registration_usable(client_info: OAuthClientInformationFull) -> None:
@@ -486,8 +496,15 @@ class OAuthClientProvider(httpx2.Auth):
         self.context.update_token_expiry(token_response)
         await self.context.storage.set_tokens(token_response)
 
-    async def _refresh_token(self) -> httpx2.Request:
-        """Build token refresh request."""
+    async def _refresh_token(self, *, include_resource: bool = True) -> httpx2.Request:
+        """Build token refresh request.
+
+        Args:
+            include_resource: Whether to attach the RFC 8707 ``resource`` parameter
+                (when the protocol version calls for it). The retry path passes False
+                for authorization servers that reject the parameter on
+                ``refresh_token`` grants (e.g. Microsoft Entra ID v2.0, AADSTS9010010).
+        """
         if not self.context.current_tokens or not self.context.current_tokens.refresh_token:
             raise OAuthTokenError("No refresh token available")  # pragma: no cover
 
@@ -507,7 +524,7 @@ class OAuthClientProvider(httpx2.Auth):
         }
 
         # Only include resource param if conditions are met
-        if self.context.should_include_resource_param(self.context.protocol_version):
+        if include_resource and self.context.should_include_resource_param(self.context.protocol_version):
             refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
@@ -588,8 +605,23 @@ class OAuthClientProvider(httpx2.Auth):
 
             if not self.context.is_token_valid() and self.context.can_refresh_token():
                 # Try to refresh token
+                resource_included = self.context.should_include_resource_param(self.context.protocol_version)
                 refresh_request = await self._refresh_token()
                 refresh_response = yield refresh_request
+
+                if (
+                    refresh_response.status_code == 400
+                    and resource_included
+                    and _refresh_error_code(await refresh_response.aread()) != "invalid_grant"
+                ):
+                    # Some authorization servers (e.g. Microsoft Entra ID v2.0,
+                    # AADSTS9010010) reject the RFC 8707 resource parameter on
+                    # refresh_token grants. Retry once without it before giving
+                    # up and forcing a full interactive re-authentication.
+                    # `invalid_grant` is excluded: it means the refresh token
+                    # itself is no longer valid, so a retry cannot succeed.
+                    refresh_request = await self._refresh_token(include_resource=False)
+                    refresh_response = yield refresh_request
 
                 if not await self._handle_refresh_response(refresh_response):
                     # Refresh failed, need full re-authentication

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -745,7 +745,7 @@ class TestProtectedResourceMetadata:
 
     @pytest.mark.anyio
     async def test_resource_param_included_with_recent_protocol_version(self, oauth_provider: OAuthClientProvider):
-        """Test resource parameter is included for protocol version >= 2025-06-18."""
+        """Test resource parameter is included in initial token requests for protocol version >= 2025-06-18."""
         # Set protocol version to 2025-06-18
         oauth_provider.context.protocol_version = "2025-06-18"
         oauth_provider.context.client_info = OAuthClientInformationFull(
@@ -762,7 +762,8 @@ class TestProtectedResourceMetadata:
         expected_resource = quote(oauth_provider.context.get_resource_url(), safe="")
         assert f"resource={expected_resource}" in content
 
-        # Test in refresh token
+        # Refresh requests never include the resource parameter: some providers
+        # (e.g. Entra ID v2.0) reject RFC 8707 resource values on refresh_token grants.
         oauth_provider.context.current_tokens = OAuthToken(
             access_token="test_access",
             token_type="Bearer",
@@ -770,7 +771,7 @@ class TestProtectedResourceMetadata:
         )
         refresh_request = await oauth_provider._refresh_token()
         refresh_content = refresh_request.content.decode()
-        assert "resource=" in refresh_content
+        assert "resource=" not in refresh_content
 
     @pytest.mark.anyio
     async def test_resource_param_excluded_with_old_protocol_version(self, oauth_provider: OAuthClientProvider):
@@ -800,7 +801,7 @@ class TestProtectedResourceMetadata:
 
     @pytest.mark.anyio
     async def test_resource_param_included_with_protected_resource_metadata(self, oauth_provider: OAuthClientProvider):
-        """Test resource parameter is always included when protected resource metadata exists."""
+        """Test resource parameter is included in initial token requests when protected resource metadata exists."""
         # Set old protocol version but with protected resource metadata
         oauth_provider.context.protocol_version = "2025-03-26"
         oauth_provider.context.protected_resource_metadata = ProtectedResourceMetadata(
@@ -817,6 +818,16 @@ class TestProtectedResourceMetadata:
         request = await oauth_provider._exchange_token_authorization_code("test_code", "test_verifier")
         content = request.content.decode()
         assert "resource=" in content
+
+        # Even with PRM present, refresh requests omit the resource parameter
+        oauth_provider.context.current_tokens = OAuthToken(
+            access_token="test_access",
+            token_type="Bearer",
+            refresh_token="test_refresh",
+        )
+        refresh_request = await oauth_provider._refresh_token()
+        refresh_content = refresh_request.content.decode()
+        assert "resource=" not in refresh_content
 
 
 @pytest.mark.parametrize(
@@ -965,6 +976,47 @@ async def test_get_resource_url_uses_canonical_when_prm_mismatches(
 
     # get_resource_url should return the canonical server URL, not the PRM resource
     assert provider.context.get_resource_url() == snapshot("https://api.example.com/v1/mcp")
+
+
+@pytest.mark.anyio
+async def test_get_resource_url_removes_root_prm_trailing_slash(
+    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
+) -> None:
+    """Bare-domain PRM resources should not pick up the trailing slash AnyHttpUrl adds."""
+    provider = OAuthClientProvider(
+        server_url="https://api.example.com",
+        client_metadata=client_metadata,
+        storage=mock_storage,
+    )
+    provider._initialized = True
+
+    # AnyHttpUrl normalizes "https://api.example.com" to "https://api.example.com/"
+    provider.context.protected_resource_metadata = ProtectedResourceMetadata(
+        resource=AnyHttpUrl("https://api.example.com"),
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+    )
+
+    assert provider.context.get_resource_url() == snapshot("https://api.example.com")
+
+
+@pytest.mark.anyio
+async def test_get_resource_url_preserves_non_root_trailing_slash(
+    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
+) -> None:
+    """RFC 9728 requires exact-string identity, so intentional trailing slashes on deeper paths stay."""
+    provider = OAuthClientProvider(
+        server_url="https://api.example.com/v1/mcp/",
+        client_metadata=client_metadata,
+        storage=mock_storage,
+    )
+    provider._initialized = True
+
+    provider.context.protected_resource_metadata = ProtectedResourceMetadata(
+        resource=AnyHttpUrl("https://api.example.com/v1/mcp/"),
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+    )
+
+    assert provider.context.get_resource_url() == snapshot("https://api.example.com/v1/mcp/")
 
 
 class TestRegistrationResponse:

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -824,6 +824,124 @@ class TestProtectedResourceMetadata:
         assert "resource=" in content
 
 
+class TestRefreshResourceParamFallback:
+    """Refresh keeps the RFC 8707 resource param per the MCP spec, but retries once
+    without it when the authorization server rejects the refresh with a 400 —
+    some servers (e.g. Microsoft Entra ID v2.0, AADSTS9010010) reject the
+    parameter on refresh_token grants (#2578)."""
+
+    def _prepare_expired_session(self, oauth_provider: OAuthClientProvider) -> httpx2.Request:
+        oauth_provider._initialized = True
+        oauth_provider.context.client_info = OAuthClientInformationFull(
+            client_id="test_client",
+            client_secret="test_secret",
+            redirect_uris=[AnyUrl("http://localhost:3030/callback")],
+        )
+        oauth_provider.context.current_tokens = OAuthToken(
+            access_token="expired_access",
+            token_type="Bearer",
+            refresh_token="test_refresh_token",
+        )
+        oauth_provider.context.token_expiry_time = time.time() - 3600
+        return httpx2.Request("GET", "https://api.example.com/mcp", headers={"mcp-protocol-version": "2025-06-18"})
+
+    @pytest.mark.anyio
+    async def test_refresh_retries_without_resource_on_400(self, oauth_provider: OAuthClientProvider):
+        test_request = self._prepare_expired_session(oauth_provider)
+        auth_flow = oauth_provider.async_auth_flow(test_request)
+
+        first_refresh = await auth_flow.__anext__()
+        first_body = first_refresh.content.decode()
+        assert "grant_type=refresh_token" in first_body
+        assert "resource=" in first_body
+
+        entra_rejection = httpx2.Response(
+            400,
+            content=b'{"error": "invalid_request", "error_description": "AADSTS9010010: ..."}',
+            request=first_refresh,
+        )
+        retry_refresh = await auth_flow.asend(entra_rejection)
+        retry_body = retry_refresh.content.decode()
+        assert "grant_type=refresh_token" in retry_body
+        assert "resource=" not in retry_body
+
+        token_response = httpx2.Response(
+            200,
+            content=(
+                b'{"access_token": "new_access_token", "token_type": "Bearer", '
+                b'"expires_in": 3600, "refresh_token": "new_refresh_token"}'
+            ),
+            request=retry_refresh,
+        )
+        original_request = await auth_flow.asend(token_response)
+        assert original_request.headers["Authorization"] == "Bearer new_access_token"
+
+        with pytest.raises(StopAsyncIteration):
+            await auth_flow.asend(httpx2.Response(200, request=original_request))
+
+    @pytest.mark.anyio
+    async def test_refresh_falls_back_to_reauth_when_retry_fails(self, oauth_provider: OAuthClientProvider):
+        test_request = self._prepare_expired_session(oauth_provider)
+        auth_flow = oauth_provider.async_auth_flow(test_request)
+
+        first_refresh = await auth_flow.__anext__()
+        entra_rejection = httpx2.Response(
+            400,
+            content=b'{"error": "invalid_request", "error_description": "AADSTS9010010: ..."}',
+            request=first_refresh,
+        )
+        retry_refresh = await auth_flow.asend(entra_rejection)
+        assert "resource=" not in retry_refresh.content.decode()
+
+        original_request = await auth_flow.asend(httpx2.Response(400, request=retry_refresh))
+        # Both refresh attempts failed: the original request goes out unauthenticated
+        # and the provider is flagged for full re-authentication.
+        assert "Authorization" not in original_request.headers
+        assert oauth_provider._initialized is False
+
+        with pytest.raises(StopAsyncIteration):
+            await auth_flow.asend(httpx2.Response(200, request=original_request))
+
+    @pytest.mark.anyio
+    async def test_no_retry_on_invalid_grant(self, oauth_provider: OAuthClientProvider):
+        test_request = self._prepare_expired_session(oauth_provider)
+        auth_flow = oauth_provider.async_auth_flow(test_request)
+
+        first_refresh = await auth_flow.__anext__()
+        assert "resource=" in first_refresh.content.decode()
+
+        # invalid_grant means the refresh token itself is dead: retrying
+        # without the resource param cannot help, so the flow goes straight
+        # to full re-authentication.
+        dead_grant = httpx2.Response(400, content=b'{"error": "invalid_grant"}', request=first_refresh)
+        original_request = await auth_flow.asend(dead_grant)
+        assert str(original_request.url) == "https://api.example.com/mcp"
+        assert "Authorization" not in original_request.headers
+        assert oauth_provider._initialized is False
+
+        with pytest.raises(StopAsyncIteration):
+            await auth_flow.asend(httpx2.Response(200, request=original_request))
+
+    @pytest.mark.anyio
+    async def test_no_retry_when_resource_was_not_sent(self, oauth_provider: OAuthClientProvider):
+        test_request = self._prepare_expired_session(oauth_provider)
+        test_request.headers["mcp-protocol-version"] = "2025-03-26"
+        auth_flow = oauth_provider.async_auth_flow(test_request)
+
+        first_refresh = await auth_flow.__anext__()
+        assert "resource=" not in first_refresh.content.decode()
+
+        # A 400 without the resource param present is a real failure: no retry,
+        # the next request is the original one, unauthenticated.
+        original_request = await auth_flow.asend(httpx2.Response(400, request=first_refresh))
+        assert str(original_request.url) == "https://api.example.com/mcp"
+        assert "Authorization" not in original_request.headers
+        assert oauth_provider._initialized is False
+
+        with pytest.raises(StopAsyncIteration):
+            await auth_flow.asend(httpx2.Response(200, request=original_request))
+
+
 @pytest.mark.parametrize(
     ("protocol_version", "expected"),
     [

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -845,6 +845,14 @@ class TestRefreshResourceParamFallback:
         oauth_provider.context.token_expiry_time = time.time() - 3600
         return httpx2.Request("GET", "https://api.example.com/mcp", headers={"mcp-protocol-version": "2025-06-18"})
 
+    def test_refresh_error_code_tolerates_malformed_bodies(self):
+        from mcp.client.auth.oauth2 import _refresh_error_code
+
+        assert _refresh_error_code(b'{"error": "invalid_grant"}') == "invalid_grant"
+        assert _refresh_error_code(b"Bad Request") is None
+        assert _refresh_error_code(b"[1, 2]") is None
+        assert _refresh_error_code(b'{"error": 42}') is None
+
     @pytest.mark.anyio
     async def test_refresh_retries_without_resource_on_400(self, oauth_provider: OAuthClientProvider):
         test_request = self._prepare_expired_session(oauth_provider)

--- a/tests/interaction/auth/test_lifecycle.py
+++ b/tests/interaction/auth/test_lifecycle.py
@@ -104,8 +104,10 @@ async def test_an_expired_access_token_is_transparently_refreshed_before_the_nex
     The provider tells the client `expires_in=-3600` for the first token while keeping the
     server-side `expires_at` in the future, so the connect's retry succeeds and the next
     request finds the token expired and refreshes. The recorded requests prove exactly one
-    `grant_type=refresh_token` exchange carrying the resource indicator, and the bearer used
-    after the refresh is the second access token, which is the one persisted to storage.
+    `grant_type=refresh_token` exchange without the resource indicator (some providers,
+    e.g. Entra ID v2.0, reject RFC 8707 resource values on refresh_token grants), and the
+    bearer used after the refresh is the second access token, which is the one persisted
+    to storage.
     """
     recorded, on_request = record_requests()
     provider = InMemoryAuthorizationServerProvider(issue_expired_first=True)
@@ -123,9 +125,8 @@ async def test_an_expired_access_token_is_transparently_refreshed_before_the_nex
     assert [b["grant_type"] for b in bodies] == snapshot(["authorization_code", "refresh_token"])
 
     refresh_body = bodies[1]
-    assert sorted(refresh_body) == snapshot(["client_id", "client_secret", "grant_type", "refresh_token", "resource"])
+    assert sorted(refresh_body) == snapshot(["client_id", "client_secret", "grant_type", "refresh_token"])
     assert refresh_body["refresh_token"].startswith("refresh_")
-    assert refresh_body["resource"].startswith(BASE_URL)
 
     bearers = {r.headers["authorization"] for r in recorded if r.path == "/mcp" and "authorization" in r.headers}
     assert len(bearers) == 2


### PR DESCRIPTION
## Motivation and Context

Fixes #2578.

Microsoft Entra ID v2.0 rejects the RFC 8707 `resource` parameter on `refresh_token` grants (`AADSTS9010010`, strictly enforced since March 2026). Because the SDK sends it on every refresh, MCP clients using Entra OAuth lose authentication after ~1 hour: the silent refresh fails, tokens are cleared, and the user is forced through interactive re-auth every hour.

At the same time, the MCP authorization spec (2025-06-18 and later, "Resource Parameter Implementation") requires the `resource` parameter in token requests, and RFC 8707 §2.2 defines it for all grant types including refresh. So unconditionally omitting it on refresh (this PR's original approach) would trade the Entra bug for a spec violation — thanks to the review feedback below for pushing on this.

**This PR now keeps the spec-required behavior and adds a targeted fallback:**

- The `resource` parameter is still sent on refresh requests exactly as before.
- If the refresh fails with HTTP 400 and the error is **not** `invalid_grant`, the refresh is retried **once** without the `resource` parameter before falling back to full re-authentication.
- `invalid_grant` (a dead refresh token) never triggers the retry, since resending without `resource` cannot help.

For conformant authorization servers nothing changes. For Entra-style servers, the cost is one extra request on an already-failing path, instead of an hourly interactive re-auth.

## How Has This Been Tested?

- `tests/client/test_auth.py` + `tests/interaction/auth/test_lifecycle.py`: 155 passed, 1 xfailed (`uv run --frozen pytest`)
- New `TestRefreshResourceParamFallback` covers: the Entra-style 400 → retry without `resource` → success path; retry failure → full re-auth; `invalid_grant` → no retry; old protocol version (no `resource` sent) → no retry
- Existing spec-conformance tests (resource included on refresh for 2025-06-18+) pass unchanged
- `ruff check` and `ruff format` clean

## Breaking Changes

None. Default behavior is unchanged for all conformant authorization servers; the retry only engages after a 400 rejection that is not `invalid_grant`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
