### PR TITLE
fix: remove dead code path in _handle_call_tool and correct call_tool return type

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import base64
 import inspect
-import json
 import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -322,14 +321,6 @@ class MCPServer(Generic[LifespanResultT]):
                 content=list(unstructured_content),  # type: ignore[arg-type]
                 structured_content=structured_content,  # type: ignore[arg-type]
             )
-        if isinstance(result, dict):  # pragma: no cover
-            # TODO: this code path is unreachable — convert_result never returns a raw dict.
-            # The call_tool return type (Sequence[ContentBlock] | dict[str, Any]) is wrong
-            # and needs to be cleaned up.
-            return CallToolResult(
-                content=[TextContent(type="text", text=json.dumps(result, indent=2))],
-                structured_content=result,
-            )
         return CallToolResult(content=list(result))
 
     async def _handle_list_resources(
@@ -399,7 +390,7 @@ class MCPServer(Generic[LifespanResultT]):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any], context: Context[LifespanResultT, Any] | None = None
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
+    ) -> CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]:
         """Call a tool by name with arguments."""
         if context is None:
             context = Context(mcp_server=self)


### PR DESCRIPTION
## Summary

Remove a dead `isinstance(result, dict)` branch in `_handle_call_tool` and correct the `call_tool` return type annotation. Per the issue analysis, `FuncMetadata.convert_result` returns exactly three shapes:

1. `CallToolResult` (when the tool returned one directly)
2. `Sequence[ContentBlock]` (no output schema)
3. `tuple[Sequence[ContentBlock], dict[str, Any]]` (with output schema)

It never returns a raw `dict`, making the dict branch unreachable (it was already marked `# pragma: no cover`).

## Changes

- **Remove** the dead `isinstance(result, dict)` branch in `_handle_call_tool`
- **Remove** the now-unused `import json`
- **Correct** `call_tool`'s return type from `Sequence[ContentBlock] | dict[str, Any]` to `CallToolResult | Sequence[ContentBlock] | tuple[Sequence[ContentBlock], dict[str, Any]]`

## Testing

- All 89 server tests pass
- All 33 func_metadata tests pass
- All 335 mcpserver tests pass

## AI assistance disclosure

I used an AI assistant to help trace the call path and structure the diff. I have reviewed every changed line and validated the diagnosis against the source.

Closes #2695