### PR TITLE
fix(client): tolerate invalid UTF-8 from server stdout in stdio_client

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -106,8 +106,13 @@ class StdioServerParameters(BaseModel):
     encoding: str = "utf-8"
     """Text encoding for messages to and from the server."""
 
-    encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
-    """Encoding error handler; see https://docs.python.org/3/library/codecs.html#error-handlers."""
+    encoding_error_handler: Literal["strict", "ignore", "replace"] = "replace"
+    """Encoding error handler; see https://docs.python.org/3/library/codecs.html#error-handlers.
+
+    Defaults to ``"replace"`` so malformed bytes from a buggy server become U+FFFD and surface
+    as an in-stream JSON parse error (kept alive for subsequent valid messages) instead of
+    crashing the transport task group. This mirrors the server-side stdin hardening.
+    """
 
 
 @asynccontextmanager

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -308,6 +308,31 @@ async def test_invalid_json_from_the_server_surfaces_as_an_in_stream_exception(
 
 
 @pytest.mark.anyio
+async def test_invalid_utf8_mid_session_surfaces_as_an_in_stream_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A line with non-UTF-8 bytes is surfaced as a parse error, not a transport crash.
+
+    Regression test for a buggy server emitting malformed bytes mid-session: the default
+    ``encoding_error_handler="replace"`` turns the bad bytes into U+FFFD so the line fails
+    JSON validation and is delivered as an Exception, keeping the transport alive for the
+    valid messages that follow (instead of a UnicodeDecodeError tearing down the task group).
+    """
+    ping = JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")
+    process = FakeProcess(on_stdin_close=lambda: process.exit(0))
+
+    install_fake_process(monkeypatch, process)
+
+    with anyio.fail_after(5):
+        async with stdio_client(FAKE_PARAMS) as (read_stream, _):
+            await process.feed(b"\xff\xfe\n" + _line(ping))
+
+            error = await read_stream.receive()
+            assert isinstance(error, ValueError)
+            assert await _next_message(read_stream) == ping
+
+
+@pytest.mark.anyio
 async def test_a_server_that_dies_before_responding_fails_initialize_with_connection_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Default `StdioServerParameters.encoding_error_handler` to `"replace"` so a server emitting malformed UTF-8 no longer crashes the client transport.
- Malformed bytes now surface as an in-stream JSON parse error and the transport stays alive for subsequent valid messages.

## Motivation

Closes #2454.

`stdio_client()` decoded child stdout with `encoding_error_handler="strict"`. When a spawned server writes invalid UTF-8 bytes to stdout, the `UnicodeDecodeError` raised during `TextReceiveStream` iteration escapes the decode loop's `except` clauses and tears down the transport task group — it surfaces as an `ExceptionGroup` out of the context manager instead of being delivered as a normal in-stream parse error.

The issue itself points at the analogous server-side hardening (#2302, `errors="replace"` on stdin), which deliberately chose to: replace invalid bytes with U+FFFD, let JSON validation fail on the malformed line, and keep the transport alive. This change brings the client to parity: defaulting `encoding_error_handler` to `"replace"` means the bad line fails JSON-RPC validation and is delivered as an `Exception` via `_parse_line`, while later valid messages still come through.

## Verification

- `uv run pytest tests/client/test_stdio.py -q` — 34 passed, 1 skipped
- `uv run pytest tests/client/ tests/interaction/transports/test_stdio.py -q` — 238 passed, 1 skipped, 1 xfailed (no regression from the default change)
- New regression test `test_invalid_utf8_mid_session_surfaces_as_an_in_stream_exception` **fails without the fix** (5s task-group hang) and **passes with it**.
- Manual repro from the issue (`\xff\xfe\n` followed by a valid `ping`) crashed the task group on `main` with an `ExceptionGroup(UnicodeDecodeError, ...)`; with the fix it surfaces a `ValidationError` then reads the following valid message.
- `ruff format --check` + `ruff check` + `pyright` clean on both changed files.

## Notes

- Salvages the intent of the stale, now-conflicting #2456 by @shaun0927 (same root cause + default flip), rebuilt cleanly against current `main` after the transport was refactored. The decode/drain plumbing moved, so this is a fresh implementation on the new code path with a mid-session regression test (distinct from the existing `test_invalid_utf8_flushed_by_a_dying_server_does_not_break_shutdown`, which only covers the raw-bytes shutdown drain).
