### PR TITLE
ci(conformance): run server --suite draft and baseline the 2026-07-28 scenarios

### DIFF
--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -46,7 +46,41 @@ client:
   # client support for the token-exchange + JWT bearer flow.
   - auth/enterprise-managed-authorization
 
-# The `active` suite (30 scenarios / 42 assertions) is fully green against
-# mcp-everything-server. Draft-suite entries are added when the workflow
-# gains a `--suite draft` step.
-server: []
+server:
+  # --- Draft-spec scenarios (in `--suite draft`; the `active` suite is green) ---
+  # SEP-2575 (stateless HTTP / _meta envelope): server has no stateless mode,
+  # _meta-derived capabilities, error-code mappings, or server/discover yet.
+  - server-stateless
+  # SEP-2322 (multi-round-trip requests / IncompleteResult): not implemented;
+  # most scenarios currently fail early with "Missing session ID" because
+  # mcp-everything-server only runs in stateful mode.
+  - input-required-result-basic-elicitation
+  - input-required-result-basic-sampling
+  - input-required-result-basic-list-roots
+  - input-required-result-request-state
+  - input-required-result-multiple-input-requests
+  - input-required-result-multi-round
+  - input-required-result-non-tool-request
+  - input-required-result-result-type
+  - input-required-result-tampered-state
+  - input-required-result-capability-check
+  # SEP-2549 (caching): no ttlMs/cacheScope support; scenario also hits the
+  # stateful-mode "Missing session ID" error.
+  - caching
+  # SEP-2243 (HTTP header standardization): -32001 HeaderMismatch handling and
+  # case-insensitive/whitespace-trimmed header validation not implemented.
+  - http-header-validation
+  - http-custom-header-server-validation
+  # WARNING-only entries: these scenarios emit no FAILURE checks, only SHOULD-level
+  # WARNINGs, but the expected-failures evaluator counts WARNINGs as failures.
+  # SEP-2164: server returns -32600 (not -32602) and omits error.data.uri.
+  - sep-2164-resource-not-found
+  # SEP-2322 SHOULD-level behaviours (re-request missing inputResponses, ignore
+  # unrecognized inputResponses keys).
+  - input-required-result-missing-input-response
+  - input-required-result-ignore-extra-params
+  # Intentionally NOT baselined (2 of 19 draft scenarios): the SEP-2322
+  # negative-case scenarios input-required-result-unsupported-methods and
+  # input-required-result-validate-input pass today only because the stateful
+  # server's -32600 "Missing session ID" satisfies their assertions. They will
+  # start failing for real once stateless mode lands; add them then.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -38,6 +38,11 @@ jobs:
           ./.github/actions/conformance/run-server.sh
           --suite active
           --expected-failures ./.github/actions/conformance/expected-failures.yml
+      - name: Run server conformance (draft suite)
+        run: >-
+          ./.github/actions/conformance/run-server.sh
+          --suite draft
+          --expected-failures ./.github/actions/conformance/expected-failures.yml
 
   client-conformance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the 2026-07-28 draft-spec server suite on top of #2877, mirroring [typescript-sdk's two-step server job](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/.github/workflows/conformance.yml) (`active` then `draft`). This is the second half of bringing the conformance harness up to date for the v2/2026 line — #2877 was the modernization, this adds the draft coverage so 2026 SEP work has a burn-down list.

## Motivation and Context

`AGENTS.md` requires new 2026-07-28 features to have a passing conformance test. With #2877 the server job only runs `--suite active` (2025-11-25 scenarios); draft-spec server scenarios were never exercised. This adds the `--suite draft` step and baselines the 17 scenarios that don't pass yet, so each SEP implementation PR can remove its entries from the baseline as it lands.

## Changes

- `conformance.yml`: second `run-server.sh --suite draft --expected-failures ...` step in the `server-conformance` job.
- `expected-failures.yml` `server:`: 17 entries grouped by SEP — same set as [typescript-sdk's server baseline](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/test/conformance/expected-failures.yaml). Two of the 19 draft scenarios (`input-required-result-unsupported-methods`, `input-required-result-validate-input`) are intentionally **not** baselined: their negative-case assertions are vacuously satisfied today by the stateful server's `-32600` response, and the runner would flag them stale. A trailing comment records this.
- `client:` section unchanged — `--suite all` already covers draft client scenarios via the #2877 baseline (re-verified post-#2838: 24 pass + 16 expected-fail, exit 0).

## How Has This Been Tested?

Run locally against `@modelcontextprotocol/conformance@0.2.0-alpha.3`:

- `server --suite draft --expected-failures ...` → 19 scenarios, 17 expected-fail, 0 unexpected, 0 stale, exit 0. Run twice on a fresh server each time; output byte-identical.
- `server --suite active --expected-failures ...` with the 17 server entries present → 30/30 pass, exit 0 (the evaluator ignores baseline entries not in the current run, so the draft entries don't trip the active step).
- `client --suite all --expected-failures ...` → 24 pass + 16 expected-fail, exit 0.
- pre-commit clean.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- Dominant draft failure mode is `-32600 Missing session ID` — `mcp-everything-server` has no stateless mode yet, so most scenarios hit the transport wall before SEP-specific checks run. Same as typescript-sdk's baseline; the entries reshuffle once SEP-2575 lands.
- The harness's stale-entry check only fires for scenarios that actually ran, so a renamed/typo'd baseline entry would linger silently. Same gap exists for the `client:` block and in typescript-sdk; would need an upstream change to validate baseline names against the scenario registry.
- `run-server.sh` is invoked twice now; cleanup relies on `uv run` forwarding SIGTERM to uvicorn. Verified to work on the sequential-restart path locally.
- Deferred to SEP-2575 burn-down: `client.py` reading `MCP_CONFORMANCE_PROTOCOL_VERSION` (typescript-sdk doesn't either), `mcp-everything-server --stateless`.
- Follow-up on the conformance repo: add a `python-sdk` (main) entry to [`known-sdks.ts`](https://github.com/modelcontextprotocol/conformance/blob/main/src/sdk-runner/known-sdks.ts).

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>