### PR TITLE
Deflake the issue-1363 tests: wait for lifespan startup instead of sleeping

### DIFF
--- a/tests/issues/test_1363_race_condition_streamable_http.py
+++ b/tests/issues/test_1363_race_condition_streamable_http.py
@@ -21,6 +21,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import anyio
+import anyio.to_thread
 import httpx
 import pytest
 from starlette.applications import Starlette
@@ -68,6 +69,7 @@ class ServerThread(threading.Thread):
         super().__init__(daemon=True)
         self.app = app
         self._stop_event = threading.Event()
+        self._ready_event = threading.Event()
 
     def run(self) -> None:
         """Run the lifespan in a new event loop."""
@@ -78,11 +80,18 @@ class ServerThread(threading.Thread):
             lifespan_context = getattr(self.app.router, "lifespan_context", None)
             assert lifespan_context is not None  # Tests always create apps with lifespan
             async with lifespan_context(self.app):
+                # Only signal readiness once lifespan startup has completed, i.e. the
+                # session manager's task group exists and requests can be handled.
+                self._ready_event.set()
                 # Wait until stop is requested
                 while not self._stop_event.is_set():
                     await anyio.sleep(0.1)
 
         anyio.run(run_lifespan)
+
+    def wait_ready(self, timeout: float = 5.0) -> None:
+        """Block until the lifespan has started; call from a worker thread, not the event loop."""
+        assert self._ready_event.wait(timeout), "server thread did not start its lifespan in time"
 
     def stop(self) -> None:
         """Signal the thread to stop."""
@@ -132,8 +141,8 @@ async def test_race_condition_invalid_accept_headers(caplog: pytest.LogCaptureFi
     server_thread.start()
 
     try:
-        # Give the server thread a moment to start
-        await anyio.sleep(0.1)
+        # Wait for the server thread to enter the lifespan before sending requests
+        await anyio.to_thread.run_sync(server_thread.wait_ready)
 
         # Suppress WARNING logs (expected validation errors) and capture ERROR logs
         with caplog.at_level(logging.ERROR):
@@ -203,8 +212,8 @@ async def test_race_condition_invalid_content_type(caplog: pytest.LogCaptureFixt
     server_thread.start()
 
     try:
-        # Give the server thread a moment to start
-        await anyio.sleep(0.1)
+        # Wait for the server thread to enter the lifespan before sending requests
+        await anyio.to_thread.run_sync(server_thread.wait_ready)
 
         # Suppress WARNING logs (expected validation errors) and capture ERROR logs
         with caplog.at_level(logging.ERROR):
@@ -243,8 +252,8 @@ async def test_race_condition_message_router_async_for(caplog: pytest.LogCapture
     server_thread.start()
 
     try:
-        # Give the server thread a moment to start
-        await anyio.sleep(0.1)
+        # Wait for the server thread to enter the lifespan before sending requests
+        await anyio.to_thread.run_sync(server_thread.wait_ready)
 
         # Suppress WARNING logs (expected validation errors) and capture ERROR logs
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
The three tests in `tests/issues/test_1363_race_condition_streamable_http.py` synchronize with their server thread via a fixed `await anyio.sleep(0.1)`. On a loaded CI runner the thread sometimes isn't ready within that window, and the test fails with `RuntimeError: Task group is not initialized. Make sure to use run().` This replaces the fixed sleep with a readiness handshake.

## Motivation and Context

These tests (added in #1384) start a `ServerThread` that spins up its own event loop, enters the Starlette lifespan, and only then sets the session manager's task group. The test waits a fixed 0.1s and then sends requests from its own event loop via `httpx.ASGITransport`. When the thread loses the scheduling race — easy under `pytest -n auto` plus coverage on a 4-vCPU runner — the first request reaches `handle_request()` while `_task_group` is still `None` and the test fails.

This has flaked 6 times since 2026-05-27, on both Ubuntu and Windows, across unrelated PRs — e.g. [3.14/locked/windows](https://github.com/modelcontextprotocol/python-sdk/actions/runs/27549928882/job/81433167160) and [3.14/locked/ubuntu](https://github.com/modelcontextprotocol/python-sdk/actions/runs/27163105755/job/80183350380). Because the test job is `continue-on-error`, these never turn a run red, so they're easy to miss.

The fix: the server thread sets a `threading.Event` once lifespan startup has completed (at that point the task group is guaranteed to exist), and the tests wait on it (bounded at 5s, via `anyio.to_thread.run_sync`) instead of sleeping. The trailing `anyio.sleep(0.2)` that gives the original #1363 race its detection window is deliberately left untouched — the tests still exercise exactly the same request paths and log checks.

## How Has This Been Tested?

- The three tests pass, and pass 150/150 with `--flake-finder --flake-runs=50 -n 4`.
- Failure-mode A/B with an artificial 0.3s delay injected at the top of `ServerThread.run()`: the old tests reproduce the exact CI error, the fixed tests pass. Repeated on a windows-latest runner (Python 3.14): unpatched + delay fails all three tests with the same `RuntimeError`; patched + delay passes; patched 50× per test under `-n 4` passes 150/150.
- `./scripts/test` passes at 100% coverage; ruff/pyright clean.

## Breaking Changes

None — test-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

All three tests in the file shared the same fixed-sleep pattern; only `test_race_condition_invalid_accept_headers` happened to be the one observed failing in CI, but the delayed-thread experiment shows the other two fail the same way, so all three call sites are converted.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
