### PR TITLE
Widen the stdio round-trip test's termination grace and overall timeout

### DIFF
--- a/tests/interaction/transports/test_stdio.py
+++ b/tests/interaction/transports/test_stdio.py
@@ -61,8 +61,10 @@ async def test_tool_call_and_notification_round_trip_over_a_stdio_subprocess(
     # post-print kill can no longer silently lose the data file -- see _stdio_server.main). The
     # production 2s default is too tight for the unwind+save tail on loaded Windows runners
     # (measured in-situ p99 of the whole test is ~7s); a kill before the print fails the stderr
-    # assertion below loudly rather than tripping the coverage gate. Not under test.
-    monkeypatch.setattr(stdio, "PROCESS_TERMINATION_TIMEOUT", 10.0)
+    # assertion below loudly rather than tripping the coverage gate. The 20s grace covers even a
+    # badly starved runner (a >10s stall has been seen once in CI) and costs nothing when the
+    # child exits promptly. Not under test.
+    monkeypatch.setattr(stdio, "PROCESS_TERMINATION_TIMEOUT", 20.0)
 
     received: list[LoggingMessageNotificationParams] = []
 
@@ -85,8 +87,8 @@ async def test_tool_call_and_notification_round_trip_over_a_stdio_subprocess(
             errlog=errlog,
         )
 
-        # Must exceed session time plus the patched PROCESS_TERMINATION_TIMEOUT (10s).
-        with anyio.fail_after(20):
+        # Must exceed session time plus the patched PROCESS_TERMINATION_TIMEOUT (20s).
+        with anyio.fail_after(30):
             async with Client(transport, logging_callback=collect) as client:
                 assert client.initialize_result.server_info.name == "stdio-echo"
                 result = await client.call_tool("echo", {"text": "across\nprocesses"})


### PR DESCRIPTION
Widens the stdio round-trip test's termination grace (10s → 20s) and its outer `fail_after` (20s → 30s) so a badly starved CI runner can't kill the child server before it writes the clean-exit line.

## Motivation and Context

`test_tool_call_and_notification_round_trip_over_a_stdio_subprocess` patches `PROCESS_TERMINATION_TIMEOUT` so the spawned server has time, after stdin closes, to unwind, save its subprocess coverage data, and print `stdio-echo: clean exit` (the ordering #2840 established so a kill can't silently lose the coverage data). On one heavily contended run ([3.13, lowest-direct, windows-latest, 2026-06-15](https://github.com/modelcontextprotocol/python-sdk/actions/runs/27527427846/job/81357591209)) the runner stalled the child past the 10s grace; it was killed before printing and the test failed with an empty stderr capture.

Measurements on a loaded windows-latest runner with the same configuration (Python 3.13, lowest-direct, subprocess coverage, background pytest + CPU load) put the post-stdin-close tail at ~0.2s median / ~0.4s max — dominated by the coverage save — so the failure needed an extreme machine-level stall rather than anything systematic. Doubling the grace keeps that class of runner pathology from failing the leg, and costs nothing on healthy runs because the wait returns as soon as the child exits. A genuinely hung child still fails, just after 20s instead of 10s.

## How Has This Been Tested?

- The test file passes locally; ruff, pyright, and the targeted coverage check (100%, strict-no-cover clean) all pass.
- The previous values' failure mode and the new margins are based on the CI log of the failing job and on timing runs on a windows-latest runner mirroring that leg.

## Breaking Changes

None — test-only change; the production `PROCESS_TERMINATION_TIMEOUT` default (2.0s) is untouched.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Since #2773 and #2840 this is the only stdio test failure observed in CI (once across all runs and matrix legs since June 12), so this is a belt-and-braces margin bump rather than a fix for an active problem.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
