### PR TITLE
Drop stale superset-leniency note from ElicitResult.content docstring

### DIFF
--- a/src/mcp/types/_types.py
+++ b/src/mcp/types/_types.py
@@ -1995,9 +1995,6 @@ class ElicitResult(Result):
     Contains values matching the requested schema. Values can be strings, integers, floats,
     booleans, arrays of strings, or null.
     For URL mode, this field is omitted.
-
-    The null value arm is superset leniency; the schema-exact surface types
-    declare no null arm.
     """
 
 


### PR DESCRIPTION
Removes a stale paragraph from the `ElicitResult.content` docstring in the superset monolith.

## Motivation and Context

The docstring claimed the `None` arm in the `content` value union was superset-only leniency and that "the schema-exact surface types declare no null arm." As of #2849, both committed per-version packages (`v2025_11_25` and `v2026_07_28`) declare `| None` in their generated `ElicitResult.content` value union, so the note is now incorrect.

## How Has This Been Tested?

Docstring-only change. `ruff format`, `ruff check`, and `pyright` pass on the touched file; pre-commit hooks pass.

## Breaking Changes

None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Follow-up nit on #2849.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>