### PR TITLE
Expand site-absolute spec links in generated docstrings to full URLs

### DIFF
--- a/scripts/gen_surface_types.py
+++ b/scripts/gen_surface_types.py
@@ -3,8 +3,9 @@
 Runs `datamodel-code-generator` over each `schema/PINNED.json` entry and
 writes the result to `src/mcp/types/v<version>/__init__.py` with only the
 fixes the raw output needs: a small JSON pre-patch for the known
-`number`-as-`integer` schema.json defect, a header, and per-version
-epilogue aliases. Run with `uv run --frozen --group codegen python scripts/gen_surface_types.py [--check]`.
+`number`-as-`integer` schema.json defect, a header, full URLs for the spec's
+site-absolute doc links, and per-version epilogue aliases. Run with
+`uv run --frozen --group codegen python scripts/gen_surface_types.py [--check]`.
 """
 
 from __future__ import annotations
@@ -198,6 +199,10 @@ def build(entry: dict[str, str]) -> str:
     # Codegen appends `| None` to forward refs of nullable models, which is a
     # runtime TypeError on a string ref and redundant since `JSONValue` includes None.
     source = source.replace('"JSONValue" | None', '"JSONValue"')
+    # Schema descriptions link to spec-site pages with site-absolute paths; expand
+    # them to full URLs so they resolve from the rendered API docs and pass the
+    # strict mkdocs link validation.
+    source = source.replace("](/", "](https://modelcontextprotocol.io/")
     source = allow_open_class_extras(source, OPEN_CLASSES[version])
     if epilogue := EPILOGUES.get(version, ""):
         # Insert before the trailing model_rebuild() block: pyright's evaluation

--- a/src/mcp/types/v2025_11_25/__init__.py
+++ b/src/mcp/types/v2025_11_25/__init__.py
@@ -41,7 +41,7 @@ class BlobResourceContents(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     blob: str
     """
@@ -280,7 +280,7 @@ class CompleteResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     completion: Completion
 
@@ -317,7 +317,7 @@ class ElicitResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     action: Literal["accept", "cancel", "decline"]
     """
@@ -397,7 +397,7 @@ class GetTaskPayloadResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
 
 
@@ -589,7 +589,7 @@ class LoggingMessageNotificationParams(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     data: Any
     """
@@ -692,7 +692,7 @@ class NotificationParams(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
 
 
@@ -714,7 +714,7 @@ class PaginatedResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     next_cursor: Annotated[str | None, Field(alias="nextCursor")] = None
     """
@@ -800,7 +800,7 @@ class PromptReference(WireModel):
 
 class Meta(WireModel):
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
 
     model_config = ConfigDict(
@@ -822,7 +822,7 @@ class ReadResourceRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     uri: str
     """
@@ -870,7 +870,7 @@ class RequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
 
 
@@ -884,7 +884,7 @@ class ResourceContents(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     mime_type: Annotated[str | None, Field(alias="mimeType")] = None
     """
@@ -919,7 +919,7 @@ class ResourceRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     uri: str
     """
@@ -952,7 +952,7 @@ class ResourceUpdatedNotificationParams(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     uri: str
     """
@@ -966,7 +966,7 @@ class Result(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
 
 
@@ -987,7 +987,7 @@ class Root(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     name: str | None = None
     """
@@ -1162,7 +1162,7 @@ class SetLevelRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     level: LoggingLevel
     """
@@ -1193,7 +1193,7 @@ class SubscribeRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     uri: str
     """
@@ -1229,7 +1229,7 @@ class TextResourceContents(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     mime_type: Annotated[str | None, Field(alias="mimeType")] = None
     """
@@ -1500,7 +1500,7 @@ class ToolUseContent(WireModel):
     Optional metadata about the tool use. Clients SHOULD preserve this field when
     including tool uses in subsequent sampling requests to enable caching optimizations.
 
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     id: str
     """
@@ -1529,7 +1529,7 @@ class UnsubscribeRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     uri: str
     """
@@ -1657,7 +1657,7 @@ class AudioContent(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: Annotations | None = None
     """
@@ -1684,7 +1684,7 @@ class CallToolRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     arguments: dict[str, Any] | None = None
     """
@@ -1729,7 +1729,7 @@ class CancelledNotificationParams(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     reason: str | None = None
     """
@@ -1755,7 +1755,7 @@ class CompleteRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     argument: Argument
     """
@@ -1778,7 +1778,7 @@ class ElicitRequestFormParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     message: str
     """
@@ -1814,7 +1814,7 @@ class ElicitRequestURLParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     elicitation_id: Annotated[str, Field(alias="elicitationId")]
     """
@@ -1857,7 +1857,7 @@ class EmbeddedResource(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: Annotations | None = None
     """
@@ -1899,7 +1899,7 @@ class GetPromptRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     arguments: dict[str, str] | None = None
     """
@@ -1949,7 +1949,7 @@ class ImageContent(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: Annotations | None = None
     """
@@ -1976,7 +1976,7 @@ class InitializeRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     capabilities: ClientCapabilities
     client_info: Annotated[Implementation, Field(alias="clientInfo")]
@@ -1996,7 +1996,7 @@ class InitializeResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     capabilities: ServerCapabilities
     instructions: str | None = None
@@ -2097,7 +2097,7 @@ class ListRootsResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     roots: list[Root]
 
@@ -2129,7 +2129,7 @@ class PaginatedRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     cursor: str | None = None
     """
@@ -2190,7 +2190,7 @@ class ProgressNotificationParams(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     message: str | None = None
     """
@@ -2220,7 +2220,7 @@ class Prompt(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     arguments: list[PromptArgument] | None = None
     """
@@ -2281,7 +2281,7 @@ class ReadResourceResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     contents: list[TextResourceContents | BlobResourceContents]
 
@@ -2296,7 +2296,7 @@ class Resource(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: Annotations | None = None
     """
@@ -2361,7 +2361,7 @@ class ResourceLink(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: Annotations | None = None
     """
@@ -2425,7 +2425,7 @@ class ResourceTemplate(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: Annotations | None = None
     """
@@ -2569,7 +2569,7 @@ class TaskAugmentedRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     task: TaskMetadata | None = None
     """
@@ -2602,7 +2602,7 @@ class TextContent(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: Annotations | None = None
     """
@@ -2625,7 +2625,7 @@ class Tool(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     annotations: ToolAnnotations | None = None
     """
@@ -2807,7 +2807,7 @@ class CreateTaskResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     task: Task
 
@@ -2895,7 +2895,7 @@ class ListPromptsResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     next_cursor: Annotated[str | None, Field(alias="nextCursor")] = None
     """
@@ -2929,7 +2929,7 @@ class ListResourceTemplatesResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     next_cursor: Annotated[str | None, Field(alias="nextCursor")] = None
     """
@@ -2963,7 +2963,7 @@ class ListResourcesResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     next_cursor: Annotated[str | None, Field(alias="nextCursor")] = None
     """
@@ -2997,7 +2997,7 @@ class ListTasksResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     next_cursor: Annotated[str | None, Field(alias="nextCursor")] = None
     """
@@ -3031,7 +3031,7 @@ class ListToolsResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     next_cursor: Annotated[str | None, Field(alias="nextCursor")] = None
     """
@@ -3105,7 +3105,7 @@ class ToolResultContent(WireModel):
     Optional metadata about the tool result. Clients SHOULD preserve this field when
     including tool results in subsequent sampling requests to enable caching optimizations.
 
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     content: list[ContentBlock]
     """
@@ -3146,7 +3146,7 @@ class CallToolResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     content: list[ContentBlock]
     """
@@ -3257,7 +3257,7 @@ class GetPromptResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     description: str | None = None
     """
@@ -3346,7 +3346,7 @@ class CreateMessageResult(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     content: (
         TextContent
@@ -3385,7 +3385,7 @@ class SamplingMessage(WireModel):
     )
     meta: Annotated[dict[str, Any] | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     content: (
         TextContent
@@ -3432,7 +3432,7 @@ class CreateMessageRequestParams(WireModel):
     )
     meta: Annotated[Meta | None, Field(alias="_meta")] = None
     """
-    See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
+    See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.
     """
     include_context: Annotated[
         Literal["allServers", "none", "thisServer"] | None,


### PR DESCRIPTION
The Deploy Docs workflow on `main` is failing since #2849: the strict mkdocs build aborts with 54 warnings, all of them mkdocs flagging the site-absolute link `(/specification/2025-11-25/basic/index#meta)` in the generated `api/mcp/types/v2025_11_25` API reference page ([failing run](https://github.com/modelcontextprotocol/python-sdk/actions/runs/27633184006/job/81713347133)).

## Motivation and Context

The vendored schema descriptions link to spec pages with site-absolute paths (they're written for modelcontextprotocol.io). `gen_surface_types.py` copies them verbatim into the per-version package docstrings, so the rendered API reference ends up with links that don't resolve from the SDK docs site, and `validation.absolute_links: warn` + `strict: true` in `mkdocs.yml` turns each occurrence into a build failure. The docs site can't deploy until this is fixed.

This PR adds one post-processing step to the generator that expands site-absolute markdown link targets to full `https://modelcontextprotocol.io/...` URLs, and regenerates the 2025-11-25 package (54 docstring lines change, nothing else). The 2026-07-28 package has no such links and is byte-identical after regeneration. The rewrite matches any site-absolute link target rather than just `/specification/`, so a future schema vendoring that links to other spec-site pages won't reintroduce the failure.

## How Has This Been Tested?

- `uv run --frozen --group codegen python scripts/gen_surface_types.py --check` passes (no drift between the generator and the committed packages).
- `uv run --frozen --group docs mkdocs build` (strict mode) now exits 0 with zero absolute-link warnings; before the change it aborted with 54.
- The built `api/mcp/types/v2025_11_25/index.html` contains 54 `href="https://modelcontextprotocol.io/specification/2025-11-25/basic/index#meta"` links and no site-absolute ones.

The "MkDocs 2.0 is incompatible with Material for MkDocs" notice in the build log is unrelated: it's informational output from mkdocs-material 9.7.x (mkdocs is locked at 1.6.1) and doesn't trip strict mode.

## Breaking Changes

None — only docstrings in a generated internal module and the generator script change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

A separate question this PR doesn't take a position on: whether the internal, versioned wire-shape packages (`mcp.types.v2025_11_25`, `mcp.types.v2026_07_28`) should appear in the rendered API reference at all — `docs/hooks/gen_ref_pages.py` currently publishes every package under `src/`. Even if they're later excluded, the full URLs are still the right thing for IDE tooltips and `help()` output.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>