### PR TITLE
fix(auth): keep root PRM resource URL canonical

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 
 class OAuthToken(BaseModel):
@@ -193,3 +194,18 @@ class ProtectedResourceMetadata(BaseModel):
     dpop_signing_alg_values_supported: list[str] | None = None
     # dpop_bound_access_tokens_required default is False, but omitted here for clarity
     dpop_bound_access_tokens_required: bool | None = None
+
+    @field_serializer("resource")
+    def _serialize_resource(self, value: AnyHttpUrl) -> str:
+        """Preserve canonical root resources without a trailing slash.
+
+        Pydantic normalizes `https://example.com` to `https://example.com/`.
+        RFC 9728 resource metadata is compared as a canonical resource URL, so
+        when the resource path is the origin root we serialize it back without
+        that synthetic slash.
+        """
+        url = str(value)
+        parsed = urlsplit(url)
+        if parsed.path != "/":
+            return url
+        return urlunsplit((parsed.scheme, parsed.netloc, "", parsed.query, parsed.fragment))

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -8,6 +8,7 @@ from inline_snapshot import snapshot
 from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 
+from mcp.shared.auth import ProtectedResourceMetadata
 from mcp.server.auth.routes import build_resource_metadata_url, create_protected_resource_routes
 
 
@@ -96,13 +97,22 @@ async def test_metadata_endpoint_without_path(root_resource_client: httpx.AsyncC
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "resource": "https://example.com/",
+            "resource": "https://example.com",
             "authorization_servers": ["https://auth.example.com/"],
             "scopes_supported": ["read"],
             "resource_name": "Root Resource",
             "bearer_methods_supported": ["header"],
         }
     )
+
+
+def test_root_resource_serializes_without_trailing_slash():
+    metadata = ProtectedResourceMetadata(
+        resource=AnyHttpUrl("https://example.com"),
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+    )
+
+    assert metadata.model_dump(mode="json")["resource"] == "https://example.com"
 
 
 # Tests for URL construction utility function

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -8,8 +8,8 @@ from inline_snapshot import snapshot
 from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
 
-from mcp.shared.auth import ProtectedResourceMetadata
 from mcp.server.auth.routes import build_resource_metadata_url, create_protected_resource_routes
+from mcp.shared.auth import ProtectedResourceMetadata
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- serialize `ProtectedResourceMetadata.resource` without a synthetic trailing slash when the resource is the origin root
- keep the internal field typed as `AnyHttpUrl`, so this only changes the served PRM wire shape
- add regression coverage for the root metadata endpoint and direct JSON serialization

## Testing
- uv run pytest tests/server/auth/test_protected_resource.py
- uv run pytest tests/interaction/auth/test_discovery.py -k prm_endpoint_serves_the_resource_url

Fixes #2883.