### PR TITLE
[v1.x] Pass a list to parametrize in test_docs_examples (pytest 9.1.0 compat)

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -100,7 +100,7 @@ async def test_desktop(monkeypatch: pytest.MonkeyPatch):
             assert "/fake/path/file2.txt" in content.text
 
 
-@pytest.mark.parametrize("example", find_examples("README.md"), ids=str)
+@pytest.mark.parametrize("example", list(find_examples("README.md")), ids=str)
 def test_docs_examples(example: CodeExample, eval_example: EvalExample):
     ruff_ignore: list[str] = ["F841", "I001", "F821"]  # F821: undefined names (snippets lack imports)
 


### PR DESCRIPTION
pytest 9.1.0 deprecates passing a non-Collection iterable (e.g. a generator) to `pytest.mark.parametrize`, raising `PytestRemovedIn10Warning`. With `filterwarnings = ["error"]` this fails collection on the `highest`-resolution CI lanes (all `lowest-direct` lanes pass since they pin an older pytest).

`pytest_examples.find_examples()` returns a generator; materialize it as a list. This is the fix pytest's own message recommends ("Please convert to a list or tuple").

Test-infrastructure only; no change to shipped code. Unblocks the v1.28.0 publish run.

The same change will be needed on `main`.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
