### PR TITLE
Pass a list to parametrize in test_docs_examples (pytest 9.1.0 compat)

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -94,7 +94,7 @@ async def test_desktop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 # TODO(v2): Change back to README.md when v2 is released
-@pytest.mark.parametrize("example", find_examples("README.v2.md"), ids=str)
+@pytest.mark.parametrize("example", list(find_examples("README.v2.md")), ids=str)
 def test_docs_examples(example: CodeExample, eval_example: EvalExample):
     ruff_ignore: list[str] = ["F841", "I001", "F821"]  # F821: undefined names (snippets lack imports)
 


### PR DESCRIPTION
pytest 9.1.0 deprecates passing a non-Collection iterable (e.g. a generator) to `pytest.mark.parametrize`, raising `PytestRemovedIn10Warning`. With `filterwarnings = ["error"]` this fails collection. `pytest_examples.find_examples()` returns a generator; materialize it as a list.

Same fix as #2889 on `v1.x`. `main`'s CI matrix uses `locked` resolution (pytest 8.4.2) so this is not currently failing there, but it future-proofs against the next pytest bump in `uv.lock`. Verified locally that `tests/test_examples.py` collects clean and all 45 tests pass under pytest 9.1.0 with `-W error`.

The `uv.lock` bump to 9.1.0 is deliberately left for a separate PR.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>