### PR TITLE
fix(client/stdio): default encoding_error_handler to 'replace' for resilient UTF-8 decoding

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -106,7 +106,7 @@ class StdioServerParameters(BaseModel):
     encoding: str = "utf-8"
     """Text encoding for messages to and from the server."""
 
-    encoding_error_handler: Literal["strict", "ignore", "replace"] = "strict"
+    encoding_error_handler: Literal["strict", "ignore", "replace"] = "replace"
     """Encoding error handler; see https://docs.python.org/3/library/codecs.html#error-handlers."""
 
 

--- a/tests/client/test_stdio.py
+++ b/tests/client/test_stdio.py
@@ -308,6 +308,30 @@ async def test_invalid_json_from_the_server_surfaces_as_an_in_stream_exception(
 
 
 @pytest.mark.anyio
+async def test_invalid_utf8_from_the_server_surfaces_as_an_in_stream_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A line containing invalid UTF-8 is replaced and delivered as an Exception on the read stream.
+
+    The transport stays alive so subsequent valid messages still come through.
+    Regression for #2454.
+    """
+    ping = JSONRPCRequest(jsonrpc="2.0", id=1, method="ping")
+    process = FakeProcess(on_stdin_close=lambda: process.exit(0))
+
+    install_fake_process(monkeypatch, process)
+
+    with anyio.fail_after(5):
+        async with stdio_client(FAKE_PARAMS) as (read_stream, _):
+            await process.feed(b"\xff\xfe\n" + _line(ping))
+
+            error = await read_stream.receive()
+            # The transport surfaces parse failures as the underlying validation error.
+            assert isinstance(error, ValueError)
+            assert await _next_message(read_stream) == ping
+
+
+@pytest.mark.anyio
 async def test_a_server_that_dies_before_responding_fails_initialize_with_connection_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Changes the default `encoding_error_handler` in `StdioServerParameters` from `"strict"` to `"replace"`.
- Malformed UTF-8 bytes from a child server stdout previously crashed the client transport with `UnicodeDecodeError`.
- With `"replace"`, invalid bytes become U+FFFD and the line fails JSON-RPC validation, which is surfaced as an in-stream `Exception` that the session can handle.
- This mirrors the server-side stdio hardening from PR #2302.

## Test Plan
- [x] Reproduced the crash with a child process emitting `\xff\xfe\n` followed by valid JSON-RPC.
- [x] Verified the fix: first item is a `ValidationError`, second item is the valid `SessionMessage`.
- [x] Added regression test `test_invalid_utf8_from_the_server_surfaces_as_an_in_stream_exception`.
- [x] Full `tests/client/test_stdio.py` suite passes (34 passed, 1 skipped).

## Notes
- Fixes #2454
- Scope intentionally small.
