### PR TITLE
Relax monolith ElicitRequestURLParams.elicitation_id for 2026-07-28

### DIFF
--- a/src/mcp/types/_types.py
+++ b/src/mcp/types/_types.py
@@ -1868,7 +1868,9 @@ class CancelledNotificationParams(NotificationParams):
     The ID of the request to cancel.
 
     This MUST correspond to the ID of a request previously issued in the same direction.
-    Required on the wire through 2025-06-18; optional from 2025-11-25.
+    Required on the wire through 2025-06-18; optional at 2025-11-25; required again from
+    2026-07-28, where it must name a request the client previously issued (servers send
+    this notification only to terminate a `subscriptions/listen` stream).
     """
     reason: str | None = None
     """An optional string describing the reason for the cancellation."""
@@ -1956,10 +1958,11 @@ class ElicitRequestURLParams(RequestParams):
     url: str
     """The URL that the user should navigate to."""
 
-    elicitation_id: str
+    elicitation_id: str | None = None
     """The ID of the elicitation, which must be unique within the context of the server.
 
-    The client MUST treat this ID as an opaque value.
+    The client MUST treat this ID as an opaque value. Required on the wire at
+    2025-11-25; removed at 2026-07-28.
     """
 
     task: TaskMetadata | None = None

--- a/tests/interaction/lowlevel/test_elicitation.py
+++ b/tests/interaction/lowlevel/test_elicitation.py
@@ -309,7 +309,7 @@ async def test_elicitation_complete_notification_carries_the_elicited_id_back_to
     returns; the same ordering already holds on in-memory and SSE transports.
     """
     elicitation_id = "auth-001"
-    elicited_ids: list[str] = []
+    elicited_ids: list[str | None] = []
     received: list[IncomingMessage] = []
 
     async def collect(message: IncomingMessage) -> None:

--- a/tests/types/test_methods.py
+++ b/tests/types/test_methods.py
@@ -674,6 +674,33 @@ def test_embedded_input_request_entries_without_method_reject_at_the_surface_ste
         methods.parse_server_result("tools/call", "2026-07-28", body)
 
 
+def test_input_required_url_elicit_without_elicitation_id_parses_at_2026():
+    """A 2026-07-28 `InputRequiredResult` embedding a URL-mode elicitation parses
+    through both the surface and monolith steps without `elicitationId`.
+
+    Spec-mandated: the field is required at 2025-11-25 only and removed at
+    2026-07-28; the monolith model carries it as optional so the superset can
+    accept both versions.
+    """
+    body = {
+        "resultType": "input_required",
+        "inputRequests": {
+            "r1": {
+                "method": "elicitation/create",
+                "params": {"mode": "url", "message": "Please sign in", "url": "https://example.com/auth"},
+            }
+        },
+    }
+    parsed = methods.parse_server_result("tools/call", "2026-07-28", body)
+    assert isinstance(parsed, types.InputRequiredResult)
+    assert parsed.input_requests is not None
+    request = parsed.input_requests["r1"]
+    assert isinstance(request, types.ElicitRequest)
+    assert isinstance(request.params, types.ElicitRequestURLParams)
+    assert request.params.url == "https://example.com/auth"
+    assert request.params.elicitation_id is None
+
+
 def test_none_params_omit_the_key_so_required_params_reject():
     with pytest.raises(pydantic.ValidationError) as excinfo:
         methods.parse_client_request("tools/call", "2025-11-25", None)


### PR DESCRIPTION
Follow-up to #2912, addressing the two review comments that landed after merge.

## Motivation and Context

#2912 re-vendored the 2026-07-28 draft schema, which dropped `elicitationId` from `ElicitRequestURLParams` and made `CancelledNotificationParams.requestId` required again. The regenerated `v2026_07_28` surface package picked both up correctly, but the version-superset monolith in `_types.py` wasn't relaxed to match. As a result `parse_server_result("tools/call", "2026-07-28", ...)` would reject a spec-valid `InputRequiredResult` carrying a URL-mode elicitation at the monolith step (the `ElicitRequest` arm fails for missing `elicitationId`).

## What changed

- `src/mcp/types/_types.py`: `ElicitRequestURLParams.elicitation_id` is now `str | None = None` with a version note. The `v2025_11_25` surface package still requires it on the wire, so 2025 callers are unchanged. Same superset pattern `CancelledNotificationParams.request_id` already uses.
- `src/mcp/types/_types.py`: `CancelledNotificationParams.request_id` docstring updated to note that 2026-07-28 makes the field required again and narrows it to client-issued requests.
- `tests/types/test_methods.py`: new test pinning that a 2026 `InputRequiredResult` with a URL elicit (no `elicitationId`) parses through both steps.
- `tests/interaction/lowlevel/test_elicitation.py`: capture-list type widened to `list[str | None]` to match the relaxed field.

The `elicit_url` / `send_elicit_complete` helper signatures in `peer.py` / `server/session.py` / `server/mcpserver/context.py` are intentionally not touched here; those are 2025-11-25 API and version-gating them belongs with #2898 / #2904.

## How Has This Been Tested?

`pyright`, `ruff`, `./scripts/test` (full suite, 100% coverage, `strict-no-cover` clean). The new test in `tests/types/test_methods.py` is the repro from the review comment.

## Breaking Changes

`mcp.types.ElicitRequestURLParams` can now be constructed without `elicitation_id`. Existing constructors that pass it are unaffected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
