### PR TITLE
fix(server): treat text/* mime types case-insensitively for FileResource

### DIFF
--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -139,7 +139,10 @@ class FileResource(Resource):
         if is_binary:
             return True
         mime_type = info.data.get("mime_type", "text/plain")
-        return not mime_type.startswith("text/")
+        # Media types are case-insensitive (RFC 9110, section 8.3.1), so normalize
+        # before the prefix check — otherwise e.g. "Text/Markdown" is misclassified
+        # as binary and read as bytes instead of text.
+        return not mime_type.lower().startswith("text/")
 
     async def read(self) -> str | bytes:
         """Read the file content."""

--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -411,7 +411,9 @@ class StreamableHTTPServerTransport:
     def _check_content_type(self, request: Request) -> bool:
         """Check if the request has the correct Content-Type."""
         content_type = request.headers.get("content-type", "")
-        content_type_parts = [part.strip() for part in content_type.split(";")[0].split(",")]
+        # Media types are case-insensitive (RFC 9110, section 8.3.1), so normalize
+        # to lower case before comparing — consistent with _check_accept_headers.
+        content_type_parts = [part.strip().lower() for part in content_type.split(";")[0].split(",")]
 
         return any(part == CONTENT_TYPE_JSON for part in content_type_parts)
 

--- a/tests/server/mcpserver/resources/test_file_resources.py
+++ b/tests/server/mcpserver/resources/test_file_resources.py
@@ -42,6 +42,18 @@ class TestFileResource:
         assert resource.path == temp_file
         assert resource.is_binary is False  # default
 
+    def test_uppercase_text_mime_type_is_treated_as_text(self, temp_file: Path):
+        """Media types are case-insensitive (RFC 9110, section 8.3.1), so an
+        upper/mixed-case ``text/*`` mime type must still be treated as text
+        (``is_binary`` stays False) rather than misclassified as binary."""
+        resource = FileResource(
+            uri=temp_file.as_uri(),
+            name="test",
+            path=temp_file,
+            mime_type="Text/Markdown",
+        )
+        assert resource.is_binary is False
+
     def test_file_resource_str_path_conversion(self, temp_file: Path):
         """Test FileResource handles string paths."""
         resource = FileResource(

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -597,6 +597,30 @@ def test_streamable_http_transport_init_validation() -> None:
         StreamableHTTPServerTransport(mcp_session_id="test\n")
 
 
+def test_check_content_type_is_case_insensitive() -> None:
+    """Content-Type media types are case-insensitive (RFC 9110, section 8.3.1).
+
+    A spec-valid request such as ``Content-Type: Application/JSON`` must be
+    accepted, consistent with ``_check_accept_headers`` (which already lowercases).
+    """
+    transport = StreamableHTTPServerTransport(mcp_session_id=None)
+
+    def request_with(content_type: str) -> Request:
+        return Request({"type": "http", "headers": [(b"content-type", content_type.encode())]})
+
+    for value in (
+        "application/json",
+        "Application/JSON",
+        "APPLICATION/JSON",
+        "application/json; charset=utf-8",
+        "Application/Json; charset=utf-8",
+    ):
+        assert transport._check_content_type(request_with(value)) is True, value
+
+    # A genuinely different media type is still rejected.
+    assert transport._check_content_type(request_with("text/plain")) is False
+
+
 @pytest.mark.anyio
 async def test_session_termination(basic_app: Starlette) -> None:
     """DELETE terminates the session, after which requests for it return 404."""


### PR DESCRIPTION
## Summary

`FileResource.set_binary_from_mime_type` decides whether to read a file as text or bytes from its `mime_type` via `mime_type.startswith("text/")`. Media types are case-insensitive (RFC 9110, §8.3.1), so a `FileResource` declared with an upper/mixed-case text type — e.g. `mime_type="Text/Markdown"` — is misclassified as binary and read with `read_bytes` instead of `read_text`, returning a `bytes` blob to clients instead of text.

## Fix

Lower-case the mime type before the prefix check, consistent with the SDK's other media-type checks (`transport_security`, client `streamable_http`).

## Test

Added `test_uppercase_text_mime_type_is_treated_as_text`: a `FileResource(mime_type="Text/Markdown")` keeps `is_binary` False.

Verified red→green: the new test fails on `main` (treated as binary) and passes with the fix. `uv run pytest tests/server/mcpserver/resources/test_file_resources.py` → **8 passed**; `ruff check` / `ruff format --check` clean.
