### PR TITLE
Ignore pre-2026 protocol_version pins at the StreamableHTTP transport

### DIFF
--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -97,7 +97,9 @@ class Client:
 
     Pinning to ``2026-07-28`` or later selects the stateless transport era: no initialize
     handshake is sent on the wire (the session synthesizes its `InitializeResult` locally),
-    and for HTTP the ``MCP-Protocol-Version`` header is set from the first request.
+    and for HTTP the ``MCP-Protocol-Version`` header is set from the first request. A modern
+    pin currently requires a URL or `Transport`; the in-memory `Server`/`MCPServer` path
+    does not yet have a modern entry point.
     Leave as ``None`` to negotiate the version via the initialize handshake.
     """
 

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -93,13 +93,14 @@ class StreamableHTTPTransport:
 
         Args:
             url: The endpoint URL.
-            protocol_version: Pin the MCP-Protocol-Version header from the first request
-                instead of waiting to snoop it from an InitializeResult. Required for
-                stateless 2026-07-28 sessions that never send initialize.
+            protocol_version: Pin the MCP-Protocol-Version header from the first request.
+                Only honoured for stateless 2026-07-28+ sessions that never send
+                initialize; for earlier (stateful) versions the header is populated
+                from the negotiated InitializeResult, so a pre-2026 value is ignored.
         """
         self.url = url
         self.session_id: str | None = None
-        self.protocol_version: str | None = protocol_version
+        self.protocol_version: str | None = protocol_version if protocol_version in MODERN_PROTOCOL_VERSIONS else None
 
     def _per_message_headers(self, message: JSONRPCMessage) -> dict[str, str]:
         """Per-POST routing headers (Mcp-Method, Mcp-Name) for 2026-07-28+ pinned transports.
@@ -158,7 +159,8 @@ class StreamableHTTPTransport:
     def _maybe_extract_protocol_version_from_message(self, message: JSONRPCMessage) -> None:
         """Extract protocol version from initialization response message."""
         if self.protocol_version is not None:
-            # Constructor pin wins over snooping the InitializeResult.
+            # Only a modern constructor pin reaches here (pre-2026 values are dropped
+            # in __init__), and a modern pin never sends initialize.
             return
         if isinstance(message, JSONRPCResponse) and message.result:  # pragma: no branch
             try:

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -15,7 +15,12 @@ import pytest
 from inline_snapshot import snapshot
 
 from mcp.client import ClientSession
-from mcp.client.streamable_http import StreamableHTTPTransport, _encode_header_value, streamable_http_client
+from mcp.client.streamable_http import (
+    MCP_PROTOCOL_VERSION,
+    StreamableHTTPTransport,
+    _encode_header_value,
+    streamable_http_client,
+)
 from mcp.types import JSONRPCMessage, JSONRPCNotification, JSONRPCRequest, JSONRPCResponse
 
 
@@ -135,8 +140,8 @@ async def test_pinned_transport_ignores_returned_session_id_and_never_opens_get_
     assert all("mcp-session-id" not in r.headers for r in recorded)
 
 
-def test_constructor_pin_is_not_overwritten_by_an_initialize_result() -> None:
-    """A protocol_version passed at construction wins over the InitializeResult snoop."""
+def test_modern_constructor_pin_is_not_overwritten_by_an_initialize_result() -> None:
+    """A 2026-07-28+ pin wins over the InitializeResult snoop (no initialize is ever sent)."""
     transport = StreamableHTTPTransport("http://test/mcp", protocol_version="2026-07-28")
     init = JSONRPCResponse(
         jsonrpc="2.0",
@@ -149,3 +154,22 @@ def test_constructor_pin_is_not_overwritten_by_an_initialize_result() -> None:
     )
     transport._maybe_extract_protocol_version_from_message(init)  # pyright: ignore[reportPrivateUsage]
     assert transport.protocol_version == "2026-07-28"
+
+
+def test_stateful_constructor_pin_is_ignored_and_the_negotiated_version_wins() -> None:
+    """A pre-2026 pin is a session-layer concern; the transport must not stamp it on the
+    initialize request and must adopt the server's negotiated version for later headers."""
+    transport = StreamableHTTPTransport("http://test/mcp", protocol_version="2025-06-18")
+    assert MCP_PROTOCOL_VERSION not in transport._prepare_headers()  # pyright: ignore[reportPrivateUsage]
+    init = JSONRPCResponse(
+        jsonrpc="2.0",
+        id=1,
+        result={
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "serverInfo": {"name": "s", "version": "0"},
+        },
+    )
+    transport._maybe_extract_protocol_version_from_message(init)  # pyright: ignore[reportPrivateUsage]
+    assert transport.protocol_version == "2025-03-26"
+    assert transport._prepare_headers()[MCP_PROTOCOL_VERSION] == "2025-03-26"  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Follow-up to #2910 / #2917 addressing post-merge review feedback.

## Motivation and Context

#2910 threaded the new `protocol_version` pin into `StreamableHTTPTransport` unconditionally and made the constructor pin win over the `InitializeResult` snoop. That's correct for a `2026-07-28` pin (no initialize is ever sent), but for a pre-2026 stateful pin it meant:

- the `MCP-Protocol-Version` header was stamped on the initialize POST itself (the spec only defines it for subsequent requests; a strict server that doesn't support the pinned version may 400 the handshake), and
- after the server negotiated a different version, the transport kept stamping the original pin on every later request — `session.protocol_version` and the wire header disagreed.

A stateful pin is a session-layer concern (it picks the `protocolVersion` field in the `InitializeRequest` body); the transport doesn't need it. This change drops pre-2026 pins at the transport constructor so the header is populated from the negotiated `InitializeResult` exactly as before #2910, while modern pins continue to be honoured from the first request.

Also adds a one-line caveat to the `Client.protocol_version` docstring noting that a `2026-07-28` pin currently requires a URL/HTTP transport (the in-memory `Server`/`MCPServer` path doesn't have a modern entry yet).

### Review threads not addressed here

- `_streamable_http_modern.py` returning `-32700` for a valid-JSON non-request body — the body-parse block is replaced by the inbound classifier in the upcoming `server-stateless` work, which returns `INVALID_REQUEST` for that case. (At 2026-07-28 there are no client→server notifications over Streamable HTTP, so 202 is not the target shape — a deliberate rejection is.)
- `_related_request_id` `# type: ignore[call-arg]` in `server/session.py` — already tracked; falls out of the `ServerRunner` driver split.

## How Has This Been Tested?

- New unit test `test_stateful_constructor_pin_is_ignored_and_the_negotiated_version_wins` covers both the header-omitted-on-initialize and negotiated-version-wins behaviours.
- Existing `test_modern_constructor_pin_is_not_overwritten_by_an_initialize_result` (renamed for clarity) still pins the 2026 case.
- `tests/interaction -k 'streamable-http and 2025'` (230 tests, which pass a stateful `2025-11-25` pin on every connection) passes unchanged.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The early-return guard in `_maybe_extract_protocol_version_from_message` is now reachable only via direct invocation in the unit test (a modern-pinned transport never sends initialize in production). Left as-is to keep this PR scoped; the single-owner refactor for the client pin will sweep it.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
