### PR TITLE
ci(conformance): bump harness to 0.2.0-alpha.5 preview

### DIFF
--- a/.github/actions/conformance/expected-failures.2026-07-28.yml
+++ b/.github/actions/conformance/expected-failures.2026-07-28.yml
@@ -10,10 +10,10 @@
 # 2026 leg reads the `server:` section. Both burn down independently of the
 # 2025 legs.
 #
-# Baseline established against @modelcontextprotocol/conformance pinned in
-# .github/workflows/conformance.yml (CONFORMANCE_VERSION = 0.2.0-alpha.4).
-# New conformance releases are adopted by deliberately bumping that pin and
-# reconciling both this file and expected-failures.yml in the same change.
+# Baseline established against the harness pinned via CONFORMANCE_PKG in
+# .github/workflows/conformance.yml. New conformance releases are adopted by
+# deliberately bumping that pin and reconciling both this file and
+# expected-failures.yml in the same change.
 #
 # Entries are grouped by what unblocks them. As each gap closes the
 # corresponding scenarios start passing and MUST be removed from this list

--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -1,11 +1,10 @@
 # Conformance scenarios not yet passing against the Python SDK on main.
 # CI exits 0 if only these fail, exits 1 on unexpected failures or stale entries.
 #
-# Baseline established against @modelcontextprotocol/conformance pinned in
-# .github/workflows/conformance.yml (CONFORMANCE_VERSION = 0.2.0-alpha.4).
-# New conformance releases are adopted by deliberately bumping that pin and
-# reconciling both this file and expected-failures.2026-07-28.yml in the same
-# change.
+# Baseline established against the harness pinned via CONFORMANCE_PKG in
+# .github/workflows/conformance.yml. New conformance releases are adopted by
+# deliberately bumping that pin and reconciling both this file and
+# expected-failures.2026-07-28.yml in the same change.
 #
 # Entries are grouped by SEP. As each SEP lands in the SDK the corresponding
 # scenarios start passing and MUST be removed from this list (the runner fails
@@ -40,9 +39,6 @@ client:
   - auth/offline-access-not-supported
 
   # --- Pre-existing scenarios that fail on checks added after conformance 0.1.15 ---
-  # SEP-2350 (scope step-up): WARNING-only; the expected-failures evaluator
-  # counts WARNINGs as failures.
-  - auth/scope-step-up
   # SEP-990 (enterprise-managed authorization extension): no fixture handler /
   # client support for the token-exchange + JWT bearer flow.
   - auth/enterprise-managed-authorization

--- a/.github/actions/conformance/run-server.sh
+++ b/.github/actions/conformance/run-server.sh
@@ -47,5 +47,5 @@ done
 
 echo "Server ready at $SERVER_URL"
 
-npx --yes @modelcontextprotocol/conformance@"${CONFORMANCE_VERSION:?set CONFORMANCE_VERSION (pinned in .github/workflows/conformance.yml)}" \
+npx --yes "${CONFORMANCE_PKG:?set CONFORMANCE_PKG (pinned in .github/workflows/conformance.yml)}" \
     server --url "$SERVER_URL" "$@"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -20,10 +20,10 @@ env:
   # .github/actions/conformance/expected-failures*.yml files in the same change.
   #
   # TODO: replace with @modelcontextprotocol/conformance@0.2.0-alpha.5 once
-  # https://github.com/modelcontextprotocol/conformance/pull/357 publishes.
-  # The pkg.pr.new URL below is the preview build of that PR pinned at commit
-  # 65fcd39 (immutable). Do not merge this branch to main with a pkg.pr.new pin.
+  # https://github.com/modelcontextprotocol/conformance/pull/357 publishes, and
+  # drop CONFORMANCE_PKG_SHA256 plus the fetch-and-verify step below.
   CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@65fcd39"
+  CONFORMANCE_PKG_SHA256: "9a381d7083f8be2fe7ae44efeca54530f18c61425805ddaf9cd88915efcc1574"
 
 jobs:
   server-conformance:
@@ -39,6 +39,19 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+      - name: Fetch and verify conformance harness
+        # Only when CONFORMANCE_PKG is a URL: download, check the recorded
+        # sha256, and re-point CONFORMANCE_PKG at the verified local tarball.
+        # When CONFORMANCE_PKG is a registry spec, this step is a no-op (npm's
+        # own integrity check applies).
+        run: |
+          case "$CONFORMANCE_PKG" in
+            https://*)
+              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
+              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
+              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
+              ;;
+          esac
       - run: uv sync --frozen --all-extras --package mcp-everything-server
       - name: Run server conformance (active suite)
         run: >-
@@ -70,6 +83,15 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+      - name: Fetch and verify conformance harness
+        run: |
+          case "$CONFORMANCE_PKG" in
+            https://*)
+              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
+              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
+              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
+              ;;
+          esac
       - run: uv sync --frozen --all-extras --package mcp
       - name: Run client conformance (all suite)
         run: >-

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,10 +14,16 @@ permissions:
   contents: read
 
 env:
-  # Pinned conformance harness version. Bump deliberately and reconcile
-  # both .github/actions/conformance/expected-failures*.yml files in the
-  # same change.
-  CONFORMANCE_VERSION: "0.2.0-alpha.4"
+  # Pinned conformance harness package spec (passed verbatim to `npx --yes`).
+  # Use a published version, e.g. @modelcontextprotocol/conformance@0.2.0-alpha.5.
+  # Bump deliberately and reconcile both
+  # .github/actions/conformance/expected-failures*.yml files in the same change.
+  #
+  # TODO: replace with @modelcontextprotocol/conformance@0.2.0-alpha.5 once
+  # https://github.com/modelcontextprotocol/conformance/pull/357 publishes.
+  # The pkg.pr.new URL below is the preview build of that PR pinned at commit
+  # 65fcd39 (immutable). Do not merge this branch to main with a pkg.pr.new pin.
+  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@65fcd39"
 
 jobs:
   server-conformance:
@@ -67,13 +73,13 @@ jobs:
       - run: uv sync --frozen --all-extras --package mcp
       - name: Run client conformance (all suite)
         run: >-
-          npx --yes @modelcontextprotocol/conformance@"$CONFORMANCE_VERSION" client
+          npx --yes "$CONFORMANCE_PKG" client
           --command 'uv run --frozen python .github/actions/conformance/client.py'
           --suite all
           --expected-failures ./.github/actions/conformance/expected-failures.yml
       - name: Run client conformance (2026-07-28 wire, all suite)
         run: >-
-          npx --yes @modelcontextprotocol/conformance@"$CONFORMANCE_VERSION" client
+          npx --yes "$CONFORMANCE_PKG" client
           --command 'uv run --frozen python .github/actions/conformance/client.py'
           --suite all
           --spec-version 2026-07-28


### PR DESCRIPTION
Bumps the conformance harness pin to the 0.2.0-alpha.5 preview build so the staging branch can assert the post-[#2907](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2907) error codes (`-32020..-32022`) once the server-stateless / header-validation work starts emitting them.

Part of #2891. Originally targeted the `v2-2026-07-28` staging branch (#2917), retargeted to `main` after #2917 merged.

## Motivation and Context

#2912 noted that the published `@modelcontextprotocol/conformance@0.2.0-alpha.4` predates [conformance#353](https://github.com/modelcontextprotocol/conformance/pull/353) (the renumber). [conformance#357](https://github.com/modelcontextprotocol/conformance/pull/357) is the alpha.5 release PR that carries it; this PR pins to its `pkg.pr.new` preview build at commit `65fcd39` so the staging branch runs against the renumbered harness without waiting for the npm release.

## What changed

- `conformance.yml`: `CONFORMANCE_VERSION` → `CONFORMANCE_PKG` (full npx package spec, so the same line accepts either a registry version or a tarball URL). Pinned to `https://pkg.pr.new/@modelcontextprotocol/conformance@65fcd39` — the immutable commit-SHA form, not the mutable `@357` PR ref. A new "Fetch and verify conformance harness" step downloads the tarball, checks it against `CONFORMANCE_PKG_SHA256`, and re-points `CONFORMANCE_PKG` at the verified local file before any `npx` call (no-op when `CONFORMANCE_PKG` is a registry spec). The comment carries a TODO to swap to `@modelcontextprotocol/conformance@0.2.0-alpha.5` once conformance#357 publishes, dropping the SHA + fetch step.
- `run-server.sh` + both client steps: `npx --yes "$CONFORMANCE_PKG"`.
- `expected-failures.yml`: removed `auth/scope-step-up` from `client:` — [conformance#337](https://github.com/modelcontextprotocol/conformance/pull/337) gated the SEP-2350 scope-union check to 2026-07-28+, so it now passes on the 2025 client leg. It stays in `expected-failures.2026-07-28.yml` (still fails there).
- Both `expected-failures*.yml` header comments updated to reference `CONFORMANCE_PKG`.

## How Has This Been Tested?

All 5 conformance legs run locally against the `65fcd39` build:

| Leg | Exit | Delta |
|---|---|---|
| server `--suite active` | 0 | none |
| server `--suite draft` | 0 | none |
| server `--suite all --spec-version 2026-07-28` | 0 | none |
| client `--suite all` | 1 → 0 | stale `auth/scope-step-up` removed |
| client `--suite all --spec-version 2026-07-28` | 0 | none |

No new scenarios appeared (the SEP-2663 tasks scenarios from [conformance#262](https://github.com/modelcontextprotocol/conformance/pull/262) and the `server/discover` mocks from [conformance#347](https://github.com/modelcontextprotocol/conformance/pull/347) are not in `active`/`draft`/`all` at this build).

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
