### PR TITLE
fix(mcpserver): preserve Annotated/Field metadata for dict[str, T] return types

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -349,9 +349,9 @@ def _try_create_model_and_schema(
         if origin is dict:
             args = get_args(type_expr)
             if len(args) == 2 and args[0] is str:
-                # TODO: should we use the original annotation? We are losing any potential `Annotated`
-                # metadata for Pydantic here:
-                model = _create_dict_model(func_name, type_expr)
+                # Use the original annotation (which may be `Annotated[dict[str, T], Field(...)]`)
+                # so that any Annotated metadata (e.g. Field description) is preserved in the schema.
+                model = _create_dict_model(func_name, original_annotation)
             else:
                 # dict with non-str keys needs wrapping
                 model = _create_wrapped_model(func_name, original_annotation)

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -261,7 +261,9 @@ def test_structured_output_dict_str_preserves_annotated_metadata():
     )
 
     # Additional metadata (title, max_length, etc.) should also be preserved
-    def get_headers() -> Annotated[dict[str, str], Field(description="HTTP headers", title="Headers")]:  # pragma: no cover
+    def get_headers() -> Annotated[
+        dict[str, str], Field(description="HTTP headers", title="Headers")
+    ]:  # pragma: no cover
         return {"Content-Type": "application/json"}
 
     meta2 = func_metadata(get_headers)

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -245,6 +245,31 @@ def test_structured_output_dict_str_types():
     assert "result" in meta.output_schema["properties"]
 
 
+def test_structured_output_dict_str_preserves_annotated_metadata():
+    """dict[str, T] return types should preserve Annotated/Field metadata in output schema.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2935
+    """
+
+    def get_config() -> Annotated[dict[str, int], Field(description="Configuration values")]:  # pragma: no cover
+        return {"timeout": 30}
+
+    meta = func_metadata(get_config)
+    assert meta.output_schema is not None
+    assert meta.output_schema.get("description") == "Configuration values", (
+        f"Expected 'description' in schema, got: {meta.output_schema}"
+    )
+
+    # Additional metadata (title, max_length, etc.) should also be preserved
+    def get_headers() -> Annotated[dict[str, str], Field(description="HTTP headers", title="Headers")]:  # pragma: no cover
+        return {"Content-Type": "application/json"}
+
+    meta2 = func_metadata(get_headers)
+    assert meta2.output_schema is not None
+    assert meta2.output_schema.get("description") == "HTTP headers"
+    assert meta2.output_schema.get("title") == "Headers"
+
+
 @pytest.mark.anyio
 async def test_lambda_function():
     """Test lambda function schema and validation"""


### PR DESCRIPTION
## Summary

When a tool declares a `dict[str, T]` return type wrapped in `Annotated` with
Pydantic `Field` metadata (e.g. a description), that metadata was silently dropped
from the generated output schema.

```python
def get_config() -> Annotated[dict[str, int], Field(description="Configuration values")]:
    return {"timeout": 30}

print(func_metadata(get_config).output_schema)
# Before: {'type': 'object', 'additionalProperties': {'type': 'integer'}, 'title': 'get_configDictOutput'}
# After:  {'type': 'object', 'additionalProperties': {'type': 'integer'}, 'title': 'get_configDictOutput', 'description': 'Configuration values'}
```

## Root cause

In `_try_create_model_and_schema`, the `dict[str, T]` branch called
`_create_dict_model(func_name, type_expr)` where `type_expr` is the
`Annotated`-stripped type. The existing TODO comment on that line even flagged
the issue. The fix is to pass `original_annotation` instead, so
`RootModel[Annotated[dict[str, T], Field(...)]]` picks up the metadata.

## Changes

- `src/mcp/server/mcpserver/utilities/func_metadata.py`: pass `original_annotation`
  instead of `type_expr` to `_create_dict_model`; replace TODO comment with a
  clarifying one
- `tests/server/mcpserver/test_func_metadata.py`: add
  `test_structured_output_dict_str_preserves_annotated_metadata` regression test
  covering `Field(description=...)` and `Field(description=..., title=...)`

Fixes #2935

<!-- oss-radar:idempotency=auto-20260621-101526.w2.modelcontextprotocol_python-sdk.2935 -->