### PR TITLE
fix: catch KeyboardInterrupt in run() for clean Ctrl+C exit

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -291,13 +291,18 @@ class MCPServer(Generic[LifespanResultT]):
         if transport not in TRANSPORTS.__args__:  # type: ignore  # pragma: no cover
             raise ValueError(f"Unknown transport: {transport}")
 
-        match transport:
-            case "stdio":
-                anyio.run(self.run_stdio_async)
-            case "sse":  # pragma: no cover
-                anyio.run(lambda: self.run_sse_async(**kwargs))
-            case "streamable-http":  # pragma: no cover
-                anyio.run(lambda: self.run_streamable_http_async(**kwargs))
+        try:
+            match transport:
+                case "stdio":
+                    anyio.run(self.run_stdio_async)
+                case "sse":  # pragma: no cover
+                    anyio.run(lambda: self.run_sse_async(**kwargs))
+                case "streamable-http":  # pragma: no cover
+                    anyio.run(lambda: self.run_streamable_http_async(**kwargs))
+        except KeyboardInterrupt:
+            # Ctrl+C should exit cleanly without a traceback when running
+            # a server from the terminal (e.g. stdio transport).
+            pass
 
     async def _handle_list_tools(
         self, ctx: ServerRequestContext[LifespanResultT], params: PaginatedRequestParams | None

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -169,3 +169,20 @@ def test_mcpserver_run_stdio_runs_lifespan_cleanup_after_stdin_closes(monkeypatc
     assert events == ["setup", "cleanup"]
     response = jsonrpc_message_adapter.validate_json(captured.getvalue().decode().strip())
     assert response == JSONRPCResponse(jsonrpc="2.0", id=1, result={})
+
+
+def test_mcpserver_run_catches_keyboard_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ctrl+C during `run()` should exit cleanly without a traceback.
+
+    Regression test for #2663: when running a stdio server from the terminal,
+    KeyboardInterrupt (Ctrl+C) should not produce a multi-frame traceback
+    through anyio.run() → asyncio.runners.
+    """
+
+    def mock_anyio_run(*args: object, **kwargs: object) -> None:
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(anyio, "run", mock_anyio_run)
+
+    # Should not raise — KeyboardInterrupt is caught inside run()
+    MCPServer(name="KeyboardInterruptServer").run("stdio")


### PR DESCRIPTION
## AI Assistance Disclosure
This contribution was developed with AI assistance (Claude / Anthropic Claude Code).

## Summary
Fix #2663: When running a stdio server from the terminal and pressing Ctrl+C, the server previously produced a noisy multi-frame traceback through `anyio.run()` → `asyncio.runners` → `anyio.streams.memory.receive`. This change wraps the `anyio.run()` call in `MCPServer.run()` with a `try/except KeyboardInterrupt` so the server exits cleanly.

## Changes
**`src/mcp/server/mcpserver/server.py`**: +7 lines (try/except + comment), −5 lines (indent shift)
**`tests/server/test_stdio.py`**: +14 lines (1 new test)

## Verification Process
1. Forked → cloned to local sandbox
2. Applied fix: `try/except KeyboardInterrupt` in `run()`
3. Wrote test mocking `anyio.run` to raise `KeyboardInterrupt`
4. Ran stdio test suite: **5/5 passed** (4 existing + 1 new)
5. Ruff format + lint: all checks passed
6. Zero new pragma/type:ignore/noqa annotations

## Test Results
```
tests/server/test_stdio.py::test_stdio_server_round_trips_messages_over_injected_streams PASSED
tests/server/test_stdio.py::test_stdio_server_invalid_utf8 PASSED
tests/server/test_stdio.py::test_mcpserver_run_stdio_serves_until_stdin_closes PASSED
tests/server/test_stdio.py::test_mcpserver_run_stdio_runs_lifespan_cleanup_after_stdin_closes PASSED
tests/server/test_stdio.py::test_mcpserver_run_catches_keyboard_interrupt PASSED [NEW]
```

## Cross-Validation
| Scenario | Before | After |
|----------|--------|-------|
| Ctrl+C during stdio run | ❌ noisy traceback | ✅ clean exit |
| Normal shutdown (EOF) | ✅ | ✅ |
| Unknown transport error | ✅ raised normally | ✅ raised normally |

Closes #2663