### PR TITLE
fix: normalize OAuth redirect URI URL subtypes

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator
 
@@ -83,6 +83,14 @@ class OAuthClientMetadata(BaseModel):
     jwks: Any | None = None
     software_id: str | None = None
     software_version: str | None = None
+
+    @field_validator("redirect_uris", mode="before")
+    @classmethod
+    def _coerce_redirect_uris_to_any_url(cls, v: object) -> object:
+        if isinstance(v, list):
+            redirect_uris = cast(list[object], v)
+            return [str(item) if isinstance(item, AnyUrl) else item for item in redirect_uris]
+        return v
 
     @field_validator(
         "client_uri",

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,9 +1,9 @@
 """Tests for OAuth 2.0 shared code."""
 
 import pytest
-from pydantic import ValidationError
+from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
-from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
+from mcp.shared.auth import InvalidRedirectUriError, OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
 
 
 def test_oauth():
@@ -107,6 +107,21 @@ def test_valid_url_passes_through_unchanged():
     }
     metadata = OAuthClientMetadata.model_validate(data)
     assert str(metadata.client_uri) == "https://udemy.com/"
+
+
+def test_redirect_uri_url_subtypes_are_normalized_for_validation():
+    client = OAuthClientInformationFull(
+        client_id="abc123",
+        redirect_uris=[AnyHttpUrl("https://example.com/callback")],
+    )
+
+    redirect_uri = AnyUrl("https://example.com/callback")
+    assert redirect_uri in (client.redirect_uris or [])
+    assert client.validate_redirect_uri(redirect_uri) == redirect_uri
+    assert client.model_dump(mode="json")["redirect_uris"] == ["https://example.com/callback"]
+
+    with pytest.raises(InvalidRedirectUriError):
+        client.validate_redirect_uri(AnyUrl("https://example.com/other"))
 
 
 def test_information_full_inherits_coercion():


### PR DESCRIPTION
Fixes #2687

## Summary

OAuth client metadata stores `redirect_uris` as `AnyUrl`, but Pydantic v2 preserves stricter URL subtype instances that callers pass in, such as `AnyHttpUrl`. Those subtype instances serialize to the same URL string as `AnyUrl`, but object equality is type-strict, so `validate_redirect_uri(AnyUrl(...))` rejects a registered `AnyHttpUrl(...)` value.

This normalizes `redirect_uris` at the model boundary by stringifying Pydantic URL objects before validation. Pydantic then rebuilds them as the declared `AnyUrl` type. Raw strings and existing validation errors still follow the normal field validation path.

## Evidence

Before the fix, the minimal repro fails:

```text
stored_types ['AnyHttpUrl']
string_equal True
object_equal False
membership False
failed Redirect URI 'https://example.com/cb' not registered for client
```

After the fix, the same repro succeeds and JSON output is unchanged:

```text
stored_types ['AnyUrl']
membership True
validated https://example.com/cb
json ['https://example.com/cb']
```

## Validation

```bash
uv run --frozen pytest tests/shared/test_auth.py
uv run --frozen ruff format --check src/mcp/shared/auth.py tests/shared/test_auth.py
uv run --frozen ruff check src/mcp/shared/auth.py tests/shared/test_auth.py
uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/shared/test_auth.py && uv run --frozen coverage combine && uv run --frozen coverage report --include='src/mcp/shared/auth.py' --fail-under=0 && UV_FROZEN=1 uv run --frozen strict-no-cover
```

## AI Assistance

AI assistance was used to prepare this patch and validation notes.
