### PR TITLE
[v1.x] fix: make request responder completion idempotent

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -122,11 +122,11 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
         Must be called within a context manager block.
         Raises:
             RuntimeError: If not used within a context manager
-            AssertionError: If request was already responded to
         """
         if not self._entered:  # pragma: no cover
             raise RuntimeError("RequestResponder must be used as a context manager")
-        assert not self._completed, "Request already responded to"
+        if self._completed:
+            return
 
         if not self.cancelled:  # pragma: no branch
             self._completed = True
@@ -143,6 +143,9 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
             raise RuntimeError("No active cancel scope")
 
         self._cancel_scope.cancel()
+        if self._completed:
+            return
+
         self._completed = True  # Mark as completed so it's removed from in_flight
         # Send an error response to indicate cancellation
         await self._session._send_response(  # type: ignore[reportPrivateUsage]

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncGenerator
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import anyio
 import pytest
@@ -10,11 +11,13 @@ from mcp.server.lowlevel.server import Server
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_client_server_memory_streams, create_connected_server_and_client_session
 from mcp.shared.message import SessionMessage
+from mcp.shared.session import RequestResponder
 from mcp.types import (
     CancelledNotification,
     CancelledNotificationParams,
     ClientNotification,
     ClientRequest,
+    ClientResult,
     EmptyResult,
     ErrorData,
     JSONRPCError,
@@ -28,6 +31,20 @@ from mcp.types import (
 @pytest.fixture
 def mcp_server() -> Server:
     return Server(name="test server")
+
+
+def make_request_responder() -> tuple[RequestResponder[ClientRequest, ClientResult], MagicMock]:
+    mock_session = MagicMock()
+    mock_session._send_response = AsyncMock()
+    request = ClientRequest(types.PingRequest())
+    responder: RequestResponder[ClientRequest, ClientResult] = RequestResponder(
+        request_id=1,
+        request_meta=None,
+        request=request,
+        session=mock_session,
+        on_complete=lambda responder: None,
+    )
+    return responder, mock_session
 
 
 @pytest.fixture
@@ -126,6 +143,33 @@ async def test_request_cancellation():
             # Give cancellation time to process
             with anyio.fail_after(1):  # pragma: no cover
                 await ev_cancelled.wait()
+
+
+@pytest.mark.anyio
+async def test_request_responder_respond_after_cancel_does_not_raise():
+    responder, mock_session = make_request_responder()
+
+    with responder:
+        await responder.cancel()
+        await responder.respond(ClientResult(root=EmptyResult()))
+
+    mock_session._send_response.assert_awaited_once()
+    assert mock_session._send_response.await_args.kwargs["response"] == ErrorData(
+        code=0, message="Request cancelled", data=None
+    )
+
+
+@pytest.mark.anyio
+async def test_request_responder_cancel_after_respond_does_not_send_error():
+    responder, mock_session = make_request_responder()
+    response = ClientResult(root=EmptyResult())
+
+    with responder:
+        await responder.respond(response)
+        await responder.cancel()
+
+    mock_session._send_response.assert_awaited_once()
+    assert mock_session._send_response.await_args.kwargs["response"] == response
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #2416.

## Summary

- make `RequestResponder.respond()` return without sending a second response when the responder has already completed
- make `RequestResponder.cancel()` cancel the active scope but skip the cancellation error response if a normal response already completed the request
- add focused regression coverage for both respond-after-cancel and cancel-after-respond orderings

## Root cause

A cancellation notification can complete a responder and send the cancellation error before a late `respond()` call reaches `RequestResponder.respond()`. The existing assertion then raises `AssertionError: Request already responded to`, which can break the session even though one JSON-RPC response has already won the race.

## Validation

- `uv run --frozen pytest tests/shared/test_session.py -q --tb=short --maxfail=1`
- `uv run --frozen pyright src/mcp/shared/session.py tests/shared/test_session.py`
- `uv run --frozen ruff check src/mcp/shared/session.py tests/shared/test_session.py`
- `uv run --frozen ruff format --check src/mcp/shared/session.py tests/shared/test_session.py`
- `git diff --check`
- local repro script now prints `PASS: no AssertionError; responses=1`

AI assistance was used to prepare this change; I reviewed and validated the final diff.
