### PR TITLE
fix: terminate streamable http sessions on shutdown

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -774,9 +774,16 @@ class StreamableHTTPServerTransport:
 
         Once terminated, all requests with this session ID will receive 404 Not Found.
         """
+        if self._terminated:
+            return
 
         self._terminated = True
         logger.info(f"Terminating session: {self.mcp_session_id}")
+
+        sse_stream_writers = list(self._sse_stream_writers.values())
+        for writer in sse_stream_writers:
+            writer.close()
+        self._sse_stream_writers.clear()
 
         # We need a copy of the keys to avoid modification during iteration
         request_stream_keys = list(self._request_streams.keys())

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -145,6 +145,11 @@ class StreamableHTTPSessionManager:
                 yield  # Let the application run
             finally:
                 logger.info("StreamableHTTP session manager shutting down")
+                for transport in list(self._server_instances.values()):
+                    try:
+                        await transport.terminate()
+                    except Exception:  # pragma: no cover
+                        logger.debug("Error terminating StreamableHTTP transport during shutdown", exc_info=True)
                 # Cancel task group to stop all spawned tasks
                 tg.cancel_scope.cancel()
                 self._task_group = None

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -65,6 +65,19 @@ async def test_run_prevents_concurrent_calls():
 
 
 @pytest.mark.anyio
+async def test_run_terminates_active_transports_before_shutdown():
+    app = Server("test-server")
+    manager = StreamableHTTPSessionManager(app=app)
+    transport = AsyncMock()
+
+    async with manager.run():
+        manager._server_instances["session-id"] = transport
+
+    transport.terminate.assert_awaited_once_with()
+    assert not manager._server_instances
+
+
+@pytest.mark.anyio
 async def test_handle_request_without_run_raises_error():
     """Test that handle_request raises error if run() hasn't been called."""
     app = Server("test-server")
@@ -267,6 +280,22 @@ async def test_stateless_requests_memory_cleanup():
 
             # Verify internal state is cleaned up
             assert len(transport._request_streams) == 0, "Transport should have no active request streams"
+
+
+@pytest.mark.anyio
+async def test_transport_terminate_closes_active_sse_writers():
+    transport = StreamableHTTPServerTransport(mcp_session_id="session-id")
+    writer, reader = anyio.create_memory_object_stream[dict[str, str]](1)
+    transport._sse_stream_writers["request-id"] = writer
+
+    await transport.terminate()
+
+    assert transport.is_terminated
+    assert not transport._sse_stream_writers
+    with pytest.raises(anyio.ClosedResourceError):
+        writer.send_nowait({"event": "message", "data": "{}"})
+
+    await reader.aclose()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Fixes #2150.

- terminate active StreamableHTTP transports before the session manager cancels its task group during shutdown
- close active SSE stream writers when a transport is terminated, so EventSourceResponse instances can complete instead of being cancelled mid-stream
- make transport termination idempotent and add regression coverage for both cleanup paths

## Why

During `StreamableHTTPSessionManager.run()` shutdown, stateful transports were cleared after cancelling the task group without first being terminated. Separately, `StreamableHTTPServerTransport.terminate()` cleaned request streams but left `_sse_stream_writers` open. Active streaming responses could therefore be cancelled before their SSE streams were closed cleanly.

## Tests

- `uv run pytest tests/server/test_streamable_http_manager.py::test_run_terminates_active_transports_before_shutdown tests/server/test_streamable_http_manager.py::test_transport_terminate_closes_active_sse_writers -q`
- `uv run pytest tests/server/test_streamable_http_manager.py -q`
- `uv run pytest tests/shared/test_streamable_http.py::test_session_termination tests/shared/test_streamable_http.py::test_streamable_http_client_session_termination tests/shared/test_streamable_http.py::test_streamable_http_client_session_termination_204 tests/shared/test_streamable_http.py::test_close_sse_stream_callback_not_provided_for_old_protocol_version tests/shared/test_streamable_http.py::test_close_sse_stream_callback_not_provided_for_unknown_protocol_version -q`
- `uv run ruff check src/mcp/server/streamable_http_manager.py src/mcp/server/streamable_http.py tests/server/test_streamable_http_manager.py`
- `uv run ruff format --check src/mcp/server/streamable_http_manager.py src/mcp/server/streamable_http.py tests/server/test_streamable_http_manager.py`
- `uv run python -m py_compile src/mcp/server/streamable_http_manager.py src/mcp/server/streamable_http.py tests/server/test_streamable_http_manager.py`
- `git diff --check`
