### PR TITLE
fix: normalize OAuth redirect URI URL subtypes

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator
 
@@ -83,6 +83,14 @@ class OAuthClientMetadata(BaseModel):
     jwks: Any | None = None
     software_id: str | None = None
     software_version: str | None = None
+
+    @field_validator("redirect_uris", mode="before")
+    @classmethod
+    def _normalize_redirect_uri_subtypes(cls, v: object) -> object:
+        if isinstance(v, list):
+            # Pydantic URL equality is type-strict, so store redirect URIs as the declared AnyUrl type.
+            return [str(item) if isinstance(item, AnyUrl) else item for item in cast(list[object], v)]
+        return v
 
     @field_validator(
         "client_uri",

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,9 +1,14 @@
 """Tests for OAuth 2.0 shared code."""
 
 import pytest
-from pydantic import ValidationError
+from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
-from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
+from mcp.shared.auth import (
+    InvalidRedirectUriError,
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+)
 
 
 def test_oauth():
@@ -138,3 +143,18 @@ def test_invalid_non_empty_url_still_rejected():
     }
     with pytest.raises(ValidationError):
         OAuthClientMetadata.model_validate(data)
+
+
+def test_redirect_uri_subtypes_normalized_for_validation():
+    client_info = OAuthClientInformationFull(
+        client_id="test-client",
+        redirect_uris=[AnyHttpUrl("https://example.com/callback")],
+    )
+
+    incoming = AnyUrl("https://example.com/callback")
+
+    assert client_info.validate_redirect_uri(incoming) == incoming
+    assert client_info.model_dump(mode="json")["redirect_uris"] == ["https://example.com/callback"]
+
+    with pytest.raises(InvalidRedirectUriError):
+        client_info.validate_redirect_uri(AnyUrl("https://example.com/other"))


### PR DESCRIPTION
## Summary

Fixes #2687 by normalizing `OAuthClientMetadata.redirect_uris` entries at the model boundary. If callers pass a Pydantic URL subtype such as `AnyHttpUrl`, the value is revalidated through the declared `AnyUrl` field type instead of being stored as the stricter subtype.

## Root cause

Pydantic v2 URL equality is type-strict. A stored `AnyHttpUrl("https://example.com/callback")` and an incoming `AnyUrl("https://example.com/callback")` serialize to the same string, but compare non-equal. That makes `validate_redirect_uri()` reject a registered redirect URI during OAuth flows.

## Changes

- Added a `redirect_uris` field validator that stringifies existing `AnyUrl` instances before Pydantic validates the field.
- Added regression coverage for `OAuthClientInformationFull(redirect_uris=[AnyHttpUrl(...)])` validating an incoming equivalent `AnyUrl(...)`.
- Kept JSON serialization unchanged and still reject unrelated redirect URIs.

## Validation

- `uv run pytest tests/shared/test_auth.py::test_redirect_uri_subtypes_normalized_for_validation -q` failed before the fix with `InvalidRedirectUriError`.
- `uv run ruff format --check src/mcp/shared/auth.py tests/shared/test_auth.py`
- `uv run ruff check src/mcp/shared/auth.py tests/shared/test_auth.py`
- `uv run pytest tests/shared/test_auth.py tests/client/test_auth.py tests/interaction/auth/test_authorize_token.py -q` -> 155 passed, 1 xfailed
- `git diff --check`
