### PR TITLE
fix: request JSON token responses

### DIFF
--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -18,6 +18,7 @@ import jwt
 from pydantic import BaseModel, Field
 
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, OAuthTokenError, TokenStorage
+from mcp.client.auth.utils import create_token_request_headers
 from mcp.shared.auth import AuthorizationCodeResult, OAuthClientInformationFull, OAuthClientMetadata
 
 
@@ -92,7 +93,7 @@ class ClientCredentialsOAuthProvider(OAuthClientProvider):
             "grant_type": "client_credentials",
         }
 
-        headers: dict[str, str] = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = create_token_request_headers()
 
         # Use standard auth methods (client_secret_basic, client_secret_post, none)
         token_data, headers = self.context.prepare_token_auth(token_data, headers)
@@ -320,7 +321,7 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
             "grant_type": "client_credentials",
         }
 
-        headers: dict[str, str] = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = create_token_request_headers()
 
         # Add JWT client authentication (RFC 7523 Section 2.2)
         await self._add_client_authentication_jwt(token_data=token_data)
@@ -480,6 +481,4 @@ class RFC7523OAuthClientProvider(OAuthClientProvider):
             token_data["scope"] = self.context.client_metadata.scope
 
         token_url = self._get_token_endpoint()
-        return httpx.Request(
-            "POST", token_url, data=token_data, headers={"Content-Type": "application/x-www-form-urlencoded"}
-        )
+        return httpx.Request("POST", token_url, data=token_data, headers=create_token_request_headers())

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -25,6 +25,7 @@ from mcp.client.auth.utils import (
     create_client_info_from_metadata_url,
     create_client_registration_request,
     create_oauth_metadata_request,
+    create_token_request_headers,
     credentials_match_issuer,
     extract_field_from_www_auth,
     extract_resource_metadata_from_www_auth,
@@ -409,7 +410,7 @@ class OAuthClientProvider(httpx.Auth):
             token_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = create_token_request_headers()
         token_data, headers = self.context.prepare_token_auth(token_data, headers)
 
         return httpx.Request("POST", token_url, data=token_data, headers=headers)
@@ -461,7 +462,7 @@ class OAuthClientProvider(httpx.Auth):
             refresh_data["resource"] = self.context.get_resource_url()  # RFC 8707
 
         # Prepare authentication based on preferred method
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = create_token_request_headers()
         refresh_data, headers = self.context.prepare_token_auth(refresh_data, headers)
 
         return httpx.Request("POST", token_url, data=refresh_data, headers=headers)

--- a/src/mcp/client/auth/utils.py
+++ b/src/mcp/client/auth/utils.py
@@ -16,6 +16,13 @@ from mcp.shared.auth import (
 from mcp.types import LATEST_PROTOCOL_VERSION
 
 
+def create_token_request_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+
 def extract_field_from_www_auth(response: Response, field_name: str) -> str | None:
     """Extract field from WWW-Authenticate header.
 

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -108,6 +108,7 @@ class TestOAuthFlowClientCredentials:
 
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
+        assert request.headers["Accept"] == "application/json"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
 
         # Check form data
@@ -252,6 +253,7 @@ class TestClientCredentialsOAuthProvider:
 
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
+        assert request.headers["Accept"] == "application/json"
 
         content = urllib.parse.unquote_plus(request.content.decode())
         assert "grant_type=client_credentials" in content
@@ -398,6 +400,7 @@ class TestPrivateKeyJWTOAuthProvider:
 
         assert request.method == "POST"
         assert str(request.url) == "https://auth.example.com/token"
+        assert request.headers["Accept"] == "application/json"
 
         content = urllib.parse.unquote_plus(request.content.decode())
         assert "grant_type=client_credentials" in content

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -602,6 +602,7 @@ class TestOAuthFallback:
 
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
+        assert request.headers["Accept"] == "application/json"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
 
         # Check form data
@@ -628,6 +629,7 @@ class TestOAuthFallback:
 
         assert request.method == "POST"
         assert str(request.url) == "https://api.example.com/token"
+        assert request.headers["Accept"] == "application/json"
         assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
 
         # Check form data


### PR DESCRIPTION
## Summary

- add an `Accept: application/json` header to OAuth token endpoint requests
- share the token request headers across authorization-code, refresh, client-credentials, private-key JWT, and JWT bearer grants
- assert the header in the relevant client auth tests

Fixes #1523.

## Validation

- `uv run pytest tests/client/test_auth.py::TestOAuthFallback::test_token_exchange_request_authorization_code tests/client/test_auth.py::TestOAuthFallback::test_refresh_token_request tests/client/auth/extensions/test_client_credentials.py::TestOAuthFlowClientCredentials::test_token_exchange_request_jwt_predefined tests/client/auth/extensions/test_client_credentials.py::TestClientCredentialsOAuthProvider::test_exchange_token_client_credentials tests/client/auth/extensions/test_client_credentials.py::TestPrivateKeyJWTOAuthProvider::test_exchange_token_client_credentials -q`
- `uv run ruff format --check src/mcp/client/auth/utils.py src/mcp/client/auth/oauth2.py src/mcp/client/auth/extensions/client_credentials.py tests/client/test_auth.py tests/client/auth/extensions/test_client_credentials.py`
- `uv run ruff check src/mcp/client/auth/utils.py src/mcp/client/auth/oauth2.py src/mcp/client/auth/extensions/client_credentials.py tests/client/test_auth.py tests/client/auth/extensions/test_client_credentials.py`
- `uv run pyright src/mcp/client/auth/utils.py src/mcp/client/auth/oauth2.py src/mcp/client/auth/extensions/client_credentials.py tests/client/test_auth.py tests/client/auth/extensions/test_client_credentials.py`
- `uv run pytest tests/client/test_auth.py tests/client/auth/extensions/test_client_credentials.py -q`
