### PR TITLE
fix(server): don't raise when tool_use is not followed by tool_result

### DIFF
--- a/src/mcp/server/validation.py
+++ b/src/mcp/server/validation.py
@@ -80,7 +80,7 @@ def validate_tool_use_result_messages(messages: list[SamplingMessage]) -> None:
         if not has_previous_tool_use:
             raise ValueError("tool_result blocks do not match any tool_use in the previous message")
 
-    if has_previous_tool_use and previous_content:
+    if has_tool_results and has_previous_tool_use and previous_content:
         tool_use_ids = {c.id for c in previous_content if c.type == "tool_use"}
         tool_result_ids = {c.tool_use_id for c in last_content if c.type == "tool_result"}
         if tool_use_ids != tool_result_ids:

--- a/tests/server/test_validation.py
+++ b/tests/server/test_validation.py
@@ -159,3 +159,27 @@ def test_validate_tool_use_result_messages_no_error_when_tool_result_matches_too
         ),
     ]
     validate_tool_use_result_messages(messages)  # Should not raise
+
+
+def test_validate_tool_use_result_messages_no_error_when_tool_use_not_followed_by_tool_result() -> None:
+    """No error when a tool_use is followed by a plain (non-tool_result) response.
+
+    Regression test for #2960: per SEP-1577, tool_result blocks MUST be preceded
+    by a tool_use block, but there is NO requirement that a tool_use MUST be
+    followed by a tool_result. A plain text response after a tool_use is valid and
+    must not raise a false "ids do not match" ValueError.
+    """
+    messages = [
+        SamplingMessage(
+            role="assistant",
+            content=[
+                TextContent(type="text", text="Hold on..."),
+                ToolUseContent(type="tool_use", id="abc", name="search", input={"q": "test"}),
+            ],
+        ),
+        SamplingMessage(
+            role="user",
+            content=TextContent(type="text", text="Thanks, no results needed"),
+        ),
+    ]
+    validate_tool_use_result_messages(messages)  # Should not raise


### PR DESCRIPTION
## Summary

- `validate_tool_use_result_messages()` no longer raises a false `ValueError` when a `tool_use` block is followed by a plain (non-`tool_result`) response.
- A model that calls a tool and then replies with text (or the user declining further results) is now accepted, matching SEP-1577.

## Motivation

Closes #2960.

Per [SEP-1577](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1577):
- `tool_result` blocks MUST be preceded by a `tool_use` block ✅ (already checked)
- There is **no** requirement that a `tool_use` MUST be followed by a `tool_result`.

The ID-matching block at the end of the function ran whenever the previous message contained a `tool_use`, regardless of whether the last message actually contained any `tool_result` blocks:

```python
if has_previous_tool_use and previous_content:
    tool_use_ids = {c.id for c in previous_content if c.type == "tool_use"}
    tool_result_ids = {c.tool_use_id for c in last_content if c.type == "tool_result"}
    if tool_use_ids != tool_result_ids:  # tool_result_ids empty -> mismatch
        raise ValueError(...)
```

When the last message has no `tool_result` blocks, `tool_result_ids` is empty and never equals the non-empty `tool_use_ids`, so a valid conversation raised `ValueError: ids of tool_result blocks and tool_use blocks from previous message do not match`.

## Fix

Gate the ID-matching check on `has_tool_results` so it only runs when the last message actually contains `tool_result` blocks:

```python
if has_tool_results and has_previous_tool_use and previous_content:
```

This is a one-line change; all existing structural checks (mixed content, missing preceding tool_use, ID mismatch when results ARE present) are unaffected.

## Verification

- `uv run pytest tests/server/test_validation.py` — 16 passed
- `uv run ruff check` / `ruff format --check` — clean

## Real behavior proof

Regression test `test_validate_tool_use_result_messages_no_error_when_tool_use_not_followed_by_tool_result` reproduces the exact case from the issue (assistant emits text + tool_use; user replies with plain text). It **fails without the fix** and passes with it:

```
# Without the source fix (test present):
tests/server/test_validation.py::...not_followed_by_tool_result  164 / 185  ValueError
Results: 1 failed

# With the fix:
Results: 16 passed
```