### PR TITLE
fix: check_capability now validates elicitation sub-capabilities (form/url)

### DIFF
--- a/src/mcp/server/connection.py
+++ b/src/mcp/server/connection.py
@@ -337,8 +337,13 @@ class Connection:
                 return False
             if capability.sampling.tools is not None and have.sampling.tools is None:
                 return False
-        if capability.elicitation is not None and have.elicitation is None:
-            return False
+        if capability.elicitation is not None:
+            if have.elicitation is None:
+                return False
+            if capability.elicitation.form is not None and have.elicitation.form is None:
+                return False
+            if capability.elicitation.url is not None and have.elicitation.url is None:
+                return False
         if capability.experimental is not None:
             if have.experimental is None:
                 return False

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -27,6 +27,7 @@ from mcp.types import (
     CreateMessageRequestParams,
     ElicitationCapability,
     EmptyResult,
+    FormElicitationCapability,
     Implementation,
     ListRootsRequest,
     ListRootsResult,
@@ -37,6 +38,7 @@ from mcp.types import (
     SamplingCapability,
     SamplingContextCapability,
     SamplingToolsCapability,
+    UrlElicitationCapability,
 )
 
 _CLIENT_INFO = Implementation(name="t", version="0")
@@ -365,6 +367,28 @@ def test_connection_check_capability_false_when_no_client_params_recorded():
         (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"b": {}}), False),
         (ClientCapabilities(experimental={"a": {"x": 1}}), ClientCapabilities(experimental={"a": {"x": 2}}), False),
         (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"a": {}}), True),
+        # Elicitation sub-capability checks (form / url)
+        (ClientCapabilities(elicitation=None), ClientCapabilities(elicitation=ElicitationCapability()), False),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            False,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            False,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability(), url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            True,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            True,
+        ),
     ],
 )
 def test_check_capability_per_field_branches(have: ClientCapabilities, want: ClientCapabilities, expected: bool):


### PR DESCRIPTION
## Summary

Closes #2965

`Connection.check_capability()` only checked the top-level `elicitation` key — if the client declared ANY elicitation support, all sub-capability checks passed. A client supporting only URL elicitation would incorrectly return `True` when checked for form elicitation.

## Fix

Added `form` / `url` sub-capability checks matching the existing `sampling` sub-capability pattern (`.context` / `.tools`).

## Tests

5 new parametrized test cases covering:
- Client has no elicitation → check fails
- Client has form only, check for url → fails
- Client has url only, check for form → fails
- Client has both, check for one → passes
- Client has form, check for form → passes

AI assistance: Bug discovered, analyzed, and fix implemented with AI assistance (opencode).