### PR TITLE
Stop flagging snake_case is_error results as tool errors in OTel span

### DIFF
--- a/src/mcp/server/_otel.py
+++ b/src/mcp/server/_otel.py
@@ -59,8 +59,9 @@ class OpenTelemetryMiddleware(ServerMiddleware[Any]):
                 span.set_status(StatusCode.ERROR, str(e))
                 raise
             if ctx.method == "tools/call":
+                # Only shapes that survive wire serialization (alias-only) are real tool errors.
                 match result:
-                    case CallToolResult(is_error=True) | {"isError": True} | {"is_error": True}:
+                    case CallToolResult(is_error=True) | {"isError": True}:
                         span.set_attribute("error.type", "tool_error")
                         span.set_status(StatusCode.ERROR)
                     case _:

--- a/src/mcp/server/_otel.py
+++ b/src/mcp/server/_otel.py
@@ -59,7 +59,10 @@ class OpenTelemetryMiddleware(ServerMiddleware[Any]):
                 span.set_status(StatusCode.ERROR, str(e))
                 raise
             if ctx.method == "tools/call":
-                # Only shapes that survive wire serialization (alias-only) are real tool errors.
+                # Tool errors are detected pre-serialization, so only shapes that reach the wire as an error
+                # count: the model, or the camelCase alias (`is_error` is dropped by the alias-only wire
+                # validation). A raw-dict `isError` is matched as a literal bool only - non-bool coercible
+                # values (1, "true") would serialize to an error but are rare enough to leave undetected.
                 match result:
                     case CallToolResult(is_error=True) | {"isError": True}:
                         span.set_attribute("error.type", "tool_error")

--- a/tests/server/test_otel.py
+++ b/tests/server/test_otel.py
@@ -92,7 +92,9 @@ async def test_tool_error_model_result_sets_error_type(server: SrvT, spans: Span
 
 
 @pytest.mark.anyio
-async def test_tool_error_snake_case_dict_result_sets_error_type(server: SrvT, spans: SpanCapture):
+async def test_snake_case_dict_result_is_not_a_tool_error(server: SrvT, spans: SpanCapture):
+    # `is_error` is alias-only on the wire, so serialization drops it; the result reaches the
+    # client as a success and the span must not contradict that.
     async def err_tool(ctx: Ctx, params: CallToolRequestParams) -> dict[str, Any]:
         return {"content": [], "is_error": True}
 
@@ -100,11 +102,12 @@ async def test_tool_error_snake_case_dict_result_sets_error_type(server: SrvT, s
     server.middleware.append(OpenTelemetryMiddleware())
     async with connected_runner(server) as (client, _):
         spans.clear()
-        await client.send_raw_request("tools/call", {"name": "mytool", "arguments": {}})
+        result = await client.send_raw_request("tools/call", {"name": "mytool", "arguments": {}})
+    assert result == {"content": []}
     [span] = [s for s in spans.finished() if s.kind == SpanKind.SERVER]
     assert span.attributes is not None
-    assert span.attributes["error.type"] == "tool_error"
-    assert span.status.status_code == StatusCode.ERROR
+    assert "error.type" not in span.attributes
+    assert span.status.status_code == StatusCode.UNSET
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Follow-up to #2970.

`OpenTelemetryMiddleware` matched three result shapes as a tool error: `CallToolResult(is_error=True)`, `{"isError": True}`, and `{"is_error": True}`. The snake_case dict arm is wrong: `serialize_server_result` validates the handler result with `by_name=False` (alias-only), so a snake_case `is_error` key is silently dropped and the client receives a **success** response with no `isError` field. The span then reported `error.type=tool_error` / `StatusCode.ERROR` for a request whose wire response was a success - false-positive error spans.

Verified against the repo's pydantic:

```
{'content': [], 'is_error': True}  ->  {'content': []}                   # success on the wire
{'content': [], 'isError': True}   ->  {'content': [], 'isError': True}  # real error
```

Only `CallToolResult` and the camelCase `{"isError": True}` dict survive serialization as wire errors, so the match now covers just those two. The previous test is repurposed to assert the snake_case shape is **not** flagged and that the result serializes to `{"content": []}`.

Thanks to the `claude[bot]` review on #2970 for catching this.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/modelcontextprotocol/python-sdk/pull/2971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

