### PR TITLE
Set Development Status classifier to Production/Stable

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,3 @@ for alphas, later `bN`/`rcN` for betas and release candidates.
    Yanking doesn't stop `==` pins from installing the broken version, so set
    the yank reason (and edit the GitHub release notes) to point at the
    replacement version.
-5. When the line moves to a new stage (first beta, first release candidate,
-   stable), update the `Development Status` classifier in `pyproject.toml`
-   before tagging — PyPI uploads are immutable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 keywords = ["mcp", "llm", "automation"]
 license = { text = "MIT" }
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Sets the `Development Status` trove classifier to `5 - Production/Stable` and removes the per-stage classifier-flip step from `RELEASE.md`. Reverts the classifier portion of #2831.

## Motivation and Context

#2831 set this to `3 - Alpha` on the basis that we're publishing alphas. After looking into it more, the ecosystem convention is overwhelmingly to treat this classifier as **project maturity**, not the pre-release stage of a given artifact:

- Of 22 major projects surveyed, only Django flips it per release stage; the other 19 (pip, setuptools, numpy, pandas, scipy, scikit-learn, matplotlib, Flask, FastAPI, aiohttp, SQLAlchemy, pydantic, httpx, anyio, attrs, hatch, etc.) keep it constant across pre-releases and finals.
- The closest analogues to our v2 — major-version rewrites of foundational libraries — all shipped pre-releases as `5 - Production/Stable`: [pydantic 2.0a1](https://pypi.org/project/pydantic/2.0a1/), [aiohttp 4.0.0a1](https://pypi.org/project/aiohttp/4.0.0a1/), [SQLAlchemy 2.1.0b2](https://pypi.org/project/SQLAlchemy/2.1.0b2/).
- No installer or resolver (pip, uv, poetry, pdm, flit, hatch) reads this classifier; PyPI uses it only as a search-filter facet. The per-artifact stability signal is already carried by the PEP 440 version segment (`a1` → excluded without `--pre`) and PyPI's pre-release banner.
- Our release process is otherwise tag-only (`dynamic = ["version"]` via `uv-dynamic-versioning`); flipping the classifier per stage was the one remaining manual source edit.

[PEP 792](https://peps.python.org/pep-0792/) does note that trove classifiers are mechanically per-distribution rather than project-wide — but treats that as a limitation, which is why it introduced project-status-markers as the replacement mechanism.

Companion: #2976 bumps `v1.x` that branch from `4 - Beta` (unchanged since Nov 2024) to `5 - Production/Stable` as well.

## How Has This Been Tested?

n/a — metadata only.

## Breaking Changes

None.

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling — n/a
- [x] I have added or updated documentation as needed

## Additional context

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>

