### PR TITLE
[v1.x] Set Development Status classifier to Production/Stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
 keywords = ["git", "mcp", "llm", "automation"]
 license = { text = "MIT" }
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Companion to #2975 — bumps the `Development Status` trove classifier on the stable line from `4 - Beta` (unchanged since the project was first published in Nov 2024) to `5 - Production/Stable`.

## Motivation and Context

The 1.x line has been in wide production use for well over a year; `Beta` no longer reflects reality. See #2975 for the full rationale on treating this classifier as project maturity rather than per-release stage.

PyPI classifiers are immutable on existing uploads, so this takes effect with the next 1.x release.

## How Has This Been Tested?

n/a — metadata only.

## Breaking Changes

None.

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling — n/a
- [x] I have added or updated documentation as needed

## Additional context

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
