### PR TITLE
fix(server): validate elicitation form/url sub-capabilities in check_capability

### DIFF
--- a/src/mcp/server/connection.py
+++ b/src/mcp/server/connection.py
@@ -337,8 +337,13 @@ class Connection:
                 return False
             if capability.sampling.tools is not None and have.sampling.tools is None:
                 return False
-        if capability.elicitation is not None and have.elicitation is None:
-            return False
+        if capability.elicitation is not None:
+            if have.elicitation is None:
+                return False
+            if capability.elicitation.form is not None and have.elicitation.form is None:
+                return False
+            if capability.elicitation.url is not None and have.elicitation.url is None:
+                return False
         if capability.experimental is not None:
             if have.experimental is None:
                 return False

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -21,6 +21,7 @@ from mcp_types import (
     CreateMessageRequestParams,
     ElicitationCapability,
     EmptyResult,
+    FormElicitationCapability,
     Implementation,
     ListRootsRequest,
     ListRootsResult,
@@ -31,6 +32,7 @@ from mcp_types import (
     SamplingCapability,
     SamplingContextCapability,
     SamplingToolsCapability,
+    UrlElicitationCapability,
 )
 from mcp_types.version import LATEST_HANDSHAKE_VERSION, LATEST_MODERN_VERSION
 from pydantic import BaseModel, ValidationError
@@ -364,6 +366,36 @@ def test_connection_check_capability_false_when_no_client_params_recorded():
         (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"b": {}}), False),
         (ClientCapabilities(experimental={"a": {"x": 1}}), ClientCapabilities(experimental={"a": {"x": 2}}), False),
         (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"a": {}}), True),
+        (
+            ClientCapabilities(elicitation=None),
+            ClientCapabilities(elicitation=ElicitationCapability()),
+            False,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            False,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            False,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            True,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            True,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability()),
+            True,
+        ),
     ],
 )
 def test_check_capability_per_field_branches(have: ClientCapabilities, want: ClientCapabilities, expected: bool):


### PR DESCRIPTION
## Summary

`Connection.check_capability()` now validates elicitation sub-capabilities (`form` / `url`) when the caller specifies them, instead of only checking whether the client declared elicitation at all.

## Motivation

Fixes #2965.

When a client supports URL-mode elicitation only, `check_capability(ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())))` incorrectly returned `True`. The function only compared top-level `have.elicitation is None`, never inspecting individual sub-capabilities.

This mirrors the existing `sampling.context` / `sampling.tools` sub-capability checks in the same function.

## Changes

- **`src/mcp/server/connection.py`**: Add nested `form` / `url` presence checks under the elicitation branch.
- **`tests/server/test_connection.py`**: Add 6 parametrized regression cases covering form/url mismatch, match, and generic elicitation checks.

## Tests

- `uv run pytest tests/server/test_connection.py` — 44 passed
- `uv run ruff check src/mcp/server/connection.py tests/server/test_connection.py` — clean
- `uv run ruff format --check src/mcp/server/connection.py tests/server/test_connection.py` — clean

## Notes

- `ServerSession.check_client_capability()` delegates to `Connection.check_capability()`, so this fix applies to both APIs.
- AI assistance disclosure: fix and tests prepared with AI assistance; locally verified and reviewed before submission.