### PR TITLE
fix(validation): only match tool_use/tool_result IDs when last message has tool_result

### DIFF
--- a/src/mcp/server/validation.py
+++ b/src/mcp/server/validation.py
@@ -81,7 +81,6 @@ def validate_tool_use_result_messages(messages: list[SamplingMessage]) -> None:
         if not has_previous_tool_use:
             raise ValueError("tool_result blocks do not match any tool_use in the previous message")
 
-    if has_previous_tool_use and previous_content:
         tool_use_ids = {c.id for c in previous_content if c.type == "tool_use"}
         tool_result_ids = {c.tool_use_id for c in last_content if c.type == "tool_result"}
         if tool_use_ids != tool_result_ids:

--- a/tests/server/test_validation.py
+++ b/tests/server/test_validation.py
@@ -146,6 +146,24 @@ def test_validate_tool_use_result_messages_raises_when_tool_result_ids_dont_matc
         validate_tool_use_result_messages(messages)
 
 
+def test_validate_tool_use_result_messages_no_error_when_tool_use_not_followed_by_tool_result() -> None:
+    """No error when previous message has tool_use but last message has no tool_result."""
+    messages = [
+        SamplingMessage(
+            role="assistant",
+            content=[
+                TextContent(type="text", text="Hold on..."),
+                ToolUseContent(type="tool_use", id="abc", name="search", input={"q": "test"}),
+            ],
+        ),
+        SamplingMessage(
+            role="user",
+            content=TextContent(type="text", text="Thanks, no results needed"),
+        ),
+    ]
+    validate_tool_use_result_messages(messages)  # Should not raise
+
+
 def test_validate_tool_use_result_messages_no_error_when_tool_result_matches_tool_use() -> None:
     """No error when tool_result IDs match tool_use IDs."""
     messages = [


### PR DESCRIPTION
## Summary

Fix a false positive in `validate_tool_use_result_messages()` when a previous `tool_use` block is followed by a plain text response without any `tool_result` blocks.

## Motivation

Per SEP-1577, `tool_result` blocks must be preceded by a `tool_use` block, but there is no requirement that `tool_use` must be followed by `tool_result`. A plain text user reply after an assistant `tool_use` is valid.

Fixes #2960

## Changes

- Move the `tool_use`/`tool_result` ID matching check inside the existing `if has_tool_results:` block in `src/mcp/server/validation.py`
- Add regression test reproducing the issue scenario

## Tests

```bash
uv run pytest tests/server/test_validation.py -v
```

Result: 16 passed

Also ran:
```bash
uv run ruff check src/mcp/server/validation.py tests/server/test_validation.py
```

Result: All checks passed

## Notes

AI assistance was used to implement this fix. The change is minimal (3-line scope move) and aligns with the root cause described in the issue.

Disclosure: This PR was prepared with AI assistance and reviewed before submission.