### PR TITLE
find_invalid_x_mcp_header: never repr a non-string annotation value

### DIFF
--- a/src/mcp/shared/inbound.py
+++ b/src/mcp/shared/inbound.py
@@ -191,10 +191,20 @@ def find_invalid_x_mcp_header(input_schema: Any) -> str | None:
             return f"{X_MCP_HEADER_KEY} found at a schema position not reachable via a pure `properties` chain"
         where = ".".join(path)
         header = schema[X_MCP_HEADER_KEY]
-        if not isinstance(header, str) or not _RFC9110_TOKEN.fullmatch(header):
+        # Wrong type and malformed value are distinct failures with distinct messages: the
+        # non-str arm returns before any interpolation, because `repr` of an arbitrary
+        # schema value is not total (a large `int` exceeds `sys.get_int_max_str_digits`).
+        if not isinstance(header, str):
+            return f"property {where!r}: {X_MCP_HEADER_KEY} must be a string, not {type(header).__name__}"
+        if not _RFC9110_TOKEN.fullmatch(header):
             return f"property {where!r}: {X_MCP_HEADER_KEY} {header!r} is not an RFC 9110 token"
         prop_type = schema.get("type")
-        if not isinstance(prop_type, str) or prop_type not in _X_MCP_HEADER_PRIMITIVE_TYPES:
+        if not isinstance(prop_type, str):
+            return (
+                f"property {where!r}: {X_MCP_HEADER_KEY} is only permitted on "
+                f"integer/string/boolean properties (the type keyword is {type(prop_type).__name__}, not a string)"
+            )
+        if prop_type not in _X_MCP_HEADER_PRIMITIVE_TYPES:
             return (
                 f"property {where!r}: {X_MCP_HEADER_KEY} is only permitted on "
                 f"integer/string/boolean properties (got {prop_type!r})"

--- a/tests/shared/test_inbound.py
+++ b/tests/shared/test_inbound.py
@@ -26,6 +26,9 @@ from mcp_types.jsonrpc import (
 from mcp_types.version import LATEST_HANDSHAKE_VERSION, LATEST_MODERN_VERSION, MODERN_PROTOCOL_VERSIONS
 
 from mcp.shared.inbound import (
+    _SUBSCHEMA_LIST,
+    _SUBSCHEMA_MAP,
+    _SUBSCHEMA_SINGLE,
     ERROR_CODE_HTTP_STATUS,
     MCP_METHOD_HEADER,
     MCP_NAME_HEADER,
@@ -379,6 +382,10 @@ def _schema(**props: Any) -> dict[str, Any]:
             id="annotation-lookalike-in-const-is-data",
         ),
         pytest.param(
+            _schema(a={"type": "string", "enum": [{"x-mcp-header": "ignored"}]}),
+            id="annotation-lookalike-in-enum-is-data",
+        ),
+        pytest.param(
             {"properties": {"a": {"type": "string", "x-mcp-header": "R"}}, "$ref": "#/$defs/loop"},
             id="ref-is-not-dereferenced",
         ),
@@ -404,12 +411,14 @@ def test_find_invalid_x_mcp_header_accepts_valid_or_absent_annotations(input_sch
         pytest.param(_schema(a={"type": "string", "x-mcp-header": "Région"}), id="non-ascii"),
         pytest.param(_schema(a={"type": "string", "x-mcp-header": "Region\t1"}), id="control-char"),
         pytest.param(_schema(a={"type": "string", "x-mcp-header": 42}), id="non-string"),
+        pytest.param(_schema(a={"type": "string", "x-mcp-header": 10**5000}), id="oversized-int-header"),
         pytest.param(_schema(a={"type": "object", "x-mcp-header": "Data"}), id="on-object"),
         pytest.param(_schema(a={"type": "array", "x-mcp-header": "Items"}), id="on-array"),
         pytest.param(_schema(a={"type": "null", "x-mcp-header": "Nil"}), id="on-null"),
         pytest.param(_schema(a={"type": "number", "x-mcp-header": "Ratio"}), id="on-number"),
         pytest.param(_schema(a={"type": ["string", "null"], "x-mcp-header": "Maybe"}), id="array-type"),
         pytest.param(_schema(a={"type": {"not": "valid"}, "x-mcp-header": "Bad"}), id="dict-type"),
+        pytest.param(_schema(a={"type": 10**5000, "x-mcp-header": "Big"}), id="oversized-int-type"),
         pytest.param(_schema(a={"x-mcp-header": "NoType"}), id="missing-type"),
         pytest.param(
             _schema(a={"type": "string", "x-mcp-header": "Region"}, b={"type": "string", "x-mcp-header": "Region"}),
@@ -420,28 +429,8 @@ def test_find_invalid_x_mcp_header_accepts_valid_or_absent_annotations(input_sch
             id="duplicate-diff-case",
         ),
         pytest.param(
-            _schema(a={"type": "array", "items": {"type": "string", "x-mcp-header": "X"}}),
-            id="under-items",
-        ),
-        pytest.param(
-            {"allOf": [{"properties": {"a": {"type": "string", "x-mcp-header": "X"}}}]},
-            id="under-allOf",
-        ),
-        pytest.param(
-            {"oneOf": [{"type": "string", "x-mcp-header": "X"}]},
-            id="under-oneOf",
-        ),
-        pytest.param(
-            _schema(a={"if": {"type": "string", "x-mcp-header": "X"}}),
-            id="under-if",
-        ),
-        pytest.param(
-            {"$defs": {"T": {"type": "string", "x-mcp-header": "X"}}, "properties": {}},
-            id="under-defs",
-        ),
-        pytest.param(
-            {"patternProperties": {"^a": {"type": "string", "x-mcp-header": "X"}}},
-            id="under-patternProperties",
+            {"allOf": [{"type": "object", "properties": {"a": {"type": "string", "x-mcp-header": "X"}}}]},
+            id="properties-chain-not-restored-below-an-applicator",
         ),
         pytest.param(
             {"type": "string", "x-mcp-header": "X"},
@@ -468,6 +457,47 @@ def test_find_invalid_x_mcp_header_rejects_malformed_annotations(input_schema: d
     """Spec-mandated: empty / non-token / non-primitive / off-chain / duplicate `x-mcp-header`
     annotations yield a reason string."""
     assert isinstance(find_invalid_x_mcp_header(input_schema), str)
+
+
+# Keyword → a value of that keyword's own JSON Schema shape carrying an annotated subschema.
+# Deliberately a literal table, independent of the `_SUBSCHEMA_*` sets in `inbound.py`:
+# dropping a keyword from the walk must FAIL its case here, not shrink the parametrization.
+_ANNOTATED = {"type": "string", "x-mcp-header": "Region"}
+_APPLICATOR_CASES: dict[str, Any] = {
+    "$defs": {"T": _ANNOTATED},
+    "additionalProperties": _ANNOTATED,
+    "allOf": [_ANNOTATED],
+    "anyOf": [_ANNOTATED],
+    "contains": _ANNOTATED,
+    "contentSchema": _ANNOTATED,
+    "definitions": {"T": _ANNOTATED},
+    "dependentSchemas": {"k": _ANNOTATED},
+    "else": _ANNOTATED,
+    "if": _ANNOTATED,
+    "items": _ANNOTATED,
+    "not": _ANNOTATED,
+    "oneOf": [_ANNOTATED],
+    "patternProperties": {"^a": _ANNOTATED},
+    "prefixItems": [_ANNOTATED],
+    "propertyNames": _ANNOTATED,
+    "then": _ANNOTATED,
+    "unevaluatedItems": _ANNOTATED,
+    "unevaluatedProperties": _ANNOTATED,
+}
+
+
+@pytest.mark.parametrize("keyword", sorted(_APPLICATOR_CASES))
+def test_find_invalid_x_mcp_header_rejects_annotations_under_every_non_properties_applicator(keyword: str) -> None:
+    """Spec-mandated: a property reached through any applicator other than `properties` is not
+    statically reachable, so its annotation invalidates the whole tool definition."""
+    schema = _schema(ok={"type": "string"}) | {keyword: _APPLICATOR_CASES[keyword]}
+    assert isinstance(find_invalid_x_mcp_header(schema), str)
+
+
+def test_schema_walk_applicator_keywords_match_the_pinned_reject_cases() -> None:
+    """SDK-defined: a keyword added to the walk must gain a literal reject case above (a removed
+    keyword already fails its case there)."""
+    assert _SUBSCHEMA_LIST | _SUBSCHEMA_MAP | _SUBSCHEMA_SINGLE == set(_APPLICATOR_CASES)
 
 
 def test_find_invalid_x_mcp_header_reports_dotted_path_for_nested_property() -> None:


### PR DESCRIPTION
Follow-up to #2974, on `find_invalid_x_mcp_header`: make its reason strings total over any `inputSchema` value, and pin the schema-position walk's applicator keywords independently of the implementation.

## Motivation and Context

`find_invalid_x_mcp_header` is meant to return a reason string or `None` for any decoded `inputSchema`, but two of its checks fused two different failures — "the value isn't a string" and "the string is invalid" — into one branch whose message interpolated the value with `!r` either way. `repr()` of an arbitrary schema value is not total: an `int` with more digits than `sys.get_int_max_str_digits()` (default 4300) raises `ValueError`. That propagates out of `ClientSession.list_tools()` instead of the offending tool being dropped, and it is reachable from the public API: the in-memory `Client(server)` path has no JSON decode step in front of the client-side filter, so the value reaches it as a live Python object and `await client.list_tools()` raises under default interpreter settings.

Each fused check is now two checks with two messages, so a value only reaches an interpolation once the preceding branch has proven it is a `str` (where `repr` is total). No guard and no helper — a non-string value structurally never reaches a `repr` — and the messages get more precise: `x-mcp-header must be a string, not int` rather than pretending an int is a malformed token.

Separately, the reject test for "annotation under a non-`properties` applicator" hand-picked 6 of the walk's 19 applicator keywords, so the other 13 — including [the chain-breakers the spec names](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/8bfc3be7dad21762e158b87cf0510513d96cdcf5/docs/specification/draft/basic/transports/streamable-http.mdx#L388-L395) `anyOf` / `not` / `then` / `else`, plus `additionalProperties` — could be removed from the walk without any test failing. The cases are now a literal keyword → shape table covering all 19 (deliberately *not* derived from the implementation's keyword sets, so dropping a keyword fails its case rather than shrinking the parametrization), with one equality test against those sets so an added keyword must gain a literal case. The hand-picked six are subsumed; one accept-side symmetry gap is filled (`enum` was the only instance-data keyword named in the source comment with no lookalike test).

## How Has This Been Tested?

- Two new reject params (`oversized-int-header`, `oversized-int-type`) fail on `main` with `ValueError: Exceeds the limit (4300 digits) for integer string conversion` — one at each message site — and pass here (checked by stashing the `src/` change and re-running them).
- End to end at the public surface: a lowlevel server advertising those schemas, driven through `Client(server).list_tools()`. On `main` that call raises `ValueError` out of `inbound.py`; here it returns, logs one warning per dropped tool, and keeps the valid one. Reason strings for string-valued annotations are unchanged.
- `./scripts/test`: full suite, 100% coverage, `strict-no-cover` clean. `pyright`: 0 errors. No new `pragma` / `type: ignore` / `noqa`.

## Breaking Changes

None. Accept/reject decisions are identical for every input; only the reason-string text for non-string values changes (e.g. `(got {'not': 'valid'})` becomes `(... the type keyword is dict, not a string)`), and that string is only ever logged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The walk itself is untouched. A deeply nested container value (the other non-total `repr` input) cannot reach this code from any transport — the in-memory server's own result serialization and the HTTP JSON parser both reject it first — so the oversized `int` is the one shape with a live path, and it is the one the regression tests pin.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
