### PR TITLE
Match URI template literals literally in `ResourceTemplate.matches`

### DIFF
--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -93,8 +93,10 @@ class ResourceTemplate(BaseModel):
 
         Extracted parameters are URL-decoded to handle percent-encoded characters.
         """
-        # Convert template to regex pattern
-        pattern = self.uri_template.replace("{", "(?P<").replace("}", ">[^/]+)")
+        # Escape the template so literal text matches literally, then turn {param}
+        # placeholders into capture groups. re.escape may backslash the braces, so
+        # the placeholder pattern tolerates an optional backslash on each side.
+        pattern = re.sub(r"\\?\{(\w+)\\?\}", r"(?P<\1>[^/]+)", re.escape(self.uri_template))
         match = re.match(f"^{pattern}$", uri)
         if match:
             # URL-decode all extracted parameter values

--- a/tests/server/mcpserver/resources/test_resource_template.py
+++ b/tests/server/mcpserver/resources/test_resource_template.py
@@ -331,3 +331,23 @@ async def test_sync_fn_runs_in_worker_thread():
     assert isinstance(resource, FunctionResource)
     assert await resource.read() == "hello world"
     assert fn_thread[0] != main_thread
+
+
+def test_matches_treats_template_specials_literally():
+    def fn(id: str) -> str:  # pragma: no cover
+        return id
+
+    template = ResourceTemplate.from_function(fn=fn, uri_template="resource://a.b+c/{id}", name="t")
+
+    assert template.matches("resource://a.b+c/42") == {"id": "42"}
+    assert template.matches("resource://aXbYc/42") is None
+
+
+def test_matches_does_not_interpret_template_as_regex():
+    def fn(id: str) -> str:  # pragma: no cover
+        return id
+
+    template = ResourceTemplate.from_function(fn=fn, uri_template="resource://(.*)/{id}", name="t")
+
+    assert template.matches("resource://(.*)/7") == {"id": "7"}
+    assert template.matches("resource://anything/7") is None


### PR DESCRIPTION
## Summary

`ResourceTemplate.matches` builds its matching regex by replacing the `{param}` braces but leaves the surrounding literal text unescaped. Any regex metacharacter present in a template (`.`, `+`, `(`, `[`, ...) is therefore interpreted as a pattern instead of a literal, so templates match URIs they shouldn't.

For example, the template `resource://a.b+c/{id}`:
- should match only `resource://a.b+c/<id>`
- but currently also matches `resource://aXbYc/<id>` (the `.` matches any char, `+` quantifies)

## Change

`re.escape` the template before substituting placeholders, so literal characters match literally and only `{param}` segments become capture groups. The placeholder substitution tolerates the optional backslash `re.escape` may add around the braces.

## Tests

Added two cases to `tests/server/mcpserver/resources/test_resource_template.py`:
- a template containing `.`/`+` matches the literal URI and rejects a metacharacter-expanded one
- a template containing `(.*)` is treated literally, not as a wildcard

Existing template/url-decoding tests still pass.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.