### PR TITLE
Switch RFC7523OAuthClientProvider warning to MCPDeprecationWarning

### DIFF
--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -8,7 +8,6 @@ Provides OAuth providers for machine-to-machine authentication flows:
 """
 
 import time
-import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal
 from uuid import uuid4
@@ -16,9 +15,11 @@ from uuid import uuid4
 import httpx
 import jwt
 from pydantic import BaseModel, Field
+from typing_extensions import deprecated
 
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, OAuthTokenError, TokenStorage
 from mcp.shared.auth import AuthorizationCodeResult, OAuthClientInformationFull, OAuthClientMetadata
+from mcp.shared.exceptions import MCPDeprecationWarning
 
 
 class ClientCredentialsOAuthProvider(OAuthClientProvider):
@@ -387,6 +388,11 @@ class JWTParameters(BaseModel):
         return assertion
 
 
+@deprecated(
+    "RFC7523OAuthClientProvider is deprecated. Use ClientCredentialsOAuthProvider "
+    "or PrivateKeyJWTOAuthProvider instead.",
+    category=MCPDeprecationWarning,
+)
 class RFC7523OAuthClientProvider(OAuthClientProvider):
     """OAuth client provider for RFC 7523 jwt-bearer grant.
 
@@ -409,12 +415,6 @@ class RFC7523OAuthClientProvider(OAuthClientProvider):
         timeout: float = 300.0,
         jwt_parameters: JWTParameters | None = None,
     ) -> None:
-        warnings.warn(
-            "RFC7523OAuthClientProvider is deprecated. Use ClientCredentialsOAuthProvider "
-            "or PrivateKeyJWTOAuthProvider instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(server_url, client_metadata, storage, redirect_handler, callback_handler, timeout)
         self.jwt_parameters = jwt_parameters
 

--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -8,6 +8,7 @@ Provides OAuth providers for machine-to-machine authentication flows:
 """
 
 import time
+import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal
 from uuid import uuid4
@@ -15,7 +16,6 @@ from uuid import uuid4
 import httpx
 import jwt
 from pydantic import BaseModel, Field
-from typing_extensions import deprecated
 
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, OAuthTokenError, TokenStorage
 from mcp.shared.auth import AuthorizationCodeResult, OAuthClientInformationFull, OAuthClientMetadata
@@ -388,11 +388,6 @@ class JWTParameters(BaseModel):
         return assertion
 
 
-@deprecated(
-    "RFC7523OAuthClientProvider is deprecated. Use ClientCredentialsOAuthProvider "
-    "or PrivateKeyJWTOAuthProvider instead.",
-    category=MCPDeprecationWarning,
-)
 class RFC7523OAuthClientProvider(OAuthClientProvider):
     """OAuth client provider for RFC 7523 jwt-bearer grant.
 
@@ -415,6 +410,12 @@ class RFC7523OAuthClientProvider(OAuthClientProvider):
         timeout: float = 300.0,
         jwt_parameters: JWTParameters | None = None,
     ) -> None:
+        warnings.warn(
+            "RFC7523OAuthClientProvider is deprecated. Use ClientCredentialsOAuthProvider "
+            "or PrivateKeyJWTOAuthProvider instead.",
+            MCPDeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(server_url, client_metadata, storage, redirect_handler, callback_handler, timeout)
         self.jwt_parameters = jwt_parameters
 

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -9,7 +9,7 @@ from mcp.client.auth.extensions.client_credentials import (
     ClientCredentialsOAuthProvider,
     JWTParameters,
     PrivateKeyJWTOAuthProvider,
-    RFC7523OAuthClientProvider,
+    RFC7523OAuthClientProvider,  # pyright: ignore[reportDeprecated]
     SignedJWTParameters,
     static_assertion_provider,
 )
@@ -20,6 +20,7 @@ from mcp.shared.auth import (
     OAuthMetadata,
     OAuthToken,
 )
+from mcp.shared.exceptions import MCPDeprecationWarning
 
 
 class MockTokenStorage:
@@ -68,8 +69,8 @@ def rfc7523_oauth_provider(client_metadata: OAuthClientMetadata, mock_storage: M
         return AuthorizationCodeResult(code="test_auth_code", state="test_state")
 
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        return RFC7523OAuthClientProvider(
+        warnings.simplefilter("ignore", MCPDeprecationWarning)
+        return RFC7523OAuthClientProvider(  # pyright: ignore[reportDeprecated]
             server_url="https://api.example.com/v1/mcp",
             client_metadata=client_metadata,
             storage=mock_storage,
@@ -78,11 +79,20 @@ def rfc7523_oauth_provider(client_metadata: OAuthClientMetadata, mock_storage: M
         )
 
 
+def test_rfc7523_provider_warns_on_instantiation(client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage):
+    with pytest.warns(MCPDeprecationWarning, match="RFC7523OAuthClientProvider is deprecated"):
+        RFC7523OAuthClientProvider(  # pyright: ignore[reportDeprecated]
+            server_url="https://api.example.com/v1/mcp",
+            client_metadata=client_metadata,
+            storage=mock_storage,
+        )
+
+
 class TestOAuthFlowClientCredentials:
     """Test OAuth flow behavior for client credentials flows."""
 
     @pytest.mark.anyio
-    async def test_token_exchange_request_jwt_predefined(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):
+    async def test_token_exchange_request_jwt_predefined(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):  # pyright: ignore[reportDeprecated]
         """Test token exchange request building with a predefined JWT assertion."""
         # Set up required context
         rfc7523_oauth_provider.context.client_info = OAuthClientInformationFull(
@@ -121,7 +131,7 @@ class TestOAuthFlowClientCredentials:
         )
 
     @pytest.mark.anyio
-    async def test_token_exchange_request_jwt(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):
+    async def test_token_exchange_request_jwt(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):  # pyright: ignore[reportDeprecated]
         """Test token exchange request building wiith a generated JWT assertion."""
         # Set up required context
         rfc7523_oauth_provider.context.client_info = OAuthClientInformationFull(

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -9,7 +9,7 @@ from mcp.client.auth.extensions.client_credentials import (
     ClientCredentialsOAuthProvider,
     JWTParameters,
     PrivateKeyJWTOAuthProvider,
-    RFC7523OAuthClientProvider,  # pyright: ignore[reportDeprecated]
+    RFC7523OAuthClientProvider,
     SignedJWTParameters,
     static_assertion_provider,
 )
@@ -70,7 +70,7 @@ def rfc7523_oauth_provider(client_metadata: OAuthClientMetadata, mock_storage: M
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", MCPDeprecationWarning)
-        return RFC7523OAuthClientProvider(  # pyright: ignore[reportDeprecated]
+        return RFC7523OAuthClientProvider(
             server_url="https://api.example.com/v1/mcp",
             client_metadata=client_metadata,
             storage=mock_storage,
@@ -79,20 +79,11 @@ def rfc7523_oauth_provider(client_metadata: OAuthClientMetadata, mock_storage: M
         )
 
 
-def test_rfc7523_provider_warns_on_instantiation(client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage):
-    with pytest.warns(MCPDeprecationWarning, match="RFC7523OAuthClientProvider is deprecated"):
-        RFC7523OAuthClientProvider(  # pyright: ignore[reportDeprecated]
-            server_url="https://api.example.com/v1/mcp",
-            client_metadata=client_metadata,
-            storage=mock_storage,
-        )
-
-
 class TestOAuthFlowClientCredentials:
     """Test OAuth flow behavior for client credentials flows."""
 
     @pytest.mark.anyio
-    async def test_token_exchange_request_jwt_predefined(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):  # pyright: ignore[reportDeprecated]
+    async def test_token_exchange_request_jwt_predefined(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):
         """Test token exchange request building with a predefined JWT assertion."""
         # Set up required context
         rfc7523_oauth_provider.context.client_info = OAuthClientInformationFull(
@@ -131,7 +122,7 @@ class TestOAuthFlowClientCredentials:
         )
 
     @pytest.mark.anyio
-    async def test_token_exchange_request_jwt(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):  # pyright: ignore[reportDeprecated]
+    async def test_token_exchange_request_jwt(self, rfc7523_oauth_provider: RFC7523OAuthClientProvider):
         """Test token exchange request building wiith a generated JWT assertion."""
         # Set up required context
         rfc7523_oauth_provider.context.client_info = OAuthClientInformationFull(

--- a/tests/docs_src/test_oauth_clients.py
+++ b/tests/docs_src/test_oauth_clients.py
@@ -10,10 +10,11 @@ from docs_src.oauth_clients import tutorial001, tutorial002
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, OAuthRegistrationError, OAuthTokenError, TokenStorage
 from mcp.client.auth.extensions.client_credentials import (
     PrivateKeyJWTOAuthProvider,
-    RFC7523OAuthClientProvider,
+    RFC7523OAuthClientProvider,  # pyright: ignore[reportDeprecated]
     static_assertion_provider,
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+from mcp.shared.exceptions import MCPDeprecationWarning
 
 # See test_index.py for why this is a per-module mark and not a conftest hook.
 pytestmark = [pytest.mark.anyio, pytest.mark.filterwarnings("error::mcp.MCPDeprecationWarning")]
@@ -105,8 +106,8 @@ async def test_the_one_more_provider_is_private_key_jwt() -> None:
 
 async def test_the_page_does_not_count_the_deprecated_provider() -> None:
     """Why the `!!! info` says *one* more provider: `RFC7523OAuthClientProvider` warns on construction."""
-    with pytest.warns(DeprecationWarning, match="RFC7523OAuthClientProvider is deprecated"):
-        RFC7523OAuthClientProvider(
+    with pytest.warns(MCPDeprecationWarning, match="RFC7523OAuthClientProvider is deprecated"):
+        RFC7523OAuthClientProvider(  # pyright: ignore[reportDeprecated]
             server_url="http://localhost:8001/mcp",
             client_metadata=tutorial001.oauth.context.client_metadata,
             storage=tutorial001.InMemoryTokenStorage(),

--- a/tests/docs_src/test_oauth_clients.py
+++ b/tests/docs_src/test_oauth_clients.py
@@ -10,7 +10,7 @@ from docs_src.oauth_clients import tutorial001, tutorial002
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError, OAuthRegistrationError, OAuthTokenError, TokenStorage
 from mcp.client.auth.extensions.client_credentials import (
     PrivateKeyJWTOAuthProvider,
-    RFC7523OAuthClientProvider,  # pyright: ignore[reportDeprecated]
+    RFC7523OAuthClientProvider,
     static_assertion_provider,
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
@@ -107,7 +107,7 @@ async def test_the_one_more_provider_is_private_key_jwt() -> None:
 async def test_the_page_does_not_count_the_deprecated_provider() -> None:
     """Why the `!!! info` says *one* more provider: `RFC7523OAuthClientProvider` warns on construction."""
     with pytest.warns(MCPDeprecationWarning, match="RFC7523OAuthClientProvider is deprecated"):
-        RFC7523OAuthClientProvider(  # pyright: ignore[reportDeprecated]
+        RFC7523OAuthClientProvider(
             server_url="http://localhost:8001/mcp",
             client_metadata=tutorial001.oauth.context.client_metadata,
             storage=tutorial001.InMemoryTokenStorage(),


### PR DESCRIPTION
`RFC7523OAuthClientProvider.__init__` emitted the built-in `DeprecationWarning`, which Python hides by default so users never saw it. This switches the category to `MCPDeprecationWarning` (a `UserWarning` subclass) so it shows up without `-W`, matching how the rest of the SDK surfaces deprecations.

The `warnings.warn` call is otherwise unchanged. The two tests that asserted the old category are updated to `MCPDeprecationWarning`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.