### PR TITLE
Client auto-resolves InputRequiredResult via existing callbacks (SEP-2322)

### DIFF
--- a/.github/actions/conformance/client.py
+++ b/.github/actions/conformance/client.py
@@ -22,7 +22,7 @@ Scenarios:
     http-standard-headers                   - Connect, call a tool (Mcp-* headers checked)
     http-invalid-tool-headers               - List tools, call every surfaced tool (x-mcp-header filter)
     elicitation-sep1034-client-defaults     - Elicitation with default accept callback
-    sep-2322-client-request-state           - Drive the manual MRTR retry surface
+    sep-2322-client-request-state           - Drive the MRTR auto-loop (SEP-2322)
     auth/client-credentials-jwt             - Client credentials with private_key_jwt
     auth/client-credentials-basic           - Client credentials with client_secret_basic
     auth/*                                  - Authorization code flow (default for auth scenarios)
@@ -374,46 +374,28 @@ async def run_elicitation_defaults(server_url: str) -> None:
 
 @register("sep-2322-client-request-state")
 async def run_mrtr_client(server_url: str) -> None:
-    """Drive the manual MRTR retry surface against the SEP-2322 client mock.
+    """Drive the SEP-2322 client mock through `Client.call_tool`'s auto-loop.
 
-    The mock speaks the modern lifecycle (server/discover, no initialize) and
-    inspects the wire params of each tools/call round, so this exercises the
-    explicit allow_input_required=True path rather than an auto-loop: round 1
-    receives an InputRequiredResult, the fixture fulfils the elicitation
-    locally, then round 2 retries with input_responses + the echoed
-    request_state. Passing request_state straight off the typed result -- a
-    str when the server sent one, None when it didn't -- lets the
-    serializer's exclude_none drop the key in the no-state case without a
-    branch here. The unrelated call between rounds proves MRTR params don't
-    leak across tools, and the no-result-type call must parse as a complete
-    CallToolResult with no retry.
+    The mock inspects raw `tools/call` params, so registering an
+    `elicitation_callback` and letting the driver run is enough to satisfy
+    all five wire-shape checks: the driver echoes `request_state` byte-exact
+    and omits it when the server sent none, every retry mints a fresh
+    JSON-RPC id, the unrelated call between auto-loops carries no MRTR
+    params, and the no-`resultType` response parses as a terminal
+    `CallToolResult` so the driver never retries it.
     """
-    async with Client(server_url, mode=client_mode()) as client:
+
+    async def confirm(
+        context: ClientRequestContext, params: types.ElicitRequestParams
+    ) -> types.ElicitResult | types.ErrorData:
+        return types.ElicitResult(action="accept", content={"confirmed": True})
+
+    async with Client(server_url, mode=client_mode(), elicitation_callback=confirm) as client:
         await client.list_tools()
-        confirm = {"confirm": types.ElicitResult(action="accept", content={"confirmed": True})}
 
-        r1 = await client.call_tool("test_mrtr_echo_state", {}, allow_input_required=True)
-        assert isinstance(r1, types.InputRequiredResult)
-
+        await client.call_tool("test_mrtr_echo_state", {})
         await client.call_tool("test_mrtr_unrelated", {})
-
-        await client.call_tool(
-            "test_mrtr_echo_state",
-            {},
-            input_responses=confirm,
-            request_state=r1.request_state,
-            allow_input_required=True,
-        )
-
-        r2 = await client.call_tool("test_mrtr_no_state", {}, allow_input_required=True)
-        assert isinstance(r2, types.InputRequiredResult)
-        await client.call_tool(
-            "test_mrtr_no_state",
-            {},
-            input_responses=confirm,
-            request_state=r2.request_state,
-            allow_input_required=True,
-        )
+        await client.call_tool("test_mrtr_no_state", {})
 
         result = await client.call_tool("test_mrtr_no_result_type", {})
         assert isinstance(result, types.CallToolResult)

--- a/docs/advanced/deprecated.md
+++ b/docs/advanced/deprecated.md
@@ -8,7 +8,7 @@ The table below names each deprecated feature, why it is going away, and the rep
 
 | Deprecated | Why | What you do instead |
 |---|---|---|
-| **Roots**: `ctx.session.list_roots()`, `client.send_roots_list_changed()`, the `list_roots_callback=` you pass to `Client(...)` | [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577) retires the capability. | Take the paths that matter as ordinary tool arguments or resource URIs. |
+| **Roots**: `ctx.session.list_roots()`, `client.send_roots_list_changed()`, the `list_roots_callback=` you pass to `Client(...)` | [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577) retires the capability. | Take the paths as ordinary tool arguments or resource URIs, or embed a `ListRootsRequest` in an `InputRequiredResult` (see **Multi-round-trip requests**). |
 | **Server-initiated sampling**: `ctx.session.create_message()`, the `sampling_callback=` you pass to `Client(...)` | SEP-2577 retires the capability. | Return `InputRequiredResult` and let the client retry the call (see **Multi-round-trip requests**). |
 | **Protocol logging**: `ctx.log()`, `ctx.debug()`, `ctx.info()`, `ctx.warning()`, `ctx.error()`, `ctx.session.send_log_message()`, `client.set_logging_level()` | SEP-2577 retires the capability. Nothing in-protocol replaces it. | Ordinary `import logging` to stderr (see **Logging**). |
 | **`ping`**: `client.send_ping()` | **Removed** from the protocol, not merely deprecated. There is no `ping` method in 2026-07-28. | Nothing. It only works against a `mode="legacy"` connection. |
@@ -17,7 +17,7 @@ The table below names each deprecated feature, why it is going away, and the rep
 Three things fall out of that table:
 
 * Roots, sampling, and logging go together. One proposal, **SEP-2577**, deprecates all three capabilities at once.
-* Sampling and roots share a deeper problem: they are the two places a **server** sends a **request** to the **client**. That whole direction is what 2026-07-28 replaces with **Multi-round-trip requests**.
+* Sampling and roots share a deeper problem: they are places a **server** sends a **request** to the **client**. That whole direction is what 2026-07-28 replaces with **Multi-round-trip requests**. It is the standalone RPC methods (`sampling/createMessage`, `roots/list`, and push-style `elicitation/create`) that are gone; the `CreateMessageRequest` / `ListRootsRequest` / `ElicitRequest` payload types survive, embedded in `InputRequiredResult.input_requests`, and on the client they hit the same callbacks.
 * `ping` is the odd one out. The protocol does not deprecate it, it removes it. The SDK method still warns (its message says *removed*, not *deprecated*) and calling it on a modern connection answers with *"Method not found"*.
 
 ## Deprecated is advisory
@@ -82,7 +82,7 @@ That is the whole API. There is no per-method switch, and you don't want one: th
 ## Recap
 
 * The 2026-07-28 spec deprecates **roots**, server-initiated **sampling**, and protocol **logging** (all SEP-2577), restricts **progress** to server-to-client, and removes **`ping`**.
-* The replacement column points you onward: **Multi-round-trip requests** for sampling, **Logging** for logging, **Progress** for progress. Roots needs no chapter (pass the paths as arguments) and `ping` needs nothing at all.
+* The replacement column points you onward: **Multi-round-trip requests** for sampling and roots, **Logging** for logging, **Progress** for progress. `ping` needs nothing at all.
 * Deprecated is advisory: no wire changes, everything keeps working against pre-2026 sessions, and you get a visible `MCPDeprecationWarning` (a `UserWarning`, so it is on by default).
 * Sampling and roots additionally need a back-channel that a 2026-07-28 session does not have. On a modern connection they warn and then they raise.
 * `warnings.filterwarnings("ignore", category=MCPDeprecationWarning)` silences the whole category; `"error::mcp.MCPDeprecationWarning"` in pytest turns it into a test failure.

--- a/docs/advanced/multi-round-trip.md
+++ b/docs/advanced/multi-round-trip.md
@@ -33,40 +33,37 @@ Everything else in that file (the explicit `input_schema`, the hand-built `CallT
 
 ## The client side
 
-`call_tool` will not hand you an `InputRequiredResult` unless you opt in.
+`Client` runs the loop for you.
 
-!!! check
-    Call a tool that needs input without opting in and `call_tool` raises:
+Register the callbacks the server might ask for (`elicitation_callback`, `sampling_callback`, `list_roots_callback`) and call the tool. When an `InputRequiredResult` arrives, `Client` dispatches each entry in `input_requests` to the matching callback, retries with the answers and the echoed `request_state`, and keeps going until a `CallToolResult` comes back:
 
-    ```text
-    Server returned InputRequiredResult; pass allow_input_required=True to receive it and retry call_tool(..., input_responses=..., request_state=result.request_state).
-    ```
-
-    That is deliberate. Most call sites expect a result or an exception, not a third thing in the
-    middle of the happy path, and pyright agrees: without the flag, `call_tool` is typed to return
-    a plain `CallToolResult`.
-
-Pass `allow_input_required=True` and the result reaches you intact:
-
-```python
-result.result_type     # 'input_required'
-result.request_state   # 'provision-v1'
-result.input_requests  # {'region': ElicitRequest(method='elicitation/create', params=ElicitRequestFormParams(...))}
+```python title="client.py" hl_lines="12 13"
+--8<-- "docs_src/mrtr/tutorial003.py"
 ```
 
-### The retry loop
+* That `elicitation_callback` is the same one a pre-2026 server's back-channel `elicitation/create` would have hit. One callback serves both eras.
+* `call_tool` returns a plain `CallToolResult`. The intermediate rounds are invisible to the caller.
+* `get_prompt` and `read_resource` drive the same loop.
 
-Now you own the loop. There is no automatic driver yet; `while isinstance(result, InputRequiredResult)` **is** the API:
+!!! check
+    Leave the callback off and the loop fails on the first round: the SDK's stand-in callback
+    answers every elicitation with an error, and `call_tool` raises `MCPError` with the message
+    *"Elicitation not supported"*.
 
-```python title="client.py" hl_lines="13-15 17-20"
+The loop is bounded. `Client(..., input_required_max_rounds=10)` is the default cap; a server that keeps returning `InputRequiredResult` past it makes `call_tool` raise. If a round carries only `request_state` and no `input_requests`, `Client` sleeps briefly (50ms doubling to a 250ms ceiling) before retrying, so a server that is just saying *"not done yet"* isn't busy-polled.
+
+### Driving the loop yourself
+
+The auto-loop holds nothing between calls. If you need to see each round (to persist `request_state` across a process restart, to show the user what was asked, to bail early) drop to the underlying session, where `allow_input_required=True` hands you the union directly:
+
+```python title="client.py" hl_lines="13 14 20"
 --8<-- "docs_src/mrtr/tutorial002.py"
 ```
 
-* `allow_input_required=True` widens the return type to `CallToolResult | InputRequiredResult`. That union is exactly what the `isinstance` is narrowing.
+* `client.session.call_tool(..., allow_input_required=True)` widens the return type to `CallToolResult | InputRequiredResult`. The `isinstance` is what narrows it back.
+* `request_state` is now in your hands. Write it down between legs and the conversation can resume from a fresh process.
 * For every entry in `input_requests` you put an `InputResponse` under the **same key** in `input_responses`. `fulfil` is where your UI goes; this one hard-codes the answer.
 * Same tool name, same `arguments`, every leg. The retry is the original call carried out again, not a new method.
-* `request_state=result.request_state`: copy it across. Never inspect it, never invent it.
-* When the server has everything it needs it returns a `CallToolResult` and the loop exits.
 
 ## A 2026-07-28 result
 
@@ -88,9 +85,8 @@ Now you own the loop. There is no automatic driver yet; `while isinstance(result
 
 * At 2026-07-28 a server that needs input mid-call **returns** an `InputRequiredResult`. It never opens a request to the client.
 * `input_requests` is what it needs. `request_state` is an opaque resume token only the server reads.
-* The client answers by calling the **same tool again** with `input_responses=` and `request_state=`.
-* By default `call_tool` raises on an `InputRequiredResult`; `allow_input_required=True` opts in and widens the return type.
-* The manual `while isinstance(result, InputRequiredResult)` loop is the whole client API; there is no auto-retry driver yet.
+* `Client` runs the retry loop for you: register `elicitation_callback` / `sampling_callback` / `list_roots_callback` and `call_tool` returns a plain `CallToolResult`. `input_required_max_rounds` (default 10) bounds it.
+* To inspect or persist rounds, use `client.session.call_tool(..., allow_input_required=True)` and own the `while isinstance(result, InputRequiredResult)` loop yourself.
 * The server side is the **low-level** `Server` only; `@mcp.tool()` has no sugar for this yet.
 
 This is the mechanism that replaces server-initiated sampling and the rest of the push-style back-channel; see **Deprecated features**.

--- a/docs/advanced/multi-round-trip.md
+++ b/docs/advanced/multi-round-trip.md
@@ -41,7 +41,7 @@ Register the callbacks the server might ask for (`elicitation_callback`, `sampli
 --8<-- "docs_src/mrtr/tutorial003.py"
 ```
 
-* That `elicitation_callback` is the same one a pre-2026 server's back-channel `elicitation/create` would have hit. One callback serves both eras.
+* That `elicitation_callback` is the same one a pre-2026 server's back-channel `elicitation/create` would have hit. The same is true of `sampling_callback` for `sampling/createMessage` and `list_roots_callback` for `roots/list`: at 2026-07-28 the standalone server->client RPCs are gone, but the identical `ElicitRequest` / `CreateMessageRequest` / `ListRootsRequest` payloads ride inside `input_requests` and dispatch to the same three callbacks. One set of callbacks serves both eras.
 * `call_tool` returns a plain `CallToolResult`. The intermediate rounds are invisible to the caller.
 * `get_prompt` and `read_resource` drive the same loop.
 
@@ -54,7 +54,13 @@ The loop is bounded. `Client(..., input_required_max_rounds=10)` is the default 
 
 ### Driving the loop yourself
 
-The auto-loop holds nothing between calls. If you need to see each round (to persist `request_state` across a process restart, to show the user what was asked, to bail early) drop to the underlying session, where `allow_input_required=True` hands you the union directly:
+The auto-loop is enough for a single-process client. Own the loop instead when:
+
+* Your client is **distributed**: the process that renders the question to the user is not the process that called `call_tool`, so a different worker issues the retry. `request_state` is the persistable token you carry across that boundary, through your own storage, and `input_responses` is what the other side sends back with it.
+* You want to **inspect** each round: log or audit every `input_requests` entry, refuse certain request kinds, or apply your own backoff between legs.
+* You want a **wall-clock** bound rather than a round-count bound: wrap your own loop in `anyio.fail_after(...)` instead of relying on `input_required_max_rounds`.
+
+Drop to the underlying session, where `allow_input_required=True` hands you the union directly:
 
 ```python title="client.py" hl_lines="13 14 20"
 --8<-- "docs_src/mrtr/tutorial002.py"

--- a/docs/client/callbacks.md
+++ b/docs/client/callbacks.md
@@ -61,6 +61,10 @@ One `tools/call` from you, one `elicitation/create` back from the server, answer
     protocol does, in-memory and over a URL alike. Pin `mode="legacy"` whenever your client has
     to answer one; every test behind this page does. **Protocol versions** has the whole story.
 
+    On a 2026-07-28 session the callback isn't dead, it's fed differently: when a tool returns an
+    `InputRequiredResult` carrying an `ElicitRequest`, `Client` dispatches that entry to the same
+    `elicitation_callback` and retries the call for you. That flow is **Multi-round-trip requests**.
+
 ## A callback is a capability
 
 You never told the server that your client can answer elicitation requests. The SDK did.
@@ -109,7 +113,7 @@ Pass all three callbacks and you get `['elicitation', 'sampling', 'roots']`. Pas
 
 `sampling_callback` answers `sampling/createMessage`: the server asking *your* model to complete something. `list_roots_callback` answers `roots/list`: the server asking which directories it may work in.
 
-Both work. Both follow the rule above. And both serve features the **2026-07-28 spec deprecates**: a modern server doesn't call back into your model mid-request, it hands the request back to you as part of the tool result (**Multi-round-trip requests**), and roots give way to plain tool arguments and resource URIs. The whole list is in **Deprecated features**.
+Both work. Both follow the rule above. And both serve RPCs the **2026-07-28 spec removes**: a modern server doesn't call back into your client mid-request, it hands the request back to you as part of the tool result (**Multi-round-trip requests**). The callbacks themselves are not dead. When an `InputRequiredResult` carries a `CreateMessageRequest` or a `ListRootsRequest`, `Client`'s auto-loop dispatches it to the same `sampling_callback` or `list_roots_callback` you registered here. The whole list is in **Deprecated features**.
 
 You still need the callbacks to talk to servers that haven't moved. The signatures:
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -395,9 +395,13 @@ For an in-process `Client(server)` (where `server` is a `Server` or `MCPServer` 
 
 `Client.send_ping()` is deprecated (ping is removed in 2026-07-28); pin `mode='legacy'` if you need it.
 
-### `call_tool` can return `InputRequiredResult` (opt-in)
+### `InputRequiredResult` handling differs between `Client` and `ClientSession`
 
-For protocol 2026-07-28, a `tools/call` request may return an `InputRequiredResult` asking the client to supply additional input and retry. By default `call_tool` (on `ClientSession`, `Client`, and `ClientSessionGroup`) still returns `CallToolResult` and raises `RuntimeError` if the server requests input. Pass `allow_input_required=True` to receive the `InputRequiredResult` instead, then retry with `input_responses=` / `request_state=`.
+For protocol 2026-07-28, `tools/call`, `prompts/get`, and `resources/read` may return an `InputRequiredResult` asking the client to supply additional input (sampling, elicitation, roots) and retry.
+
+On the high-level `Client`, `call_tool`, `get_prompt`, and `read_resource` resolve this automatically: they dispatch each requested input to the matching callback (`sampling_callback`, `elicitation_callback`, `list_roots_callback`) and retry until a final result is returned, so the call still returns the bare `CallToolResult` / `GetPromptResult` / `ReadResourceResult`. The round limit is `Client(input_required_max_rounds=...)` (default 10). Earlier v2 prereleases exposed an `allow_input_required` parameter on these `Client` methods; that parameter has been removed. For manual control use `client.session.call_tool(..., allow_input_required=True)`. Note that `read_timeout_seconds` now bounds each underlying round, not the whole loop; wrap the call in `anyio.fail_after(...)` for a whole-loop bound.
+
+On `ClientSession`, `call_tool` / `get_prompt` / `read_resource` still return the bare result and raise `RuntimeError` if the server requests input. Pass `allow_input_required=True` to receive the `InputRequiredResult` instead, then drive the loop yourself with `input_responses=` / `request_state=`. `ClientSessionGroup.call_tool` accepts the same flag.
 
 ### `call_tool` mirrors `x-mcp-header` arguments into `Mcp-Param-*` headers (SEP-2243)
 

--- a/docs/tutorial/elicitation.md
+++ b/docs/tutorial/elicitation.md
@@ -149,5 +149,6 @@ Now swap in the URL-mode `server.py` and point the same `main()` at `pay_deposit
 * `result.action` is `"accept"`, `"decline"` or `"cancel"`; `result.data` exists only on accept.
 * `await ctx.elicit_url(message, url, elicitation_id)` is for everything that must not pass through the model; `ctx.session.send_elicit_complete(elicitation_id)` says the out-of-band part is done.
 * The client answers with one `elicitation_callback`, branching on the params type; registering it is what declares the capability.
+* On a 2026-07-28 connection the server returns the question instead of pushing it; the same callback is fed by **Multi-round-trip requests**.
 
 A tool that can ask is good. A tool that says how far along it is (**Progress**) is next.

--- a/docs_src/mrtr/tutorial002.py
+++ b/docs_src/mrtr/tutorial002.py
@@ -10,10 +10,10 @@ def fulfil(request: InputRequest) -> InputResponse:
 
 
 async def provision(client: Client, name: str) -> CallToolResult:
-    result = await client.call_tool("provision", {"name": name}, allow_input_required=True)
+    result = await client.session.call_tool("provision", {"name": name}, allow_input_required=True)
     while isinstance(result, InputRequiredResult):
         responses = {key: fulfil(request) for key, request in (result.input_requests or {}).items()}
-        result = await client.call_tool(
+        result = await client.session.call_tool(
             "provision",
             {"name": name},
             input_responses=responses,

--- a/docs_src/mrtr/tutorial003.py
+++ b/docs_src/mrtr/tutorial003.py
@@ -1,0 +1,14 @@
+from mcp_types import ElicitRequestParams, ElicitResult
+
+from mcp import Client
+from mcp.client import ClientRequestContext
+
+
+async def handle_elicitation(context: ClientRequestContext, params: ElicitRequestParams) -> ElicitResult:
+    return ElicitResult(action="accept", content={"region": "eu-west-1"})
+
+
+async def main() -> None:
+    async with Client("http://127.0.0.1:8000/mcp", elicitation_callback=handle_elicitation) as client:
+        result = await client.call_tool("provision", {"name": "orders"})
+        print(result.content)

--- a/examples/stories/manifest.toml
+++ b/examples/stories/manifest.toml
@@ -34,6 +34,9 @@ multi_connection = true
 # progress + log notifications dropped on the modern streamable-HTTP path pending SSE wiring
 xfail = ["http-asgi:modern"]
 
+[story.mrtr]
+era = "modern"
+
 [story.legacy_elicitation]
 era    = "legacy"
 status = "legacy"
@@ -140,7 +143,6 @@ fixed_port    = 8000                            # issuer/PRM metadata bake in :8
 
 [deferred]
 caching       = "client honouring + per-result override unlanded"
-mrtr          = "#2898 — InputRequiredResult runtime"
 subscriptions = "#2901 — Client.listen / ServerEventBus"
 tasks         = "extensions capability map + tasks runtime"
 apps          = "#2896 — extensions capability map"

--- a/examples/stories/mrtr/README.md
+++ b/examples/stories/mrtr/README.md
@@ -1,30 +1,54 @@
 # mrtr
 
-Multi-round tool results: a 2026-era tool call returns
-`resultType: "input_required"` with a `requestState` HMAC instead of pushing an
-`elicitation/create` request. The client fulfils the input and resubmits, and
-the server resumes from the carried state. The story will show both the
-auto-fulfil helper and a manual resubmit loop.
+Multi-round tool result: on the 2026-07-28 protocol a tool that needs user
+input mid-call **returns** `resultType: "input_required"` with embedded
+`inputRequests` and an opaque `requestState`, instead of pushing a
+server→client request. The client fulfils the embedded requests and retries the
+original `tools/call` carrying `inputResponses` and the echoed `requestState`.
+The story shows both the `Client` auto-loop (one `await call_tool`, callbacks
+fired transparently) and a manual `client.session` loop (the persistable form).
 
-**Status: not yet implemented** ([#2898](https://github.com/modelcontextprotocol/python-sdk/issues/2898)).
-The lowlevel registration surface is in this base —
-[#2967](https://github.com/modelcontextprotocol/python-sdk/pull/2967)
-(`ae13ede`) widened the tool/prompt/resource handler return types to include
-`InputRequiredResult`. The runnable story is deliberately a follow-up PR to
-keep this one reviewable.
+## Run it
+
+```bash
+# HTTP — the client self-hosts the server on a free port, runs, then tears it
+# down (the InputRequiredResult round-trip is 2026-era only)
+uv run python -m stories.mrtr.client --http
+# same, against the lowlevel-API server variant
+uv run python -m stories.mrtr.client --http --server server_lowlevel
+```
+
+## What to look at
+
+- `client.py` `main` — the auto-loop is invisible at the call site:
+  `Client(target, mode=mode, elicitation_callback=on_elicit)` then
+  `await client.call_tool("deploy", ...)`. The same `on_elicit` callback the
+  legacy push path uses is dispatched for each embedded `inputRequests` entry.
+- `client.py` manual block — `client.session.call_tool(...,
+  allow_input_required=True)` returns the raw `InputRequiredResult` so
+  `request_state` can be persisted between rounds; the retry is just another
+  `tools/call` with `input_responses=` / `request_state=`.
+- `server.py` `deploy` — `ctx.input_responses` / `ctx.request_state` read the
+  retry payload; the first round returns
+  `InputRequiredResult(input_requests={...}, request_state=...)`, the second
+  returns the final string.
+- `server_lowlevel.py` — same wire contract via `params.input_responses` /
+  `params.request_state` and a hand-built `InputRequiredResult`.
+
+## Caveats
+
+- **Loop bound.** The auto-loop gives up after `input_required_max_rounds`
+  (default 10) with `InputRequiredRoundsExceededError`; raise it on the
+  `Client` ctor or drop to the manual loop.
+- **`requestState` integrity is the server's job.** The client echoes it
+  byte-exact and never inspects it; the server MUST treat it as
+  attacker-controlled. The SDK ships no signing helper yet.
 
 ## Spec
 
-[Multi-round tool results — server features](https://modelcontextprotocol.io/specification/draft/server/tools#multi-round-results)
-
-## Working example elsewhere
-
-The TypeScript SDK ships a runnable `mrtr` story:
-[typescript-sdk/examples/mrtr](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples/mrtr).
+[Multi-round results — server features](https://modelcontextprotocol.io/specification/draft/server/tools#multi-round-results)
 
 ## See also
 
-`legacy_elicitation/` and `sampling/` — the handshake-era push equivalents that
-this mechanism replaces on the 2026 protocol. The TypeScript SDK ships a single
-dual-era `elicitation/` story covering both eras in one place; we re-merge
-`legacy_elicitation/` back into `elicitation/` once MRTR lands.
+`legacy_elicitation/` and `sampling/` — the handshake-era push equivalents this
+mechanism replaces on the 2026 protocol.

--- a/examples/stories/mrtr/client.py
+++ b/examples/stories/mrtr/client.py
@@ -1,0 +1,46 @@
+"""Drive the deploy tool both ways: the Client auto-loop, and a manual session-level loop."""
+
+import mcp_types as types
+
+from mcp.client import Client, ClientRequestContext
+from stories._harness import Target, run_client
+
+
+async def on_elicit(context: ClientRequestContext, params: types.ElicitRequestParams) -> types.ElicitResult:
+    # The same callback serves legacy push-style elicitation/create requests AND embedded
+    # InputRequiredResult.input_requests entries — the driver dispatches both here.
+    assert isinstance(params, types.ElicitRequestFormParams)
+    assert "confirm" in params.requested_schema["properties"]
+    return types.ElicitResult(action="accept", content={"confirm": True})
+
+
+async def main(target: Target, *, mode: str = "auto") -> None:
+    async with Client(target, mode=mode, elicitation_callback=on_elicit) as client:
+        # ── auto-loop: Client.call_tool dispatches input_requests to on_elicit and retries
+        # internally; the caller just sees the final CallToolResult.
+        deployed = await client.call_tool("deploy", {"env": "production"})
+        assert isinstance(deployed.content[0], types.TextContent)
+        assert deployed.content[0].text == "deployed to production", deployed
+
+        # ── manual loop: drop to client.session for the raw InputRequiredResult so the
+        # request_state can be persisted between rounds (e.g. across a process restart).
+        first = await client.session.call_tool("deploy", {"env": "staging"}, allow_input_required=True)
+        assert isinstance(first, types.InputRequiredResult)
+        assert first.input_requests is not None and "confirm" in first.input_requests
+        assert first.request_state == "awaiting-confirm"
+        # Decline this time so the path diverges from the auto-loop run above.
+        responses: types.InputResponses = {"confirm": types.ElicitResult(action="decline")}
+        second = await client.session.call_tool(
+            "deploy",
+            {"env": "staging"},
+            input_responses=responses,
+            request_state=first.request_state,
+            allow_input_required=True,
+        )
+        assert isinstance(second, types.CallToolResult)
+        assert isinstance(second.content[0], types.TextContent)
+        assert second.content[0].text == "deployment to staging cancelled", second
+
+
+if __name__ == "__main__":
+    run_client(main)

--- a/examples/stories/mrtr/server.py
+++ b/examples/stories/mrtr/server.py
@@ -1,0 +1,39 @@
+"""Multi-round tool result (2026 era): a tool returns input_required and resumes from echoed state."""
+
+from mcp_types import ElicitRequest, ElicitRequestedSchema, ElicitRequestFormParams, ElicitResult, InputRequiredResult
+
+from mcp.server.mcpserver import Context, MCPServer
+from stories._hosting import run_server_from_args
+
+CONFIRM_SCHEMA: ElicitRequestedSchema = {
+    "type": "object",
+    "properties": {"confirm": {"type": "boolean", "description": "Proceed with the deployment?"}},
+    "required": ["confirm"],
+}
+
+
+def build_server() -> MCPServer:
+    mcp = MCPServer("mrtr-example")
+
+    @mcp.tool(description="Deploy to an environment, asking the user to confirm first.")
+    async def deploy(env: str, ctx: Context) -> str | InputRequiredResult:
+        responses = ctx.input_responses
+        if responses is None or "confirm" not in responses:
+            # First round: ask the client to elicit confirmation. request_state is opaque
+            # to the client; here it carries the step name so the retry can verify the echo.
+            ask = ElicitRequest(
+                params=ElicitRequestFormParams(message=f"Deploy to {env}?", requested_schema=CONFIRM_SCHEMA)
+            )
+            return InputRequiredResult(input_requests={"confirm": ask}, request_state="awaiting-confirm")
+        # Retry round: the client echoed request_state byte-exact and supplied the answer.
+        assert ctx.request_state == "awaiting-confirm", ctx.request_state
+        answer = responses["confirm"]
+        if isinstance(answer, ElicitResult) and answer.action == "accept" and (answer.content or {}).get("confirm"):
+            return f"deployed to {env}"
+        return f"deployment to {env} cancelled"
+
+    return mcp
+
+
+if __name__ == "__main__":
+    run_server_from_args(build_server)

--- a/examples/stories/mrtr/server_lowlevel.py
+++ b/examples/stories/mrtr/server_lowlevel.py
@@ -1,0 +1,62 @@
+"""Multi-round tool result (2026 era) against the low-level Server."""
+
+from typing import Any
+
+import mcp_types as types
+
+from mcp.server.context import ServerRequestContext
+from mcp.server.lowlevel import Server
+from stories._hosting import run_server_from_args
+
+CONFIRM_SCHEMA: types.ElicitRequestedSchema = {
+    "type": "object",
+    "properties": {"confirm": {"type": "boolean", "description": "Proceed with the deployment?"}},
+    "required": ["confirm"],
+}
+DEPLOY_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"env": {"type": "string"}},
+    "required": ["env"],
+}
+
+
+def build_server() -> Server[Any]:
+    async def list_tools(
+        ctx: ServerRequestContext[Any], params: types.PaginatedRequestParams | None
+    ) -> types.ListToolsResult:
+        return types.ListToolsResult(
+            tools=[
+                types.Tool(
+                    name="deploy",
+                    description="Deploy to an environment, asking the user to confirm first.",
+                    input_schema=DEPLOY_INPUT_SCHEMA,
+                )
+            ]
+        )
+
+    async def call_tool(
+        ctx: ServerRequestContext[Any], params: types.CallToolRequestParams
+    ) -> types.CallToolResult | types.InputRequiredResult:
+        assert params.name == "deploy" and params.arguments is not None
+        env = params.arguments["env"]
+        responses = params.input_responses
+        if responses is None or "confirm" not in responses:
+            ask = types.ElicitRequest(
+                params=types.ElicitRequestFormParams(message=f"Deploy to {env}?", requested_schema=CONFIRM_SCHEMA)
+            )
+            return types.InputRequiredResult(input_requests={"confirm": ask}, request_state="awaiting-confirm")
+        assert params.request_state == "awaiting-confirm", params.request_state
+        answer = responses["confirm"]
+        if (
+            isinstance(answer, types.ElicitResult)
+            and answer.action == "accept"
+            and (answer.content or {}).get("confirm")
+        ):
+            return types.CallToolResult(content=[types.TextContent(text=f"deployed to {env}")])
+        return types.CallToolResult(content=[types.TextContent(text=f"deployment to {env} cancelled")])
+
+    return Server("mrtr-example", on_list_tools=list_tools, on_call_tool=call_tool)
+
+
+if __name__ == "__main__":
+    run_server_from_args(build_server)

--- a/src/mcp-types/mcp_types/_types.py
+++ b/src/mcp-types/mcp_types/_types.py
@@ -2061,7 +2061,7 @@ class InputRequiredResult(Result):
 
     @model_validator(mode="after")
     def _require_one_field(self) -> Self:
-        if self.input_requests is None and self.request_state is None:
+        if not self.input_requests and self.request_state is None:
             raise ValueError("InputRequiredResult requires at least one of input_requests or request_state")
         return self
 

--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -58,6 +58,7 @@ from mcp_types import (
 )
 from mcp_types import Role as SamplingRole
 
+from .client._input_required import InputRequiredRoundsExceededError
 from .client.client import Client
 from .client.session import ClientSession
 from .client.session_group import ClientSessionGroup
@@ -87,6 +88,7 @@ __all__ = [
     "InitializeRequest",
     "InitializeResult",
     "InitializedNotification",
+    "InputRequiredRoundsExceededError",
     "JSONRPCError",
     "JSONRPCRequest",
     "JSONRPCResponse",

--- a/src/mcp/client/__init__.py
+++ b/src/mcp/client/__init__.py
@@ -1,8 +1,9 @@
 """MCP Client module."""
 
+from mcp.client._input_required import InputRequiredRoundsExceededError
 from mcp.client._transport import Transport
 from mcp.client.client import Client
 from mcp.client.context import ClientRequestContext
 from mcp.client.session import ClientSession
 
-__all__ = ["Client", "ClientRequestContext", "ClientSession", "Transport"]
+__all__ = ["Client", "ClientRequestContext", "ClientSession", "InputRequiredRoundsExceededError", "Transport"]

--- a/src/mcp/client/_input_required.py
+++ b/src/mcp/client/_input_required.py
@@ -1,0 +1,127 @@
+"""SEP-2322 client-side multi-round-trip driver.
+
+When a server returns `InputRequiredResult` instead of the normal result of a
+`tools/call` / `prompts/get` / `resources/read`, the client fulfils the
+embedded `input_requests` (sampling, elicitation, roots) and retries the
+original request carrying the responses and the echoed opaque `request_state`.
+This module implements that retry loop as a pure function so it can drive any
+of the three methods identically; `Client` builds the `dispatch` and `retry`
+closures, `ClientSession` stays mechanics-only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+import anyio
+import anyio.abc
+from mcp_types import ErrorData, InputRequest, InputRequiredResult, InputResponse, InputResponses
+
+from mcp.shared.exceptions import MCPError
+
+DEFAULT_INPUT_REQUIRED_MAX_ROUNDS = 10
+"""Default cap on `InputRequiredResult` retry rounds before the driver gives up.
+
+Matches the typescript-sdk default; csharp-sdk and go-sdk use the same value
+as a hard constant.
+"""
+
+_STATE_ONLY_BACKOFF_INITIAL_SECONDS = 0.05
+"""First sleep when an `InputRequiredResult` carries only `request_state` (no input requests)."""
+
+_STATE_ONLY_BACKOFF_CAP_SECONDS = 0.25
+"""Upper bound on the state-only backoff sleep; reached after three consecutive state-only legs."""
+
+
+ResultT = TypeVar("ResultT")
+
+
+class InputRequiredRoundsExceededError(RuntimeError):
+    """The server kept returning `InputRequiredResult` past the configured `max_rounds`."""
+
+    def __init__(self, max_rounds: int) -> None:
+        super().__init__(
+            f"Server returned InputRequiredResult for more than {max_rounds} rounds; "
+            "raise input_required_max_rounds on the Client, or use "
+            "client.session.<method>(..., allow_input_required=True) to drive the loop manually."
+        )
+        self.max_rounds = max_rounds
+
+
+async def run_input_required_driver(
+    first: InputRequiredResult,
+    *,
+    dispatch: Callable[[str, InputRequest], Awaitable[InputResponse | ErrorData]],
+    retry: Callable[[InputResponses | None, str | None], Awaitable[ResultT | InputRequiredResult]],
+    max_rounds: int = DEFAULT_INPUT_REQUIRED_MAX_ROUNDS,
+) -> ResultT:
+    """Resolve an `InputRequiredResult` to its terminal result.
+
+    Loops until `retry` returns a non-`InputRequiredResult`, or `max_rounds` is
+    exhausted. Each round either dispatches all `input_requests` concurrently
+    and retries with the collected responses, or — when the server sent only
+    `request_state` — sleeps with exponential backoff (50ms doubling to a 250ms
+    cap, reset by any leg that carries input requests) and retries empty.
+    `request_state` is passed through byte-exact and never inspected.
+
+    Args:
+        first: The `InputRequiredResult` the original call returned.
+        dispatch: Runs one embedded `InputRequest` through the client's
+            sampling / elicitation / roots callbacks. Called concurrently per
+            request key. An `ErrorData` return aborts the loop as an `MCPError`.
+        retry: Re-issues the original request with the collected responses and
+            the latest `request_state`. Each call mints a fresh JSON-RPC id.
+        max_rounds: Cap on retry rounds.
+
+    Raises:
+        InputRequiredRoundsExceededError: `max_rounds` exhausted.
+        MCPError: A `dispatch` call returned `ErrorData`.
+    """
+    rounds = 0
+    state_only_delay = _STATE_ONLY_BACKOFF_INITIAL_SECONDS
+    current: ResultT | InputRequiredResult = first
+    while isinstance(current, InputRequiredResult):
+        rounds += 1
+        if rounds > max_rounds:
+            raise InputRequiredRoundsExceededError(max_rounds)
+        if current.input_requests:
+            state_only_delay = _STATE_ONLY_BACKOFF_INITIAL_SECONDS
+            responses: InputResponses | None = await _dispatch_all(current.input_requests, dispatch)
+        else:
+            await anyio.sleep(state_only_delay)
+            state_only_delay = min(state_only_delay * 2, _STATE_ONLY_BACKOFF_CAP_SECONDS)
+            responses = None
+        current = await retry(responses, current.request_state)
+    return current
+
+
+async def _dispatch_all(
+    requests: dict[str, InputRequest],
+    dispatch: Callable[[str, InputRequest], Awaitable[InputResponse | ErrorData]],
+) -> InputResponses:
+    """Run `dispatch` concurrently for every key, raising `MCPError` on the first `ErrorData`.
+
+    The first task to return `ErrorData` cancels its siblings via the task
+    group's cancel scope, so a refused input does not wait on a slow peer.
+    A callback that *raises* propagates as an `ExceptionGroup` like any other
+    task-group failure.
+    """
+    responses: InputResponses = {}
+    refused: ErrorData | None = None
+
+    async def run_one(tg: anyio.abc.TaskGroup, key: str, req: InputRequest) -> None:
+        nonlocal refused
+        result = await dispatch(key, req)
+        if isinstance(result, ErrorData):
+            refused = result
+            tg.cancel_scope.cancel()
+        else:
+            responses[key] = result
+
+    async with anyio.create_task_group() as tg:
+        for key, req in requests.items():
+            tg.start_soon(run_one, tg, key, req)
+    if refused is not None:
+        raise MCPError.from_error_data(refused)
+    return responses

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack
 from dataclasses import KW_ONLY, dataclass, field
-from typing import Any, Literal, TypeVar, overload
+from typing import Any, Literal, TypeVar
 
 import anyio
 import mcp_types as types
@@ -13,9 +13,12 @@ from mcp_types import (
     CallToolResult,
     CompleteResult,
     EmptyResult,
+    ErrorData,
     GetPromptResult,
     Implementation,
+    InputRequest,
     InputRequiredResult,
+    InputResponse,
     InputResponses,
     ListPromptsResult,
     ListResourcesResult,
@@ -32,10 +35,19 @@ from mcp_types import (
 from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
 from typing_extensions import deprecated
 
+from mcp.client._input_required import DEFAULT_INPUT_REQUIRED_MAX_ROUNDS, run_input_required_driver
 from mcp.client._memory import InMemoryTransport
 from mcp.client._probe import negotiate_auto
 from mcp.client._transport import Transport
-from mcp.client.session import ClientSession, ElicitationFnT, ListRootsFnT, LoggingFnT, MessageHandlerFnT, SamplingFnT
+from mcp.client.session import (
+    ClientRequestContext,
+    ClientSession,
+    ElicitationFnT,
+    ListRootsFnT,
+    LoggingFnT,
+    MessageHandlerFnT,
+    SamplingFnT,
+)
 from mcp.client.streamable_http import streamable_http_client
 from mcp.server import Server
 from mcp.server.mcpserver import MCPServer
@@ -51,6 +63,7 @@ initialize), or a modern protocol-version string (adopt directly). The ``str`` a
 forward-compat; ``Client.__post_init__`` rejects anything outside that set at construction."""
 
 _T = TypeVar("_T")
+_ResultT = TypeVar("_ResultT")
 
 _Connector = Callable[[AsyncExitStack, ConnectMode, bool], Awaitable["Dispatcher[Any]"]]
 """Resolved at ``__post_init__`` from the shape of ``server`` alone: enter whatever resources
@@ -198,6 +211,11 @@ class Client:
 
     elicitation_callback: ElicitationFnT | None = None
     """Callback for handling elicitation requests."""
+
+    input_required_max_rounds: int = DEFAULT_INPUT_REQUIRED_MAX_ROUNDS
+    """Cap on `InputRequiredResult` retry rounds before `call_tool` / `get_prompt` /
+    `read_resource` give up. Use `client.session.<method>(..., allow_input_required=True)`
+    to drive the loop manually instead."""
 
     _entered: bool = field(init=False, default=False)
     _session: ClientSession | None = field(init=False, default=None)
@@ -356,17 +374,42 @@ class Client:
         """List available resource templates from the server."""
         return await self.session.list_resource_templates(params=PaginatedRequestParams(cursor=cursor, _meta=meta))
 
-    async def read_resource(self, uri: str, *, meta: RequestParamsMeta | None = None) -> ReadResourceResult:
+    async def read_resource(
+        self,
+        uri: str,
+        *,
+        input_responses: InputResponses | None = None,
+        request_state: str | None = None,
+        meta: RequestParamsMeta | None = None,
+    ) -> ReadResourceResult:
         """Read a resource from the server.
+
+        If the server returns an `InputRequiredResult`, the embedded input
+        requests are dispatched to this client's sampling / elicitation / roots
+        callbacks and the read is retried automatically (up to
+        `input_required_max_rounds`).
 
         Args:
             uri: The URI of the resource to read.
+            input_responses: Responses to seed the first call with (e.g. when
+                resuming from a persisted `InputRequiredResult`).
+            request_state: Opaque state to seed the first call with.
             meta: Additional metadata for the request.
 
         Returns:
             The resource content.
+
+        Raises:
+            InputRequiredRoundsExceededError: `input_required_max_rounds` exhausted.
+            MCPError: A callback returned `ErrorData` for an embedded input request.
         """
-        return await self.session.read_resource(uri, meta=meta)
+
+        async def retry(r: InputResponses | None, s: str | None) -> ReadResourceResult | InputRequiredResult:
+            return await self.session.read_resource(
+                uri, input_responses=r, request_state=s, meta=meta, allow_input_required=True
+            )
+
+        return await self._drive_input_required(await retry(input_responses, request_state), retry)
 
     async def subscribe_resource(self, uri: str, *, meta: RequestParamsMeta | None = None) -> EmptyResult:
         """Subscribe to resource updates."""
@@ -376,7 +419,6 @@ class Client:
         """Unsubscribe from resource updates."""
         return await self.session.unsubscribe_resource(uri, meta=meta)
 
-    @overload
     async def call_tool(
         self,
         name: str,
@@ -387,69 +429,47 @@ class Client:
         input_responses: InputResponses | None = None,
         request_state: str | None = None,
         meta: RequestParamsMeta | None = None,
-        allow_input_required: Literal[False] = False,
-    ) -> CallToolResult: ...
-
-    @overload
-    async def call_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any] | None = None,
-        read_timeout_seconds: float | None = None,
-        progress_callback: ProgressFnT | None = None,
-        *,
-        input_responses: InputResponses | None = None,
-        request_state: str | None = None,
-        meta: RequestParamsMeta | None = None,
-        allow_input_required: bool,
-    ) -> CallToolResult | InputRequiredResult: ...
-
-    async def call_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any] | None = None,
-        read_timeout_seconds: float | None = None,
-        progress_callback: ProgressFnT | None = None,
-        *,
-        input_responses: InputResponses | None = None,
-        request_state: str | None = None,
-        meta: RequestParamsMeta | None = None,
-        allow_input_required: bool = False,
-    ) -> CallToolResult | InputRequiredResult:
+    ) -> CallToolResult:
         """Call a tool on the server.
 
+        If the server returns an `InputRequiredResult`, the embedded input
+        requests are dispatched to this client's sampling / elicitation / roots
+        callbacks and the call is retried automatically (up to
+        `input_required_max_rounds`). To drive the loop yourself — e.g. to
+        persist `request_state` across process restarts — use
+        `client.session.call_tool(..., allow_input_required=True)`.
+
         Args:
-            name: The name of the tool to call
-            arguments: Arguments to pass to the tool
-            read_timeout_seconds: Timeout for the tool call
-            progress_callback: Callback for progress updates
-            input_responses: Responses to a prior `InputRequiredResult.input_requests`
-            request_state: Opaque state echoed from a prior `InputRequiredResult`
-            meta: Additional metadata for the request
-            allow_input_required: When ``False`` (default), an `InputRequiredResult`
-                from the server raises `RuntimeError`; when ``True``, it is returned
-                so the caller can resolve the requests and retry.
+            name: The name of the tool to call.
+            arguments: Arguments to pass to the tool.
+            read_timeout_seconds: Timeout for each underlying `tools/call` round.
+            progress_callback: Callback for progress updates.
+            input_responses: Responses to seed the first call with (e.g. when
+                resuming from a persisted `InputRequiredResult`).
+            request_state: Opaque state to seed the first call with.
+            meta: Additional metadata for the request.
 
         Returns:
-            The tool result. When ``allow_input_required=True``, may instead be an
-            `InputRequiredResult` carrying the server's input requests and opaque
-            ``request_state`` for the retry.
+            The tool result.
 
         Raises:
-            RuntimeError: If the server returns an `InputRequiredResult` and
-                ``allow_input_required`` is ``False``.
+            InputRequiredRoundsExceededError: `input_required_max_rounds` exhausted.
+            MCPError: A callback returned `ErrorData` for an embedded input request.
         """
-        # TODO(L84): stop forwarding allow_input_required; run the MRTR auto-loop driver here (S6).
-        return await self.session.call_tool(
-            name=name,
-            arguments=arguments,
-            read_timeout_seconds=read_timeout_seconds,
-            progress_callback=progress_callback,
-            input_responses=input_responses,
-            request_state=request_state,
-            meta=meta,
-            allow_input_required=allow_input_required,
-        )
+
+        async def retry(r: InputResponses | None, s: str | None) -> CallToolResult | InputRequiredResult:
+            return await self.session.call_tool(
+                name,
+                arguments,
+                read_timeout_seconds=read_timeout_seconds,
+                progress_callback=progress_callback,
+                input_responses=r,
+                request_state=s,
+                meta=meta,
+                allow_input_required=True,
+            )
+
+        return await self._drive_input_required(await retry(input_responses, request_state), retry)
 
     async def list_prompts(
         self,
@@ -461,19 +481,66 @@ class Client:
         return await self.session.list_prompts(params=PaginatedRequestParams(cursor=cursor, _meta=meta))
 
     async def get_prompt(
-        self, name: str, arguments: dict[str, str] | None = None, *, meta: RequestParamsMeta | None = None
+        self,
+        name: str,
+        arguments: dict[str, str] | None = None,
+        *,
+        input_responses: InputResponses | None = None,
+        request_state: str | None = None,
+        meta: RequestParamsMeta | None = None,
     ) -> GetPromptResult:
         """Get a prompt from the server.
 
+        If the server returns an `InputRequiredResult`, the embedded input
+        requests are dispatched to this client's sampling / elicitation / roots
+        callbacks and the get is retried automatically (up to
+        `input_required_max_rounds`).
+
         Args:
-            name: The name of the prompt
-            arguments: Arguments to pass to the prompt
-            meta: Additional metadata for the request
+            name: The name of the prompt.
+            arguments: Arguments to pass to the prompt.
+            input_responses: Responses to seed the first call with (e.g. when
+                resuming from a persisted `InputRequiredResult`).
+            request_state: Opaque state to seed the first call with.
+            meta: Additional metadata for the request.
 
         Returns:
             The prompt content.
+
+        Raises:
+            InputRequiredRoundsExceededError: `input_required_max_rounds` exhausted.
+            MCPError: A callback returned `ErrorData` for an embedded input request.
         """
-        return await self.session.get_prompt(name=name, arguments=arguments, meta=meta)
+
+        async def retry(r: InputResponses | None, s: str | None) -> GetPromptResult | InputRequiredResult:
+            return await self.session.get_prompt(
+                name, arguments, input_responses=r, request_state=s, meta=meta, allow_input_required=True
+            )
+
+        return await self._drive_input_required(await retry(input_responses, request_state), retry)
+
+    async def _drive_input_required(
+        self,
+        first: _ResultT | InputRequiredResult,
+        retry: Callable[[InputResponses | None, str | None], Awaitable[_ResultT | InputRequiredResult]],
+    ) -> _ResultT:
+        """Hand an `InputRequiredResult` to the SEP-2322 driver, or pass a terminal result through.
+
+        `dispatch` routes each embedded request through the same callback table
+        that serves legacy server→client RPCs, so the two paths stay
+        behaviourally identical by construction.
+        """
+        if not isinstance(first, InputRequiredResult):
+            return first
+        session = self.session
+
+        async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+            ctx = ClientRequestContext(session=session, request_id=key, meta=req.params.meta if req.params else None)
+            return await session._dispatch_input_request(ctx, req)  # pyright: ignore[reportPrivateUsage]
+
+        return await run_input_required_driver(
+            first, dispatch=dispatch, retry=retry, max_rounds=self.input_required_max_rounds
+        )
 
     async def complete(
         self,

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -185,6 +185,19 @@ ClientResponse: TypeAdapter[types.ClientResult | types.ErrorData] = TypeAdapter(
 _CallToolResultAdapter: TypeAdapter[types.CallToolResult | types.InputRequiredResult] = TypeAdapter(
     types.CallToolResult | types.InputRequiredResult
 )
+_GetPromptResultAdapter: TypeAdapter[types.GetPromptResult | types.InputRequiredResult] = TypeAdapter(
+    types.GetPromptResult | types.InputRequiredResult
+)
+_ReadResourceResultAdapter: TypeAdapter[types.ReadResourceResult | types.InputRequiredResult] = TypeAdapter(
+    types.ReadResourceResult | types.InputRequiredResult
+)
+
+
+def _input_required_unexpected(method: str) -> RuntimeError:
+    return RuntimeError(
+        "Server returned InputRequiredResult; pass allow_input_required=True to receive it "
+        f"and retry {method}(..., input_responses=..., request_state=result.request_state)."
+    )
 
 
 class ClientSession:
@@ -591,12 +604,64 @@ class ClientSession:
             types.ListResourceTemplatesResult,
         )
 
-    async def read_resource(self, uri: str, *, meta: RequestParamsMeta | None = None) -> types.ReadResourceResult:
-        """Send a resources/read request."""
-        return await self.send_request(
-            types.ReadResourceRequest(params=types.ReadResourceRequestParams(uri=uri, _meta=meta)),
-            types.ReadResourceResult,
+    @overload
+    async def read_resource(
+        self,
+        uri: str,
+        *,
+        input_responses: types.InputResponses | None = None,
+        request_state: str | None = None,
+        meta: RequestParamsMeta | None = None,
+        allow_input_required: Literal[False] = False,
+    ) -> types.ReadResourceResult: ...
+
+    @overload
+    async def read_resource(
+        self,
+        uri: str,
+        *,
+        input_responses: types.InputResponses | None = None,
+        request_state: str | None = None,
+        meta: RequestParamsMeta | None = None,
+        allow_input_required: bool,
+    ) -> types.ReadResourceResult | types.InputRequiredResult: ...
+
+    async def read_resource(
+        self,
+        uri: str,
+        *,
+        input_responses: types.InputResponses | None = None,
+        request_state: str | None = None,
+        meta: RequestParamsMeta | None = None,
+        allow_input_required: bool = False,
+    ) -> types.ReadResourceResult | types.InputRequiredResult:
+        """Send a resources/read request.
+
+        Args:
+            input_responses: Responses to a prior `InputRequiredResult.input_requests`.
+            request_state: Opaque state echoed from a prior `InputRequiredResult`.
+            allow_input_required: When `False` (default), an `InputRequiredResult`
+                from the server raises `RuntimeError`; when `True`, it is returned
+                so the caller can resolve the requests and retry.
+
+        Raises:
+            RuntimeError: If the server returns an `InputRequiredResult` and
+                `allow_input_required` is `False`.
+        """
+        result = await self.send_request(
+            types.ReadResourceRequest(
+                params=types.ReadResourceRequestParams(
+                    uri=uri,
+                    input_responses=input_responses,
+                    request_state=request_state,
+                    _meta=meta,
+                ),
+            ),
+            _ReadResourceResultAdapter,
         )
+        if isinstance(result, types.InputRequiredResult) and not allow_input_required:
+            raise _input_required_unexpected("read_resource")
+        return result
 
     async def subscribe_resource(self, uri: str, *, meta: RequestParamsMeta | None = None) -> types.EmptyResult:
         """Send a resources/subscribe request."""
@@ -689,10 +754,7 @@ class ClientSession:
             await self._validate_tool_result(name, result)
 
         if isinstance(result, types.InputRequiredResult) and not allow_input_required:
-            raise RuntimeError(
-                "Server returned InputRequiredResult; pass allow_input_required=True to receive it "
-                "and retry call_tool(..., input_responses=..., request_state=result.request_state)."
-            )
+            raise _input_required_unexpected("call_tool")
         return result
 
     def _resolve_param_headers(self, name: str, arguments: Mapping[str, Any]) -> dict[str, str]:
@@ -734,18 +796,68 @@ class ClientSession:
         """
         return await self.send_request(types.ListPromptsRequest(params=params), types.ListPromptsResult)
 
+    @overload
     async def get_prompt(
         self,
         name: str,
         arguments: dict[str, str] | None = None,
         *,
+        input_responses: types.InputResponses | None = None,
+        request_state: str | None = None,
         meta: RequestParamsMeta | None = None,
-    ) -> types.GetPromptResult:
-        """Send a prompts/get request."""
-        return await self.send_request(
-            types.GetPromptRequest(params=types.GetPromptRequestParams(name=name, arguments=arguments, _meta=meta)),
-            types.GetPromptResult,
+        allow_input_required: Literal[False] = False,
+    ) -> types.GetPromptResult: ...
+
+    @overload
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, str] | None = None,
+        *,
+        input_responses: types.InputResponses | None = None,
+        request_state: str | None = None,
+        meta: RequestParamsMeta | None = None,
+        allow_input_required: bool,
+    ) -> types.GetPromptResult | types.InputRequiredResult: ...
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, str] | None = None,
+        *,
+        input_responses: types.InputResponses | None = None,
+        request_state: str | None = None,
+        meta: RequestParamsMeta | None = None,
+        allow_input_required: bool = False,
+    ) -> types.GetPromptResult | types.InputRequiredResult:
+        """Send a prompts/get request.
+
+        Args:
+            input_responses: Responses to a prior `InputRequiredResult.input_requests`.
+            request_state: Opaque state echoed from a prior `InputRequiredResult`.
+            allow_input_required: When `False` (default), an `InputRequiredResult`
+                from the server raises `RuntimeError`; when `True`, it is returned
+                so the caller can resolve the requests and retry.
+
+        Raises:
+            RuntimeError: If the server returns an `InputRequiredResult` and
+                `allow_input_required` is `False`.
+        """
+        result = await self.send_request(
+            types.GetPromptRequest(
+                params=types.GetPromptRequestParams(
+                    name=name,
+                    arguments=arguments,
+                    input_responses=input_responses,
+                    request_state=request_state,
+                    _meta=meta,
+                ),
+            ),
+            _GetPromptResultAdapter,
         )
+        if isinstance(result, types.InputRequiredResult) and not allow_input_required:
+            raise _input_required_unexpected("get_prompt")
+        return result
 
     async def complete(
         self,
@@ -829,13 +941,7 @@ class ClientSession:
             ctx = ClientRequestContext(
                 session=self, request_id=dctx.request_id, meta=request.params.meta if request.params else None
             )
-            match request:
-                case types.CreateMessageRequest(params=sampling_params):
-                    response = await self._sampling_callback(ctx, sampling_params)
-                case types.ElicitRequest(params=elicit_params):
-                    response = await self._elicitation_callback(ctx, elicit_params)
-                case types.ListRootsRequest():  # pragma: no branch
-                    response = await self._list_roots_callback(ctx)
+            response = await self._dispatch_input_request(ctx, request)
         client_response = ClientResponse.validate_python(response)
         if isinstance(client_response, types.ErrorData):
             raise MCPError.from_error_data(client_response)
@@ -846,6 +952,23 @@ class ClientSession:
             logger.exception("client callback for %r returned an invalid result", method)
             raise MCPError(code=INTERNAL_ERROR, message="Client callback returned an invalid result") from None
         return dumped
+
+    async def _dispatch_input_request(
+        self, ctx: ClientRequestContext, req: types.InputRequest
+    ) -> types.InputResponse | types.ErrorData:
+        """Route a server-initiated input request to the matching constructor callback.
+
+        Shared by the legacy server→client RPC path (`_on_request`) and the
+        2026-07-28 multi-round-trip driver, which dispatches the embedded
+        `InputRequiredResult.input_requests` through the same callbacks.
+        """
+        match req:
+            case types.CreateMessageRequest(params=p):
+                return await self._sampling_callback(ctx, p)
+            case types.ElicitRequest(params=p):
+                return await self._elicitation_callback(ctx, p)
+            case types.ListRootsRequest():  # pragma: no branch
+                return await self._list_roots_callback(ctx)
 
     async def _on_notify(
         self, dctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -33,14 +33,16 @@ from mcp_types import (
     ToolsCapability,
 )
 from mcp_types.version import LATEST_HANDSHAKE_VERSION
+from pydantic import FileUrl
 
 from mcp import MCPError
 from mcp.client._memory import InMemoryTransport
 from mcp.client._transport import TransportStreams
 from mcp.client.client import Client
+from mcp.client.session import ClientRequestContext
 from mcp.client.streamable_http import streamable_http_client
 from mcp.server import Server, ServerRequestContext
-from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.shared.memory import MessageStream, create_client_server_memory_streams
 from mcp.shared.message import SessionMessage
 from tests.interaction._connect import BASE_URL, mounted_app
@@ -513,3 +515,237 @@ def test_client_rejects_handshake_era_mode_at_construction() -> None:
         Client(server, mode="2025-06-18")
     with pytest.raises(ValueError, match=r"mode must be 'legacy', 'auto', or one of"):
         Client(server, mode="not-a-version")
+
+
+# ── SEP-2322 multi-round-trip auto-loop ────────────────────────────────────────
+
+
+_NAME_SCHEMA = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+
+
+def _name_elicitation(message: str = "What is your name?") -> types.ElicitRequest:
+    return types.ElicitRequest(params=types.ElicitRequestFormParams(message=message, requested_schema=_NAME_SCHEMA))
+
+
+async def test_call_tool_auto_loop_dispatches_elicitation_then_returns_final_result() -> None:
+    """When the server returns `InputRequiredResult` carrying an elicitation,
+    `Client.call_tool` routes it to `elicitation_callback` and retries
+    automatically — the caller sees only the terminal `CallToolResult`."""
+    server = MCPServer("test")
+
+    @server.tool()
+    async def greet(ctx: Context) -> str | types.InputRequiredResult:
+        responses = ctx.input_responses
+        if responses and "user_name" in responses:
+            answer = responses["user_name"]
+            assert isinstance(answer, types.ElicitResult)
+            assert answer.content is not None
+            return f"Hello, {answer.content['name']}!"
+        return types.InputRequiredResult(input_requests={"user_name": _name_elicitation()})
+
+    callback_params: list[types.ElicitRequestParams] = []
+
+    async def elicitation_callback(
+        context: ClientRequestContext, params: types.ElicitRequestParams
+    ) -> types.ElicitResult | types.ErrorData:
+        callback_params.append(params)
+        assert context.request_id == "user_name"  # the inputRequests key is the request id
+        return types.ElicitResult(action="accept", content={"name": "Ada"})
+
+    with anyio.fail_after(5):
+        async with Client(server, elicitation_callback=elicitation_callback) as client:
+            result = await client.call_tool("greet")
+
+    assert result == snapshot(
+        CallToolResult(content=[TextContent(text="Hello, Ada!")], structured_content={"result": "Hello, Ada!"})
+    )
+    assert len(callback_params) == 1
+    assert isinstance(callback_params[0], types.ElicitRequestFormParams)
+    assert callback_params[0].message == "What is your name?"
+    assert callback_params[0].requested_schema == _NAME_SCHEMA
+
+
+async def test_call_tool_auto_loop_dispatches_sampling_then_returns_final_result() -> None:
+    """`InputRequiredResult` with an embedded `CreateMessageRequest` is routed
+    to `sampling_callback` and the call retried with the model's reply."""
+    server = MCPServer("test")
+
+    @server.tool()
+    async def ask(ctx: Context) -> str | types.InputRequiredResult:
+        responses = ctx.input_responses
+        if responses and "q" in responses:
+            answer = responses["q"]
+            assert isinstance(answer, types.CreateMessageResult)
+            assert answer.content.type == "text"
+            return f"Model said: {answer.content.text}"
+        return types.InputRequiredResult(
+            input_requests={
+                "q": types.CreateMessageRequest(
+                    params=types.CreateMessageRequestParams(
+                        messages=[types.SamplingMessage(role="user", content=TextContent(text="Capital of France?"))],
+                        max_tokens=10,
+                    )
+                )
+            }
+        )
+
+    callback_params: list[types.CreateMessageRequestParams] = []
+
+    async def sampling_callback(
+        context: ClientRequestContext, params: types.CreateMessageRequestParams
+    ) -> types.CreateMessageResult | types.ErrorData:
+        callback_params.append(params)
+        return types.CreateMessageResult(role="assistant", content=TextContent(text="Paris"), model="echo")
+
+    with anyio.fail_after(5):
+        async with Client(server, sampling_callback=sampling_callback) as client:
+            result = await client.call_tool("ask")
+
+    assert result == snapshot(
+        CallToolResult(
+            content=[TextContent(text="Model said: Paris")], structured_content={"result": "Model said: Paris"}
+        )
+    )
+    assert len(callback_params) == 1
+    assert callback_params[0].messages[0].content == TextContent(text="Capital of France?")
+
+
+async def test_call_tool_auto_loop_dispatches_list_roots_then_returns_final_result() -> None:
+    """`InputRequiredResult` with an embedded `ListRootsRequest` is routed to
+    `list_roots_callback` and the call retried with the returned roots."""
+    server = MCPServer("test")
+
+    @server.tool()
+    async def count_roots(ctx: Context) -> str | types.InputRequiredResult:
+        responses = ctx.input_responses
+        if responses and "roots" in responses:
+            answer = responses["roots"]
+            assert isinstance(answer, types.ListRootsResult)
+            return f"Client exposed {len(answer.roots)} root(s)."
+        return types.InputRequiredResult(input_requests={"roots": types.ListRootsRequest()})
+
+    callback_called: list[ClientRequestContext] = []
+
+    async def list_roots_callback(context: ClientRequestContext) -> types.ListRootsResult | types.ErrorData:
+        callback_called.append(context)
+        return types.ListRootsResult(roots=[types.Root(uri=FileUrl("file:///workspace"))])
+
+    with anyio.fail_after(5):
+        async with Client(server, list_roots_callback=list_roots_callback) as client:
+            result = await client.call_tool("count_roots")
+
+    assert result == snapshot(
+        CallToolResult(
+            content=[TextContent(text="Client exposed 1 root(s).")],
+            structured_content={"result": "Client exposed 1 root(s)."},
+        )
+    )
+    assert len(callback_called) == 1
+    assert callback_called[0].request_id == "roots"
+
+
+async def test_call_tool_auto_loop_round_trips_evolving_request_state_across_three_rounds() -> None:
+    """A three-round flow where each `InputRequiredResult.request_state`
+    encodes the round number: the driver echoes it back byte-exact, the server
+    advances per round, and the elicitation callback runs once per round."""
+    server = MCPServer("test")
+
+    @server.tool()
+    async def multi(ctx: Context) -> str | types.InputRequiredResult:
+        # Round number is the integer the server stashed in `request_state` last leg.
+        round_num = int(ctx.request_state) if ctx.request_state else 0
+        if round_num == 3:
+            return "done after 3 rounds"
+        next_round = round_num + 1
+        return types.InputRequiredResult(
+            input_requests={f"step{next_round}": _name_elicitation(f"Round {next_round}?")},
+            request_state=str(next_round),
+        )
+
+    messages: list[str] = []
+
+    async def elicitation_callback(
+        context: ClientRequestContext, params: types.ElicitRequestParams
+    ) -> types.ElicitResult | types.ErrorData:
+        assert isinstance(params, types.ElicitRequestFormParams)
+        messages.append(params.message)
+        return types.ElicitResult(action="accept", content={"name": "x"})
+
+    with anyio.fail_after(5):
+        async with Client(server, elicitation_callback=elicitation_callback) as client:
+            result = await client.call_tool("multi")
+
+    assert result.content == [TextContent(text="done after 3 rounds")]
+    assert messages == ["Round 1?", "Round 2?", "Round 3?"]
+
+
+async def test_call_tool_auto_loop_raises_mcp_error_when_no_callback_registered() -> None:
+    """SDK-defined: with no `elicitation_callback`, the default returns
+    `ErrorData(INVALID_REQUEST, ...)` and the driver raises it as `MCPError`
+    rather than retrying."""
+    server = MCPServer("test")
+
+    @server.tool()
+    async def needs_input(ctx: Context) -> str | types.InputRequiredResult:
+        if ctx.input_responses:
+            raise NotImplementedError  # unreachable: client errors before retrying
+        return types.InputRequiredResult(input_requests={"ask": _name_elicitation()})
+
+    async with Client(server) as client:
+        with anyio.fail_after(5), pytest.raises(MCPError) as exc:
+            await client.call_tool("needs_input")
+    assert exc.value.error.code == types.INVALID_REQUEST
+
+
+async def test_get_prompt_auto_loop_resolves_input_required_via_callbacks() -> None:
+    """`Client.get_prompt` runs the same driver as `call_tool`: an
+    `InputRequiredResult` from `prompts/get` is fulfilled and retried."""
+
+    async def handler(
+        ctx: ServerRequestContext, params: types.GetPromptRequestParams
+    ) -> types.GetPromptResult | types.InputRequiredResult:
+        assert params.name == "summary"
+        if params.input_responses and "ask" in params.input_responses:
+            return GetPromptResult(messages=[PromptMessage(role="user", content=TextContent(text="ok"))])
+        return types.InputRequiredResult(input_requests={"ask": _name_elicitation()})
+
+    server = Server("test")
+    server.add_request_handler("prompts/get", types.GetPromptRequestParams, handler)
+
+    async def elicitation_callback(
+        context: ClientRequestContext, params: types.ElicitRequestParams
+    ) -> types.ElicitResult | types.ErrorData:
+        return types.ElicitResult(action="accept", content={"name": "x"})
+
+    with anyio.fail_after(5):
+        async with Client(server, mode="2026-07-28", elicitation_callback=elicitation_callback) as client:
+            result = await client.get_prompt("summary")
+    assert result == snapshot(GetPromptResult(messages=[PromptMessage(role="user", content=TextContent(text="ok"))]))
+
+
+async def test_read_resource_auto_loop_resolves_input_required_via_callbacks() -> None:
+    """`Client.read_resource` runs the same driver as `call_tool`: an
+    `InputRequiredResult` from `resources/read` is fulfilled and retried."""
+
+    async def handler(
+        ctx: ServerRequestContext, params: types.ReadResourceRequestParams
+    ) -> types.ReadResourceResult | types.InputRequiredResult:
+        assert params.uri == "memory://gated"
+        if params.input_responses and "ask" in params.input_responses:
+            return ReadResourceResult(contents=[TextResourceContents(uri="memory://gated", text="unlocked")])
+        return types.InputRequiredResult(input_requests={"ask": _name_elicitation()})
+
+    server = Server("test")
+    server.add_request_handler("resources/read", types.ReadResourceRequestParams, handler)
+
+    async def elicitation_callback(
+        context: ClientRequestContext, params: types.ElicitRequestParams
+    ) -> types.ElicitResult | types.ErrorData:
+        return types.ElicitResult(action="accept", content={"name": "x"})
+
+    with anyio.fail_after(5):
+        async with Client(server, mode="2026-07-28", elicitation_callback=elicitation_callback) as client:
+            result = await client.read_resource("memory://gated")
+    assert result == snapshot(
+        ReadResourceResult(contents=[TextResourceContents(uri="memory://gated", text="unlocked")])
+    )

--- a/tests/client/test_input_required.py
+++ b/tests/client/test_input_required.py
@@ -1,0 +1,266 @@
+"""Unit tests for the SEP-2322 client-side multi-round-trip driver.
+
+`run_input_required_driver` is pure: it takes the first `InputRequiredResult`
+plus `dispatch` / `retry` closures and loops until a terminal result. These
+tests build those closures by hand (scripted lists, recording lists) so the
+driver is exercised without a `ClientSession`. Integration against a real
+server lives in `test_client.py`.
+"""
+
+import anyio
+import pytest
+from inline_snapshot import snapshot
+from mcp_types import (
+    INVALID_REQUEST,
+    CallToolResult,
+    ElicitRequest,
+    ElicitRequestFormParams,
+    ElicitResult,
+    ErrorData,
+    InputRequest,
+    InputRequiredResult,
+    InputResponse,
+    InputResponses,
+    TextContent,
+)
+from trio.testing import MockClock
+
+from mcp import MCPError
+from mcp.client._input_required import (
+    _STATE_ONLY_BACKOFF_CAP_SECONDS,
+    _STATE_ONLY_BACKOFF_INITIAL_SECONDS,
+    DEFAULT_INPUT_REQUIRED_MAX_ROUNDS,
+    InputRequiredRoundsExceededError,
+    run_input_required_driver,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+def _elicit(message: str = "What is your name?") -> ElicitRequest:
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}
+    return ElicitRequest(params=ElicitRequestFormParams(message=message, requested_schema=schema))
+
+
+async def _never_dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+    """Dispatch closure for tests whose script never carries `input_requests`."""
+    raise NotImplementedError
+
+
+async def test_single_round_dispatches_then_retries_to_terminal_result() -> None:
+    """One `InputRequiredResult` with one elicit request: dispatch runs once,
+    retry runs once with the collected response, and the terminal result is returned."""
+    first = InputRequiredResult(input_requests={"ask": _elicit()})
+    terminal = CallToolResult(content=[TextContent(text="done")])
+    dispatched: list[tuple[str, InputRequest]] = []
+    retried: list[tuple[InputResponses | None, str | None]] = []
+
+    async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+        dispatched.append((key, req))
+        return ElicitResult(action="accept", content={"name": "Ada"})
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        retried.append((responses, state))
+        return terminal
+
+    with anyio.fail_after(5):
+        result = await run_input_required_driver(first, dispatch=dispatch, retry=retry, max_rounds=3)
+
+    assert result is terminal
+    assert first.input_requests is not None
+    assert dispatched == [("ask", first.input_requests["ask"])]
+    assert retried == [({"ask": ElicitResult(action="accept", content={"name": "Ada"})}, None)]
+
+
+async def test_multi_round_loops_until_retry_returns_non_input_required() -> None:
+    """Two consecutive `InputRequiredResult` legs followed by a terminal result:
+    the driver dispatches and retries each leg in order."""
+    terminal = CallToolResult(content=[TextContent(text="done")])
+    script: list[CallToolResult | InputRequiredResult] = [
+        InputRequiredResult(input_requests={"b": _elicit("second?")}),
+        terminal,
+    ]
+    retried: list[tuple[InputResponses | None, str | None]] = []
+    dispatched_keys: list[str] = []
+
+    async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+        dispatched_keys.append(key)
+        return ElicitResult(action="decline")
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        retried.append((responses, state))
+        return script.pop(0)
+
+    first = InputRequiredResult(input_requests={"a": _elicit("first?")})
+    with anyio.fail_after(5):
+        result = await run_input_required_driver(first, dispatch=dispatch, retry=retry, max_rounds=5)
+
+    assert result is terminal
+    assert dispatched_keys == ["a", "b"]
+    assert retried == snapshot(
+        [
+            ({"a": ElicitResult(action="decline")}, None),
+            ({"b": ElicitResult(action="decline")}, None),
+        ]
+    )
+
+
+async def test_exceeding_max_rounds_raises_with_the_configured_cap() -> None:
+    """When every retry returns another `InputRequiredResult`, the driver gives
+    up after `max_rounds` retries with `InputRequiredRoundsExceededError`."""
+    rounds: list[int] = []
+
+    async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+        return ElicitResult(action="decline")
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        rounds.append(len(rounds))
+        return InputRequiredResult(input_requests={"again": _elicit()})
+
+    first = InputRequiredResult(input_requests={"again": _elicit()})
+    with anyio.fail_after(5):
+        with pytest.raises(InputRequiredRoundsExceededError) as exc:
+            await run_input_required_driver(first, dispatch=dispatch, retry=retry, max_rounds=3)
+
+    assert exc.value.max_rounds == 3
+    # `first` counts as round 1; rounds 1-3 each retry, round 4 trips the cap before dispatching.
+    assert len(rounds) == 3
+
+
+async def test_dispatch_returning_error_data_aborts_the_loop_as_mcp_error() -> None:
+    """SDK-defined: a callback that refuses an embedded request returns
+    `ErrorData`; the driver surfaces it as `MCPError` rather than retrying."""
+
+    async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+        return ErrorData(code=INVALID_REQUEST, message="not supported")
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        raise NotImplementedError  # unreachable: dispatch errored before any retry
+
+    first = InputRequiredResult(input_requests={"ask": _elicit()})
+    with anyio.fail_after(5):
+        with pytest.raises(MCPError) as exc:
+            await run_input_required_driver(first, dispatch=dispatch, retry=retry, max_rounds=3)
+    assert exc.value.error.code == INVALID_REQUEST
+
+
+async def test_request_state_passes_through_byte_identical() -> None:
+    """`request_state` is opaque to the driver: each leg's value reaches `retry`
+    as the same object the server sent, never parsed or rebuilt."""
+    states = ['{"round": 1, "tag": "héllo"}', '{"round": 2, "tag": "wörld"}']
+    received_states: list[str | None] = []
+
+    async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+        return ElicitResult(action="decline")
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        received_states.append(state)
+        if len(received_states) < 2:
+            return InputRequiredResult(input_requests={"k": _elicit()}, request_state=states[1])
+        return CallToolResult(content=[])
+
+    first = InputRequiredResult(input_requests={"k": _elicit()}, request_state=states[0])
+    with anyio.fail_after(5):
+        await run_input_required_driver(first, dispatch=dispatch, retry=retry, max_rounds=3)
+
+    assert received_states[0] is states[0]
+    assert received_states[1] is states[1]
+
+
+# Runs on trio's autojumping virtual clock so the backoff sleeps add zero
+# wall-clock and the recorded deltas are exact: `anyio.sleep` advances the
+# MockClock by precisely the requested duration once every task is idle.
+@pytest.mark.parametrize(
+    "anyio_backend",
+    [pytest.param(("trio", {"clock": MockClock(autojump_threshold=0)}), id="trio-mockclock")],
+)
+async def test_state_only_legs_back_off_exponentially_to_the_cap() -> None:
+    """SDK-defined pacing: state-only legs sleep 50ms, 100ms, 200ms, then cap at
+    250ms. Six state-only rounds → deltas `[0.05, 0.1, 0.2, 0.25, 0.25, 0.25]`."""
+    retry_times: list[float] = []
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        retry_times.append(anyio.current_time())
+        assert responses is None
+        if len(retry_times) == 6:
+            return CallToolResult(content=[])
+        return InputRequiredResult(request_state="poll")
+
+    start = anyio.current_time()
+    first = InputRequiredResult(request_state="poll")
+    await run_input_required_driver(first, dispatch=_never_dispatch, retry=retry, max_rounds=10)
+
+    deltas = [round(retry_times[0] - start, 9)] + [
+        round(retry_times[i] - retry_times[i - 1], 9) for i in range(1, len(retry_times))
+    ]
+    assert deltas == snapshot([0.05, 0.1, 0.2, 0.25, 0.25, 0.25])
+    assert _STATE_ONLY_BACKOFF_INITIAL_SECONDS == 0.05
+    assert _STATE_ONLY_BACKOFF_CAP_SECONDS == 0.25
+
+
+@pytest.mark.parametrize(
+    "anyio_backend",
+    [pytest.param(("trio", {"clock": MockClock(autojump_threshold=0)}), id="trio-mockclock")],
+)
+async def test_backoff_counter_resets_after_a_leg_with_input_requests() -> None:
+    """A leg carrying `input_requests` resets `consecutive_state_only`: the
+    next state-only leg sleeps the initial 50ms again, not the prior position."""
+    # state-only, state-only, dispatch leg (no sleep), state-only, terminal.
+    script: list[CallToolResult | InputRequiredResult] = [
+        InputRequiredResult(request_state="s"),
+        InputRequiredResult(input_requests={"k": _elicit()}),
+        InputRequiredResult(request_state="s"),
+        CallToolResult(content=[]),
+    ]
+    retry_times: list[float] = []
+
+    async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+        return ElicitResult(action="decline")
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        retry_times.append(anyio.current_time())
+        return script.pop(0)
+
+    start = anyio.current_time()
+    first = InputRequiredResult(request_state="s")
+    await run_input_required_driver(first, dispatch=dispatch, retry=retry, max_rounds=10)
+
+    deltas = [round(retry_times[0] - start, 9)] + [
+        round(retry_times[i] - retry_times[i - 1], 9) for i in range(1, len(retry_times))
+    ]
+    # 0.05, 0.1 (two state-only), 0.0 (dispatch leg has no sleep), 0.05 (reset).
+    assert deltas == snapshot([0.05, 0.1, 0.0, 0.05])
+
+
+async def test_input_requests_are_dispatched_concurrently() -> None:
+    """All `input_requests` in a round are dispatched together: each dispatch
+    blocks on a shared gate that only opens once every key has started, so a
+    sequential implementation would deadlock under the `fail_after`."""
+    keys = ["a", "b", "c"]
+    started: set[str] = set()
+    all_started = anyio.Event()
+
+    async def dispatch(key: str, req: InputRequest) -> InputResponse | ErrorData:
+        started.add(key)
+        if started == set(keys):
+            all_started.set()
+        await all_started.wait()  # blocks until every sibling is in-flight
+        return ElicitResult(action="accept", content={"name": key})
+
+    received: list[InputResponses | None] = []
+
+    async def retry(responses: InputResponses | None, state: str | None) -> CallToolResult | InputRequiredResult:
+        received.append(responses)
+        return CallToolResult(content=[])
+
+    first = InputRequiredResult(input_requests={k: _elicit() for k in keys})
+    with anyio.fail_after(5):
+        await run_input_required_driver(first, dispatch=dispatch, retry=retry, max_rounds=2)
+
+    assert received[0] is not None
+    assert received[0] == {k: ElicitResult(action="accept", content={"name": k}) for k in keys}
+
+
+def test_default_max_rounds_constant() -> None:
+    """SDK-defined default; matches the typescript-sdk."""
+    assert DEFAULT_INPUT_REQUIRED_MAX_ROUNDS == 10

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -1662,7 +1662,10 @@ async def test_discover_reraises_unsupported_version_with_malformed_error_data()
 
 
 @pytest.mark.anyio
-async def test_call_tool_returns_input_required_result_when_server_requests_input() -> None:
+async def test_session_call_tool_returns_input_required_result_when_opted_in() -> None:
+    """`ClientSession.call_tool(..., allow_input_required=True)` surfaces the
+    raw `InputRequiredResult` so the caller can drive the loop manually."""
+
     # `on_call_tool` is still typed `-> CallToolResult` on this branch (#2967 widens it later);
     # `add_request_handler` is `HandlerResult`-typed and accepts `InputRequiredResult` cleanly.
     async def handler(ctx: ServerRequestContext, params: types.CallToolRequestParams) -> types.InputRequiredResult:
@@ -1672,7 +1675,7 @@ async def test_call_tool_returns_input_required_result_when_server_requests_inpu
     server.add_request_handler("tools/call", types.CallToolRequestParams, handler)
     with anyio.fail_after(5):
         async with Client(server, mode="2026-07-28") as client:
-            result = await client.call_tool("ask", allow_input_required=True)
+            result = await client.session.call_tool("ask", allow_input_required=True)
     assert isinstance(result, types.InputRequiredResult)
     assert result.request_state == "s"
 
@@ -1703,7 +1706,11 @@ async def test_call_tool_threads_input_responses_and_request_state_into_params()
 
 
 @pytest.mark.anyio
-async def test_client_call_tool_raises_on_input_required_without_opt_in() -> None:
+async def test_session_call_tool_raises_on_input_required_without_opt_in() -> None:
+    """SDK-defined: `ClientSession.call_tool` is mechanics-only; an
+    `InputRequiredResult` with the default `allow_input_required=False` raises
+    `RuntimeError` (the auto-loop policy lives on `Client`, not here)."""
+
     async def handler(ctx: ServerRequestContext, params: types.CallToolRequestParams) -> types.InputRequiredResult:
         return types.InputRequiredResult(request_state="s")
 
@@ -1711,7 +1718,45 @@ async def test_client_call_tool_raises_on_input_required_without_opt_in() -> Non
     server.add_request_handler("tools/call", types.CallToolRequestParams, handler)
     with anyio.fail_after(5):
         async with Client(server, mode="2026-07-28") as client:
-            with pytest.raises(RuntimeError):
-                await client.call_tool("t")
-            result = await client.call_tool("t", allow_input_required=True)
+            with pytest.raises(RuntimeError, match="allow_input_required=True"):
+                await client.session.call_tool("t")
+            result = await client.session.call_tool("t", allow_input_required=True)
     assert isinstance(result, types.InputRequiredResult)
+
+
+@pytest.mark.anyio
+async def test_session_get_prompt_returns_input_required_result_when_opted_in() -> None:
+    """`ClientSession.get_prompt` mirrors `call_tool`: opting in returns the
+    raw `InputRequiredResult`; the default raises `RuntimeError`."""
+
+    async def handler(ctx: ServerRequestContext, params: types.GetPromptRequestParams) -> types.InputRequiredResult:
+        return types.InputRequiredResult(request_state="prompt-state")
+
+    server = Server("test")
+    server.add_request_handler("prompts/get", types.GetPromptRequestParams, handler)
+    with anyio.fail_after(5):
+        async with Client(server, mode="2026-07-28") as client:
+            with pytest.raises(RuntimeError, match="allow_input_required=True"):
+                await client.session.get_prompt("p")
+            result = await client.session.get_prompt("p", allow_input_required=True)
+    assert isinstance(result, types.InputRequiredResult)
+    assert result.request_state == "prompt-state"
+
+
+@pytest.mark.anyio
+async def test_session_read_resource_returns_input_required_result_when_opted_in() -> None:
+    """`ClientSession.read_resource` mirrors `call_tool`: opting in returns the
+    raw `InputRequiredResult`; the default raises `RuntimeError`."""
+
+    async def handler(ctx: ServerRequestContext, params: types.ReadResourceRequestParams) -> types.InputRequiredResult:
+        return types.InputRequiredResult(request_state="resource-state")
+
+    server = Server("test")
+    server.add_request_handler("resources/read", types.ReadResourceRequestParams, handler)
+    with anyio.fail_after(5):
+        async with Client(server, mode="2026-07-28") as client:
+            with pytest.raises(RuntimeError, match="allow_input_required=True"):
+                await client.session.read_resource("memory://r")
+            result = await client.session.read_resource("memory://r", allow_input_required=True)
+    assert isinstance(result, types.InputRequiredResult)
+    assert result.request_state == "resource-state"

--- a/tests/docs_src/test_mrtr.py
+++ b/tests/docs_src/test_mrtr.py
@@ -4,6 +4,7 @@ import pytest
 from inline_snapshot import snapshot
 from mcp_types import (
     INTERNAL_ERROR,
+    INVALID_REQUEST,
     CallToolResult,
     CreateMessageRequest,
     CreateMessageRequestParams,
@@ -14,7 +15,7 @@ from mcp_types import (
     TextContent,
 )
 
-from docs_src.mrtr import tutorial001, tutorial002
+from docs_src.mrtr import tutorial001, tutorial002, tutorial003
 from mcp import Client, MCPError
 
 # See test_index.py for why this is a per-module mark and not a conftest hook.
@@ -24,7 +25,7 @@ pytestmark = [pytest.mark.anyio, pytest.mark.filterwarnings("error::mcp.MCPDepre
 async def test_first_call_returns_an_input_required_result() -> None:
     """tutorial001: a tool that is missing input returns `InputRequiredResult` instead of calling back."""
     async with Client(tutorial001.server) as client:
-        result = await client.call_tool("provision", {"name": "orders"}, allow_input_required=True)
+        result = await client.session.call_tool("provision", {"name": "orders"}, allow_input_required=True)
         assert result == snapshot(
             InputRequiredResult(
                 result_type="input_required",
@@ -47,15 +48,22 @@ async def test_first_call_returns_an_input_required_result() -> None:
         )
 
 
-async def test_call_tool_raises_without_the_opt_in() -> None:
-    """The page's `!!! check`: `allow_input_required` defaults to `False` and the result is a hard error."""
+async def test_the_auto_loop_drives_the_call_to_completion() -> None:
+    """tutorial003: register `elicitation_callback`, call the tool, get a plain `CallToolResult` back."""
+    async with Client(tutorial001.server, elicitation_callback=tutorial003.handle_elicitation) as client:
+        result = await client.call_tool("provision", {"name": "orders"})
+        assert result == snapshot(
+            CallToolResult(content=[TextContent(type="text", text="Provisioned 'orders' in eu-west-1.")])
+        )
+
+
+async def test_the_auto_loop_without_a_callback_raises_mcp_error() -> None:
+    """The page's `!!! check`: no `elicitation_callback` means the SDK's stand-in answers with an error."""
     async with Client(tutorial001.server) as client:
-        with pytest.raises(RuntimeError) as exc:
+        with pytest.raises(MCPError) as exc:
             await client.call_tool("provision", {"name": "orders"})
-    assert str(exc.value) == (
-        "Server returned InputRequiredResult; pass allow_input_required=True to receive it "
-        "and retry call_tool(..., input_responses=..., request_state=result.request_state)."
-    )
+    assert exc.value.error.code == INVALID_REQUEST
+    assert exc.value.error.message == "Elicitation not supported"
 
 
 async def test_retry_with_input_responses_and_request_state_completes_the_call() -> None:
@@ -73,7 +81,7 @@ async def test_retry_with_input_responses_and_request_state_completes_the_call()
 
 
 async def test_the_manual_loop_drives_the_call_to_completion() -> None:
-    """tutorial002: `while isinstance(result, InputRequiredResult)` is the whole client API, and it terminates."""
+    """tutorial002: `client.session.call_tool(..., allow_input_required=True)` for callers who own the loop."""
     async with Client(tutorial001.server) as client:
         result = await tutorial002.provision(client, "billing")
         assert result == snapshot(
@@ -91,7 +99,7 @@ async def test_a_pre_2026_session_has_nowhere_to_put_the_result() -> None:
     """The page's `!!! warning`: on a legacy session the runner cannot serialize an `InputRequiredResult`."""
     async with Client(tutorial001.server, mode="legacy") as client:
         with pytest.raises(MCPError) as exc:
-            await client.call_tool("provision", {"name": "orders"}, allow_input_required=True)
+            await client.call_tool("provision", {"name": "orders"})
     assert exc.value.error.code == INTERNAL_ERROR
     assert exc.value.error.message == "Handler returned an invalid result"
 

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1588,7 +1588,7 @@ async def test_tool_returning_input_required_result_reaches_client_unchanged():
 
     with anyio.fail_after(5):
         async with Client(mcp, mode="2026-07-28") as client:
-            result = await client.call_tool("ask", allow_input_required=True)
+            result = await client.session.call_tool("ask", allow_input_required=True)
 
     assert isinstance(result, InputRequiredResult)
     assert result.request_state == "round-1"
@@ -1624,11 +1624,11 @@ async def test_tool_reads_input_responses_and_request_state_from_context_on_retr
 
     with anyio.fail_after(5):
         async with Client(mcp, mode="2026-07-28") as client:
-            r1 = await client.call_tool("greet", allow_input_required=True)
+            r1 = await client.session.call_tool("greet", allow_input_required=True)
             assert isinstance(r1, InputRequiredResult)
             assert r1.input_requests is not None and "who" in r1.input_requests
 
-            r2 = await client.call_tool(
+            r2 = await client.session.call_tool(
                 "greet",
                 input_responses={"who": ElicitResult(action="accept", content={"name": "Alice"})},
                 request_state=r1.request_state,

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -444,5 +444,6 @@ def test_input_required_result_dumps_its_discriminating_tag():
 def test_input_required_result_requires_at_least_one_of_input_requests_or_request_state():
     with pytest.raises(ValidationError):
         InputRequiredResult()
-    assert InputRequiredResult(input_requests={}).request_state is None
+    with pytest.raises(ValidationError):
+        InputRequiredResult(input_requests={})
     assert InputRequiredResult(request_state="s").input_requests is None


### PR DESCRIPTION
`Client.call_tool` / `get_prompt` / `read_resource` now resolve `InputRequiredResult` automatically: each entry in `input_requests` is dispatched to the same `sampling_callback` / `elicitation_callback` / `list_roots_callback` that already serve legacy server-to-client RPCs, the responses are collected, and the call is retried with `input_responses` + the echoed `request_state` until a terminal result arrives. `allow_input_required` is removed from `Client`; for manual control (inspecting rounds, persisting `request_state` across processes) use `client.session.call_tool(..., allow_input_required=True)` which still returns the raw union.

## Motivation and Context

Client half of SEP-2322 / #2898. The server side and the manual `ClientSession` surface landed in #2974; this adds the policy-layer driver so a high-level `Client` user never sees `InputRequiredResult` directly.

## Shape

- **`client/_input_required.py`** (new): pure, method-agnostic driver. `run_input_required_driver(first, *, dispatch, retry, max_rounds)` loops until non-IIR. Concurrent dispatch via `anyio.create_task_group()`. State-only legs (server returned `request_state` with no `input_requests`) back off exponentially: 50ms doubling to a 250ms cap, counter reset by any leg with input requests. `request_state` is a byte-exact `str | None` pass-through, never inspected. `max_rounds` default 10 (matches typescript-sdk; csharp/go use the same constant). `InputRequiredRoundsExceededError` on cap; `MCPError` when a callback returns `ErrorData`.
- **`ClientSession._dispatch_input_request`**: extracted from the existing `_on_request` match-case so the legacy RPC path and the driver share one dispatch table. `ClientRequestContext.request_id` carries the `input_requests` key (a `str`, fits the existing `RequestId = str | int`).
- **`ClientSession.get_prompt` / `read_resource`**: gain the same `input_responses` / `request_state` / `allow_input_required` overload set that `call_tool` already has, with union `TypeAdapter`s alongside `_CallToolResultAdapter`.
- **`Client`**: `input_required_max_rounds: int = 10` dataclass field; shared `_drive_input_required` helper; `call_tool` / `get_prompt` / `read_resource` collapse to one signature returning the bare result type.

Also: `examples/stories/mrtr/` promoted from deferred stub; `docs/advanced/multi-round-trip.md` + `docs_src/mrtr/tutorial003.py` rewritten; conformance fixture `sep-2322-client-request-state` rewritten to drive the same five wire-shape checks via the auto-loop with a registered `elicitation_callback`.

## How Has This Been Tested?

- 9 driver unit tests in `tests/client/test_input_required.py` (single/multi-round, max-rounds cap, ErrorData raises, byte-exact `request_state`, backoff sequence, concurrent dispatch with event-gate, state-only counter reset).
- 7 integration tests in `tests/client/test_client.py` against in-memory `MCPServer` (all three callback types, multi-round with evolving state, no-callback-registered raises, `get_prompt`/`read_resource` happy path).
- `tests/client/test_session.py` covers the widened `get_prompt`/`read_resource`.
- `tests/docs_src/test_mrtr.py` exercises the new tutorial.
- Conformance `sep-2322-client-request-state` (CI).

## Breaking Changes

Alpha-only API removal: `Client.call_tool` / `get_prompt` / `read_resource` no longer accept `allow_input_required`. Use `client.session.<method>(..., allow_input_required=True)` for the manual surface. Noted in `docs/migration.md`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Open for review:

- `ClientSessionGroup.call_tool` is left at the mechanics layer (still forwards `allow_input_required`).
- `read_timeout_seconds` applies per round, not to the whole loop.
- No conformance scenario exercises the auto-loop's input-gathering directly; the existing scenario only checks wire shapes (which the auto-loop produces correctly). Worth a conformance-repo issue.

Part of #2898.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
