### PR TITLE
Pin conformance harness to main@b18aa918 (merge of #371) via pkg.pr.new

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,13 +21,14 @@ env:
   #
   # Temporarily pinned to the pkg.pr.new preview build of conformance#371, which
   # fixes the http-custom-headers fixture's spec-forbidden `number`-typed
-  # x-mcp-header annotations. Because this is a mutable URL (not a registry
-  # spec), CONFORMANCE_PKG_SHA256 pins the tarball and the fetch-and-verify step
-  # below downloads, checks the digest, and repoints CONFORMANCE_PKG at the
-  # verified local copy. Repin to the published release that includes #371 once
-  # it ships, then drop CONFORMANCE_PKG_SHA256 and the fetch-and-verify steps.
-  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@371"
-  CONFORMANCE_PKG_SHA256: "9d8b25874d55e304b006cbaa066571773582f5828143c53a2b8a6830f203ca1d"
+  # x-mcp-header annotations. Pinned by commit SHA (not PR number) so a new push
+  # to #371 cannot silently change the tarball; CONFORMANCE_PKG_SHA256 then pins
+  # the bytes and the fetch-and-verify step below downloads, checks the digest,
+  # and repoints CONFORMANCE_PKG at the verified local copy. Repin to the
+  # published release that includes #371 once it ships, then drop
+  # CONFORMANCE_PKG_SHA256 and the fetch-and-verify steps.
+  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@ed314a73"
+  CONFORMANCE_PKG_SHA256: "e9f6bc25085b4692e988cbdbd024a4203d54a52a6aaa065376cf8ecaa09bb680"
 
 jobs:
   server-conformance:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,15 +19,16 @@ env:
   # Bump deliberately and reconcile both
   # .github/actions/conformance/expected-failures*.yml files in the same change.
   #
-  # Temporarily pinned to the pkg.pr.new preview build of conformance#371, which
-  # fixes the http-custom-headers fixture's spec-forbidden `number`-typed
-  # x-mcp-header annotations. Pinned by commit SHA (not PR number) so a new push
-  # to #371 cannot silently change the tarball; CONFORMANCE_PKG_SHA256 then pins
-  # the bytes and the fetch-and-verify step below downloads, checks the digest,
-  # and repoints CONFORMANCE_PKG at the verified local copy. Repin to the
-  # published release that includes #371 once it ships, then drop
+  # Temporarily pinned to the pkg.pr.new build of conformance main@b18aa918
+  # (the merge of #371, which fixes the http-custom-headers fixture's
+  # spec-forbidden `number`-typed x-mcp-header annotations) — no published
+  # release includes it yet. Pinned by commit SHA so the tarball cannot move
+  # under us; CONFORMANCE_PKG_SHA256 pins the bytes and the fetch-and-verify
+  # step below downloads, checks the digest, and repoints CONFORMANCE_PKG at the
+  # verified local copy. Repin to the next published @modelcontextprotocol/
+  # conformance release (>0.2.0-alpha.7) once it ships, then drop
   # CONFORMANCE_PKG_SHA256 and the fetch-and-verify steps.
-  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@ed314a73"
+  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@b18aa918"
   CONFORMANCE_PKG_SHA256: "e9f6bc25085b4692e988cbdbd024a4203d54a52a6aaa065376cf8ecaa09bb680"
 
 jobs:


### PR DESCRIPTION
A second commit landed on modelcontextprotocol/conformance#371, which caused pkg.pr.new to rebuild the `@371` tarball; the new bytes no longer matched `CONFORMANCE_PKG_SHA256`, so the fetch-and-verify step started failing on every conformance run. #371 has since merged to conformance main as `b18aa918`.

## Motivation and Context
Re-pin to the per-commit pkg.pr.new build of `b18aa918` (the merge commit on conformance main) and bump `CONFORMANCE_PKG_SHA256` to match. No published `@modelcontextprotocol/conformance` release includes #371 yet — `0.2.0-alpha.7` was cut the day before the merge — so the pkg.pr.new + SHA256-verify machinery stays for now. Once the next release ships, we'll repin to the registry version and drop the fetch-and-verify steps (per the comment in the workflow).

## How Has This Been Tested?
Downloaded `https://pkg.pr.new/@modelcontextprotocol/conformance@b18aa918` and verified its SHA256 is `e9f6bc25085b4692e988cbdbd024a4203d54a52a6aaa065376cf8ecaa09bb680`. The conformance workflow on this branch will confirm.

## Breaking Changes
None — CI config only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
The first commit on this branch pinned to the PR-branch commit `ed314a73`; the second retargets to the merge commit on main (same tarball bytes, but durable against PR-branch deletion).

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>