### PR TITLE
Preserve userinfo case in resource URLs

### DIFF
--- a/src/mcp/shared/auth_utils.py
+++ b/src/mcp/shared/auth_utils.py
@@ -6,6 +6,19 @@ from urllib.parse import urlparse, urlsplit, urlunsplit
 from pydantic import AnyUrl, HttpUrl
 
 
+def _lowercase_host(netloc: str) -> str:
+    userinfo, separator, hostport = netloc.rpartition("@")
+    prefix = f"{userinfo}{separator}" if separator else ""
+
+    if hostport.startswith("["):
+        end = hostport.find("]")
+        if end != -1:
+            return f"{prefix}{hostport[: end + 1].lower()}{hostport[end + 1 :]}"
+
+    host, separator, port = hostport.partition(":")
+    return f"{prefix}{host.lower()}{separator}{port}"
+
+
 def resource_url_from_server_url(url: str | HttpUrl | AnyUrl) -> str:
     """Convert server URL to canonical resource URL per RFC 8707.
 
@@ -23,7 +36,13 @@ def resource_url_from_server_url(url: str | HttpUrl | AnyUrl) -> str:
 
     # Parse the URL and remove fragment, create canonical form
     parsed = urlsplit(url_str)
-    canonical = urlunsplit(parsed._replace(scheme=parsed.scheme.lower(), netloc=parsed.netloc.lower(), fragment=""))
+    canonical = urlunsplit(
+        parsed._replace(
+            scheme=parsed.scheme.lower(),
+            netloc=_lowercase_host(parsed.netloc),
+            fragment="",
+        )
+    )
 
     return canonical
 

--- a/tests/shared/test_auth_utils.py
+++ b/tests/shared/test_auth_utils.py
@@ -40,6 +40,14 @@ def test_resource_url_from_server_url_lowercase_scheme_and_host():
     assert resource_url_from_server_url("Http://Example.Com:8080/") == "http://example.com:8080/"
 
 
+def test_resource_url_from_server_url_preserves_userinfo_case():
+    """Only the scheme and host are canonicalized; userinfo is preserved byte-for-byte."""
+    assert (
+        resource_url_from_server_url("HTTPS://User:PaSs@EXAMPLE.COM/path#fragment")
+        == "https://User:PaSs@example.com/path"
+    )
+
+
 def test_resource_url_from_server_url_handles_pydantic_urls():
     """Should handle Pydantic URL types."""
     url = HttpUrl("https://example.com/path")


### PR DESCRIPTION
## What changed

`resource_url_from_server_url()` now lowercases only the scheme and host when canonicalizing an RFC 8707 resource URL, while preserving userinfo and port and still removing fragments.

## Why

The docstring says the function lowercases the scheme/host. The previous implementation lowercased the whole `netloc`, so `HTTPS://User:PaSs@EXAMPLE.COM/path#fragment` became `https://user:pass@example.com/path`. Userinfo is part of the URI authority and can be case-sensitive, so host canonicalization should not alter it.

## Validation

- `uv run --frozen pytest tests/shared/test_auth_utils.py::test_resource_url_from_server_url_preserves_userinfo_case -q` -> 1 passed
- `uv run --frozen pytest tests/shared/test_auth_utils.py -q` -> 16 passed
- `uv run --frozen ruff check src/mcp/shared/auth_utils.py tests/shared/test_auth_utils.py`
- `uv run --frozen pyright src/mcp/shared/auth_utils.py tests/shared/test_auth_utils.py`
- `git diff --check -- src/mcp/shared/auth_utils.py tests/shared/test_auth_utils.py`

I also attempted the full `./scripts/test` flow. `sh` is not available on this Windows host, so I ran the script's commands in PowerShell. The full run hit unrelated existing Windows/snapshot tooling failures in `tests/interaction/lowlevel/test_elicitation.py` (`ElicitRequest...` snapshot expecting `_meta` while the model exposes `meta`) and a later `coverage json` temp-config read error. The targeted checks for this change pass.