### PR TITLE
Add list_all_* helpers that drain pagination on the client

### DIFF
--- a/docs/advanced/pagination.md
+++ b/docs/advanced/pagination.md
@@ -62,7 +62,7 @@ That loop is the same one in every client that pages, so `Client` ships it. The 
 * `iter_all_resources()` yields one resource at a time and only fetches the next page when you ask for it, so you can stop early without dragging down the whole catalog. Same four: `iter_all_tools`, `iter_all_prompts`, and so on.
 * The single-page `list_*` methods are unchanged. Use them when you want one page and the cursor; use the drains when you want everything and don't want to own the loop.
 
-`ClientSessionGroup` aggregation drains the same way, so a group fronting several servers reports the full collection instead of each server's first page. That aggregator is **[Session groups](session-groups.md)**.
+`ClientSessionGroup` aggregation drains the same way, so a group fronting several servers reports the full collection instead of each server's first page. That aggregator is **[Session groups](../client/session-groups.md)**.
 
 !!! warning
     A drain trusts the server to advance the cursor. A server that keeps returning the same

--- a/docs/advanced/pagination.md
+++ b/docs/advanced/pagination.md
@@ -65,10 +65,11 @@ That loop is the same one in every client that pages, so `Client` ships it. The 
 `ClientSessionGroup` aggregation drains the same way, so a group fronting several servers reports the full collection instead of each server's first page. That aggregator is **[Session groups](../client/session-groups.md)**.
 
 !!! warning
-    A drain trusts the server to advance the cursor. A server that keeps returning the same
-    `next_cursor` it was handed would page forever, so the drains stop and raise `RuntimeError`
-    the moment a cursor fails to move. A page that does not advance is a broken server, and a
-    loud failure beats a silent hang or a half-read list.
+    A drain trusts the server to advance the cursor. A server that echoes back the
+    `next_cursor` it was handed, or cycles through a longer loop of them, would page forever,
+    so the drains remember every cursor they have seen and raise `RuntimeError` the moment one
+    repeats. A repeated cursor is a broken server, and a loud failure beats a silent hang or a
+    half-read list.
 
 ## The three rules
 

--- a/docs/advanced/pagination.md
+++ b/docs/advanced/pagination.md
@@ -50,6 +50,26 @@ Run its `main()` and it prints `100 resources`: ten pages of ten, stitched toget
 
 This is the same loop **[The Client](../client/index.md)** shows for every `list_*` verb, and it costs nothing against a server that doesn't page: `next_cursor` is `None` on the first response and the loop runs once.
 
+## Draining in one call
+
+That loop is the same one in every client that pages, so `Client` ships it. The server here is the bookshop from before; only the client changed:
+
+```python title="client.py" hl_lines="27 31"
+--8<-- "docs_src/pagination/tutorial003.py"
+```
+
+* `list_all_resources()` walks `next_cursor` for you and hands back every page stitched into one list. There is one per pageable list: `list_all_tools`, `list_all_prompts`, `list_all_resources`, `list_all_resource_templates`.
+* `iter_all_resources()` yields one resource at a time and only fetches the next page when you ask for it, so you can stop early without dragging down the whole catalog. Same four: `iter_all_tools`, `iter_all_prompts`, and so on.
+* The single-page `list_*` methods are unchanged. Use them when you want one page and the cursor; use the drains when you want everything and don't want to own the loop.
+
+`ClientSessionGroup` aggregation drains the same way, so a group fronting several servers reports the full collection instead of each server's first page. That aggregator is **[Session groups](session-groups.md)**.
+
+!!! warning
+    A drain trusts the server to advance the cursor. A server that keeps returning the same
+    `next_cursor` it was handed would page forever, so the drains stop and raise `RuntimeError`
+    the moment a cursor fails to move. A page that does not advance is a broken server, and a
+    loud failure beats a silent hang or a half-read list.
+
 ## The three rules
 
 **Cursors are opaque.** A client must never parse, build, or guess one. The only legal source of a cursor is the previous page's `next_cursor`, verbatim.

--- a/docs/advanced/pagination.md
+++ b/docs/advanced/pagination.md
@@ -71,6 +71,27 @@ That loop is the same one in every client that pages, so `Client` ships it. The 
     repeats. A repeated cursor is a broken server, and a loud failure beats a silent hang or a
     half-read list.
 
+### Drains and the response cache
+
+A server may attach a `ttlMs` freshness hint to a list result (**[Caching](../client/caching.md)**), and the
+client will serve a later `list_*` call for that method from cache instead of going back to the
+server. Only the first page is ever cached; a call carrying a cursor always goes to the wire.
+
+That split matters for a drain. If it started from a cached first page, it would take that
+page's `next_cursor` — minted against a listing that may since have changed — and pair it with
+freshly fetched later pages, returning a stitched-together listing the server never served. So
+the drains default to `cache_mode="refresh"`: the first page is re-fetched, and the fresh copy
+is written back to the cache for later single-page callers.
+
+```python
+async def list_the_tools(client: Client) -> None:
+    fresh = await client.list_all_tools()  # re-fetches the first page: always current
+    saved = await client.list_all_tools(cache_mode="use")  # one fewer request, may be stale
+```
+
+Pass `cache_mode="use"` when you would rather have the saved copy than the current one. The
+single-page `list_*` methods still default to `"use"`, unchanged.
+
 ## The three rules
 
 **Cursors are opaque.** A client must never parse, build, or guess one. The only legal source of a cursor is the previous page's `next_cursor`, verbatim.

--- a/docs_src/pagination/tutorial003.py
+++ b/docs_src/pagination/tutorial003.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from mcp_types import ListResourcesResult, PaginatedRequestParams, Resource
+
+from mcp import Client
+from mcp.server import Server, ServerRequestContext
+
+BOOKS = [f"book-{n}" for n in range(1, 101)]
+
+PAGE_SIZE = 10
+
+
+async def list_books(ctx: ServerRequestContext[Any], params: PaginatedRequestParams | None) -> ListResourcesResult:
+    start = 0 if params is None or params.cursor is None else int(params.cursor)
+    end = start + PAGE_SIZE
+    page = [Resource(uri=f"books://catalog/{name}", name=name) for name in BOOKS[start:end]]
+    next_cursor = str(end) if end < len(BOOKS) else None
+    return ListResourcesResult(resources=page, next_cursor=next_cursor)
+
+
+server = Server("Bookshop", on_list_resources=list_books)
+
+
+async def main() -> None:
+    async with Client(server) as client:
+        # Every page, stitched into one list.
+        resources = await client.list_all_resources()
+        print(f"{len(resources)} resources")
+
+        # Or stream them, and stop as soon as you have what you need.
+        async for resource in client.iter_all_resources():
+            print(f"first: {resource.name}")
+            break

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -955,8 +955,10 @@ class Client:
         materializing the full list in memory.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_tools(cursor=cursor, meta=meta)
@@ -964,10 +966,9 @@ class Client:
                 yield tool
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_tools(self, *, meta: RequestParamsMeta | None = None) -> list[Tool]:
@@ -978,7 +979,8 @@ class Client:
         list.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [tool async for tool in self.iter_all_tools(meta=meta)]
 
@@ -986,8 +988,10 @@ class Client:
         """Yield every prompt from the server, paging through `next_cursor`.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_prompts(cursor=cursor, meta=meta)
@@ -995,17 +999,17 @@ class Client:
                 yield prompt
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> list[Prompt]:
         """List every prompt from the server, draining `next_cursor` across pages.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [prompt async for prompt in self.iter_all_prompts(meta=meta)]
 
@@ -1013,8 +1017,10 @@ class Client:
         """Yield every resource from the server, paging through `next_cursor`.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_resources(cursor=cursor, meta=meta)
@@ -1022,17 +1028,17 @@ class Client:
                 yield resource
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_resources(self, *, meta: RequestParamsMeta | None = None) -> list[Resource]:
         """List every resource from the server, draining `next_cursor` across pages.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [resource async for resource in self.iter_all_resources(meta=meta)]
 
@@ -1042,8 +1048,10 @@ class Client:
         """Yield every resource template from the server, paging through `next_cursor`.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_resource_templates(cursor=cursor, meta=meta)
@@ -1051,17 +1059,17 @@ class Client:
                 yield template
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_resource_templates(self, *, meta: RequestParamsMeta | None = None) -> list[ResourceTemplate]:
         """List every resource template from the server, draining `next_cursor` across pages.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [template async for template in self.iter_all_resource_templates(meta=meta)]
 

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -953,6 +953,9 @@ class Client:
 
         Useful for streaming consumers that want to process tools without
         materializing the full list in memory.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
         """
         cursor: str | None = None
         while True:
@@ -961,6 +964,10 @@ class Client:
                 yield tool
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_tools(self, *, meta: RequestParamsMeta | None = None) -> list[Tool]:
@@ -969,11 +976,18 @@ class Client:
         Unlike `list_tools`, which returns one page, this walks pagination
         until the server reports no further pages and returns the combined
         list.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
         """
         return [tool async for tool in self.iter_all_tools(meta=meta)]
 
     async def iter_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Prompt]:
-        """Yield every prompt from the server, paging through `next_cursor`."""
+        """Yield every prompt from the server, paging through `next_cursor`.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         cursor: str | None = None
         while True:
             result = await self.list_prompts(cursor=cursor, meta=meta)
@@ -981,14 +995,26 @@ class Client:
                 yield prompt
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> list[Prompt]:
-        """List every prompt from the server, draining `next_cursor` across pages."""
+        """List every prompt from the server, draining `next_cursor` across pages.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         return [prompt async for prompt in self.iter_all_prompts(meta=meta)]
 
     async def iter_all_resources(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Resource]:
-        """Yield every resource from the server, paging through `next_cursor`."""
+        """Yield every resource from the server, paging through `next_cursor`.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         cursor: str | None = None
         while True:
             result = await self.list_resources(cursor=cursor, meta=meta)
@@ -996,16 +1022,28 @@ class Client:
                 yield resource
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_resources(self, *, meta: RequestParamsMeta | None = None) -> list[Resource]:
-        """List every resource from the server, draining `next_cursor` across pages."""
+        """List every resource from the server, draining `next_cursor` across pages.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         return [resource async for resource in self.iter_all_resources(meta=meta)]
 
     async def iter_all_resource_templates(
         self, *, meta: RequestParamsMeta | None = None
     ) -> AsyncIterator[ResourceTemplate]:
-        """Yield every resource template from the server, paging through `next_cursor`."""
+        """Yield every resource template from the server, paging through `next_cursor`.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         cursor: str | None = None
         while True:
             result = await self.list_resource_templates(cursor=cursor, meta=meta)
@@ -1013,10 +1051,18 @@ class Client:
                 yield template
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_resource_templates(self, *, meta: RequestParamsMeta | None = None) -> list[ResourceTemplate]:
-        """List every resource template from the server, draining `next_cursor` across pages."""
+        """List every resource template from the server, draining `next_cursor` across pages.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         return [template async for template in self.iter_all_resource_templates(meta=meta)]
 
     @deprecated("The roots capability is deprecated as of 2026-07-28 (SEP-2577).", category=MCPDeprecationWarning)

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import uuid
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack
 from dataclasses import KW_ONLY, dataclass, field
 from typing import Any, Literal, TypeVar, cast
@@ -32,12 +32,16 @@ from mcp_types import (
     ListToolsResult,
     LoggingLevel,
     PaginatedRequestParams,
+    Prompt,
     PromptReference,
     ReadResourceResult,
     RequestParamsMeta,
+    Resource,
+    ResourceTemplate,
     ResourceTemplateReference,
     Result,
     ServerCapabilities,
+    Tool,
 )
 from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
 from typing_extensions import deprecated
@@ -580,7 +584,11 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListResourcesResult:
-        """List available resources from the server."""
+        """List a single page of available resources from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_resources` to drain every page.
+        """
         return await self._cached_fetch(
             "resources/list",
             cursor=cursor,
@@ -596,7 +604,12 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListResourceTemplatesResult:
-        """List available resource templates from the server."""
+        """List a single page of available resource templates from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_resource_templates` to drain every
+        page.
+        """
         return await self._cached_fetch(
             "resources/templates/list",
             cursor=cursor,
@@ -814,7 +827,11 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListPromptsResult:
-        """List available prompts from the server."""
+        """List a single page of available prompts from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_prompts` to drain every page.
+        """
         return await self._cached_fetch(
             "prompts/list",
             cursor=cursor,
@@ -912,7 +929,11 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListToolsResult:
-        """List available tools from the server."""
+        """List a single page of available tools from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_tools` to drain every page.
+        """
         return await self._cached_fetch(
             "tools/list",
             cursor=cursor,
@@ -926,6 +947,77 @@ class Client:
                 hit, complete=hit.next_cursor is None
             ),
         )
+
+    async def iter_all_tools(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Tool]:
+        """Yield every tool from the server, paging through `next_cursor`.
+
+        Useful for streaming consumers that want to process tools without
+        materializing the full list in memory.
+        """
+        cursor: str | None = None
+        while True:
+            result = await self.list_tools(cursor=cursor, meta=meta)
+            for tool in result.tools:
+                yield tool
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_tools(self, *, meta: RequestParamsMeta | None = None) -> list[Tool]:
+        """List every tool from the server, draining `next_cursor` across pages.
+
+        Unlike `list_tools`, which returns one page, this walks pagination
+        until the server reports no further pages and returns the combined
+        list.
+        """
+        return [tool async for tool in self.iter_all_tools(meta=meta)]
+
+    async def iter_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Prompt]:
+        """Yield every prompt from the server, paging through `next_cursor`."""
+        cursor: str | None = None
+        while True:
+            result = await self.list_prompts(cursor=cursor, meta=meta)
+            for prompt in result.prompts:
+                yield prompt
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> list[Prompt]:
+        """List every prompt from the server, draining `next_cursor` across pages."""
+        return [prompt async for prompt in self.iter_all_prompts(meta=meta)]
+
+    async def iter_all_resources(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Resource]:
+        """Yield every resource from the server, paging through `next_cursor`."""
+        cursor: str | None = None
+        while True:
+            result = await self.list_resources(cursor=cursor, meta=meta)
+            for resource in result.resources:
+                yield resource
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_resources(self, *, meta: RequestParamsMeta | None = None) -> list[Resource]:
+        """List every resource from the server, draining `next_cursor` across pages."""
+        return [resource async for resource in self.iter_all_resources(meta=meta)]
+
+    async def iter_all_resource_templates(
+        self, *, meta: RequestParamsMeta | None = None
+    ) -> AsyncIterator[ResourceTemplate]:
+        """Yield every resource template from the server, paging through `next_cursor`."""
+        cursor: str | None = None
+        while True:
+            result = await self.list_resource_templates(cursor=cursor, meta=meta)
+            for template in result.resource_templates:
+                yield template
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_resource_templates(self, *, meta: RequestParamsMeta | None = None) -> list[ResourceTemplate]:
+        """List every resource template from the server, draining `next_cursor` across pages."""
+        return [template async for template in self.iter_all_resource_templates(meta=meta)]
 
     @deprecated("The roots capability is deprecated as of 2026-07-28 (SEP-2577).", category=MCPDeprecationWarning)
     async def send_roots_list_changed(self) -> None:

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -964,11 +964,22 @@ class Client:
             ),
         )
 
-    async def iter_all_tools(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Tool]:
+    async def iter_all_tools(
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
+    ) -> AsyncIterator[Tool]:
         """Yield every tool from the server, paging through `next_cursor`.
 
         Useful for streaming consumers that want to process tools without
         materializing the full list in memory.
+
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see `CacheMode`).
+                Defaults to `"refresh"`, unlike the single-page `list_tools`:
+                continuation pages bypass the cache unconditionally, so a
+                cached first page would pair a stale cursor with freshly
+                fetched later pages and silently return a listing the server
+                never served. Pass `"use"` to accept a cached first page.
 
         Raises:
             RuntimeError: The server returned a pagination cursor it already
@@ -977,7 +988,7 @@ class Client:
         seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
-            result = await self.list_tools(cursor=cursor, meta=meta)
+            result = await self.list_tools(cursor=cursor, meta=meta, cache_mode=cache_mode)
             for tool in result.tools:
                 yield tool
             if result.next_cursor is None:
@@ -987,21 +998,35 @@ class Client:
             seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
-    async def list_all_tools(self, *, meta: RequestParamsMeta | None = None) -> list[Tool]:
+    async def list_all_tools(
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
+    ) -> list[Tool]:
         """List every tool from the server, draining `next_cursor` across pages.
 
         Unlike `list_tools`, which returns one page, this walks pagination
         until the server reports no further pages and returns the combined
         list.
 
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see
+                `iter_all_tools`); defaults to `"refresh"`.
+
         Raises:
             RuntimeError: The server returned a pagination cursor it already
                 returned, which would page forever.
         """
-        return [tool async for tool in self.iter_all_tools(meta=meta)]
+        return [tool async for tool in self.iter_all_tools(meta=meta, cache_mode=cache_mode)]
 
-    async def iter_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Prompt]:
+    async def iter_all_prompts(
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
+    ) -> AsyncIterator[Prompt]:
         """Yield every prompt from the server, paging through `next_cursor`.
+
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see
+                `iter_all_tools`); defaults to `"refresh"`.
 
         Raises:
             RuntimeError: The server returned a pagination cursor it already
@@ -1010,7 +1035,7 @@ class Client:
         seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
-            result = await self.list_prompts(cursor=cursor, meta=meta)
+            result = await self.list_prompts(cursor=cursor, meta=meta, cache_mode=cache_mode)
             for prompt in result.prompts:
                 yield prompt
             if result.next_cursor is None:
@@ -1020,17 +1045,31 @@ class Client:
             seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
-    async def list_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> list[Prompt]:
+    async def list_all_prompts(
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
+    ) -> list[Prompt]:
         """List every prompt from the server, draining `next_cursor` across pages.
+
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see
+                `iter_all_tools`); defaults to `"refresh"`.
 
         Raises:
             RuntimeError: The server returned a pagination cursor it already
                 returned, which would page forever.
         """
-        return [prompt async for prompt in self.iter_all_prompts(meta=meta)]
+        return [prompt async for prompt in self.iter_all_prompts(meta=meta, cache_mode=cache_mode)]
 
-    async def iter_all_resources(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Resource]:
+    async def iter_all_resources(
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
+    ) -> AsyncIterator[Resource]:
         """Yield every resource from the server, paging through `next_cursor`.
+
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see
+                `iter_all_tools`); defaults to `"refresh"`.
 
         Raises:
             RuntimeError: The server returned a pagination cursor it already
@@ -1039,7 +1078,7 @@ class Client:
         seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
-            result = await self.list_resources(cursor=cursor, meta=meta)
+            result = await self.list_resources(cursor=cursor, meta=meta, cache_mode=cache_mode)
             for resource in result.resources:
                 yield resource
             if result.next_cursor is None:
@@ -1049,19 +1088,31 @@ class Client:
             seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
-    async def list_all_resources(self, *, meta: RequestParamsMeta | None = None) -> list[Resource]:
+    async def list_all_resources(
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
+    ) -> list[Resource]:
         """List every resource from the server, draining `next_cursor` across pages.
+
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see
+                `iter_all_tools`); defaults to `"refresh"`.
 
         Raises:
             RuntimeError: The server returned a pagination cursor it already
                 returned, which would page forever.
         """
-        return [resource async for resource in self.iter_all_resources(meta=meta)]
+        return [resource async for resource in self.iter_all_resources(meta=meta, cache_mode=cache_mode)]
 
     async def iter_all_resource_templates(
-        self, *, meta: RequestParamsMeta | None = None
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
     ) -> AsyncIterator[ResourceTemplate]:
         """Yield every resource template from the server, paging through `next_cursor`.
+
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see
+                `iter_all_tools`); defaults to `"refresh"`.
 
         Raises:
             RuntimeError: The server returned a pagination cursor it already
@@ -1070,7 +1121,7 @@ class Client:
         seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
-            result = await self.list_resource_templates(cursor=cursor, meta=meta)
+            result = await self.list_resource_templates(cursor=cursor, meta=meta, cache_mode=cache_mode)
             for template in result.resource_templates:
                 yield template
             if result.next_cursor is None:
@@ -1080,14 +1131,21 @@ class Client:
             seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
-    async def list_all_resource_templates(self, *, meta: RequestParamsMeta | None = None) -> list[ResourceTemplate]:
+    async def list_all_resource_templates(
+        self, *, meta: RequestParamsMeta | None = None, cache_mode: CacheMode = "refresh"
+    ) -> list[ResourceTemplate]:
         """List every resource template from the server, draining `next_cursor` across pages.
+
+        Args:
+            meta: Additional metadata for the request.
+            cache_mode: Cache behavior for the first page (see
+                `iter_all_tools`); defaults to `"refresh"`.
 
         Raises:
             RuntimeError: The server returned a pagination cursor it already
                 returned, which would page forever.
         """
-        return [template async for template in self.iter_all_resource_templates(meta=meta)]
+        return [template async for template in self.iter_all_resource_templates(meta=meta, cache_mode=cache_mode)]
 
     @deprecated("The roots capability is deprecated as of 2026-07-28 (SEP-2577).", category=MCPDeprecationWarning)
     async def send_roots_list_changed(self) -> None:

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -971,8 +971,10 @@ class Client:
         materializing the full list in memory.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_tools(cursor=cursor, meta=meta)
@@ -980,10 +982,9 @@ class Client:
                 yield tool
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_tools(self, *, meta: RequestParamsMeta | None = None) -> list[Tool]:
@@ -994,7 +995,8 @@ class Client:
         list.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [tool async for tool in self.iter_all_tools(meta=meta)]
 
@@ -1002,8 +1004,10 @@ class Client:
         """Yield every prompt from the server, paging through `next_cursor`.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_prompts(cursor=cursor, meta=meta)
@@ -1011,17 +1015,17 @@ class Client:
                 yield prompt
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> list[Prompt]:
         """List every prompt from the server, draining `next_cursor` across pages.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [prompt async for prompt in self.iter_all_prompts(meta=meta)]
 
@@ -1029,8 +1033,10 @@ class Client:
         """Yield every resource from the server, paging through `next_cursor`.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_resources(cursor=cursor, meta=meta)
@@ -1038,17 +1044,17 @@ class Client:
                 yield resource
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_resources(self, *, meta: RequestParamsMeta | None = None) -> list[Resource]:
         """List every resource from the server, draining `next_cursor` across pages.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [resource async for resource in self.iter_all_resources(meta=meta)]
 
@@ -1058,8 +1064,10 @@ class Client:
         """Yield every resource template from the server, paging through `next_cursor`.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
+        seen_cursors: set[str] = set()
         cursor: str | None = None
         while True:
             result = await self.list_resource_templates(cursor=cursor, meta=meta)
@@ -1067,17 +1075,17 @@ class Client:
                 yield template
             if result.next_cursor is None:
                 return
-            if result.next_cursor == cursor:
-                raise RuntimeError(
-                    "Server returned a pagination cursor that did not advance; refusing to page forever."
-                )
+            if result.next_cursor in seen_cursors:
+                raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+            seen_cursors.add(result.next_cursor)
             cursor = result.next_cursor
 
     async def list_all_resource_templates(self, *, meta: RequestParamsMeta | None = None) -> list[ResourceTemplate]:
         """List every resource template from the server, draining `next_cursor` across pages.
 
         Raises:
-            RuntimeError: The server returned a pagination cursor that did not advance.
+            RuntimeError: The server returned a pagination cursor it already
+                returned, which would page forever.
         """
         return [template async for template in self.iter_all_resource_templates(meta=meta)]
 

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import uuid
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from contextlib import AbstractAsyncContextManager, AsyncExitStack
 from dataclasses import KW_ONLY, dataclass, field
 from typing import Any, Literal, TypeVar, cast
@@ -32,12 +32,16 @@ from mcp_types import (
     ListToolsResult,
     LoggingLevel,
     PaginatedRequestParams,
+    Prompt,
     PromptReference,
     ReadResourceResult,
     RequestParamsMeta,
+    Resource,
+    ResourceTemplate,
     ResourceTemplateReference,
     Result,
     ServerCapabilities,
+    Tool,
 )
 from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS, MODERN_PROTOCOL_VERSIONS
 from typing_extensions import deprecated
@@ -596,7 +600,11 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListResourcesResult:
-        """List available resources from the server."""
+        """List a single page of available resources from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_resources` to drain every page.
+        """
         return await self._cached_fetch(
             "resources/list",
             cursor=cursor,
@@ -612,7 +620,12 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListResourceTemplatesResult:
-        """List available resource templates from the server."""
+        """List a single page of available resource templates from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_resource_templates` to drain every
+        page.
+        """
         return await self._cached_fetch(
             "resources/templates/list",
             cursor=cursor,
@@ -830,7 +843,11 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListPromptsResult:
-        """List available prompts from the server."""
+        """List a single page of available prompts from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_prompts` to drain every page.
+        """
         return await self._cached_fetch(
             "prompts/list",
             cursor=cursor,
@@ -928,7 +945,11 @@ class Client:
         meta: RequestParamsMeta | None = None,
         cache_mode: CacheMode = "use",
     ) -> ListToolsResult:
-        """List available tools from the server."""
+        """List a single page of available tools from the server.
+
+        Returns one page only. The result may include a `next_cursor` if more
+        pages are available. Use `list_all_tools` to drain every page.
+        """
         return await self._cached_fetch(
             "tools/list",
             cursor=cursor,
@@ -942,6 +963,77 @@ class Client:
                 hit, complete=hit.next_cursor is None
             ),
         )
+
+    async def iter_all_tools(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Tool]:
+        """Yield every tool from the server, paging through `next_cursor`.
+
+        Useful for streaming consumers that want to process tools without
+        materializing the full list in memory.
+        """
+        cursor: str | None = None
+        while True:
+            result = await self.list_tools(cursor=cursor, meta=meta)
+            for tool in result.tools:
+                yield tool
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_tools(self, *, meta: RequestParamsMeta | None = None) -> list[Tool]:
+        """List every tool from the server, draining `next_cursor` across pages.
+
+        Unlike `list_tools`, which returns one page, this walks pagination
+        until the server reports no further pages and returns the combined
+        list.
+        """
+        return [tool async for tool in self.iter_all_tools(meta=meta)]
+
+    async def iter_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Prompt]:
+        """Yield every prompt from the server, paging through `next_cursor`."""
+        cursor: str | None = None
+        while True:
+            result = await self.list_prompts(cursor=cursor, meta=meta)
+            for prompt in result.prompts:
+                yield prompt
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> list[Prompt]:
+        """List every prompt from the server, draining `next_cursor` across pages."""
+        return [prompt async for prompt in self.iter_all_prompts(meta=meta)]
+
+    async def iter_all_resources(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Resource]:
+        """Yield every resource from the server, paging through `next_cursor`."""
+        cursor: str | None = None
+        while True:
+            result = await self.list_resources(cursor=cursor, meta=meta)
+            for resource in result.resources:
+                yield resource
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_resources(self, *, meta: RequestParamsMeta | None = None) -> list[Resource]:
+        """List every resource from the server, draining `next_cursor` across pages."""
+        return [resource async for resource in self.iter_all_resources(meta=meta)]
+
+    async def iter_all_resource_templates(
+        self, *, meta: RequestParamsMeta | None = None
+    ) -> AsyncIterator[ResourceTemplate]:
+        """Yield every resource template from the server, paging through `next_cursor`."""
+        cursor: str | None = None
+        while True:
+            result = await self.list_resource_templates(cursor=cursor, meta=meta)
+            for template in result.resource_templates:
+                yield template
+            if result.next_cursor is None:
+                return
+            cursor = result.next_cursor
+
+    async def list_all_resource_templates(self, *, meta: RequestParamsMeta | None = None) -> list[ResourceTemplate]:
+        """List every resource template from the server, draining `next_cursor` across pages."""
+        return [template async for template in self.iter_all_resource_templates(meta=meta)]
 
     @deprecated("The roots capability is deprecated as of 2026-07-28 (SEP-2577).", category=MCPDeprecationWarning)
     async def send_roots_list_changed(self) -> None:

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -969,6 +969,9 @@ class Client:
 
         Useful for streaming consumers that want to process tools without
         materializing the full list in memory.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
         """
         cursor: str | None = None
         while True:
@@ -977,6 +980,10 @@ class Client:
                 yield tool
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_tools(self, *, meta: RequestParamsMeta | None = None) -> list[Tool]:
@@ -985,11 +992,18 @@ class Client:
         Unlike `list_tools`, which returns one page, this walks pagination
         until the server reports no further pages and returns the combined
         list.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
         """
         return [tool async for tool in self.iter_all_tools(meta=meta)]
 
     async def iter_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Prompt]:
-        """Yield every prompt from the server, paging through `next_cursor`."""
+        """Yield every prompt from the server, paging through `next_cursor`.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         cursor: str | None = None
         while True:
             result = await self.list_prompts(cursor=cursor, meta=meta)
@@ -997,14 +1011,26 @@ class Client:
                 yield prompt
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_prompts(self, *, meta: RequestParamsMeta | None = None) -> list[Prompt]:
-        """List every prompt from the server, draining `next_cursor` across pages."""
+        """List every prompt from the server, draining `next_cursor` across pages.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         return [prompt async for prompt in self.iter_all_prompts(meta=meta)]
 
     async def iter_all_resources(self, *, meta: RequestParamsMeta | None = None) -> AsyncIterator[Resource]:
-        """Yield every resource from the server, paging through `next_cursor`."""
+        """Yield every resource from the server, paging through `next_cursor`.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         cursor: str | None = None
         while True:
             result = await self.list_resources(cursor=cursor, meta=meta)
@@ -1012,16 +1038,28 @@ class Client:
                 yield resource
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_resources(self, *, meta: RequestParamsMeta | None = None) -> list[Resource]:
-        """List every resource from the server, draining `next_cursor` across pages."""
+        """List every resource from the server, draining `next_cursor` across pages.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         return [resource async for resource in self.iter_all_resources(meta=meta)]
 
     async def iter_all_resource_templates(
         self, *, meta: RequestParamsMeta | None = None
     ) -> AsyncIterator[ResourceTemplate]:
-        """Yield every resource template from the server, paging through `next_cursor`."""
+        """Yield every resource template from the server, paging through `next_cursor`.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         cursor: str | None = None
         while True:
             result = await self.list_resource_templates(cursor=cursor, meta=meta)
@@ -1029,10 +1067,18 @@ class Client:
                 yield template
             if result.next_cursor is None:
                 return
+            if result.next_cursor == cursor:
+                raise RuntimeError(
+                    "Server returned a pagination cursor that did not advance; refusing to page forever."
+                )
             cursor = result.next_cursor
 
     async def list_all_resource_templates(self, *, meta: RequestParamsMeta | None = None) -> list[ResourceTemplate]:
-        """List every resource template from the server, draining `next_cursor` across pages."""
+        """List every resource template from the server, draining `next_cursor` across pages.
+
+        Raises:
+            RuntimeError: The server returned a pagination cursor that did not advance.
+        """
         return [template async for template in self.iter_all_resource_templates(meta=meta)]
 
     @deprecated("The roots capability is deprecated as of 2026-07-28 (SEP-2577).", category=MCPDeprecationWarning)

--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -8,7 +8,7 @@ This abstraction can handle naming collisions using a custom user-provided hook.
 
 import contextlib
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Any, Literal, TypeAlias, overload
@@ -65,6 +65,28 @@ class StreamableHttpParameters(BaseModel):
 
 
 ServerParameters: TypeAlias = StdioServerParameters | SseServerParameters | StreamableHttpParameters
+
+
+async def _drain_paginated(
+    fetch_page: Callable[..., Awaitable[Any]],
+    attribute: str,
+) -> list[Any]:
+    """Drain a paginated `session.list_*` call across `next_cursor` pages.
+
+    `fetch_page` is one of the ClientSession `list_*` methods that takes a
+    `params=PaginatedRequestParams(...)` keyword. `attribute` is the name of
+    the list attribute on the result (e.g. `"tools"`, `"prompts"`).
+    """
+    items: list[Any] = []
+    cursor: str | None = None
+    while True:
+        params = types.PaginatedRequestParams(cursor=cursor) if cursor is not None else None
+        result = await fetch_page(params=params)
+        items.extend(getattr(result, attribute))
+        next_cursor = getattr(result, "next_cursor", None)
+        if next_cursor is None:
+            return items
+        cursor = next_cursor
 
 
 # Use dataclass instead of Pydantic BaseModel
@@ -383,9 +405,11 @@ class ClientSessionGroup:
         tools_temp: dict[str, types.Tool] = {}
         tool_to_session_temp: dict[str, mcp.ClientSession] = {}
 
-        # Query the server for its prompts and aggregate to list.
+        # Query the server for its prompts and aggregate to list. Drain
+        # pagination so we don't drop later pages on servers that split
+        # results across multiple `next_cursor` responses.
         try:
-            prompts = (await session.list_prompts()).prompts
+            prompts = await _drain_paginated(session.list_prompts, "prompts")
             for prompt in prompts:
                 name = self._component_name(prompt.name, server_info)
                 prompts_temp[name] = prompt
@@ -395,7 +419,7 @@ class ClientSessionGroup:
 
         # Query the server for its resources and aggregate to list.
         try:
-            resources = (await session.list_resources()).resources
+            resources = await _drain_paginated(session.list_resources, "resources")
             for resource in resources:
                 name = self._component_name(resource.name, server_info)
                 resources_temp[name] = resource
@@ -405,7 +429,7 @@ class ClientSessionGroup:
 
         # Query the server for its tools and aggregate to list.
         try:
-            tools = (await session.list_tools()).tools
+            tools = await _drain_paginated(session.list_tools, "tools")
             for tool in tools:
                 name = self._component_name(tool.name, server_info)
                 tools_temp[name] = tool

--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -76,6 +76,9 @@ async def _drain_paginated(
     `fetch_page` is one of the ClientSession `list_*` methods that takes a
     `params=PaginatedRequestParams(...)` keyword. `attribute` is the name of
     the list attribute on the result (e.g. `"tools"`, `"prompts"`).
+
+    Raises:
+        RuntimeError: The server returned a pagination cursor that did not advance.
     """
     items: list[Any] = []
     cursor: str | None = None
@@ -86,6 +89,8 @@ async def _drain_paginated(
         next_cursor = getattr(result, "next_cursor", None)
         if next_cursor is None:
             return items
+        if next_cursor == cursor:
+            raise RuntimeError("Server returned a pagination cursor that did not advance; refusing to page forever.")
         cursor = next_cursor
 
 
@@ -435,8 +440,8 @@ class ClientSessionGroup:
                 tools_temp[name] = tool
                 tool_to_session_temp[name] = session
                 component_names.tools.add(name)
-        except MCPError as err:  # pragma: no cover
-            logging.warning(f"Could not fetch tools: {err}")
+        except MCPError as err:
+            logging.warning(f"Could not fetch tools: {err}")  # pragma: no cover
 
         # Clean up exit stack for session if we couldn't retrieve anything
         # from the server.

--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -78,9 +78,11 @@ async def _drain_paginated(
     the list attribute on the result (e.g. `"tools"`, `"prompts"`).
 
     Raises:
-        RuntimeError: The server returned a pagination cursor that did not advance.
+        RuntimeError: The server returned a pagination cursor it already
+            returned, which would page forever.
     """
     items: list[Any] = []
+    seen_cursors: set[str] = set()
     cursor: str | None = None
     while True:
         params = types.PaginatedRequestParams(cursor=cursor) if cursor is not None else None
@@ -89,8 +91,9 @@ async def _drain_paginated(
         next_cursor = getattr(result, "next_cursor", None)
         if next_cursor is None:
             return items
-        if next_cursor == cursor:
-            raise RuntimeError("Server returned a pagination cursor that did not advance; refusing to page forever.")
+        if next_cursor in seen_cursors:
+            raise RuntimeError("Server returned a pagination cursor it already returned; refusing to page forever.")
+        seen_cursors.add(next_cursor)
         cursor = next_cursor
 
 

--- a/tests/client/test_list_all_pagination.py
+++ b/tests/client/test_list_all_pagination.py
@@ -70,6 +70,25 @@ def _stuck_cursor_handler(
     return handler
 
 
+def _cycling_cursor_handler(
+    make_item: Callable[[str], ItemT],
+    result_cls: Callable[..., ResultT],
+    items_field: str,
+) -> Callable[[ServerRequestContext, types.PaginatedRequestParams | None], Awaitable[ResultT]]:
+    """Build a malformed handler that alternates between two cursors forever.
+
+    The cursor always advances relative to the previous page, so a guard that
+    only compares against the immediately preceding cursor would page forever.
+    """
+
+    async def handler(_ctx: ServerRequestContext, params: types.PaginatedRequestParams | None) -> ResultT:
+        cursor = params.cursor if params else None
+        next_cursor = "b" if cursor == "a" else "a"
+        return result_cls(**{items_field: [make_item("x")]}, next_cursor=next_cursor)
+
+    return handler
+
+
 def _make_tool(name: str) -> types.Tool:
     return types.Tool(name=name, input_schema={"type": "object"})
 
@@ -269,5 +288,21 @@ async def test_drain_raises_when_cursor_does_not_advance(
     server = build_server()
 
     async with Client(server) as client:
-        with pytest.raises(RuntimeError, match="did not advance"):
+        with pytest.raises(RuntimeError, match="already returned"):
             await getattr(client, client_method)()
+
+
+async def test_drain_raises_when_cursors_cycle():
+    """A server whose cursors cycle (a, b, a, ...) must fail loudly, not loop forever.
+
+    Each cursor differs from the one before it, so this specifically exercises
+    the seen-set guard rather than the simpler stuck-cursor case above.
+    """
+    server = Server(
+        "cycling-tools",
+        on_list_tools=_cycling_cursor_handler(_make_tool, types.ListToolsResult, "tools"),
+    )
+
+    async with Client(server) as client:
+        with pytest.raises(RuntimeError, match="already returned"):
+            await client.list_all_tools()

--- a/tests/client/test_list_all_pagination.py
+++ b/tests/client/test_list_all_pagination.py
@@ -1,0 +1,207 @@
+"""Tests for client `list_all_*` and `iter_all_*` pagination helpers.
+
+These helpers drain `next_cursor` across pages, so a server can split
+its tools/prompts/resources/resource_templates across multiple list
+calls and the client still sees the full collection.
+
+See: https://github.com/modelcontextprotocol/python-sdk/issues/2556
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+import mcp_types as types
+import pytest
+
+from mcp import Client
+from mcp.server import Server, ServerRequestContext
+
+from .conftest import StreamSpyCollection
+
+pytestmark = pytest.mark.anyio
+
+ItemT = TypeVar("ItemT")
+ResultT = TypeVar("ResultT")
+
+
+def _paginated_handler(
+    pages: list[list[str]],
+    make_item: Callable[[str], ItemT],
+    result_cls: Callable[..., ResultT],
+    items_field: str,
+) -> Callable[[ServerRequestContext, types.PaginatedRequestParams | None], Awaitable[ResultT]]:
+    """Build a lowlevel-server handler that serves `pages` of items.
+
+    Each page advances `next_cursor` from `"1"` ... `"N-1"` and the last
+    page returns no cursor. The handler is keyed by the cursor it receives
+    in the request, so cursor handling on both sides is exercised.
+    """
+    # Map incoming cursor (None for first page) to the page index to return.
+    cursor_to_page: dict[str | None, int] = {None: 0}
+    for index in range(len(pages) - 1):
+        cursor_to_page[str(index + 1)] = index + 1
+
+    async def handler(_ctx: ServerRequestContext, params: types.PaginatedRequestParams | None) -> ResultT:
+        cursor = params.cursor if params else None
+        page_index = cursor_to_page[cursor]
+        page = pages[page_index]
+        next_cursor = str(page_index + 1) if page_index + 1 < len(pages) else None
+        return result_cls(
+            **{items_field: [make_item(name) for name in page]},
+            next_cursor=next_cursor,
+        )
+
+    return handler
+
+
+def _make_tool(name: str) -> types.Tool:
+    return types.Tool(name=name, input_schema={"type": "object"})
+
+
+def _make_prompt(name: str) -> types.Prompt:
+    return types.Prompt(name=name)
+
+
+def _make_resource(name: str) -> types.Resource:
+    return types.Resource(name=name, uri=f"test://{name}")
+
+
+def _make_resource_template(name: str) -> types.ResourceTemplate:
+    return types.ResourceTemplate(name=name, uri_template=f"test://{name}/{{id}}")
+
+
+# ---- list_all_tools / iter_all_tools ---------------------------------------
+
+
+async def test_list_all_tools_drains_all_pages(
+    stream_spy: Callable[[], StreamSpyCollection],
+):
+    """list_all_tools follows `next_cursor` and returns the union of pages."""
+    pages = [["a", "b"], ["c", "d"], ["e"]]
+    server = Server(
+        "paginated-tools",
+        on_list_tools=_paginated_handler(pages, _make_tool, types.ListToolsResult, "tools"),
+    )
+
+    async with Client(server, mode="legacy") as client:
+        spies = stream_spy()
+        tools = await client.list_all_tools()
+
+        assert [t.name for t in tools] == ["a", "b", "c", "d", "e"]
+        # One request per page.
+        requests = spies.get_client_requests(method="tools/list")
+        assert len(requests) == 3
+        # First request has no cursor; subsequent ones carry the previous cursor.
+        assert requests[0].params is None or "cursor" not in requests[0].params
+        assert requests[1].params is not None and requests[1].params["cursor"] == "1"
+        assert requests[2].params is not None and requests[2].params["cursor"] == "2"
+
+
+async def test_list_all_tools_single_page():
+    """A server that returns one page (no cursor) should give back one list."""
+
+    async def handle_list_tools(
+        _ctx: ServerRequestContext, _params: types.PaginatedRequestParams | None
+    ) -> types.ListToolsResult:
+        return types.ListToolsResult(tools=[_make_tool("only")])
+
+    server = Server("single-page-tools", on_list_tools=handle_list_tools)
+
+    async with Client(server) as client:
+        tools = await client.list_all_tools()
+        assert [t.name for t in tools] == ["only"]
+
+
+async def test_list_all_tools_empty_server():
+    """An empty server should yield an empty list, not raise."""
+
+    async def handle_list_tools(
+        _ctx: ServerRequestContext, _params: types.PaginatedRequestParams | None
+    ) -> types.ListToolsResult:
+        return types.ListToolsResult(tools=[])
+
+    server = Server("no-tools", on_list_tools=handle_list_tools)
+
+    async with Client(server) as client:
+        tools = await client.list_all_tools()
+        assert tools == []
+
+
+async def test_iter_all_tools_streams_pages(
+    stream_spy: Callable[[], StreamSpyCollection],
+):
+    """iter_all_tools yields one tool at a time and only pages when needed."""
+    pages = [["a", "b"], ["c"]]
+    server = Server(
+        "stream-tools",
+        on_list_tools=_paginated_handler(pages, _make_tool, types.ListToolsResult, "tools"),
+    )
+
+    async with Client(server, mode="legacy") as client:
+        spies = stream_spy()
+        seen = [tool.name async for tool in client.iter_all_tools()]
+
+        assert seen == ["a", "b", "c"]
+        assert len(spies.get_client_requests(method="tools/list")) == 2
+
+
+# ---- list_all_prompts ------------------------------------------------------
+
+
+async def test_list_all_prompts_drains_all_pages(
+    stream_spy: Callable[[], StreamSpyCollection],
+):
+    pages = [["p1", "p2"], ["p3"]]
+    server = Server(
+        "paginated-prompts",
+        on_list_prompts=_paginated_handler(pages, _make_prompt, types.ListPromptsResult, "prompts"),
+    )
+
+    async with Client(server, mode="legacy") as client:
+        spies = stream_spy()
+        prompts = await client.list_all_prompts()
+        assert [p.name for p in prompts] == ["p1", "p2", "p3"]
+        assert len(spies.get_client_requests(method="prompts/list")) == 2
+
+
+# ---- list_all_resources ----------------------------------------------------
+
+
+async def test_list_all_resources_drains_all_pages(
+    stream_spy: Callable[[], StreamSpyCollection],
+):
+    pages = [["r1", "r2"], ["r3"], ["r4"]]
+    server = Server(
+        "paginated-resources",
+        on_list_resources=_paginated_handler(pages, _make_resource, types.ListResourcesResult, "resources"),
+    )
+
+    async with Client(server, mode="legacy") as client:
+        spies = stream_spy()
+        resources = await client.list_all_resources()
+        assert [r.name for r in resources] == ["r1", "r2", "r3", "r4"]
+        assert len(spies.get_client_requests(method="resources/list")) == 3
+
+
+# ---- list_all_resource_templates ------------------------------------------
+
+
+async def test_list_all_resource_templates_drains_all_pages(
+    stream_spy: Callable[[], StreamSpyCollection],
+):
+    pages = [["t1"], ["t2", "t3"]]
+    server = Server(
+        "paginated-templates",
+        on_list_resource_templates=_paginated_handler(
+            pages,
+            _make_resource_template,
+            types.ListResourceTemplatesResult,
+            "resource_templates",
+        ),
+    )
+
+    async with Client(server, mode="legacy") as client:
+        spies = stream_spy()
+        templates = await client.list_all_resource_templates()
+        assert [t.name for t in templates] == ["t1", "t2", "t3"]
+        assert len(spies.get_client_requests(method="resources/templates/list")) == 2

--- a/tests/client/test_list_all_pagination.py
+++ b/tests/client/test_list_all_pagination.py
@@ -8,7 +8,7 @@ See: https://github.com/modelcontextprotocol/python-sdk/issues/2556
 """
 
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import mcp_types as types
 import pytest
@@ -50,6 +50,22 @@ def _paginated_handler(
             **{items_field: [make_item(name) for name in page]},
             next_cursor=next_cursor,
         )
+
+    return handler
+
+
+def _stuck_cursor_handler(
+    make_item: Callable[[str], ItemT],
+    result_cls: Callable[..., ResultT],
+    items_field: str,
+) -> Callable[[ServerRequestContext, types.PaginatedRequestParams | None], Awaitable[ResultT]]:
+    """Build a malformed handler that always returns the same non-null cursor.
+
+    A drain loop that trusts the cursor would page forever against this server.
+    """
+
+    async def handler(_ctx: ServerRequestContext, _params: types.PaginatedRequestParams | None) -> ResultT:
+        return result_cls(**{items_field: [make_item("x")]}, next_cursor="stuck")
 
     return handler
 
@@ -205,3 +221,53 @@ async def test_list_all_resource_templates_drains_all_pages(
         templates = await client.list_all_resource_templates()
         assert [t.name for t in templates] == ["t1", "t2", "t3"]
         assert len(spies.get_client_requests(method="resources/templates/list")) == 2
+
+
+# ---- malformed server: non-advancing cursor --------------------------------
+
+
+@pytest.mark.parametrize(
+    "build_server,client_method",
+    [
+        (
+            lambda: Server(
+                "stuck-tools",
+                on_list_tools=_stuck_cursor_handler(_make_tool, types.ListToolsResult, "tools"),
+            ),
+            "list_all_tools",
+        ),
+        (
+            lambda: Server(
+                "stuck-prompts",
+                on_list_prompts=_stuck_cursor_handler(_make_prompt, types.ListPromptsResult, "prompts"),
+            ),
+            "list_all_prompts",
+        ),
+        (
+            lambda: Server(
+                "stuck-resources",
+                on_list_resources=_stuck_cursor_handler(_make_resource, types.ListResourcesResult, "resources"),
+            ),
+            "list_all_resources",
+        ),
+        (
+            lambda: Server(
+                "stuck-templates",
+                on_list_resource_templates=_stuck_cursor_handler(
+                    _make_resource_template, types.ListResourceTemplatesResult, "resource_templates"
+                ),
+            ),
+            "list_all_resource_templates",
+        ),
+    ],
+)
+async def test_drain_raises_when_cursor_does_not_advance(
+    build_server: Callable[[], Server[Any]],
+    client_method: str,
+):
+    """A server that keeps returning the same cursor must fail loudly, not loop forever."""
+    server = build_server()
+
+    async with Client(server) as client:
+        with pytest.raises(RuntimeError, match="did not advance"):
+            await getattr(client, client_method)()

--- a/tests/client/test_list_all_pagination.py
+++ b/tests/client/test_list_all_pagination.py
@@ -306,3 +306,72 @@ async def test_drain_raises_when_cursors_cycle():
     async with Client(server) as client:
         with pytest.raises(RuntimeError, match="already returned"):
             await client.list_all_tools()
+
+
+# ---- interaction with the SEP-2549 response cache --------------------------
+#
+# These run on the default (2026-07-28) client path rather than `mode="legacy"`
+# used above: `ttlMs` is a 2026-07-28 field, so the legacy wire path strips the
+# server's freshness hint and nothing is ever cached.
+
+
+def _relisting_tools_server(state: dict[str, int]) -> Server[Any]:
+    """Build a server whose tool listing is replaced when `state["version"]` flips to 2.
+
+    Version 1 serves [a, b] with cursor "1"; version 2 serves [x, y] -> [z].
+    Version 2 still honors version 1's cursor, so a drain that starts from a
+    stale first page gets a plausible answer rather than an error. Both tests
+    flip to version 2 before draining, so version 1 only ever serves page one.
+    """
+    # A freshness hint is what makes the client cache the first page at all (SEP-2549).
+    hint: dict[str, Any] = {"ttl_ms": 60_000, "cache_scope": "private"}
+
+    async def handle_list_tools(
+        _ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
+    ) -> types.ListToolsResult:
+        cursor = params.cursor if params else None
+        if state["version"] == 1:
+            assert cursor is None
+            return types.ListToolsResult(tools=[_make_tool("a"), _make_tool("b")], next_cursor="1", **hint)
+        if cursor is None:
+            return types.ListToolsResult(tools=[_make_tool("x"), _make_tool("y")], next_cursor="2", **hint)
+        if cursor == "1":  # version 1's cursor, carried over on a stale first page
+            return types.ListToolsResult(tools=[_make_tool("c")], **hint)
+        assert cursor == "2"
+        return types.ListToolsResult(tools=[_make_tool("z")], **hint)
+
+    return Server("relisting-tools", on_list_tools=handle_list_tools)
+
+
+async def test_drain_refetches_a_cached_first_page():
+    """A drain returns the current listing even when the first page is already cached.
+
+    Continuation pages bypass the response cache, so serving a cached first page
+    would pair its stale cursor with freshly fetched later pages and return a
+    listing the server never served. SDK-defined: the drains default to
+    `cache_mode="refresh"` to avoid that.
+    """
+    state = {"version": 1}
+    server = _relisting_tools_server(state)
+
+    async with Client(server) as client:
+        await client.list_tools()  # caches page 0 of the first listing
+        state["version"] = 2
+
+        assert [t.name for t in await client.list_all_tools()] == ["x", "y", "z"]
+
+
+async def test_drain_reuses_a_cached_first_page_when_asked():
+    """`cache_mode="use"` opts back into serving the drain's first page from cache.
+
+    SDK-defined escape hatch: the caller accepts a stale first page (and the
+    stale cursor it carries) in exchange for one fewer request.
+    """
+    state = {"version": 1}
+    server = _relisting_tools_server(state)
+
+    async with Client(server) as client:
+        await client.list_tools()  # caches page 0 of the first listing
+        state["version"] = 2
+
+        assert [t.name for t in await client.list_all_tools(cache_mode="use")] == ["a", "b", "c"]

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -116,9 +116,9 @@ async def test_client_session_group_connect_to_server(mock_exit_stack: contextli
     mock_resource1.name = "resource_b"
     mock_prompt1 = mock.Mock(spec=types.Prompt)
     mock_prompt1.name = "prompt_c"
-    mock_session.list_tools.return_value = mock.AsyncMock(tools=[mock_tool1])
-    mock_session.list_resources.return_value = mock.AsyncMock(resources=[mock_resource1])
-    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[mock_prompt1])
+    mock_session.list_tools.return_value = mock.AsyncMock(tools=[mock_tool1], next_cursor=None)
+    mock_session.list_resources.return_value = mock.AsyncMock(resources=[mock_resource1], next_cursor=None)
+    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[mock_prompt1], next_cursor=None)
 
     # --- Test Execution ---
     group = ClientSessionGroup(exit_stack=mock_exit_stack)
@@ -151,9 +151,9 @@ async def test_client_session_group_connect_to_server_with_name_hook(mock_exit_s
     mock_session = mock.AsyncMock(spec=mcp.ClientSession)
     mock_tool = mock.Mock(spec=types.Tool)
     mock_tool.name = "base_tool"
-    mock_session.list_tools.return_value = mock.AsyncMock(tools=[mock_tool])
-    mock_session.list_resources.return_value = mock.AsyncMock(resources=[])
-    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[])
+    mock_session.list_tools.return_value = mock.AsyncMock(tools=[mock_tool], next_cursor=None)
+    mock_session.list_resources.return_value = mock.AsyncMock(resources=[], next_cursor=None)
+    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[], next_cursor=None)
 
     # --- Test Setup ---
     def name_hook(name: str, server_info: types.Implementation) -> str:
@@ -262,10 +262,10 @@ async def test_client_session_group_connect_to_server_duplicate_tool_raises_erro
     # Configure the new session to return a tool with the *same name*
     duplicate_tool = mock.Mock(spec=types.Tool)
     duplicate_tool.name = existing_tool_name
-    mock_session_new.list_tools.return_value = mock.AsyncMock(tools=[duplicate_tool])
+    mock_session_new.list_tools.return_value = mock.AsyncMock(tools=[duplicate_tool], next_cursor=None)
     # Keep other lists empty for simplicity
-    mock_session_new.list_resources.return_value = mock.AsyncMock(resources=[])
-    mock_session_new.list_prompts.return_value = mock.AsyncMock(prompts=[])
+    mock_session_new.list_resources.return_value = mock.AsyncMock(resources=[], next_cursor=None)
+    mock_session_new.list_prompts.return_value = mock.AsyncMock(prompts=[], next_cursor=None)
 
     # --- Test Execution and Assertion ---
     with pytest.raises(MCPError) as excinfo:
@@ -402,3 +402,45 @@ async def test_client_session_group_establish_session_parameterized(
             # 3. Assert returned values
             assert returned_server_info is mock_initialize_result.server_info
             assert returned_session is mock_entered_session
+
+
+@pytest.mark.anyio
+async def test_client_session_group_aggregates_paginated_tools(
+    mock_exit_stack: contextlib.AsyncExitStack,
+):
+    """ClientSessionGroup must drain `next_cursor` so it sees every page.
+
+    Regression for https://github.com/modelcontextprotocol/python-sdk/issues/2556:
+    aggregators across multiple MCP servers are the most likely place to hit
+    pagination, so the group should not stop at page one.
+    """
+    mock_server_info = mock.Mock(spec=types.Implementation)
+    mock_server_info.name = "PaginatedServer"
+    mock_session = mock.AsyncMock(spec=mcp.ClientSession)
+
+    tool_page1_a = mock.Mock(spec=types.Tool)
+    tool_page1_a.name = "tool_a"
+    tool_page1_b = mock.Mock(spec=types.Tool)
+    tool_page1_b.name = "tool_b"
+    tool_page2 = mock.Mock(spec=types.Tool)
+    tool_page2.name = "tool_c"
+
+    list_tools_responses = [
+        mock.AsyncMock(tools=[tool_page1_a, tool_page1_b], next_cursor="page-2"),
+        mock.AsyncMock(tools=[tool_page2], next_cursor=None),
+    ]
+    mock_session.list_tools.side_effect = list_tools_responses
+    mock_session.list_resources.return_value = mock.AsyncMock(resources=[], next_cursor=None)
+    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[], next_cursor=None)
+
+    group = ClientSessionGroup(exit_stack=mock_exit_stack)
+    with mock.patch.object(group, "_establish_session", return_value=(mock_server_info, mock_session)):
+        await group.connect_to_server(StdioServerParameters(command="test"))
+
+    assert set(group.tools.keys()) == {"tool_a", "tool_b", "tool_c"}
+    # Two pages -> two `list_tools` calls.
+    assert mock_session.list_tools.await_count == 2
+    # Second call should have supplied the cursor returned by the first.
+    second_call_kwargs = mock_session.list_tools.await_args_list[1].kwargs
+    assert second_call_kwargs["params"] is not None
+    assert second_call_kwargs["params"].cursor == "page-2"

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -463,5 +463,5 @@ async def test_client_session_group_rejects_non_advancing_cursor(
 
     group = ClientSessionGroup(exit_stack=mock_exit_stack)
     with mock.patch.object(group, "_establish_session", return_value=(mock_server_info, mock_session)):
-        with pytest.raises(RuntimeError, match="did not advance"):
+        with pytest.raises(RuntimeError, match="already returned"):
             await group.connect_to_server(StdioServerParameters(command="test"))

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -444,3 +444,24 @@ async def test_client_session_group_aggregates_paginated_tools(
     second_call_kwargs = mock_session.list_tools.await_args_list[1].kwargs
     assert second_call_kwargs["params"] is not None
     assert second_call_kwargs["params"].cursor == "page-2"
+
+
+@pytest.mark.anyio
+async def test_client_session_group_rejects_non_advancing_cursor(
+    mock_exit_stack: contextlib.AsyncExitStack,
+):
+    """A server that keeps returning the cursor it was handed must fail loudly, not page forever."""
+    mock_server_info = mock.Mock(spec=types.Implementation)
+    mock_server_info.name = "StuckCursorServer"
+    mock_session = mock.AsyncMock(spec=mcp.ClientSession)
+
+    stuck_tool = mock.Mock(spec=types.Tool)
+    stuck_tool.name = "tool_a"
+    mock_session.list_tools.return_value = mock.AsyncMock(tools=[stuck_tool], next_cursor="page-2")
+    mock_session.list_resources.return_value = mock.AsyncMock(resources=[], next_cursor=None)
+    mock_session.list_prompts.return_value = mock.AsyncMock(prompts=[], next_cursor=None)
+
+    group = ClientSessionGroup(exit_stack=mock_exit_stack)
+    with mock.patch.object(group, "_establish_session", return_value=(mock_server_info, mock_session)):
+        with pytest.raises(RuntimeError, match="did not advance"):
+            await group.connect_to_server(StdioServerParameters(command="test"))

--- a/tests/docs_src/test_pagination.py
+++ b/tests/docs_src/test_pagination.py
@@ -3,7 +3,7 @@
 import pytest
 from mcp_types import Resource
 
-from docs_src.pagination import tutorial001, tutorial002
+from docs_src.pagination import tutorial001, tutorial002, tutorial003
 from mcp import Client, MCPError
 from mcp.server import MCPServer
 from mcp.server.mcpserver.resources import TextResource
@@ -69,6 +69,21 @@ async def test_the_client_program_on_the_page_runs(capsys: pytest.CaptureFixture
     """tutorial002: `main()` is the literal client program on the page and prints the stitched total."""
     await tutorial002.main()
     assert capsys.readouterr().out == "100 resources\n"
+
+
+async def test_list_all_stitches_the_whole_catalog() -> None:
+    """tutorial003: `list_all_resources` drains every page into one list, no cursor handling."""
+    async with Client(tutorial003.server) as client:
+        resources = await client.list_all_resources()
+        assert len(resources) == 100
+        assert resources[0].name == "book-1"
+        assert resources[-1].name == "book-100"
+
+
+async def test_the_drain_helpers_program_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    """tutorial003: `main()` stitches all pages, then streams and stops at the first."""
+    await tutorial003.main()
+    assert capsys.readouterr().out == "100 resources\nfirst: book-1\n"
 
 
 async def test_an_invented_cursor_is_an_error() -> None:


### PR DESCRIPTION
Closes #2556.

This continues #2658 by @adityasingh2400, which implemented the helpers but went stale against the v2 rework on `main`. I opened the original issue, so I rebased the work onto current `main`, added a guard, and am putting it up as a ready-to-merge PR. Aditya's authorship is preserved on the feature commit. Happy to close this in favor of an updated #2658 if he would rather carry it forward.

## What this adds

- `list_all_tools` / `list_all_prompts` / `list_all_resources` / `list_all_resource_templates` on `Client`: each walks `next_cursor` until the server reports no more pages and returns the combined list.
- `iter_all_tools` / `iter_all_prompts` / `iter_all_resources` / `iter_all_resource_templates`: async iterators for streaming consumers that do not want to materialize every page.
- The single-page `list_*` methods get docstrings pointing at the new drains.
- `ClientSessionGroup` aggregation drains pagination, so multi-server consumers see the full collection instead of only page 0.

The single-page primitives are unchanged; the drains are opt-in.

## Non-advancing cursor guard

A server that keeps returning the same cursor it was handed would make a naive drain loop page forever. The loops raise `RuntimeError` when a cursor repeats, rather than looping or silently truncating (silent truncation being the exact failure the issue describes). Documented in each helper's `Raises:` section and covered by a parametrized test across tools, prompts, resources, and templates, plus a cycling-cursor case. This addresses the malformed-server concern @agaonker raised on the issue. Easy to switch to a quiet stop instead if that is preferred.

## Interaction with the SEP-2549 response cache

`#3164` landed the SEP-2549 response cache while this PR was open, and it interacts badly with draining. `Client.list_*` can now serve a first page from cache, but `_cached_fetch` returns early for any request carrying a cursor, so continuation pages always go to the wire. A drain starting from a cached first page therefore pairs that page's stale `next_cursor` with freshly fetched later pages and returns a stitched-together listing that never existed on the server. That is the same silent-wrong-list failure this PR exists to prevent.

It needs no client configuration to hit: a stock `Client` against a server that advertises `ttlMs` on `tools/list`, which is what SEP-2549 asks servers to do, is enough.

So the four `list_all_*` / `iter_all_*` pairs take `cache_mode` and default it to `"refresh"` rather than inheriting the single-page `"use"`. `"refresh"` still writes the fetched page back to the cache, so single-page callers keep the SEP-2549 benefit and the drain pays only the one request it cannot avoid. `cache_mode="use"` opts back into a cached first page.

Considered and rejected: refreshing only when the cached first page carries a `next_cursor`, since a cached single-page listing is internally coherent. It saves a request in the common case but costs two first-page fetches on a cache miss with pagination.

`ClientSessionGroup` is unaffected here: `_drain_paginated` calls `session.list_*` directly and never passes through the response cache.

## Notes on the v2 rebase

The original PR predated the v2 rework. Bringing it current meant: types import from `mcp_types`, the cursor-spy tests run with `mode="legacy"` (the default client path is now streamless, so the wire spy has nothing to observe otherwise), and the test `Tool` carries a valid `input_schema` now that `type` is required. The helper logic itself is unchanged.

Note that `mode="legacy"` is also why the cache interaction above went unnoticed at first: `ttlMs` is a 2026-07-28 field, so the legacy wire path strips the server's hint and nothing is ever cached. The two cache tests run on the default 2026-07-28 path and assert on returned items rather than the wire spy.

## Docs

`docs/advanced/pagination.md` gets a "Draining in one call" section covering `list_all_*`/`iter_all_*`, the `ClientSessionGroup` behavior, and the cursor guard, plus a "Drains and the response cache" subsection on the `cache_mode` default. It is backed by a runnable `docs_src/pagination/tutorial003.py` snippet with matching tests, so the page keeps proving every claim against the SDK.

## Verification

- `uv run pytest`: 5603 passed, 10 skipped, 1 xfailed
- `./scripts/test`: 100% coverage (branch), `strict-no-cover` clean
- `uv run pyright` clean
- `uv run ruff check . && uv run ruff format --check .` clean
- pre-commit clean (prettier, markdownlint, ruff)

AI disclosure: developed with AI assistance (Claude, Fable 5 and Opus 5). I have read and tested every change and can speak to all of it myself.
