### PR TITLE
fix(server): exit cleanly on KeyboardInterrupt in MCPServer.run

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -358,13 +358,16 @@ class MCPServer(Generic[LifespanResultT]):
         if transport not in TRANSPORTS.__args__:  # type: ignore  # pragma: no cover
             raise ValueError(f"Unknown transport: {transport}")
 
-        match transport:
-            case "stdio":
-                anyio.run(self.run_stdio_async)
-            case "sse":  # pragma: no cover
-                anyio.run(lambda: self.run_sse_async(**kwargs))
-            case "streamable-http":  # pragma: no cover
-                anyio.run(lambda: self.run_streamable_http_async(**kwargs))
+        try:
+            match transport:
+                case "stdio":
+                    anyio.run(self.run_stdio_async)
+                case "sse":  # pragma: no cover
+                    anyio.run(lambda: self.run_sse_async(**kwargs))
+                case "streamable-http":  # pragma: no cover
+                    anyio.run(lambda: self.run_streamable_http_async(**kwargs))
+        except KeyboardInterrupt:
+            return
 
     async def _handle_list_tools(
         self, ctx: ServerRequestContext[LifespanResultT], params: PaginatedRequestParams | None

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -87,6 +87,27 @@ class TestServer:
         mcp_no_deps = MCPServer("test")
         assert mcp_no_deps.dependencies == []
 
+    def test_run_suppresses_keyboard_interrupt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mcp = MCPServer("test")
+
+        def raise_keyboard_interrupt(*args: Any, **kwargs: Any) -> None:
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("mcp.server.mcpserver.server.anyio.run", raise_keyboard_interrupt)
+
+        assert mcp.run(transport="stdio") is None
+
+    def test_run_reraises_other_exceptions(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mcp = MCPServer("test")
+
+        def raise_runtime_error(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("startup failed")
+
+        monkeypatch.setattr("mcp.server.mcpserver.server.anyio.run", raise_runtime_error)
+
+        with pytest.raises(RuntimeError, match="startup failed"):
+            mcp.run(transport="stdio")
+
     async def test_sse_app_returns_starlette_app(self):
         """Test that sse_app returns a Starlette application with correct routes."""
         mcp = MCPServer("test")


### PR DESCRIPTION
## Summary

- Catch `KeyboardInterrupt` at the `MCPServer.run()` sync boundary so Ctrl-C during stdio server execution exits cleanly instead of printing a noisy anyio/asyncio cancellation traceback.
- Adds unit tests verifying `KeyboardInterrupt` is suppressed while other exceptions still propagate.

## Test plan

- [x] `uv run pytest tests/server/mcpserver/test_server.py::TestServer::test_run_suppresses_keyboard_interrupt tests/server/mcpserver/test_server.py::TestServer::test_run_reraises_other_exceptions -v`
- [x] `uv run ruff check src/mcp/server/mcpserver/server.py tests/server/mcpserver/test_server.py`

Fixes #2663