### PR TITLE
Surface skipped conformance scenarios as baselined known failures

### DIFF
--- a/.github/actions/conformance/expected-failures.2026-07-28.yml
+++ b/.github/actions/conformance/expected-failures.2026-07-28.yml
@@ -23,6 +23,9 @@
 client: []
 
 server:
+  # SEP-2575 subscriptions/listen is not implemented yet; see the matching
+  # entry in expected-failures.yml for the full rationale.
+  - server-stateless
   # SEP-2243 Mcp-Param-* server-side validation is not implemented yet; see
   # the matching entry in expected-failures.yml for the full rationale.
   - http-custom-header-server-validation

--- a/.github/actions/conformance/expected-failures.2026-07-28.yml
+++ b/.github/actions/conformance/expected-failures.2026-07-28.yml
@@ -22,4 +22,7 @@
 
 client: []
 
-server: []
+server:
+  # SEP-2243 Mcp-Param-* server-side validation is not implemented yet; see
+  # the matching entry in expected-failures.yml for the full rationale.
+  - http-custom-header-server-validation

--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -12,4 +12,23 @@
 
 client: []
 
-server: []
+server:
+  # SEP-2663 (io.modelcontextprotocol/tasks): the SDK does not implement the
+  # tasks extension yet. These extension-tagged scenarios are selected only by
+  # the bare `--suite all` leg — extension scenarios never match a
+  # --spec-version filter and the active/draft suites exclude them — so these
+  # entries are inert for the other legs that read this file.
+  #
+  # `tasks-status-notifications` is intentionally NOT listed: the harness
+  # skips it unconditionally (pending its rewrite against subscriptions/
+  # listen), and a baseline entry for a scenario with no failing checks is
+  # flagged stale.
+  - tasks-lifecycle
+  - tasks-capability-negotiation
+  - tasks-wire-fields
+  - tasks-request-state-removal
+  - tasks-mrtr-input
+  - tasks-request-headers
+  - tasks-dispatch-and-envelope
+  - tasks-required-task-error
+  - tasks-mrtr-composition

--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -13,6 +13,13 @@
 client: []
 
 server:
+  # SEP-2243 Mcp-Param-* server-side validation is not implemented yet. The
+  # everything-server's `test_x_mcp_header` tool arms these checks (without an
+  # x-mcp-header-annotated tool the harness skips all of them silently); the
+  # accept-path checks pass, the reject-path checks fail until the server
+  # validates Mcp-Param headers against body params. Read by the draft leg and
+  # the bare `--suite all` leg; the 2026-07-28 leg carries its own entry.
+  - http-custom-header-server-validation
   # SEP-2663 (io.modelcontextprotocol/tasks): the SDK does not implement the
   # tasks extension yet. These extension-tagged scenarios are selected only by
   # the bare `--suite all` leg — extension scenarios never match a

--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -13,6 +13,16 @@
 client: []
 
 server:
+  # SEP-2575 subscriptions/listen is not implemented yet. The everything-
+  # server's legacy resources/subscribe handlers make it advertise
+  # `resources.subscribe` in server/discover, and as of conformance #372 a
+  # server that advertises a subscription capability but answers
+  # subscriptions/listen with -32601 fails the three listen MUST checks
+  # ("Not testable") instead of skipping them. Remove this entry when the
+  # listen runtime lands. NOTE: while listed, this entry also masks new
+  # failures in the scenario's other 25 (currently passing) checks — the
+  # baseline is per-scenario, not per-check.
+  - server-stateless
   # SEP-2243 Mcp-Param-* server-side validation is not implemented yet. The
   # everything-server's `test_x_mcp_header` tool arms these checks (without an
   # x-mcp-header-annotated tool the harness skips all of them silently); the

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -75,6 +75,22 @@ jobs:
           --suite all
           --spec-version 2026-07-28
           --expected-failures ./.github/actions/conformance/expected-failures.2026-07-28.yml
+      - name: Run server conformance (all suite, extension scenarios)
+        # A bare `--suite all` (no --spec-version) selects every scenario
+        # shipped with the pinned harness — including the extension-tagged
+        # tasks-* scenarios and pending-listed ones like server-sse-polling,
+        # which no other leg reaches (extension scenarios never match a
+        # --spec-version filter, and the pending list keeps them out of the
+        # active suite). Running the full set keeps unimplemented surfaces
+        # visible as baselined known failures in expected-failures.yml instead
+        # of silent exclusions, and stays robust to scenarios moving between
+        # harness suite lists across pin bumps. `--suite pending` would cover
+        # the same union slightly faster; the full set is preferred for the
+        # self-contained run and for parity with typescript-sdk's CI.
+        run: >-
+          ./.github/actions/conformance/run-server.sh
+          --suite all
+          --expected-failures ./.github/actions/conformance/expected-failures.yml
 
   client-conformance:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,17 +19,17 @@ env:
   # Bump deliberately and reconcile both
   # .github/actions/conformance/expected-failures*.yml files in the same change.
   #
-  # Temporarily pinned to the pkg.pr.new build of conformance main@b18aa918
-  # (the merge of #371, which fixes the http-custom-headers fixture's
-  # spec-forbidden `number`-typed x-mcp-header annotations) — no published
-  # release includes it yet. Pinned by commit SHA so the tarball cannot move
-  # under us; CONFORMANCE_PKG_SHA256 pins the bytes and the fetch-and-verify
-  # step below downloads, checks the digest, and repoints CONFORMANCE_PKG at the
+  # Temporarily pinned to the pkg.pr.new build of conformance main@4944b268
+  # (0.2.0-alpha.8, which includes #372: fail checks whose prerequisite is
+  # missing instead of skipping them) — alpha.8 is not published to npm yet.
+  # Pinned by commit SHA so the tarball cannot move under us;
+  # CONFORMANCE_PKG_SHA256 pins the bytes and the fetch-and-verify step below
+  # downloads, checks the digest, and repoints CONFORMANCE_PKG at the
   # verified local copy. Repin to the next published @modelcontextprotocol/
-  # conformance release (>0.2.0-alpha.7) once it ships, then drop
+  # conformance release (>=0.2.0-alpha.8) once it ships, then drop
   # CONFORMANCE_PKG_SHA256 and the fetch-and-verify steps.
-  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@b18aa918"
-  CONFORMANCE_PKG_SHA256: "e9f6bc25085b4692e988cbdbd024a4203d54a52a6aaa065376cf8ecaa09bb680"
+  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@4944b268"
+  CONFORMANCE_PKG_SHA256: "0f70c035782d319d72ab427653c5275db5c50429d59fae0241a645b33aeda1a7"
 
 jobs:
   server-conformance:

--- a/examples/servers/everything-server/mcp_everything_server/server.py
+++ b/examples/servers/everything-server/mcp_everything_server/server.py
@@ -11,7 +11,7 @@ import hashlib
 import hmac
 import json
 import logging
-from typing import Any
+from typing import Annotated, Any
 
 import click
 from mcp.server import ServerRequestContext
@@ -325,6 +325,24 @@ async def test_elicitation_sep1330_enums(ctx: Context) -> str:
 def test_error_handling() -> str:
     """Tests error response handling"""
     raise RuntimeError("This tool intentionally returns an error for testing")
+
+
+@mcp.tool()
+def test_x_mcp_header(
+    region: Annotated[
+        str,
+        Field(
+            description="Mirrored into the Mcp-Param-Region header",
+            json_schema_extra={"x-mcp-header": "Region"},
+        ),
+    ] = "<none>",
+) -> str:
+    """Tests SEP-2243 Mcp-Param-* server-side validation.
+
+    Arms the http-custom-header-server-validation conformance scenario, which
+    skips when no tool with an `x-mcp-header` annotation is found.
+    """
+    return f"region={region}"
 
 
 @mcp.tool()


### PR DESCRIPTION
Conformance CI's green currently overstates coverage in two ways: 11 of the harness's server scenarios are never selected at all (the 10 extension-tagged `tasks-*` scenarios never match a `--spec-version` filter and sit on the harness's pending list, so the `active`, `draft`, and 2026 legs all exclude them; `server-sse-polling` is pending-listed and removed at 2026-07-28, so no leg can reach it), and several checks inside running scenarios skip silently when a prerequisite is missing — all 5 SEP-2243 `Mcp-Param-*` server-validation checks skip because no fixture tool carries an `x-mcp-header` annotation, and the SEP-2575 `subscriptions/listen` checks skip on `-32601`.

This PR makes those surfaces visible as baselined known failures instead of silent exclusions, in three steps (one commit each):

1. **New server leg: bare `--suite all`** (no `--spec-version`) — selects every scenario shipped with the pinned harness, including the extension-tagged and pending-listed ones that no existing leg reaches. With it, `server-sse-polling` turns out to already pass (3/3), and the 9 runnable `tasks-*` scenarios fail and are baselined in `expected-failures.yml` as a burn-down ledger — the harness's stale-entry rule forces each entry out as tasks support lands. `tasks-status-notifications` is deliberately not listed: the harness skips it unconditionally (pending its rewrite against `subscriptions/listen`), and a baseline entry for a scenario with no failing checks is itself flagged stale. This is the same pattern typescript-sdk uses ([their extensions leg](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/.github/workflows/conformance.yml) runs `--suite all` with no `--spec-version` and baselines the same nine tasks failures).
2. **`test_x_mcp_header` fixture tool** in the everything-server (string param annotated `x-mcp-header: Region` via `json_schema_extra`, mirroring typescript-sdk's fixture) — the 5 Mcp-Param server-validation checks now execute: the 3 accept-path checks pass, the reject-path checks fail because server-side `Mcp-Param` validation isn't implemented yet, and the scenario is baselined in both expected-failures files.
3. **Conformance pin bump `b18aa918` → `4944b268`** (0.2.0-alpha.8, which includes [conformance#372](https://github.com/modelcontextprotocol/conformance/pull/372); not published to npm yet, so the same sha256-verified pkg.pr.new mechanics as before). #372 turns missing-prerequisite skips into "Not testable" failures, which surfaces one more unimplemented surface: **`server-stateless` now fails its 3 `subscriptions/listen` MUST checks** — the everything-server's legacy `resources/subscribe` handlers make it advertise `resources.subscribe` in `server/discover` while `subscriptions/listen` answers `-32601`, and advertised-but-rejected is now a failure. The scenario is baselined in both files until the listen runtime lands (#2804). The 2 `listChanged` SHOULD checks remain legitimately skipped (declared `false`, which #372 still treats as honest feature absence), and the `tasks-*` scenarios fail with higher check counts (their cascade skips now fail too) without needing entry changes.

Net effect on the baseline: zero waivers for implemented surfaces is unchanged — every entry added here tracks a not-yet-built surface that previously produced no signal at all.

## Motivation and Context

A green conformance run currently overstates coverage: unimplemented surfaces (tasks extension, server-side Mcp-Param validation, subscriptions/listen) produce no signal because their scenarios are filtered or their checks skip upstream of the expected-failures mechanism. Visible baselined failures are strictly better — they show up in the run output, they can't rot silently across harness pin bumps, and the stale-entry rule turns the baseline into a forced burn-down list as features land.

## How Has This Been Tested?

Replicated all six CI legs locally against the new pinned tarball (sha256-verified), exactly as CI invokes them: the four server legs and both client legs exit 0 with "Baseline check passed" —

- `--suite active` → 42 passed, 0 failed (new entries inert — those scenarios aren't in the suite)
- `--suite draft` → 74 passed, 9 expected-failed (`server-stateless` 3 listen checks + `http-custom-header-server-validation`)
- `--suite all --spec-version 2026-07-28` → 103 passed, 9 expected-failed (same two)
- `--suite all` (new leg) → 134 passed, 34 expected-failed (the above + 9 `tasks-*`); `server-sse-polling` and `json-schema-2020-12` pass
- both client legs → 421/370 checks passed, 0 failed, 0 warnings

Also verified the generated `tools/list` schema carries `"x-mcp-header": "Region"` through pydantic's `json_schema_extra`, and ran the discovery pass at the new pin before updating baselines to confirm `server-stateless` was the only newly-unexpected failure (no stale entries, no warnings anywhere).

## Breaking Changes

None — CI configuration and a conformance fixture tool only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- Suite choice for the new leg: `--suite pending` (14 scenarios) would cover the same job-level union slightly faster, since `all = active ∪ draft ∪ pending` at this harness and the other two suites already run in this job. Bare `--suite all` is preferred for the self-contained full-denominator run, robustness to scenarios moving between harness suite lists across pin bumps, and parity with typescript-sdk's CI.
- Why per-scenario waivers and not something finer: the harness baseline is keyed by scenario name only; one entry waives every failing check in that scenario. For `tasks-*` and `http-custom-header-server-validation` that's cheap (each tracks exactly one unimplemented surface). For `server-stateless` it carries a real masking cost, called out in the baseline comment: while listed, new failures in the scenario's other 25 (currently passing) envelope/error-handling checks are also absorbed. The trade is deliberate — a visible, forced-burn-down known failure for the listen gap beats a silent skip — but it makes landing the listen runtime (#2804) the way to get those 25 checks back under guard.
- The capability inconsistency the harness flags is real, not a harness artifact: on the 2026 wire the server advertises `resources.subscribe` while the subscribe methods themselves answer 404/`-32601` there. Implementing listen resolves it from one side; era-aware capability reporting in `server/discover` would resolve it from the other.
- The bare-all leg re-runs the active/draft scenarios at their default wire versions (same connections as the existing legs), so most of its runtime is duplicate coverage; the harness has a 10s per-request timeout, and the tasks scenarios fail fast on `-32601` rather than hanging. The one genuinely new timing-sensitive scenario is `server-sse-polling` (real-time SSE reconnect waits); it passed consistently in local runs and runs green in typescript-sdk's identical leg, but if it proves flaky on 2-core runners it cannot be pre-waived (a baseline entry for a passing scenario is flagged stale), so a flake would need a rerun or a harness-side fix.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
