### PR TITLE
Bump the conformance pin to 0.2.0-alpha.8 and baseline the listen checks it surfaces

### DIFF
--- a/.github/actions/conformance/expected-failures.2026-07-28.yml
+++ b/.github/actions/conformance/expected-failures.2026-07-28.yml
@@ -23,6 +23,9 @@
 client: []
 
 server:
+  # SEP-2575 subscriptions/listen is not implemented yet; see the matching
+  # entry in expected-failures.yml for the full rationale.
+  - server-stateless
   # SEP-2243 Mcp-Param-* server-side validation is not implemented yet; see
   # the matching entry in expected-failures.yml for the full rationale.
   - http-custom-header-server-validation

--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -13,6 +13,16 @@
 client: []
 
 server:
+  # SEP-2575 subscriptions/listen is not implemented yet. The everything-
+  # server's legacy resources/subscribe handlers make it advertise
+  # `resources.subscribe` in server/discover, and as of conformance #372 a
+  # server that advertises a subscription capability but answers
+  # subscriptions/listen with -32601 fails the three listen MUST checks
+  # ("Not testable") instead of skipping them. Remove this entry when the
+  # listen runtime lands. NOTE: while listed, this entry also masks new
+  # failures in the scenario's other 25 (currently passing) checks — the
+  # baseline is per-scenario, not per-check.
+  - server-stateless
   # SEP-2243 Mcp-Param-* server-side validation is not implemented yet. The
   # everything-server's `test_x_mcp_header` tool arms these checks (without an
   # x-mcp-header-annotated tool the harness skips all of them silently); the

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -19,17 +19,17 @@ env:
   # Bump deliberately and reconcile both
   # .github/actions/conformance/expected-failures*.yml files in the same change.
   #
-  # Temporarily pinned to the pkg.pr.new build of conformance main@b18aa918
-  # (the merge of #371, which fixes the http-custom-headers fixture's
-  # spec-forbidden `number`-typed x-mcp-header annotations) — no published
-  # release includes it yet. Pinned by commit SHA so the tarball cannot move
-  # under us; CONFORMANCE_PKG_SHA256 pins the bytes and the fetch-and-verify
-  # step below downloads, checks the digest, and repoints CONFORMANCE_PKG at the
+  # Temporarily pinned to the pkg.pr.new build of conformance main@4944b268
+  # (0.2.0-alpha.8, which includes #372: fail checks whose prerequisite is
+  # missing instead of skipping them) — alpha.8 is not published to npm yet.
+  # Pinned by commit SHA so the tarball cannot move under us;
+  # CONFORMANCE_PKG_SHA256 pins the bytes and the fetch-and-verify step below
+  # downloads, checks the digest, and repoints CONFORMANCE_PKG at the
   # verified local copy. Repin to the next published @modelcontextprotocol/
-  # conformance release (>0.2.0-alpha.7) once it ships, then drop
+  # conformance release (>=0.2.0-alpha.8) once it ships, then drop
   # CONFORMANCE_PKG_SHA256 and the fetch-and-verify steps.
-  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@b18aa918"
-  CONFORMANCE_PKG_SHA256: "e9f6bc25085b4692e988cbdbd024a4203d54a52a6aaa065376cf8ecaa09bb680"
+  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@4944b268"
+  CONFORMANCE_PKG_SHA256: "0f70c035782d319d72ab427653c5275db5c50429d59fae0241a645b33aeda1a7"
 
 jobs:
   server-conformance:


### PR DESCRIPTION
> [!NOTE]
> Stacked on #3030 (base branch `conformance-skips`); will be retargeted to `main` when that merges.

Bumps the conformance harness pin from `b18aa918` to `4944b268` (0.2.0-alpha.8 + [conformance#372](https://github.com/modelcontextprotocol/conformance/pull/372), neither published to npm yet — same sha256-verified pkg.pr.new mechanics as the previous pin).

\#372 changes skip semantics: a check whose prerequisite is missing — a fixture tool the server doesn't ship, or a capability the server advertises but then rejects — now **fails** with a "Not testable:" message instead of silently skipping outside the pass/fail denominator. That makes one more unimplemented surface visible as a baselined known failure:

- **`server-stateless` now fails its 3 `subscriptions/listen` MUST checks** (new entry in both expected-failures files). The everything-server's legacy `resources/subscribe` handlers make it advertise `resources.subscribe` in `server/discover`, while `subscriptions/listen` answers `-32601` — under #372 that's claims-but-doesn't-serve, a failure. The entry burns down when the listen runtime lands (#2804). The two `listChanged` SHOULD checks remain legitimately skipped (the capability is declared `false`, which #372 still treats as honest feature absence).
- The `tasks-*` scenarios fail with higher check counts (their "no task created" cascade skips now fail too), but they were already baselined — no entry changes.
- `tasks-status-notifications` still skips unconditionally under #372 and must stay unbaselined.
- Client legs are unaffected (421/370 checks pass, zero warnings, both exit 0).

## Motivation and Context

Same goal as #3030, finished by the upstream half: #3030 made the filtered-out scenarios run; #372 makes the prerequisite-gap *checks inside running scenarios* count. After both, the only remaining green-without-evidence surfaces are the ones the harness deliberately exempts.

## How Has This Been Tested?

Replicated all six CI legs locally against the new pinned tarball (sha256-verified), exactly as CI invokes them: the four server legs and both client legs exit 0 with "Baseline check passed", with `server-stateless` failing only the 3 listen checks (25 still passing) and all other failures matching the existing baseline. Also confirmed the discovery state before the baseline update: only `server-stateless` was newly unexpected; no stale entries; no warnings anywhere.

## Breaking Changes

None — CI configuration only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- The `server-stateless` waiver carries a real masking cost, called out in the baseline comment: while listed, new failures in the scenario's other 25 (currently passing) envelope/error-handling checks are also absorbed, because the baseline is per-scenario. The trade is deliberate — a visible, forced-burn-down known failure for the listen gap beats the pre-#372 state where the same gap was invisible — but it makes landing the listen runtime (#2804) the way to get those 25 checks back under guard.
- The capability inconsistency the harness is flagging is real, not a harness artifact: on the 2026 wire the server advertises `resources.subscribe` while the subscribe methods themselves answer 404/`-32601` there. Implementing listen resolves it from one side; era-aware capability reporting in `server/discover` would resolve it from the other.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
