### PR TITLE
Document pydantic.ValidationError in client Raises sections

### DIFF
--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -629,6 +629,8 @@ class Client:
         Raises:
             InputRequiredRoundsExceededError: `input_required_max_rounds` exhausted.
             MCPError: A callback returned `ErrorData` for an embedded input request.
+            pydantic.ValidationError: The server returned a result that does not
+                conform to the negotiated protocol version.
         """
 
         async def retry(r: InputResponses | None, s: str | None) -> ReadResourceResult | InputRequiredResult:
@@ -711,6 +713,8 @@ class Client:
         Raises:
             InputRequiredRoundsExceededError: `input_required_max_rounds` exhausted.
             MCPError: A callback returned `ErrorData` for an embedded input request.
+            pydantic.ValidationError: The server returned a result that does not
+                conform to the negotiated protocol version.
         """
 
         async def retry(r: InputResponses | None, s: str | None) -> CallToolResult | InputRequiredResult | Result:
@@ -787,6 +791,8 @@ class Client:
         Raises:
             InputRequiredRoundsExceededError: `input_required_max_rounds` exhausted.
             MCPError: A callback returned `ErrorData` for an embedded input request.
+            pydantic.ValidationError: The server returned a result that does not
+                conform to the negotiated protocol version.
         """
 
         async def retry(r: InputResponses | None, s: str | None) -> GetPromptResult | InputRequiredResult:

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -452,6 +452,8 @@ class ClientSession:
             MCPError: Error response, read timeout, or connection closed.
             RuntimeError: Called before entering the context manager.
             ValueError: The request declares `name_param` but its params carry no string name.
+            pydantic.ValidationError: The server returned a result that does not
+                conform to the negotiated protocol version.
         """
         data = request.model_dump(by_alias=True, mode="json", exclude_none=True)
         method: str = data["method"]


### PR DESCRIPTION
When a server returns a result that does not conform to the negotiated protocol version (for example, a 2026-07-28 result missing a required field), the client surfaces the `pydantic.ValidationError` from result validation. The `Raises` sections on `ClientSession.send_request` and the `Client.call_tool` / `get_prompt` / `read_resource` loops didn't mention it.

Docstring-only; no behavior change.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>