### PR TITLE
Point pre-release install pins at 2.0.0b1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Python 3.10+.
 ## Installation
 
 ```bash
-uv add "mcp[cli]==2.0.0a3"          # or: pip install "mcp[cli]==2.0.0a3"
+uv add "mcp[cli]==2.0.0b1"          # or: pip install "mcp[cli]==2.0.0b1"
 ```
 
-The pin matters while v2 is in pre-release: an unpinned install resolves to the latest stable v1.x, which this README does not describe. Check [PyPI](https://pypi.org/project/mcp/#history) for the newest pre-release, and use `uv run --with "mcp==2.0.0a3"` for one-off commands.
+The pin matters while v2 is in pre-release: an unpinned install resolves to the latest stable v1.x, which this README does not describe. Check [PyPI](https://pypi.org/project/mcp/#history) for the newest pre-release, and use `uv run --with "mcp==2.0.0b1"` for one-off commands.
 
 ## A server in 15 lines
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,21 +21,21 @@ Python 3.10+.
 === "uv"
 
     ```bash
-    uv add "mcp[cli]==2.0.0a3"
+    uv add "mcp[cli]==2.0.0b1"
     ```
 
 === "pip"
 
     ```bash
-    pip install "mcp[cli]==2.0.0a3"
+    pip install "mcp[cli]==2.0.0b1"
     ```
 
 The `[cli]` extra gives you the `mcp` command; you'll want it for development.
 
-!!! warning "Pin the version while v2 is in alpha"
+!!! warning "Pin the version while v2 is in beta"
     Installers never select a pre-release unless you name one, so an unpinned `uv add "mcp[cli]"`
     gives you the latest **v1.x** release, which this documentation does not describe. Check
-    [PyPI](https://pypi.org/project/mcp/#history) for the newest alpha before you copy the line
+    [PyPI](https://pypi.org/project/mcp/#history) for the newest beta before you copy the line
     above. See [Installation](installation.md) for the details.
 
 ## Example

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,27 +2,27 @@
 
 The Python SDK is on PyPI as [`mcp`](https://pypi.org/project/mcp/). It requires **Python 3.10+**.
 
-These docs describe **v2**, which is in alpha, so the version pin is not optional yet:
+These docs describe **v2**, which is in beta, so the version pin is not optional yet:
 
 === "uv"
 
     ```bash
-    uv add "mcp[cli]==2.0.0a3"
+    uv add "mcp[cli]==2.0.0b1"
     ```
 
 === "pip"
 
     ```bash
-    pip install "mcp[cli]==2.0.0a3"
+    pip install "mcp[cli]==2.0.0b1"
     ```
 
 !!! warning "Why the pin"
     Installers never select a pre-release unless you name one, so an unpinned `uv add "mcp[cli]"`
     gives you the latest **v1.x** release, which these docs do not describe. Check the
-    [release history](https://pypi.org/project/mcp/#history) for the newest alpha before you copy
+    [release history](https://pypi.org/project/mcp/#history) for the newest beta before you copy
     the line above.
 
-    The same applies to one-off commands: `uv run --with "mcp==2.0.0a3" ...`, not `uv run --with mcp ...`.
+    The same applies to one-off commands: `uv run --with "mcp==2.0.0b1" ...`, not `uv run --with mcp ...`.
 
     If your *package* depends on `mcp`, add a `<2` upper bound (for example `mcp>=1.27,<2`) before
     the stable v2 lands so the major version bump doesn't surprise you.


### PR DESCRIPTION
Pre-tag flip for the first v2 beta, per RELEASE.md ("v2 Pre-releases", step 1):

- all `2.0.0a3` install-pin examples become `2.0.0b1` (README.md, `docs/index.md`, `docs/installation.md`)
- the four "v2 is in alpha" phase mentions in the docs become "in beta" (the README banner already covers both phases)

`docs/migration.md`'s "earlier alphas" wording is historical and stays. No source changes; the package version comes from the tag.

This needs to be in the tagged commit so the published README and docs name the version being released — intended to merge last before the `v2.0.0b1` tag.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>