### PR TITLE
Preserve dict output Field metadata

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -397,9 +397,7 @@ def _try_create_model_and_schema(
         if origin is dict:
             args = get_args(type_expr)
             if len(args) == 2 and args[0] is str:
-                # TODO: should we use the original annotation? We are losing any potential `Annotated`
-                # metadata for Pydantic here:
-                model = _create_dict_model(func_name, type_expr)
+                model = _create_dict_model(func_name, original_annotation)
             else:
                 # dict with non-str keys needs wrapping
                 model = _create_wrapped_model(func_name, original_annotation)

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -258,6 +258,19 @@ def test_structured_output_dict_str_types():
         "title": "func_dict_listDictOutput",
     }
 
+    def func_dict_with_description() -> Annotated[
+        dict[str, int], Field(description="Configuration values")
+    ]:  # pragma: no cover
+        return {"timeout": 30}
+
+    meta = func_metadata(func_dict_with_description)
+    assert meta.output_schema == {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+        "title": "func_dict_with_descriptionDictOutput",
+        "description": "Configuration values",
+    }
+
     # Test dict[int, str] - should be wrapped since key is not str
     def func_dict_int_key() -> dict[int, str]:  # pragma: no cover
         return {1: "a", 2: "b"}


### PR DESCRIPTION
## Summary
- preserve top-level Annotated/Field metadata for dict[str, T] tool return types
- pass the original return annotation into the dict RootModel path
- add a regression test covering Field(description=...) on dict outputs

## Testing
- PYTHONPATH=src:src/mcp-types python -m pytest -q tests/server/mcpserver/test_func_metadata.py -k structured_output_dict_str_types
- PYTHONPATH=src:src/mcp-types python -m pytest -q tests/server/mcpserver/test_func_metadata.py

Fixes #2935