### PR TITLE
fix(client): surface streamable HTTP 401 as JSON-RPC error

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -356,6 +356,8 @@ class StreamableHTTPTransport:
                             error_data = ErrorData(code=METHOD_NOT_FOUND, message="Not Found")
                         else:
                             error_data = ErrorData(code=INVALID_REQUEST, message="Session terminated")
+                    elif response.status_code == 401:
+                        error_data = ErrorData(code=INTERNAL_ERROR, message="Unauthorized")
                     else:
                         error_data = ErrorData(code=INTERNAL_ERROR, message="Server returned an error response")
                     session_message = SessionMessage(JSONRPCError(jsonrpc="2.0", id=message.id, error=error_data))

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -18,6 +18,7 @@ from inline_snapshot import snapshot
 from mcp_types import (
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
+    INTERNAL_ERROR,
     METHOD_NOT_FOUND,
     PROTOCOL_VERSION_META_KEY,
     JSONRPCError,
@@ -122,6 +123,32 @@ async def test_pre_session_bare_404_maps_to_method_not_found() -> None:
     assert isinstance(reply, SessionMessage)
     assert isinstance(reply.message, JSONRPCError)
     assert reply.message.error.code == METHOD_NOT_FOUND
+
+
+@pytest.mark.anyio
+async def test_bare_401_request_maps_to_unauthorized_jsonrpc_error() -> None:
+    """A bare HTTP 401 should reach the caller as a correlated JSON-RPC error.
+
+    Authorization failures can be operation-specific. The client transport must
+    leave room for the agent/session layer to handle the denial instead of
+    collapsing it into an indistinguishable transport failure.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401)
+
+    with anyio.fail_after(5):
+        async with (
+            httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http,
+            streamable_http_client("http://test/mcp", http_client=http) as (read, write),
+        ):
+            await write.send(SessionMessage(JSONRPCRequest(jsonrpc="2.0", id=1, method="tools/call", params={})))
+            reply = await read.receive()
+    assert isinstance(reply, SessionMessage)
+    assert isinstance(reply.message, JSONRPCError)
+    assert reply.message.id == 1
+    assert reply.message.error.code == INTERNAL_ERROR
+    assert reply.message.error.message == "Unauthorized"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- map bare Streamable HTTP 401 POST responses for JSON-RPC requests to a correlated JSON-RPC error instead of the generic fallback
- keep existing JSON-RPC error bodies, 404 pre-session, and session-terminated handling unchanged
- add a regression test for operation-specific authorization failures

Fixes #1295.

## Verification
- RED: `PATH=/tmp/codex-uv-0.9.5/bin:$PATH uv run pytest tests/client/test_streamable_http.py::test_bare_401_request_maps_to_unauthorized_jsonrpc_error -q` failed with `Server returned an error response` vs `Unauthorized`
- GREEN: `PATH=/tmp/codex-uv-0.9.5/bin:$PATH uv run pytest tests/client/test_streamable_http.py::test_bare_401_request_maps_to_unauthorized_jsonrpc_error tests/client/test_streamable_http.py -q`
- `PATH=/tmp/codex-uv-0.9.5/bin:$PATH uv run ruff check src/mcp/client/streamable_http.py tests/client/test_streamable_http.py`
- `PATH=/tmp/codex-uv-0.9.5/bin:$PATH uv run ruff format --check src/mcp/client/streamable_http.py tests/client/test_streamable_http.py`
- `PATH=/tmp/codex-uv-0.9.5/bin:$PATH uv run pyright src/mcp/client/streamable_http.py tests/client/test_streamable_http.py`
- `git diff --check`

Note: the local Homebrew uv is 0.9.4 while this repo requires >=0.9.5, so verification used an isolated `/tmp/codex-uv-0.9.5` binary.