### PR TITLE
fix(client): unblock streamable HTTP calls on early SSE close

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -13,6 +13,7 @@ import httpx
 from anyio.abc import TaskGroup
 from httpx_sse import EventSource, ServerSentEvent, aconnect_sse
 from mcp_types import (
+    CONNECTION_CLOSED,
     INTERNAL_ERROR,
     INVALID_REQUEST,
     METHOD_NOT_FOUND,
@@ -381,6 +382,17 @@ class StreamableHTTPTransport:
         if last_event_id is not None:  # pragma: no branch
             logger.info("SSE stream disconnected, reconnecting...")
             await self._handle_reconnection(ctx, last_event_id, retry_interval_ms)
+        else:
+            await self._send_connection_closed(ctx, original_request_id)
+
+    async def _send_connection_closed(self, ctx: RequestContext, request_id: RequestId) -> None:
+        """Resolve a pending POST SSE request when the stream closes before a reply."""
+        error_data = ErrorData(code=CONNECTION_CLOSED, message="Connection closed")
+        error_msg = SessionMessage(JSONRPCError(jsonrpc="2.0", id=request_id, error=error_data))
+        try:
+            await ctx.read_stream_writer.send(error_msg)
+        except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+            logger.debug("dropped connection-closed error for %r: read stream closed", request_id)
 
     async def _handle_reconnection(
         self,
@@ -393,6 +405,8 @@ class StreamableHTTPTransport:
         # Bail if max retries exceeded
         if attempt >= MAX_RECONNECTION_ATTEMPTS:  # pragma: no cover
             logger.debug(f"Max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
+            if isinstance(ctx.session_message.message, JSONRPCRequest):
+                await self._send_connection_closed(ctx, ctx.session_message.message.id)
             return
 
         # Always wait - use server value or default

--- a/tests/client/test_notification_response.py
+++ b/tests/client/test_notification_response.py
@@ -6,13 +6,14 @@ that don't follow SDK conventions.
 
 import json
 
+import anyio
 import httpx
 import mcp_types as types
 import pytest
 from mcp_types import RootsListChangedNotification
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
 from mcp import ClientSession, MCPError
@@ -72,6 +73,24 @@ def _create_unexpected_content_type_app() -> Starlette:
     return Starlette(debug=True, routes=[Route("/mcp", handle_mcp_request, methods=["POST"])])
 
 
+def _create_empty_sse_response_app() -> Starlette:
+    """Create a server that closes a POST SSE response without a JSON-RPC reply."""
+
+    async def handle_mcp_request(request: Request) -> Response:
+        body = await request.body()
+        data = json.loads(body)
+
+        if data.get("method") == "initialize":
+            return _init_json_response(data)
+
+        if "id" not in data:
+            return Response(status_code=202)
+
+        return StreamingResponse(iter(()), media_type="text/event-stream")
+
+    return Starlette(debug=True, routes=[Route("/mcp", handle_mcp_request, methods=["POST"])])
+
+
 async def test_non_compliant_notification_response() -> None:
     """Verify the client ignores unexpected responses to notifications.
 
@@ -115,6 +134,20 @@ async def test_unexpected_content_type_sends_jsonrpc_error() -> None:
 
                 with pytest.raises(MCPError, match="Unexpected content type: text/plain"):  # pragma: no branch
                     await session.list_tools()
+
+
+async def test_empty_post_sse_response_unblocks_pending_tool_call() -> None:
+    """An SSE response that closes before a JSON-RPC reply raises instead of hanging."""
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=_create_empty_sse_response_app())) as client:
+        async with streamable_http_client("http://localhost/mcp", http_client=client) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:  # pragma: no branch
+                await session.initialize()
+
+                with pytest.raises(MCPError) as exc_info:
+                    with anyio.fail_after(1):
+                        await session.call_tool("greet", {})
+
+                assert exc_info.value.error.code == types.CONNECTION_CLOSED
 
 
 def _create_http_error_app(error_status: int, *, error_on_notifications: bool = False) -> Starlette:


### PR DESCRIPTION
## Summary

Fixes a streamable HTTP client hang when a POST request receives an SSE response that closes before sending a JSON-RPC response.

This targets #1577. It overlaps with the older #1578, but keeps the current-main patch narrow: preserve the existing reconnect behavior when a resumable event id is available, and only resolve the pending request with the existing SDK `CONNECTION_CLOSED` error when there is no response and no resumable event to follow.

## Root Cause

`_handle_sse_response()` consumed the POST SSE stream and returned silently if the stream ended before a response and no `Last-Event-ID` had been observed. Because no `JSONRPCError` or transport exception was written to the read stream, the JSON-RPC dispatcher kept the corresponding `call_tool()` waiter pending forever.

## Changes

- Send a correlated `JSONRPCError(CONNECTION_CLOSED)` when a POST SSE response closes before a reply and cannot be resumed.
- Also resolve the pending request with `CONNECTION_CLOSED` if reconnection attempts are exhausted.
- Add a non-SDK server regression test that closes an SSE response without a JSON-RPC reply and asserts `call_tool()` raises instead of hanging.

## Validation

- `uv run --frozen pytest tests/client/test_notification_response.py::test_empty_post_sse_response_unblocks_pending_tool_call -q`
- `uv run --frozen pytest tests/client/test_notification_response.py -q`
- `uv run --frozen pytest tests/shared/test_streamable_http.py -q`
- `uv run --frozen ruff format src/mcp/client/streamable_http.py tests/client/test_notification_response.py --check`
- `uv run --frozen ruff check src/mcp/client/streamable_http.py tests/client/test_notification_response.py`
- `uv run --frozen pyright src/mcp/client/streamable_http.py tests/client/test_notification_response.py`
- `uv run --frozen coverage erase && uv run --frozen coverage run -m pytest tests/client/test_notification_response.py tests/shared/test_streamable_http.py && uv run --frozen coverage combine && uv run --frozen coverage report --include='src/mcp/client/streamable_http.py' --fail-under=0 && UV_FROZEN=1 uv run --frozen strict-no-cover`
