### PR TITLE
Clarify missing tool_result validation error

### DIFF
--- a/src/mcp/server/validation.py
+++ b/src/mcp/server/validation.py
@@ -89,5 +89,7 @@ def validate_tool_use_result_messages(messages: list[SamplingMessage]) -> None:
     if has_previous_tool_use and previous_content:
         tool_use_ids = {c.id for c in previous_content if c.type == "tool_use"}
         tool_result_ids = {c.tool_use_id for c in last_content if c.type == "tool_result"}
+        if not has_tool_results:
+            raise ValueError("tool_use blocks must be followed by matching tool_result blocks")
         if tool_use_ids != tool_result_ids:
             raise ValueError("ids of tool_result blocks and tool_use blocks from previous message do not match")

--- a/src/mcp/server/validation.py
+++ b/src/mcp/server/validation.py
@@ -84,5 +84,7 @@ def validate_tool_use_result_messages(messages: list[SamplingMessage]) -> None:
     if has_previous_tool_use and previous_content:
         tool_use_ids = {c.id for c in previous_content if c.type == "tool_use"}
         tool_result_ids = {c.tool_use_id for c in last_content if c.type == "tool_result"}
+        if not has_tool_results:
+            raise ValueError("tool_use blocks must be followed by matching tool_result blocks")
         if tool_use_ids != tool_result_ids:
             raise ValueError("ids of tool_result blocks and tool_use blocks from previous message do not match")

--- a/tests/server/test_validation.py
+++ b/tests/server/test_validation.py
@@ -146,6 +146,23 @@ def test_validate_tool_use_result_messages_raises_when_tool_result_ids_dont_matc
         validate_tool_use_result_messages(messages)
 
 
+def test_validate_tool_use_result_messages_raises_when_tool_use_has_no_following_tool_result() -> None:
+    """Raises a specific error when the previous assistant tool_use has no following tool_result."""
+    messages = [
+        SamplingMessage(
+            role="assistant",
+            content=ToolUseContent(type="tool_use", id="tool-1", name="test", input={}),
+        ),
+        SamplingMessage(
+            role="user",
+            content=TextContent(type="text", text="No tool result is provided"),
+        ),
+    ]
+    with pytest.raises(ValueError) as exc_info:
+        validate_tool_use_result_messages(messages)
+    assert str(exc_info.value) == "tool_use blocks must be followed by matching tool_result blocks"
+
+
 def test_validate_tool_use_result_messages_no_error_when_tool_result_matches_tool_use() -> None:
     """No error when tool_result IDs match tool_use IDs."""
     messages = [


### PR DESCRIPTION
## Summary
- keep `tool_use` / `tool_result` balance validation strict
- split the missing-follow-up case into a clearer `ValueError`
- add a direct regression test for an assistant `tool_use` followed by user text instead of `tool_result`

Related to #2960. This PR does not relax the balance rule; it only makes the diagnostic distinguish a missing `tool_result` from an ID mismatch when a `tool_use` is followed by a non-result message.

## Tests
- `uv run --frozen pytest tests/server/test_validation.py -q`
- `uv run --frozen ruff check src/mcp/server/validation.py tests/server/test_validation.py`
- `uv run --frozen ruff format --check src/mcp/server/validation.py tests/server/test_validation.py`
- `git diff --check`