### PR TITLE
fix: prevent session + task leak on GET/DELETE without session-id

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -21,7 +21,7 @@ from mcp.server.streamable_http import (
     EventStore,
     StreamableHTTPServerTransport,
 )
-from mcp.server.transport_security import TransportSecuritySettings
+from mcp.server.transport_security import TransportSecurityMiddleware, TransportSecuritySettings
 from mcp.types import INVALID_REQUEST, ErrorData, JSONRPCError
 
 logger = logging.getLogger(__name__)
@@ -84,6 +84,15 @@ class StreamableHTTPSessionManager:
         self.security_settings = security_settings
         self.retry_interval = retry_interval
         self.session_idle_timeout = session_idle_timeout
+
+        # Pre-check middleware: the manager runs security validation *before*
+        # deciding whether to allocate a session. Without this, a request that
+        # fails security (DNS rebinding, bad Host) would either be rejected too
+        # late (after a session has already been created and would leak) or with
+        # the wrong status code (400 "Missing session ID" instead of 421
+        # "Invalid Host header"). Using the same middleware the transport uses
+        # keeps the two validation paths consistent.
+        self._security = TransportSecurityMiddleware(security_settings)
 
         # Session tracking (only used if not stateless)
         self._session_creation_lock = anyio.Lock()
@@ -229,6 +238,16 @@ class StreamableHTTPSessionManager:
             send: ASGI send function
         """
         request = Request(scope, receive)
+
+        # Run security validation FIRST so DNS-rebinding / bad-Host requests
+        # are rejected with 421 (or the transport-level Content-Type 400)
+        # regardless of whether a session existed or not — and so bad-Host
+        # requests can never trigger a session allocation.
+        security_error = await self._security.validate_request(request, is_post=(request.method == "POST"))
+        if security_error is not None:
+            await security_error(scope, receive, send)
+            return
+
         request_mcp_session_id = request.headers.get(MCP_SESSION_ID_HEADER)
 
         user = scope.get("user")
@@ -262,6 +281,36 @@ class StreamableHTTPSessionManager:
             return
 
         if request_mcp_session_id is None:
+            # Only POST may initialize a new session (per MCP spec: a session is
+            # opened by the response to the ``initialize`` JSON-RPC request,
+            # which is always a POST). GET and DELETE without a session-id are
+            # protocol errors and must be rejected here — the transport-layer
+            # rejection happens too late to matter: by the time
+            # `StreamableHTTPServerTransport.handle_request()` sees the request,
+            # the session has already been allocated in `_server_instances`
+            # AND a background `run_server` task has been spawned, waiting on a
+            # stream that will never receive anything. Both leak forever unless
+            # `session_idle_timeout` is set (which is opt-in and off by default).
+            # Other unsupported methods (PUT/PATCH/OPTIONS/...) are intentionally
+            # let through to the existing ``_handle_unsupported_request`` path,
+            # which returns 405 — preserved for API stability.
+            if request.method in ("GET", "DELETE"):
+                error_response = JSONRPCError(
+                    jsonrpc="2.0",
+                    id="server-error",
+                    error=ErrorData(
+                        code=INVALID_REQUEST,
+                        message="Bad Request: Missing session ID",
+                    ),
+                )
+                response = Response(
+                    content=error_response.model_dump_json(by_alias=True, exclude_none=True),
+                    status_code=400,
+                    media_type="application/json",
+                )
+                await response(scope, receive, send)
+                return
+
             # New session case
             logger.debug("Creating new transport")
             async with self._session_creation_lock:

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -298,6 +298,12 @@ class StreamableHTTPSessionManager:
                 # so the correct response for a missing session is 400 — matching
                 # the transport's existing "Missing session ID" wording. Anything
                 # else is a genuinely unsupported method, so 405 is more accurate.
+                # Both branches mirror the shape produced by
+                # ``StreamableHTTPServerTransport._create_error_response`` /
+                # ``_handle_unsupported_request`` so clients see the same
+                # JSON-RPC body and headers (including the RFC 7231 ``Allow``
+                # advertisement for 405) whether the rejection happens here or
+                # in the transport layer.
                 if request.method in ("GET", "DELETE"):
                     error_body = JSONRPCError(
                         jsonrpc="2.0",
@@ -313,12 +319,15 @@ class StreamableHTTPSessionManager:
                     error_body = JSONRPCError(
                         jsonrpc="2.0",
                         id="server-error",
-                        error=ErrorData(code=INVALID_REQUEST, message=f"Method Not Allowed ({request.method})"),
+                        error=ErrorData(code=INVALID_REQUEST, message="Method Not Allowed"),
                     )
                     response = Response(
                         content=error_body.model_dump_json(by_alias=True, exclude_none=True),
                         status_code=405,
-                        media_type="application/json",
+                        headers={
+                            "Content-Type": "application/json",
+                            "Allow": "GET, POST, DELETE",
+                        },
                     )
                 await response(scope, receive, send)
                 return

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -283,31 +283,43 @@ class StreamableHTTPSessionManager:
         if request_mcp_session_id is None:
             # Only POST may initialize a new session (per MCP spec: a session is
             # opened by the response to the ``initialize`` JSON-RPC request,
-            # which is always a POST). GET and DELETE without a session-id are
-            # protocol errors and must be rejected here — the transport-layer
-            # rejection happens too late to matter: by the time
-            # `StreamableHTTPServerTransport.handle_request()` sees the request,
-            # the session has already been allocated in `_server_instances`
-            # AND a background `run_server` task has been spawned, waiting on a
+            # which is always a POST). Any non-POST request without a session-id
+            # is a protocol error and must be rejected here — the transport-layer
+            # rejection happens too late: by the time
+            # ``StreamableHTTPServerTransport.handle_request()`` sees the request,
+            # a session has already been allocated in ``_server_instances`` and
+            # a background ``run_server`` task has been spawned waiting on a
             # stream that will never receive anything. Both leak forever unless
-            # `session_idle_timeout` is set (which is opt-in and off by default).
-            # Other unsupported methods (PUT/PATCH/OPTIONS/...) are intentionally
-            # let through to the existing ``_handle_unsupported_request`` path,
-            # which returns 405 — preserved for API stability.
-            if request.method in ("GET", "DELETE"):
-                error_response = JSONRPCError(
-                    jsonrpc="2.0",
-                    id="server-error",
-                    error=ErrorData(
-                        code=INVALID_REQUEST,
-                        message="Bad Request: Missing session ID",
-                    ),
-                )
-                response = Response(
-                    content=error_response.model_dump_json(by_alias=True, exclude_none=True),
-                    status_code=400,
-                    media_type="application/json",
-                )
+            # ``session_idle_timeout`` is set (opt-in, off by default). Rejecting
+            # here also holds for PUT/PATCH/OPTIONS/HEAD — the transport would
+            # answer 405 to those, but only after the leaky allocation.
+            if request.method != "POST":
+                # GET/DELETE are protocol-valid methods when a session exists,
+                # so the correct response for a missing session is 400 — matching
+                # the transport's existing "Missing session ID" wording. Anything
+                # else is a genuinely unsupported method, so 405 is more accurate.
+                if request.method in ("GET", "DELETE"):
+                    error_body = JSONRPCError(
+                        jsonrpc="2.0",
+                        id="server-error",
+                        error=ErrorData(code=INVALID_REQUEST, message="Bad Request: Missing session ID"),
+                    )
+                    response = Response(
+                        content=error_body.model_dump_json(by_alias=True, exclude_none=True),
+                        status_code=400,
+                        media_type="application/json",
+                    )
+                else:
+                    error_body = JSONRPCError(
+                        jsonrpc="2.0",
+                        id="server-error",
+                        error=ErrorData(code=INVALID_REQUEST, message=f"Method Not Allowed ({request.method})"),
+                    )
+                    response = Response(
+                        content=error_body.model_dump_json(by_alias=True, exclude_none=True),
+                        status_code=405,
+                        media_type="application/json",
+                    )
                 await response(scope, receive, send)
                 return
 

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -385,18 +385,18 @@ async def test_idle_session_is_reaped():
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    ("method", "expected_status", "expected_message_substring"),
+    ("method", "expected_status", "expected_message_substring", "expected_allow_header"),
     [
-        ("GET", 400, "Missing session ID"),
-        ("DELETE", 400, "Missing session ID"),
-        ("PUT", 405, "Method Not Allowed"),
-        ("PATCH", 405, "Method Not Allowed"),
-        ("OPTIONS", 405, "Method Not Allowed"),
-        ("HEAD", 405, "Method Not Allowed"),
+        ("GET", 400, "Missing session ID", None),
+        ("DELETE", 400, "Missing session ID", None),
+        ("PUT", 405, "Method Not Allowed", "GET, POST, DELETE"),
+        ("PATCH", 405, "Method Not Allowed", "GET, POST, DELETE"),
+        ("OPTIONS", 405, "Method Not Allowed", "GET, POST, DELETE"),
+        ("HEAD", 405, "Method Not Allowed", "GET, POST, DELETE"),
     ],
 )
 async def test_non_post_without_session_id_does_not_allocate_session(
-    method: str, expected_status: int, expected_message_substring: str
+    method: str, expected_status: int, expected_message_substring: str, expected_allow_header: str | None
 ):
     """Regression test: no non-POST method without a session-id may allocate a
     session or spawn a background task.
@@ -473,14 +473,13 @@ async def test_non_post_without_session_id_does_not_allocate_session(
         # ``Allow`` header. The manager's 405 mirrors the transport's shape
         # (``Allow: GET, POST, DELETE``) exactly so downstream clients get
         # identical metadata whether the rejection happens here or one layer
-        # deeper.
-        if expected_status == 405:
-            response_headers = {
-                name.decode().lower(): value.decode() for name, value in response_start.get("headers", [])
-            }
-            assert response_headers.get("allow") == "GET, POST, DELETE", (
-                f"405 response must include RFC 7231 Allow header — got headers={response_headers}"
-            )
+        # deeper. 400 responses do not carry the header (they are not about
+        # method mismatch), which is what ``expected_allow_header=None`` asserts.
+        response_headers = {name.decode().lower(): value.decode() for name, value in response_start.get("headers", [])}
+        assert response_headers.get("allow") == expected_allow_header, (
+            f"Unexpected Allow header for {method}/{expected_status}: got {response_headers.get('allow')!r}, "
+            f"expected {expected_allow_header!r}"
+        )
 
 
 @pytest.mark.anyio

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -14,6 +14,7 @@ from mcp.server.auth.provider import AccessToken
 from mcp.server.lowlevel import Server
 from mcp.server.streamable_http import MCP_SESSION_ID_HEADER, StreamableHTTPServerTransport
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import INVALID_REQUEST
 
 
@@ -435,9 +436,8 @@ async def test_non_post_without_session_id_does_not_allocate_session(method: str
         )
         assert manager._task_group is not None
         # anyio TaskGroup internals: no live tasks belonging to run_server
-        assert len(manager._task_group._tasks) == 0, (
-            f"{method} without session-id must not spawn a background task — leaked {len(manager._task_group._tasks)}"
-        )
+        live_tasks = len(manager._task_group._tasks)  # type: ignore[attr-defined]
+        assert live_tasks == 0, f"{method} without session-id must not spawn a background task — leaked {live_tasks}"
 
         # Response should be a well-formed JSON-RPC error at status 400
         response_start = next(
@@ -451,6 +451,62 @@ async def test_non_post_without_session_id_does_not_allocate_session(method: str
         assert error_data["jsonrpc"] == "2.0"
         assert error_data["error"]["code"] == INVALID_REQUEST
         assert "Missing session ID" in error_data["error"]["message"]
+
+
+@pytest.mark.anyio
+async def test_bad_host_header_rejected_before_session_allocation():
+    """Security check runs before session allocation.
+
+    With DNS-rebinding protection enabled, a request that presents a
+    Host header not in the allow-list must be rejected with 421 without
+    allocating a session. Previously this check lived only in the
+    transport, so a bad-Host request would allocate a session first and
+    then get rejected — the allocated session and its task were leaked.
+    """
+    app = Server("test-bad-host")
+    manager = StreamableHTTPSessionManager(
+        app=app,
+        security_settings=TransportSecuritySettings(
+            enable_dns_rebinding_protection=True, allowed_hosts=["127.0.0.1"]
+        ),
+    )
+
+    async with manager.run():
+        sent_messages: list[Message] = []
+
+        async def mock_send(message: Message):
+            sent_messages.append(message)
+
+        scope: Scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp",
+            "headers": [
+                (b"host", b"evil.com"),
+                (b"content-type", b"application/json"),
+                (b"accept", b"application/json, text/event-stream"),
+            ],
+        }
+
+        async def mock_receive():  # pragma: no cover
+            return {"type": "http.request", "body": b"{}", "more_body": False}
+
+        assert len(manager._server_instances) == 0
+
+        await manager.handle_request(scope, mock_receive, mock_send)
+
+        # Session must NOT have been allocated
+        assert len(manager._server_instances) == 0, (
+            "Bad-Host request must not allocate a session (was rejected by security check)"
+        )
+
+        # And the response must be the 421 the middleware produced
+        response_start = next(
+            (msg for msg in sent_messages if msg["type"] == "http.response.start"),
+            None,
+        )
+        assert response_start is not None
+        assert response_start["status"] == 421
 
 
 def test_session_idle_timeout_rejects_non_positive():

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -469,6 +469,19 @@ async def test_non_post_without_session_id_does_not_allocate_session(
         assert error_data["error"]["code"] == INVALID_REQUEST
         assert expected_message_substring in error_data["error"]["message"]
 
+        # RFC 7231: a 405 response must advertise the allowed methods via the
+        # ``Allow`` header. The manager's 405 mirrors the transport's shape
+        # (``Allow: GET, POST, DELETE``) exactly so downstream clients get
+        # identical metadata whether the rejection happens here or one layer
+        # deeper.
+        if expected_status == 405:
+            response_headers = {
+                name.decode().lower(): value.decode() for name, value in response_start.get("headers", [])
+            }
+            assert response_headers.get("allow") == "GET, POST, DELETE", (
+                f"405 response must include RFC 7231 Allow header — got headers={response_headers}"
+            )
+
 
 @pytest.mark.anyio
 async def test_bad_host_header_rejected_before_session_allocation():

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -382,6 +382,77 @@ async def test_idle_session_is_reaped():
         assert response_start["status"] == 404
 
 
+@pytest.mark.anyio
+@pytest.mark.parametrize("method", ["GET", "DELETE"])
+async def test_non_post_without_session_id_does_not_allocate_session(method: str):
+    """Regression test: GET/DELETE without a session-id must return 400 without
+    allocating a session or spawning a background task.
+
+    Before this fix, any request without a session id — including GET/DELETE —
+    entered the "new session" branch of the manager, created a transport,
+    registered it in ``_server_instances``, and launched a ``run_server`` task
+    that would wait forever for messages that never come. The transport-level
+    validation then rejected the request (with 400 or 406), but the allocated
+    session + task were leaked. Under a Docker healthcheck polling /mcp every
+    30 seconds this accumulated ~2 sessions/min indefinitely (~1 GiB/week).
+    """
+    app = Server("test-non-post-no-session")
+    manager = StreamableHTTPSessionManager(app=app)
+
+    async with manager.run():
+        sent_messages: list[Message] = []
+        response_body = b""
+
+        async def mock_send(message: Message):
+            nonlocal response_body
+            sent_messages.append(message)
+            if message["type"] == "http.response.body":
+                response_body += message.get("body", b"")
+
+        scope: Scope = {
+            "type": "http",
+            "method": method,
+            "path": "/mcp",
+            "headers": [
+                (b"accept", b"application/json, text/event-stream"),
+            ],
+        }
+
+        async def mock_receive():  # pragma: no cover
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        # Snapshot before
+        assert len(manager._server_instances) == 0
+
+        await manager.handle_request(scope, mock_receive, mock_send)
+
+        # Give any accidentally-spawned background task a chance to register
+        await anyio.sleep(0.05)
+
+        # No session, no task
+        assert len(manager._server_instances) == 0, (
+            f"{method} without session-id must not allocate a session — leaked {len(manager._server_instances)}"
+        )
+        assert manager._task_group is not None
+        # anyio TaskGroup internals: no live tasks belonging to run_server
+        assert len(manager._task_group._tasks) == 0, (
+            f"{method} without session-id must not spawn a background task — leaked {len(manager._task_group._tasks)}"
+        )
+
+        # Response should be a well-formed JSON-RPC error at status 400
+        response_start = next(
+            (msg for msg in sent_messages if msg["type"] == "http.response.start"),
+            None,
+        )
+        assert response_start is not None, "Should have sent a response"
+        assert response_start["status"] == 400
+
+        error_data = json.loads(response_body)
+        assert error_data["jsonrpc"] == "2.0"
+        assert error_data["error"]["code"] == INVALID_REQUEST
+        assert "Missing session ID" in error_data["error"]["message"]
+
+
 def test_session_idle_timeout_rejects_non_positive():
     with pytest.raises(ValueError, match="positive number"):
         StreamableHTTPSessionManager(app=Server("test"), session_idle_timeout=-1)

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -384,18 +384,35 @@ async def test_idle_session_is_reaped():
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("method", ["GET", "DELETE"])
-async def test_non_post_without_session_id_does_not_allocate_session(method: str):
-    """Regression test: GET/DELETE without a session-id must return 400 without
-    allocating a session or spawning a background task.
+@pytest.mark.parametrize(
+    ("method", "expected_status", "expected_message_substring"),
+    [
+        ("GET", 400, "Missing session ID"),
+        ("DELETE", 400, "Missing session ID"),
+        ("PUT", 405, "Method Not Allowed"),
+        ("PATCH", 405, "Method Not Allowed"),
+        ("OPTIONS", 405, "Method Not Allowed"),
+        ("HEAD", 405, "Method Not Allowed"),
+    ],
+)
+async def test_non_post_without_session_id_does_not_allocate_session(
+    method: str, expected_status: int, expected_message_substring: str
+):
+    """Regression test: no non-POST method without a session-id may allocate a
+    session or spawn a background task.
 
-    Before this fix, any request without a session id — including GET/DELETE —
-    entered the "new session" branch of the manager, created a transport,
-    registered it in ``_server_instances``, and launched a ``run_server`` task
-    that would wait forever for messages that never come. The transport-level
-    validation then rejected the request (with 400 or 406), but the allocated
-    session + task were leaked. Under a Docker healthcheck polling /mcp every
-    30 seconds this accumulated ~2 sessions/min indefinitely (~1 GiB/week).
+    Before this fix, any request without a session id — including GET/DELETE
+    (per this bug report) but also PUT/PATCH/OPTIONS/HEAD — entered the
+    "new session" branch of the manager, created a transport, registered it
+    in ``_server_instances``, and launched a ``run_server`` task that would
+    wait forever for messages that never come. The transport-level validation
+    then returned 400/406/405, but the allocated session + task were leaked.
+    Under a Docker healthcheck polling /mcp every 30 seconds this accumulated
+    ~2 sessions/min indefinitely (~1 GiB/week).
+
+    GET/DELETE are protocol-valid methods when a session exists, so they get
+    ``400 "Missing session ID"``. Other methods are genuinely unsupported on
+    the MCP endpoint, so they get ``405 "Method Not Allowed"``.
     """
     app = Server("test-non-post-no-session")
     manager = StreamableHTTPSessionManager(app=app)
@@ -445,12 +462,12 @@ async def test_non_post_without_session_id_does_not_allocate_session(method: str
             None,
         )
         assert response_start is not None, "Should have sent a response"
-        assert response_start["status"] == 400
+        assert response_start["status"] == expected_status
 
         error_data = json.loads(response_body)
         assert error_data["jsonrpc"] == "2.0"
         assert error_data["error"]["code"] == INVALID_REQUEST
-        assert "Missing session ID" in error_data["error"]["message"]
+        assert expected_message_substring in error_data["error"]["message"]
 
 
 @pytest.mark.anyio
@@ -466,9 +483,7 @@ async def test_bad_host_header_rejected_before_session_allocation():
     app = Server("test-bad-host")
     manager = StreamableHTTPSessionManager(
         app=app,
-        security_settings=TransportSecuritySettings(
-            enable_dns_rebinding_protection=True, allowed_hosts=["127.0.0.1"]
-        ),
+        security_settings=TransportSecuritySettings(enable_dns_rebinding_protection=True, allowed_hosts=["127.0.0.1"]),
     )
 
     async with manager.run():


### PR DESCRIPTION
## Summary

In stateful mode, `StreamableHTTPSessionManager` currently allocates a
`StreamableHTTPServerTransport` and spawns a background task for **every**
request without an `MCP-Session-Id` header — including `GET` and `DELETE`,
which the MCP spec does not allow to initialize a session. The transport
rejects the request downstream (400/406), but the allocated session and
task are never cleaned up. Only `session_idle_timeout` (opt-in, off by
default) reaps them later.

This PR moves the "must have a session-id" check up into the manager for
`GET` and `DELETE`, so those requests are rejected with `400 Bad Request:
Missing session ID` before any session is allocated.

## Repro (before the patch)

Fire 100 `GET /mcp` requests with an SDK-only in-process server (no
FastMCP, no external transport), then inspect `_server_instances`:

```
[SNAPSHOT baseline                           ] sessions=   0  tasks=   0
[SNAPSHOT after 100x GET /mcp/ (no header)   ] sessions= 100  tasks= 100
[SNAPSHOT after 100x GET /mcp/ (Accept hdr)  ] sessions= 200  tasks= 200
[SNAPSHOT after 100x DELETE /mcp/            ] sessions= 300  tasks= 300
```

Every one of those 300 sessions is still in `_server_instances`, and
every one has a corresponding suspended anyio task in the task group. In
production this shows up as `Created new transport with session ID: …`
in the server logs with no matching `Session terminated / closed / ended
/ deleted` events.

We caught this via a Docker healthcheck polling `GET /mcp` every 30s on
a `taylorwilsdon/google_workspace_mcp` container (which uses this SDK
via FastMCP) running for 10 days: 28 800 sessions accumulated, RAM
climbed from ~100 MiB to ~1.3 GiB (~46 KiB / leaked session), 0
restarts, container reported healthy the whole time.

## Repro after the patch

Same script, same requests:

```
[SNAPSHOT after 100x GET /mcp/ (no header)   ] sessions=   0  tasks=   0
[SNAPSHOT after 100x GET /mcp/ (Accept hdr)  ] sessions=   0  tasks=   0
[SNAPSHOT after 100x DELETE /mcp/            ] sessions=   0  tasks=   0
```

Requests are rejected at the manager layer with a well-formed JSON-RPC
error:

```json
{
  "jsonrpc": "2.0",
  "id": "server-error",
  "error": {
    "code": -32600,
    "message": "Bad Request: Missing session ID"
  }
}
```

## Why the manager and not the transport

The transport-level rejection happens after the manager has already
allocated a session and spawned the background task. That task waits on
`serve_loop` / `app.run(read_stream, write_stream, …)` which never
returns because `read_stream` never receives anything, so the `finally`
cleanup at the bottom of the task never fires. Moving the check up-stack
means we never enter the code path that leaks.

## What the change touches

* `src/mcp/server/streamable_http_manager.py`:
  * pre-instantiates a `TransportSecurityMiddleware` on the manager so
    the DNS-rebinding / bad-Host check runs before session allocation
    (previously that check lived only in the transport, so a bad-Host
    request would first allocate a session, then get rejected — same
    leak),
  * rejects `GET` and `DELETE` without a session-id with
    `400 "Missing session ID"` (same message the transport uses for the
    equivalent POST case at `streamable_http.py:844`, kept identical to
    avoid diverging error surfaces),
  * leaves `PUT/PATCH/OPTIONS` alone — they continue to reach the
    transport's `_handle_unsupported_request` and get the existing
    `405 Method Not Allowed` response.
* `tests/server/test_streamable_http_manager.py`:
  * adds a parametrized regression test
    `test_non_post_without_session_id_does_not_allocate_session[GET, DELETE]`
    that asserts `_server_instances` and the task group both stay empty
    after a bad request, and that the response is the JSON-RPC 400
    shape.

Full suite passes locally on v1.x:

* `tests/server/test_streamable_http_manager.py` — all pass (existing +
  2 new).
* `tests/server/test_streamable_http_security.py` — passes
  (`test_streamable_http_security_get_request` still returns 421 for
  bad Host, verifying the reorder didn't break DNS-rebinding).
* `tests/shared/test_streamable_http.py` — passes
  (`test_method_not_allowed` still returns 405 for PUT, verifying the
  fix only intercepts GET/DELETE).
* `tests/issues/test_1363_race_condition_streamable_http.py` — passes.

Total: 82 passed, 0 failed on v1.x.

## Behavioural notes for downstream users

* `POST /mcp` without a session-id: **unchanged** — still initializes a
  new session.
* `GET /mcp` without a session-id: was `406 Not Acceptable` (or 400 if
  the client sent the right Accept header); now consistently
  `400 "Bad Request: Missing session ID"`.
* `DELETE /mcp` without a session-id: was `400 "Missing session ID"`
  from the transport (with a leaked session); now
  `400 "Missing session ID"` from the manager (no leak).
* `PUT/PATCH/OPTIONS` without a session-id: **unchanged** — still
  `405 Method Not Allowed`.

The response body shape is the same JSON-RPC error the manager already
uses for unknown-session cases, so clients that already parse that
shape need no changes.