### PR TITLE
Validate elicitation sub-capabilities in check_capability

### DIFF
--- a/docs/handlers/elicitation.md
+++ b/docs/handlers/elicitation.md
@@ -124,6 +124,24 @@ Some things must not go through the model or the client: credentials, card numbe
 
 Look at the second tool. When your server learns the out-of-band flow finished (a webhook, a poll; here it's modelled as a second tool), `ctx.session.send_elicit_complete(...)` sends `notifications/elicitation/complete` with the same `elicitation_id`. That is how the client knows it can stop showing *"waiting for payment..."*. Without it, the client can only guess.
 
+## Ask only in a mode the client supports
+
+A client can declare one mode without the other - a terminal that renders a form but has no browser to open a URL, or a kiosk that can only open a URL. `ctx.session.check_client_capability` reads the `form` / `url` sub-capabilities, so a tool can pick a mode the client actually supports before it asks:
+
+```python
+from mcp_types import ClientCapabilities, ElicitationCapability, FormElicitationCapability
+
+
+async def book_table(ctx: Context) -> str:
+    wants_form = ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability()))
+    if not ctx.session.check_client_capability(wants_form):
+        return "This client can't render a form; send a URL or return a default instead."
+    result = await ctx.elicit("Which date?", schema=AlternativeDate)
+    return "booked" if result.action == "accept" else "no change"
+```
+
+A bare `ElicitationCapability()` (no mode set) matches any client that supports elicitation at all, so name a mode only when you need that specific one. This is the same *"what if I can't ask?"* design the client-side check below calls out - now decided per mode.
+
 ## The client side
 
 Servers ask. Clients answer by passing an **`elicitation_callback`** to `Client(...)`:

--- a/src/mcp/server/connection.py
+++ b/src/mcp/server/connection.py
@@ -388,8 +388,13 @@ class Connection:
                 return False
             if capability.sampling.tools is not None and have.sampling.tools is None:
                 return False
-        if capability.elicitation is not None and have.elicitation is None:
-            return False
+        if capability.elicitation is not None:
+            if have.elicitation is None:
+                return False
+            if capability.elicitation.form is not None and have.elicitation.form is None:
+                return False
+            if capability.elicitation.url is not None and have.elicitation.url is None:
+                return False
         if capability.experimental is not None:
             if have.experimental is None:
                 return False

--- a/tests/server/test_connection.py
+++ b/tests/server/test_connection.py
@@ -21,6 +21,7 @@ from mcp_types import (
     CreateMessageRequestParams,
     ElicitationCapability,
     EmptyResult,
+    FormElicitationCapability,
     Implementation,
     ListRootsRequest,
     ListRootsResult,
@@ -31,6 +32,7 @@ from mcp_types import (
     SamplingCapability,
     SamplingContextCapability,
     SamplingToolsCapability,
+    UrlElicitationCapability,
 )
 from mcp_types.version import LATEST_HANDSHAKE_VERSION, LATEST_MODERN_VERSION
 from pydantic import BaseModel, ValidationError
@@ -364,6 +366,35 @@ def test_connection_check_capability_false_when_no_client_params_recorded():
         (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"b": {}}), False),
         (ClientCapabilities(experimental={"a": {"x": 1}}), ClientCapabilities(experimental={"a": {"x": 2}}), False),
         (ClientCapabilities(experimental={"a": {}}), ClientCapabilities(experimental={"a": {}}), True),
+        (ClientCapabilities(elicitation=None), ClientCapabilities(elicitation=ElicitationCapability()), False),
+        # The client offers only URL-mode elicitation, but form mode is requested.
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            False,
+        ),
+        # The client offers only form-mode elicitation, but URL mode is requested.
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            False,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(form=FormElicitationCapability())),
+            True,
+        ),
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            True,
+        ),
+        # A bare elicitation request (no sub-capability) is satisfied by any elicitation support.
+        (
+            ClientCapabilities(elicitation=ElicitationCapability(url=UrlElicitationCapability())),
+            ClientCapabilities(elicitation=ElicitationCapability()),
+            True,
+        ),
     ],
 )
 def test_check_capability_per_field_branches(have: ClientCapabilities, want: ClientCapabilities, expected: bool):


### PR DESCRIPTION
`Connection.check_capability()` (exposed publicly via `ServerSession.check_client_capability`) rejected a requested `elicitation` capability only when the client declared **no** elicitation support at all. It never inspected the `form` / `url` sub-capabilities, so a client that advertised only URL-mode elicitation would incorrectly pass a check for form-mode elicitation, and vice versa.

Handle elicitation the same way as `sampling`: when a specific mode is requested, require the client to declare that mode. A bare elicitation request is still satisfied by any elicitation support.

Fixes #2965

## Motivation and Context

`check_capability` mirrors the (correct) `sampling` handling for the top-level presence check but omits the per-sub-capability checks that `sampling` performs for `context` / `tools`:

```python
if capability.elicitation is not None and have.elicitation is None:
    return False
```

Because it only returns `False` when the client has no elicitation at all, a caller checking for form-mode elicitation against a URL-only client (or vice versa) gets a wrong `True`. This is public API, so once a caller relies on it (e.g. checking for form support before `elicit_form`), it silently returns incorrect results.

The fix adds the `form` / `url` sub-capability checks, matching the `sampling` pattern:

```python
if capability.elicitation is not None:
    if have.elicitation is None:
        return False
    if capability.elicitation.form is not None and have.elicitation.form is None:
        return False
    if capability.elicitation.url is not None and have.elicitation.url is None:
        return False
```

Scope kept to elicitation. The issue also mentioned `extensions` and `tasks` as lower-priority gaps: `extensions` is already handled on `main` (SEP-2133), and `tasks` is left out to keep this tightly scoped — happy to follow up separately if desired.

## How Has This Been Tested?

Extended the existing `test_check_capability_per_field_branches` parametrization in `tests/server/test_connection.py` with the elicitation branches: the two bug cases (URL-only client vs. form request, and form-only client vs. URL request), the matching positive cases, and the bare-request case. The two bug cases fail on `main` and pass with this change; the full `test_connection.py` suite is green (44 passed). `ruff check`, `ruff format --check`, and `pyright` are all clean on the changed files.

Docs: added a short "Ask only in a mode the client supports" section to `docs/handlers/elicitation.md` showing how a server uses `check_client_capability` to pick a form/url mode the client supports before eliciting. `mkdocs build --strict` passes.

## Breaking Changes

No API change. `check_capability` now returns the correct `False` for a requested elicitation mode the client does not support (previously a wrong `True`). Callers that were (incorrectly) relying on the old always-true-when-any-elicitation behavior would see the corrected result.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

*AI assistance: I used AI tooling to help analyze the issue, draft the fix, and scaffold the tests. I reviewed and understand the change, stand behind it, and can discuss it directly.*
