### PR TITLE
fix: forbid extra arguments in FastMCP tool arg models (#3067)

### DIFF
--- a/docs/handlers/dependencies.md
+++ b/docs/handlers/dependencies.md
@@ -35,7 +35,7 @@ Here is the input schema `tools/list` reports for `reserve_book`:
 }
 ```
 
-One property. Like the `Context` in **[The Context](context.md)**, a resolved parameter is a contract between you and the SDK: `stock` is not in the schema, the model is never told about it, and a client that sends a `stock` value anyway is ignored. The resolver's value is the only one your tool can receive.
+One property. Like the `Context` in **[The Context](context.md)**, a resolved parameter is a contract between you and the SDK: `stock` is not in the schema, the model is never told about it, and a client that sends a `stock` value anyway is rejected. The resolver's value is the only one your tool can receive.
 
 That last part is the point. A parameter the model cannot supply is a parameter the model cannot get wrong.
 

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -60,7 +60,7 @@ class ArgModelBase(BaseModel):
             kwargs[output_name] = value
         return kwargs
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
 
 class FuncMetadata(BaseModel):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -156,6 +156,7 @@ async def test_client_list_tools(app: MCPServer):
                         description="Greet someone by name.",
                         input_schema={
                             "properties": {"name": {"title": "Name", "type": "string"}},
+                            "additionalProperties": False,
                             "required": ["name"],
                             "title": "greetArguments",
                             "type": "object",

--- a/tests/docs_src/test_client.py
+++ b/tests/docs_src/test_client.py
@@ -53,6 +53,7 @@ async def test_list_tools_returns_the_full_definition() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "query": {"title": "Query", "type": "string"},
                     "limit": {"default": 10, "title": "Limit", "type": "integer"},

--- a/tests/docs_src/test_context.py
+++ b/tests/docs_src/test_context.py
@@ -20,6 +20,7 @@ async def test_the_context_parameter_is_not_in_the_input_schema() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {"query": {"title": "Query", "type": "string"}},
                 "required": ["query"],
                 "title": "search_booksArguments",
@@ -56,7 +57,7 @@ async def test_a_context_only_tool_takes_no_arguments() -> None:
     async with Client(tutorial002.mcp) as client:
         tools = {tool.name: tool for tool in (await client.list_tools()).tools}
         assert tools["describe_catalog"].input_schema == snapshot(
-            {"type": "object", "properties": {}, "title": "describe_catalogArguments"}
+            {"type": "object", "additionalProperties": False, "properties": {}, "title": "describe_catalogArguments"}
         )
 
 

--- a/tests/docs_src/test_dependencies.py
+++ b/tests/docs_src/test_dependencies.py
@@ -31,6 +31,7 @@ async def test_the_resolved_parameter_is_invisible_to_the_model() -> None:
     assert tool.input_schema == snapshot(
         {
             "type": "object",
+            "additionalProperties": False,
             "properties": {"title": {"title": "Title", "type": "string"}},
             "required": ["title"],
             "title": "reserve_bookArguments",
@@ -38,12 +39,15 @@ async def test_the_resolved_parameter_is_invisible_to_the_model() -> None:
     )
 
 
-async def test_a_client_supplied_value_for_a_resolved_parameter_is_ignored() -> None:
-    """tutorial001: the resolver's value is the only one the tool can receive."""
+async def test_a_client_supplied_value_for_a_resolved_parameter_is_rejected() -> None:
+    """tutorial001: resolved parameters are not in the schema, so extra arguments fail validation."""
     async with Client(tutorial001.mcp) as client:
         result = await client.call_tool("reserve_book", {"title": "Dune", "stock": {"title": "Dune", "copies": 999}})
 
-    assert result.content == [TextContent(type="text", text="Reserved 'Dune' (6 copies left).")]
+    assert result.is_error
+    assert isinstance(result.content[0], TextContent)
+    # pydantic's "Extra inputs are not permitted" wording changes across versions.
+    assert result.content[0].text.startswith("Error executing tool reserve_book:")
 
 
 async def test_a_resolver_can_depend_on_another_resolver() -> None:

--- a/tests/docs_src/test_first_steps.py
+++ b/tests/docs_src/test_first_steps.py
@@ -26,6 +26,7 @@ async def test_each_decorator_registers_one_primitive() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "a": {"title": "A", "type": "integer"},
                     "b": {"title": "B", "type": "integer"},

--- a/tests/docs_src/test_lifespan.py
+++ b/tests/docs_src/test_lifespan.py
@@ -29,6 +29,7 @@ async def test_context_parameter_never_reaches_the_input_schema() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {"genre": {"title": "Genre", "type": "string"}},
                 "required": ["genre"],
                 "title": "count_booksArguments",

--- a/tests/docs_src/test_real_host.py
+++ b/tests/docs_src/test_real_host.py
@@ -20,6 +20,7 @@ async def test_the_host_sees_exactly_what_the_decorators_registered() -> None:
         assert search.input_schema == snapshot(
             {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {"query": {"title": "Query", "type": "string"}},
                 "required": ["query"],
                 "title": "search_booksArguments",

--- a/tests/docs_src/test_tools.py
+++ b/tests/docs_src/test_tools.py
@@ -20,6 +20,7 @@ async def test_signature_becomes_the_schema() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "query": {"title": "Query", "type": "string"},
                     "limit": {"title": "Limit", "type": "integer"},
@@ -49,6 +50,7 @@ async def test_default_value_makes_the_argument_optional() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
+                "additionalProperties": False,
                 "properties": {
                     "query": {"title": "Query", "type": "string"},
                     "limit": {"default": 10, "title": "Limit", "type": "integer"},

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -11,7 +11,7 @@ import annotated_types
 import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, InputRequiredResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from mcp.server.mcpserver.exceptions import InvalidSignature
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
@@ -275,6 +275,7 @@ async def test_lambda_function():
 
     # Test schema
     assert meta.arg_model.model_json_schema() == {
+        "additionalProperties": False,
         "properties": {
             "x": {"title": "x", "type": "string"},
             "y": {"default": 5, "title": "y", "type": "string"},
@@ -464,6 +465,7 @@ def test_complex_function_json_schema():
             "my_model_a_forward_ref",
             "my_model_b",
         ],
+        "additionalProperties": False,
         "title": "complex_arguments_fnArguments",
         "type": "object",
     }
@@ -1295,6 +1297,17 @@ def test_call_tool_result_in_union_with_input_required_result_is_still_rejected(
 
     with pytest.raises(InvalidSignature, match="CallToolResult cannot be used in Union"):
         func_metadata(fn)
+
+
+def test_unknown_argument_raises_validation_error():
+    """SDK-defined: a tools/call argument name not on the tool schema fails validation."""
+
+    def read_doc(topic: str = "") -> str:
+        return topic
+
+    meta = func_metadata(read_doc)
+    with pytest.raises(ValidationError):
+        meta.arg_model.model_validate({"path": "something"})
 
 
 def test_union_of_only_input_required_subclasses_yields_no_output_schema():

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1302,8 +1302,7 @@ def test_call_tool_result_in_union_with_input_required_result_is_still_rejected(
 def test_unknown_argument_raises_validation_error():
     """SDK-defined: a tools/call argument name not on the tool schema fails validation."""
 
-    def read_doc(topic: str = "") -> str:
-        return topic
+    def read_doc(topic: str = "") -> str: ...  # pragma: no branch
 
     meta = func_metadata(read_doc)
     with pytest.raises(ValidationError):

--- a/tests/server/mcpserver/test_resolve.py
+++ b/tests/server/mcpserver/test_resolve.py
@@ -2719,23 +2719,25 @@ async def test_a_resolver_may_depend_on_another_resolvers_value():
 
 
 @pytest.mark.anyio
-async def test_a_client_supplied_value_for_a_resolved_parameter_is_discarded():
-    """A value the client sends under a resolved parameter's name never reaches the
-    tool; the resolver's value wins. SDK-defined: resolved parameters are server-side only."""
+async def test_a_client_supplied_value_for_a_resolved_parameter_is_rejected():
+    """A value the client sends under a resolved parameter's name fails validation.
+    SDK-defined: resolved parameters are absent from the schema, so extras are forbidden."""
     mcp = MCPServer(name="Walk", request_state_security=RequestStateSecurity.ephemeral())
 
     def price_of(title: str) -> int:
-        return 42
+        return 42  # pragma: no cover - never reached; call fails at arg validation
 
     @mcp.tool()
     async def quote(title: str, price: Annotated[int, Resolve(price_of)]) -> str:
-        return f"{title}: {price}"
+        return f"{title}: {price}"  # pragma: no cover - never reached; call fails at arg validation
 
     async with Client(mcp) as client:
         result = await client.call_tool("quote", {"title": "Dune", "price": 999})
 
-    assert not result.is_error
-    assert result.content == [TextContent(type="text", text="Dune: 42")]
+    assert result.is_error
+    assert isinstance(result.content[0], TextContent)
+    # pydantic's "Extra inputs are not permitted" wording changes across versions.
+    assert result.content[0].text.startswith("Error executing tool quote:")
 
 
 @pytest.mark.anyio
@@ -2757,6 +2759,7 @@ async def test_resolved_parameters_are_absent_from_the_advertised_tool_schema():
     assert advertised.input_schema == snapshot(
         {
             "type": "object",
+            "additionalProperties": False,
             "properties": {"title": {"title": "Title", "type": "string"}},
             "required": ["title"],
             "title": "quoteArguments",


### PR DESCRIPTION
Closes #3067 
ArgModelBase now uses extra="forbid" so unknown or misspelled tool arguments raise a validation error instead of being silently ignored.
Added a regression test confirming unknown args are rejected.