### PR TITLE
docs: pin mkdocs<2 and silence the mkdocs-material advisory banner in CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Build combined docs (v1.x at /, main at /v2/)
         run: bash scripts/build-docs.sh site
+        env:
+          # Silence mkdocs-material's MkDocs 2.0 warning banner in CI logs.
+          NO_MKDOCS_2_WARNING: "1"
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -130,6 +130,9 @@ jobs:
 
       - run: uv sync --frozen --group docs
       - run: uv run --frozen --no-sync mkdocs build
+        env:
+          # Silence mkdocs-material's MkDocs 2.0 warning banner in CI logs.
+          NO_MKDOCS_2_WARNING: "1"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -125,3 +125,6 @@ jobs:
 
       - name: Build the docs in strict mode
         run: uv run --frozen --no-sync mkdocs build --strict
+        env:
+          # Silence mkdocs-material's MkDocs 2.0 warning banner in CI logs.
+          NO_MKDOCS_2_WARNING: "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,9 @@ dev = [
     "opentelemetry-sdk>=1.39.1",
 ]
 docs = [
-    "mkdocs>=1.6.1",
+    # MkDocs 2.0 is a ground-up rewrite (no plugin system) that is incompatible
+    # with mkdocs-material and every plugin below; stay on the 1.x line.
+    "mkdocs>=1.6.1,<2",
     "mkdocs-gen-files>=0.5.0",
     "mkdocs-glightbox>=0.4.0",
     "mkdocs-literate-nav>=0.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1016,7 +1016,7 @@ dev = [
     { name = "trio", specifier = ">=0.26.2" },
 ]
 docs = [
-    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs", specifier = ">=1.6.1,<2" },
     { name = "mkdocs-gen-files", specifier = ">=0.5.0" },
     { name = "mkdocs-glightbox", specifier = ">=0.4.0" },
     { name = "mkdocs-literate-nav", specifier = ">=0.6.1" },
@@ -1593,7 +1593,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.2"
+version = "9.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -1608,9 +1608,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/57/5d3c8c9e2ff9d66dc8f63aa052eb0bac5041fecff7761d8689fe65c39c13/mkdocs_material-9.7.2.tar.gz", hash = "sha256:6776256552290b9b7a7aa002780e25b1e04bc9c3a8516b6b153e82e16b8384bd", size = 4097818, upload-time = "2026-02-18T15:53:07.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/19/d194e75e82282b1d688f0720e21b5ac250ed64ddea333a228aaf83105f2e/mkdocs_material-9.7.2-py3-none-any.whl", hash = "sha256:9bf6f53452d4a4d527eac3cef3f92b7b6fc4931c55d57766a7d87890d47e1b92", size = 9305052, upload-time = "2026-02-18T15:53:05.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Hardens the docs toolchain against the upcoming MkDocs 2.0 split and quiets the advisory banner mkdocs-material now prints on every build.

## Motivation and Context

MkDocs 1.x is no longer receiving releases (latest is 1.6.1 from Aug 2024), and "MkDocs 2.0" is being developed as a ground-up rewrite ([announcement](https://github.com/mkdocs/mkdocs/discussions/4077)) that removes the plugin system — so it's incompatible with mkdocs-material and every plugin we use (mkdocstrings, gen-files, literate-nav, glightbox). mkdocs-material entered maintenance mode in [9.7.0](https://github.com/squidfunk/mkdocs-material/releases/tag/9.7.0) and added its own `mkdocs<2` pin in [9.7.5](https://github.com/squidfunk/mkdocs-material/releases/tag/9.7.5); the Material team's analysis is [here](https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/).

Three changes:

- **`mkdocs>=1.6.1,<2`** in the docs group. Our locked mkdocs-material (9.7.2) predates the upstream pin, and if 2.0 is ever published to PyPI under the `mkdocs` name, an unbounded re-lock could pick it up and break the docs build. Mirroring the bound on our direct dependency makes the guard independent of the theme's metadata.
- **mkdocs-material 9.7.2 → 9.7.6** in the lockfile: moves the advisory banner from stdout to stderr, sandboxes the social-cards plugin's template environment, and carries the upstream `mkdocs<2` pin.
- **`NO_MKDOCS_2_WARNING=1`** in the three docs CI jobs, so the red banner stays out of build logs. Local builds still show it, which seems right — it's genuinely useful information for contributors.

This is the "pin and wait" posture most of the ecosystem has taken (e.g. pydantic and the astral repos pin mkdocs 1.6.1 + mkdocs-material 9.7.6). Zensical is the likely eventual destination, but it has no equivalent of gen-files ([zensical/zensical#8](https://github.com/zensical/zensical/issues/8)), literate-nav ([zensical/zensical#13](https://github.com/zensical/zensical/issues/13)), or MkDocs `hooks:` yet — our entire generated-API-reference and llms.txt pipeline — so migrating now isn't viable. Worth re-evaluating around November 2026 when mkdocs-material's committed maintenance window ends.

Note: `deploy-docs.yml` also builds the `v1.x` branch, whose pyproject has an unbounded `mkdocs>=1.6.1`. It's protected today by its frozen lockfile and by mkdocs-material 9.6.19's own `mkdocs~=1.6` requirement, so no urgency, but a `[v1.x]` backport of the same bound would be reasonable hygiene.

## How Has This Been Tested?

Built the docs locally against the updated lock: `uv run --frozen mkdocs build --strict` passes on 9.7.6; the banner goes to stderr only, and disappears with `NO_MKDOCS_2_WARNING=1` set. Verified the generated site is intact (`api/` reference pages, `llms.txt`), that `uv lock --check` passes with the new specifier, and that the step-level `env:` propagates through `scripts/build-docs.sh` to both branch builds. Also confirmed social cards still render on 9.7.6's sandboxed environment when `ENABLE_SOCIAL_CARDS` is set.

## Breaking Changes

None — CI/dependency hygiene only; no API or rendered-docs changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

The `NO_MKDOCS_2_WARNING` env var is mkdocs-material's only supported off-switch — a config-level option was [declined upstream](https://github.com/squidfunk/mkdocs-material/issues/8581), and 9.7.6 already auto-suppresses the banner for non-`mkdocs` entry points, so wrapper tools like `mike` are unaffected.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
