### PR TITLE
[v1.x] docs: pin mkdocs<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ dev = [
     "coverage[toml]==7.10.7",
 ]
 docs = [
-    "mkdocs>=1.6.1",
+    # MkDocs 2.0 is a ground-up rewrite (no plugin system) that is incompatible
+    # with mkdocs-material and every plugin below; stay on the 1.x line.
+    "mkdocs>=1.6.1,<2",
     "mkdocs-glightbox>=0.4.0",
     "mkdocs-material[imaging]>=9.6.19",
     "mkdocstrings-python>=1.12.2",

--- a/uv.lock
+++ b/uv.lock
@@ -865,7 +865,7 @@ dev = [
     { name = "trio", specifier = ">=0.26.2" },
 ]
 docs = [
-    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs", specifier = ">=1.6.1,<2" },
     { name = "mkdocs-glightbox", specifier = ">=0.4.0" },
     { name = "mkdocs-material", extras = ["imaging"], specifier = ">=9.6.19" },
     { name = "mkdocstrings-python", specifier = ">=1.12.2" },


### PR DESCRIPTION
Backports the `mkdocs<2` bound from #3072 to the v1.x line.

## Motivation and Context

"MkDocs 2.0" is a ground-up rewrite that removes the plugin system, so it's incompatible with mkdocs-material and the docs plugin stack ([context in #3072](https://github.com/modelcontextprotocol/python-sdk/pull/3072)). This branch's docs group had an unbounded `mkdocs>=1.6.1`; today it's protected only by the frozen lockfile and transitively by mkdocs-material 9.6.x's own `mkdocs~=1.6` requirement. Pinning the direct dependency makes the guard explicit so a future re-lock on this branch can't resolve 2.0.

No locked versions change — the diff is the specifier plus its lockfile manifest entry. The advisory-banner silencing from #3072 isn't needed here: v1.x locks mkdocs-material 9.6.19, which predates the banner.

## How Has This Been Tested?

`uv lock` re-resolves cleanly with the new bound (mkdocs stays 1.6.1); pre-commit's lock consistency check passes.

## Breaking Changes

None.

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally