### PR TITLE
fix: stop the standalone GET stream reconnecting forever on empty connections

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -166,6 +166,8 @@ class MessageHandlerFnT(Protocol):
 async def _default_message_handler(
     message: RequestResponder[types.ServerRequest, types.ClientResult] | types.ServerNotification | Exception,
 ) -> None:
+    if isinstance(message, Exception):
+        logger.warning("Unhandled exception in message handler: %s", message)
     await anyio.lowlevel.checkpoint()
 
 

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -214,7 +214,9 @@ class StreamableHTTPTransport:
                     event_source.response.raise_for_status()
                     logger.debug("GET SSE connection established")
 
+                    received_events = False
                     async for sse in event_source.aiter_sse():
+                        received_events = True
                         # Track last event ID for reconnection
                         if sse.id:
                             last_event_id = sse.id
@@ -224,14 +226,18 @@ class StreamableHTTPTransport:
 
                         await self._handle_sse_event(sse, read_stream_writer)
 
-                    # Stream ended normally (server closed) - reset attempt counter
-                    attempt = 0
+                    # Only reset attempts if we actually received events;
+                    # empty connections count toward MAX_RECONNECTION_ATTEMPTS
+                    if received_events:
+                        attempt = 0
+                    else:
+                        attempt += 1
 
             except Exception:
                 logger.debug("GET stream error", exc_info=True)
                 attempt += 1
 
-            if attempt >= MAX_RECONNECTION_ATTEMPTS:  # pragma: no cover
+            if attempt >= MAX_RECONNECTION_ATTEMPTS:
                 logger.debug(f"GET stream max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
                 return
 

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -38,7 +38,7 @@ from pydantic import FileUrl, ValidationError
 from mcp import MCPError
 from mcp.client import ClientRequestContext
 from mcp.client.client import Client
-from mcp.client.session import DEFAULT_CLIENT_INFO, ClientSession
+from mcp.client.session import DEFAULT_CLIENT_INFO, ClientSession, _default_message_handler
 from mcp.client.subscriptions import ToolsListChanged, listen
 from mcp.server import Server, ServerRequestContext
 from mcp.shared.direct_dispatcher import create_direct_dispatcher_pair
@@ -1028,6 +1028,15 @@ async def test_raising_message_handler_on_transport_exception_costs_the_delivery
     assert isinstance(out.message, JSONRPCResponse)
     assert out.message.id == 9
     assert "message_handler raised on transport exception" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_default_message_handler_logs_unhandled_transport_exceptions(caplog: pytest.LogCaptureFixture):
+    """The default handler has no per-request waiter to resolve, so a transport-level `Exception`
+    item (e.g. a GET stream failure) would vanish silently; it logs a warning as a safety net."""
+    with caplog.at_level("WARNING", logger="client"):
+        await _default_message_handler(RuntimeError("boom"))
+    assert "Unhandled exception in message handler" in caplog.text
 
 
 @pytest.mark.anyio

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -748,3 +748,26 @@ async def test_resolving_an_abandoned_request_after_the_reader_closed_is_contain
                 _abandoned_request_context(http, send), "evt-7", None, MAX_RECONNECTION_ATTEMPTS
             )
     send.close()
+
+
+@pytest.mark.anyio
+async def test_get_stream_gives_up_after_repeated_empty_connections(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A GET stream that keeps opening but closing with no events counts each empty connection toward
+    the reconnection budget, so the loop terminates instead of reconnecting forever."""
+    monkeypatch.setattr("mcp.client.streamable_http.DEFAULT_RECONNECTION_DELAY_MS", 0)
+    get_requests = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal get_requests
+        get_requests += 1
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=b"")
+
+    transport = StreamableHTTPTransport("http://test/mcp")
+    transport.session_id = "sess-1"
+    send, receive = create_context_streams[SessionMessage | Exception](1)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http:
+        with anyio.fail_after(5):
+            await transport.handle_get_stream(http, send)
+    assert get_requests == MAX_RECONNECTION_ATTEMPTS
+    send.close()
+    receive.close()


### PR DESCRIPTION
## Summary

Split out from #2122. Since that PR was opened, its core fix — propagating an error to a waiting request when an SSE stream ends without a response — has landed upstream independently via the `_resolve_abandoned_request` helper (introduced in #3047), which resolves an abandoned request with a synthesized error both when an id-bearing stream ends unresumably and when reconnection attempts are exhausted.

This PR carries forward only the two fixes from #2122 that are **not** covered by that work. Relates to #1401.

### What changed

**Stop the standalone GET stream reconnecting forever on empty connections.** `handle_get_stream` reset its attempt counter to `0` whenever a connection ended "normally" — i.e. the `async for` over the SSE events completed without raising. A server that accepts the GET but immediately closes the stream with no events hits exactly this path, so the counter never advances and the client reconnects in an unbounded loop (throttled only by the reconnect delay). The counter now resets only when events were actually received; empty connections count toward `MAX_RECONNECTION_ATTEMPTS`, so the loop gives up. That give-up branch was previously marked unreachable (`# pragma: no cover`) — it is now reachable and covered by a test.

**Log unhandled exceptions in the default message handler.** Transport-level errors not tied to a specific pending request (e.g. a GET stream failure) reach `_default_message_handler` as an `Exception` item and were silently discarded. It now logs a warning as an observability safety net.

### Testing

- New regression test drives repeated empty GET streams and asserts the loop terminates after `MAX_RECONNECTION_ATTEMPTS` rather than reconnecting forever.
- New test asserts `_default_message_handler` logs a warning for an `Exception` item.
- Full suite green; both changed files at 100% branch coverage.
