### PR TITLE
[v1.x] fix: guard respond() and cancel() against concurrent cancellation race (#2416)

### DIFF
--- a/src/mcp/shared/session.py
+++ b/src/mcp/shared/session.py
@@ -122,11 +122,11 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
         Must be called within a context manager block.
         Raises:
             RuntimeError: If not used within a context manager
-            AssertionError: If request was already responded to
         """
         if not self._entered:  # pragma: no cover
             raise RuntimeError("RequestResponder must be used as a context manager")
-        assert not self._completed, "Request already responded to"
+        if self._completed:
+            return
 
         if not self.cancelled:  # pragma: no branch
             self._completed = True
@@ -141,6 +141,8 @@ class RequestResponder(Generic[ReceiveRequestT, SendResultT]):
             raise RuntimeError("RequestResponder must be used as a context manager")
         if not self._cancel_scope:  # pragma: no cover
             raise RuntimeError("No active cancel scope")
+        if self._completed:  # pragma: no cover
+            return
 
         self._cancel_scope.cancel()
         self._completed = True  # Mark as completed so it's removed from in_flight

--- a/tests/shared/test_session.py
+++ b/tests/shared/test_session.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncGenerator
 from typing import Any
+from unittest import mock
 
 import anyio
 import pytest
@@ -10,6 +11,7 @@ from mcp.server.lowlevel.server import Server
 from mcp.shared.exceptions import McpError
 from mcp.shared.memory import create_client_server_memory_streams, create_connected_server_and_client_session
 from mcp.shared.message import SessionMessage
+from mcp.shared.session import RequestResponder
 from mcp.types import (
     CancelledNotification,
     CancelledNotificationParams,
@@ -339,3 +341,29 @@ async def test_connection_closed():
                 await ev_closed.wait()
             with anyio.fail_after(1):  # pragma: no cover
                 await ev_response.wait()
+
+
+@pytest.mark.anyio
+async def test_respond_after_cancel_does_not_raise():
+    """
+    Test that calling respond() after cancel() does not raise AssertionError.
+
+    Regression test for https://github.com/modelcontextprotocol/python-sdk/issues/2416.
+    When a CancelledNotification arrives after the handler returns but before
+    respond() is called, both cancel() and respond() see _completed=False.
+    cancel() sets it to True and sends the cancellation error; respond() should
+    silently return instead of asserting.
+    """
+    mock_session: Any = mock.AsyncMock()
+    mock_session._send_response = mock.AsyncMock()
+    request = JSONRPCRequest(jsonrpc="2.0", id=1, method="tools/call")
+    responder: RequestResponder[Any, Any] = RequestResponder(
+        request_id=1,
+        request_meta=None,
+        request=request,  # type: ignore[reportArgumentType]
+        session=mock_session,
+        on_complete=lambda r: None,
+    )
+    with responder:
+        await responder.cancel()
+        await responder.respond(ErrorData(code=0, message="ok"))


### PR DESCRIPTION
## Summary

When a client sends \
otifications/cancelled\ after the handler has returned but before \espond()\ is called, the server crashes with \AssertionError: Request already responded to\.

## Related Issue
Fixes #2416

## What changed
- \RequestResponder.respond()\ — replace \ssert not self._completed\ with a silent early return, so a concurrent cancellation that already errored is not double-replied to.
- \RequestResponder.cancel()\ — early-return if \_completed\ is already set, so the reverse ordering (respond then cancel) is also safe.
- New regression test \	est_respond_after_cancel_does_not_raise\.

## Why this approach
The root cause is a race window between handler return and \espond()\. There is no \wait\ checkpoint in that gap, so \CancelledError\ cannot be delivered to the handler task. The fix makes \espond()\ idempotent: whichever path (\cancel()\ via the notification handler or \espond()\ via \_handle_request\) sets \_completed\ first wins; the other path silently no-ops. This is safe under cooperative multitasking since \_completed\ is set synchronously before the first \wait\ in each method.

## Testing done
- New regression test drives a \RequestResponder\ through cancel-then-respond and asserts no exception is raised
- Existing \	est_request_cancellation\ and \	est_connection_closed\ still pass
- Lint (ruff), format, and type check (pyright) all clean

## Checklist
- [x] Tests added/updated
- [ ] Docs updated (not user-facing — internal race fix)
- [x] Lint/format passes
- [x] Linked issue referenced (Fixes #2416)
- [x] Commits signed off (DCO)
- [x] No unrelated changes bundled in