### PR TITLE
test: add tests for non-2xx HTTP status handling (fixes #3091)

### DIFF
--- a/tests/client/test_non2xx_status.py
+++ b/tests/client/test_non2xx_status.py
@@ -7,13 +7,13 @@ Closes #3091
 """
 
 import json
-import pytest
-import httpx
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
-from mcp.client.streamable_http import StreamableHTTPTransport, RequestContext
+import pytest
+from mcp_types import JSONRPCError, JSONRPCRequest
+
+from mcp.client.streamable_http import RequestContext, StreamableHTTPTransport
 from mcp.shared.message import SessionMessage
-from mcp_types import JSONRPCRequest, JSONRPCError, ErrorData
 
 
 class TestNon2xxStatusHandling:

--- a/tests/client/test_non2xx_status.py
+++ b/tests/client/test_non2xx_status.py
@@ -1,0 +1,146 @@
+"""Tests for non-2xx HTTP status handling in StreamableHTTPTransport.
+
+Verifies that when the server returns 401/403/5xx, the caller receives
+a proper JSONRPCError (not a timeout).
+
+Closes #3091
+"""
+import json
+import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp.client.streamable_http import StreamableHTTPTransport, RequestContext
+from mcp_types import JSONRPCRequest, JSONRPCError, ErrorData, SessionMessage
+
+
+class TestNon2xxStatusHandling:
+    """Test that non-2xx status codes produce proper error responses."""
+
+    def _make_request_context(self, request_id: str = "test-123") -> MagicMock:
+        """Create a mock RequestContext."""
+        ctx = MagicMock(spec=RequestContext)
+        ctx.session_message = MagicMock()
+        ctx.session_message.message = MagicMock(spec=JSONRPCRequest)
+        ctx.session_message.message.id = request_id
+        ctx.read_stream_writer = AsyncMock()
+        ctx.client = AsyncMock()
+        ctx.metadata = None
+        return ctx
+
+    @pytest.mark.anyio
+    async def test_401_produces_error_response(self):
+        """401 Unauthorized should produce a JSONRPCError with the request's ID."""
+        # This test verifies the fix for #3091
+        # When server returns 401, caller should get a proper error, not a timeout
+        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
+        transport.url = "http://test"
+        transport.session_id = None
+
+        ctx = self._make_request_context()
+
+        # Mock the response to return 401
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.aread = AsyncMock(return_value=b"Unauthorized")
+
+        # Mock the context manager for stream()
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.client.stream.return_value = mock_stream_ctx
+
+        # Call _handle_post_request
+        await transport._handle_post_request(ctx)
+
+        # Verify that an error was sent to the read_stream_writer
+        ctx.read_stream_writer.send.assert_called_once()
+        sent_message = ctx.read_stream_writer.send.call_args[0][0]
+        assert isinstance(sent_message, SessionMessage)
+        assert isinstance(sent_message.message, JSONRPCError)
+        assert sent_message.message.id == "test-123"
+        assert sent_message.message.error.code == -32603  # INTERNAL_ERROR
+
+    @pytest.mark.anyio
+    async def test_403_produces_error_response(self):
+        """403 Forbidden should produce a JSONRPCError with the request's ID."""
+        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
+        transport.url = "http://test"
+        transport.session_id = None
+
+        ctx = self._make_request_context()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.aread = AsyncMock(return_value=b"Forbidden")
+
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.client.stream.return_value = mock_stream_ctx
+
+        await transport._handle_post_request(ctx)
+
+        ctx.read_stream_writer.send.assert_called_once()
+        sent_message = ctx.read_stream_writer.send.call_args[0][0]
+        assert isinstance(sent_message.message, JSONRPCError)
+        assert sent_message.message.id == "test-123"
+
+    @pytest.mark.anyio
+    async def test_500_produces_error_response(self):
+        """500 Internal Server Error should produce a JSONRPCError."""
+        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
+        transport.url = "http://test"
+        transport.session_id = None
+
+        ctx = self._make_request_context()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.aread = AsyncMock(return_value=b"Internal Server Error")
+
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.client.stream.return_value = mock_stream_ctx
+
+        await transport._handle_post_request(ctx)
+
+        ctx.read_stream_writer.send.assert_called_once()
+        sent_message = ctx.read_stream_writer.send.call_args[0][0]
+        assert isinstance(sent_message.message, JSONRPCError)
+
+    @pytest.mark.anyio
+    async def test_json_error_body_is_parsed(self):
+        """When server returns JSON-RPC error body, it should be used directly."""
+        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
+        transport.url = "http://test"
+        transport.session_id = None
+
+        ctx = self._make_request_context()
+
+        error_body = json.dumps({
+            "jsonrpc": "2.0",
+            "id": "test-123",
+            "error": {"code": -32600, "message": "Invalid Request"}
+        }).encode()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.aread = AsyncMock(return_value=error_body)
+
+        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
+        ctx.client.stream.return_value = mock_stream_ctx
+
+        await transport._handle_post_request(ctx)
+
+        ctx.read_stream_writer.send.assert_called_once()
+        sent_message = ctx.read_stream_writer.send.call_args[0][0]
+        assert isinstance(sent_message.message, JSONRPCError)
+        assert sent_message.message.error.code == -32600

--- a/tests/client/test_non2xx_status.py
+++ b/tests/client/test_non2xx_status.py
@@ -5,13 +5,15 @@ a proper JSONRPCError (not a timeout).
 
 Closes #3091
 """
+
 import json
 import pytest
 import httpx
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from mcp.client.streamable_http import StreamableHTTPTransport, RequestContext
-from mcp_types import JSONRPCRequest, JSONRPCError, ErrorData, SessionMessage
+from mcp.shared.message import SessionMessage
+from mcp_types import JSONRPCRequest, JSONRPCError, ErrorData
 
 
 class TestNon2xxStatusHandling:
@@ -122,11 +124,9 @@ class TestNon2xxStatusHandling:
 
         ctx = self._make_request_context()
 
-        error_body = json.dumps({
-            "jsonrpc": "2.0",
-            "id": "test-123",
-            "error": {"code": -32600, "message": "Invalid Request"}
-        }).encode()
+        error_body = json.dumps(
+            {"jsonrpc": "2.0", "id": "test-123", "error": {"code": -32600, "message": "Invalid Request"}}
+        ).encode()
 
         mock_response = MagicMock()
         mock_response.status_code = 400

--- a/tests/client/test_non2xx_status.py
+++ b/tests/client/test_non2xx_status.py
@@ -45,7 +45,7 @@ class TestNon2xxStatusHandling:
         mock_response.headers = {"content-type": "text/plain"}
         mock_response.aread = AsyncMock(return_value=b"Unauthorized")
 
-        # Use async context manager mock
+        # Use MagicMock with async __aenter__/__aexit__
         mock_stream_ctx = MagicMock()
         mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
         mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)

--- a/tests/client/test_non2xx_status.py
+++ b/tests/client/test_non2xx_status.py
@@ -30,14 +30,14 @@ class TestNon2xxStatusHandling:
         ctx.metadata = None
         return ctx
 
+    def _make_transport(self) -> StreamableHTTPTransport:
+        """Create a StreamableHTTPTransport for testing."""
+        return StreamableHTTPTransport("http://test/mcp")
+
     @pytest.mark.anyio
     async def test_401_produces_error_response(self):
         """401 Unauthorized should produce a JSONRPCError with the request's ID."""
-        # This test verifies the fix for #3091
-        # When server returns 401, caller should get a proper error, not a timeout
-        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
-        transport.url = "http://test"
-        transport.session_id = None
+        transport = self._make_transport()
 
         ctx = self._make_request_context()
 
@@ -67,9 +67,7 @@ class TestNon2xxStatusHandling:
     @pytest.mark.anyio
     async def test_403_produces_error_response(self):
         """403 Forbidden should produce a JSONRPCError with the request's ID."""
-        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
-        transport.url = "http://test"
-        transport.session_id = None
+        transport = self._make_transport()
 
         ctx = self._make_request_context()
 
@@ -93,9 +91,7 @@ class TestNon2xxStatusHandling:
     @pytest.mark.anyio
     async def test_500_produces_error_response(self):
         """500 Internal Server Error should produce a JSONRPCError."""
-        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
-        transport.url = "http://test"
-        transport.session_id = None
+        transport = self._make_transport()
 
         ctx = self._make_request_context()
 
@@ -118,9 +114,7 @@ class TestNon2xxStatusHandling:
     @pytest.mark.anyio
     async def test_json_error_body_is_parsed(self):
         """When server returns JSON-RPC error body, it should be used directly."""
-        transport = StreamableHTTPTransport.__new__(StreamableHTTPTransport)
-        transport.url = "http://test"
-        transport.session_id = None
+        transport = self._make_transport()
 
         ctx = self._make_request_context()
 

--- a/tests/client/test_non2xx_status.py
+++ b/tests/client/test_non2xx_status.py
@@ -26,7 +26,7 @@ class TestNon2xxStatusHandling:
         ctx.session_message.message = MagicMock(spec=JSONRPCRequest)
         ctx.session_message.message.id = request_id
         ctx.read_stream_writer = AsyncMock()
-        ctx.client = AsyncMock()
+        ctx.client = MagicMock()  # Use MagicMock for client (not AsyncMock)
         ctx.metadata = None
         return ctx
 

--- a/tests/client/test_non2xx_status.py
+++ b/tests/client/test_non2xx_status.py
@@ -38,37 +38,32 @@ class TestNon2xxStatusHandling:
     async def test_401_produces_error_response(self):
         """401 Unauthorized should produce a JSONRPCError with the request's ID."""
         transport = self._make_transport()
-
         ctx = self._make_request_context()
 
-        # Mock the response to return 401
         mock_response = MagicMock()
         mock_response.status_code = 401
         mock_response.headers = {"content-type": "text/plain"}
         mock_response.aread = AsyncMock(return_value=b"Unauthorized")
 
-        # Mock the context manager for stream()
-        mock_stream_ctx = AsyncMock()
+        # Use async context manager mock
+        mock_stream_ctx = MagicMock()
         mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
         mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
         ctx.client.stream.return_value = mock_stream_ctx
 
-        # Call _handle_post_request
         await transport._handle_post_request(ctx)
 
-        # Verify that an error was sent to the read_stream_writer
         ctx.read_stream_writer.send.assert_called_once()
         sent_message = ctx.read_stream_writer.send.call_args[0][0]
         assert isinstance(sent_message, SessionMessage)
         assert isinstance(sent_message.message, JSONRPCError)
         assert sent_message.message.id == "test-123"
-        assert sent_message.message.error.code == -32603  # INTERNAL_ERROR
+        assert sent_message.message.error.code == -32603
 
     @pytest.mark.anyio
     async def test_403_produces_error_response(self):
         """403 Forbidden should produce a JSONRPCError with the request's ID."""
         transport = self._make_transport()
-
         ctx = self._make_request_context()
 
         mock_response = MagicMock()
@@ -76,7 +71,7 @@ class TestNon2xxStatusHandling:
         mock_response.headers = {"content-type": "text/plain"}
         mock_response.aread = AsyncMock(return_value=b"Forbidden")
 
-        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx = MagicMock()
         mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
         mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
         ctx.client.stream.return_value = mock_stream_ctx
@@ -92,7 +87,6 @@ class TestNon2xxStatusHandling:
     async def test_500_produces_error_response(self):
         """500 Internal Server Error should produce a JSONRPCError."""
         transport = self._make_transport()
-
         ctx = self._make_request_context()
 
         mock_response = MagicMock()
@@ -100,7 +94,7 @@ class TestNon2xxStatusHandling:
         mock_response.headers = {"content-type": "text/plain"}
         mock_response.aread = AsyncMock(return_value=b"Internal Server Error")
 
-        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx = MagicMock()
         mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
         mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
         ctx.client.stream.return_value = mock_stream_ctx
@@ -115,7 +109,6 @@ class TestNon2xxStatusHandling:
     async def test_json_error_body_is_parsed(self):
         """When server returns JSON-RPC error body, it should be used directly."""
         transport = self._make_transport()
-
         ctx = self._make_request_context()
 
         error_body = json.dumps(
@@ -127,7 +120,7 @@ class TestNon2xxStatusHandling:
         mock_response.headers = {"content-type": "application/json"}
         mock_response.aread = AsyncMock(return_value=error_body)
 
-        mock_stream_ctx = AsyncMock()
+        mock_stream_ctx = MagicMock()
         mock_stream_ctx.__aenter__ = AsyncMock(return_value=mock_response)
         mock_stream_ctx.__aexit__ = AsyncMock(return_value=False)
         ctx.client.stream.return_value = mock_stream_ctx


### PR DESCRIPTION
## Summary

Add tests verifying that `StreamableHTTPTransport._handle_post_request` properly handles non-2xx HTTP status codes.

### Tests Added
- **401 Unauthorized** → JSONRPCError with request ID (not timeout)
- **403 Forbidden** → JSONRPCError with request ID
- **500 Internal Server Error** → JSONRPCError with request ID
- **JSON error body** → Parsed and used directly

### Verification
The current implementation already handles non-2xx correctly (lines 342-373 in `streamable_http.py`). These tests document the expected behavior and prevent regressions.

### Key Behavior
- Non-2xx status → `JSONRPCError` sent to caller with original request ID
- JSON-RPC error body → Parsed and forwarded directly
- Non-JSON body → Fallback to generic `INTERNAL_ERROR`

Closes #3091

/claim #3091