### PR TITLE
fix: propagate McpError as JSON-RPC error response in lowlevel server

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -90,7 +90,7 @@ from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.models import InitializationOptions
 from mcp.server.session import ServerSession
 from mcp.shared.context import RequestContext
-from mcp.shared.exceptions import McpError, UrlElicitationRequiredError
+from mcp.shared.exceptions import McpError
 from mcp.shared.message import ServerMessageMetadata, SessionMessage
 from mcp.shared.session import RequestResponder
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
@@ -582,9 +582,11 @@ class Server(Generic[LifespanResultT, RequestT]):
                             isError=False,
                         )
                     )
-                except UrlElicitationRequiredError:
-                    # Re-raise UrlElicitationRequiredError so it can be properly handled
-                    # by _handle_request, which converts it to an error response with code -32042
+                except McpError:
+                    # Re-raise McpError (including subclasses such as
+                    # UrlElicitationRequiredError) so it can be properly handled by
+                    # _handle_request, which converts it to a JSON-RPC error response
+                    # preserving the structured error code.
                     raise
                 except Exception as e:
                     return self._make_error_result(str(e))
@@ -774,7 +776,7 @@ class Server(Generic[LifespanResultT, RequestT]):
                     )
                 )
                 response = await handler(req)
-            except McpError as err:  # pragma: no cover
+            except McpError as err:
                 response = err.error
             except anyio.get_cancelled_exc_class():
                 if message.cancelled:

--- a/tests/server/test_lowlevel_exception_handling.py
+++ b/tests/server/test_lowlevel_exception_handling.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -5,6 +6,8 @@ import pytest
 import mcp.types as types
 from mcp.server.lowlevel.server import Server
 from mcp.server.session import ServerSession
+from mcp.shared.exceptions import McpError
+from mcp.shared.memory import create_connected_server_and_client_session
 from mcp.shared.session import RequestResponder
 
 
@@ -72,3 +75,48 @@ async def test_normal_message_handling_not_affected():
 
     # Verify _handle_request was called
     server._handle_request.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_mcp_error_propagates_as_jsonrpc_error():
+    """Test that McpError raised in a tool handler propagates as a JSON-RPC error.
+
+    The structured error code must be preserved on the wire instead of being
+    swallowed into a CallToolResult with isError=True.
+    """
+    server = Server("test-server")
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextContent]:
+        raise McpError(types.ErrorData(code=-32000, message="server fault", data={"reason": "demo"}))
+
+    async with create_connected_server_and_client_session(server) as client_session:
+        await client_session.initialize()
+
+        with pytest.raises(McpError) as exc_info:
+            await client_session.call_tool("faulty_tool", {})
+
+        error = exc_info.value.error
+        assert error.code == -32000
+        assert error.message == "server fault"
+        assert error.data == {"reason": "demo"}
+
+
+@pytest.mark.anyio
+async def test_generic_exception_still_returns_error_result():
+    """Test that non-McpError exceptions are still returned as isError=True results."""
+    server = Server("test-server")
+
+    @server.call_tool()
+    async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextContent]:
+        raise ValueError("Something went wrong")
+
+    async with create_connected_server_and_client_session(server) as client_session:
+        await client_session.initialize()
+
+        result = await client_session.call_tool("failing_tool", {})
+
+        assert result.isError is True
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], types.TextContent)
+        assert "Something went wrong" in result.content[0].text


### PR DESCRIPTION
Fixes #2770

## Motivation and Context

When a tool handler registered via the lowlevel server's `@server.call_tool()` decorator raises `McpError`, the handler catches it via the generic `except Exception` block and wraps it as `CallToolResult(isError=True)`. This drops the structured error code on the wire, so clients cannot distinguish error types without parsing the message string.

The `UrlElicitationRequiredError` subclass already has a re-raise bypass for exactly this reason, but the parent `McpError` class does not. (The v2 high-level API on `main` already handles this correctly.)

## How Has This Been Tested?

- Added a regression test asserting that `McpError` raised in a lowlevel tool handler reaches the client as a JSON-RPC error with the original code, message, and data preserved (it fails without this change), plus a companion test asserting non-`McpError` exceptions still return `CallToolResult(isError=True)`.
- Ran the lowlevel server and elicitation test suites locally: all passing.

## Breaking Changes

Tool handlers that deliberately raise `McpError` now produce a JSON-RPC error response (the documented behavior for the error, matching `UrlElicitationRequiredError` and the v2 API) instead of an `isError: true` result. Handlers that raise other exceptions are unaffected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This scopes the fix to the lowlevel server per the issue's proposed fix. #2772 covers related ground but also changes FastMCP `Tool.run()` behavior; this PR is the minimal lowlevel-only change with regression tests at the lowlevel layer, in case the maintainers prefer to take that separately.