### PR TITLE
fix: Raise StreamableHTTPError on reconnection failure

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -200,6 +200,7 @@ class StreamableHTTPTransport:
         last_event_id: str | None = None
         retry_interval_ms: int | None = None
         attempt: int = 0
+        last_exc: Exception | None = None
 
         while attempt < MAX_RECONNECTION_ATTEMPTS:  # pragma: no branch
             try:
@@ -227,13 +228,16 @@ class StreamableHTTPTransport:
                     # Stream ended normally (server closed) - reset attempt counter
                     attempt = 0
 
-            except Exception:
+            except Exception as exc:
                 logger.debug("GET stream error", exc_info=True)
                 attempt += 1
+                last_exc = exc
 
-            if attempt >= MAX_RECONNECTION_ATTEMPTS:  # pragma: no cover
+            if attempt >= MAX_RECONNECTION_ATTEMPTS:
                 logger.debug(f"GET stream max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
-                return
+                raise StreamableHTTPError(
+                    f"Failed to connect to GET stream after {MAX_RECONNECTION_ATTEMPTS} attempts"
+                ) from last_exc
 
             # Wait before reconnecting
             delay_ms = retry_interval_ms if retry_interval_ms is not None else DEFAULT_RECONNECTION_DELAY_MS

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -62,6 +62,21 @@ class ResumptionError(StreamableHTTPError):
     """Raised when resumption request is invalid."""
 
 
+def _unwrap_exception(exc: BaseException) -> BaseException:
+    """Recursively find and return the first StreamableHTTPError in an exception's tree/group."""
+    if isinstance(exc, StreamableHTTPError):
+        return exc
+
+    exceptions = getattr(exc, "exceptions", None)
+    if exceptions is not None:
+        for sub_exc in exceptions:
+            unwrapped = _unwrap_exception(sub_exc)
+            if isinstance(unwrapped, StreamableHTTPError):
+                return unwrapped
+    return exc
+
+
+
 @dataclass
 class RequestContext:
     """Context for a request operation."""
@@ -228,10 +243,11 @@ class StreamableHTTPTransport:
                     # Stream ended normally (server closed) - reset attempt counter
                     attempt = 0
 
-            except Exception as exc:
+            except httpx2.HTTPError as exc:
                 logger.debug("GET stream error", exc_info=True)
                 attempt += 1
                 last_exc = exc
+
 
             if attempt >= MAX_RECONNECTION_ATTEMPTS:
                 logger.debug(f"GET stream max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
@@ -448,8 +464,9 @@ class StreamableHTTPTransport:
                 if is_complete:
                     await response.aclose()
                     return  # Normal completion, no reconnect needed
-        except Exception:
+        except httpx2.HTTPError:
             logger.debug("SSE stream ended", exc_info=True)  # pragma: lax no cover
+
 
         # Stream ended without response - reconnect if we received an event with ID
         if last_event_id is not None:
@@ -532,10 +549,11 @@ class StreamableHTTPTransport:
                 # Stream ended again without response - reconnect again (reset attempt counter)
                 logger.info("SSE stream disconnected, reconnecting...")
                 await self._handle_reconnection(ctx, reconnect_last_event_id, reconnect_retry_ms, 0)
-        except Exception as e:  # pragma: no cover
+        except httpx2.HTTPError as e:  # pragma: no cover
             logger.debug(f"Reconnection failed: {e}")
             # Try to reconnect again if we still have an event ID
             await self._handle_reconnection(ctx, last_event_id, retry_interval_ms, attempt + 1)
+
 
     async def post_writer(
         self,
@@ -684,39 +702,46 @@ async def streamable_http_client(
 
     logger.debug(f"Connecting to StreamableHTTP endpoint: {url}")
 
-    async with contextlib.AsyncExitStack() as stack:
-        # Only manage client lifecycle if we created it
-        if not client_provided:
-            await stack.enter_async_context(client)
+    try:
+        async with contextlib.AsyncExitStack() as stack:
+            # Only manage client lifecycle if we created it
+            if not client_provided:
+                await stack.enter_async_context(client)
 
-        read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
-        write_stream, write_stream_reader = create_context_streams[SessionMessage](0)
+            read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
+            write_stream, write_stream_reader = create_context_streams[SessionMessage](0)
 
-        async with (
-            read_stream_writer,
-            read_stream,
-            write_stream,
-            write_stream_reader,
-            anyio.create_task_group() as tg,
-        ):
-
-            def start_get_stream() -> None:
-                tg.start_soon(transport.handle_get_stream, client, read_stream_writer)
-
-            tg.start_soon(
-                transport.post_writer,
-                client,
-                write_stream_reader,
+            async with (
                 read_stream_writer,
+                read_stream,
                 write_stream,
-                start_get_stream,
-                tg,
-            )
+                write_stream_reader,
+                anyio.create_task_group() as tg,
+            ):
 
-            try:
-                yield read_stream, write_stream
-            finally:
-                if transport.session_id and terminate_on_close:
-                    await transport.terminate_session(client)
-                tg.cancel_scope.cancel()
-        await resync_tracer()
+                def start_get_stream() -> None:
+                    tg.start_soon(transport.handle_get_stream, client, read_stream_writer)
+
+                tg.start_soon(
+                    transport.post_writer,
+                    client,
+                    write_stream_reader,
+                    read_stream_writer,
+                    write_stream,
+                    start_get_stream,
+                    tg,
+                )
+
+                try:
+                    yield read_stream, write_stream
+                finally:
+                    if transport.session_id and terminate_on_close:
+                        await transport.terminate_session(client)
+                    tg.cancel_scope.cancel()
+            await resync_tracer()
+    except BaseException as exc:
+        unwrapped = _unwrap_exception(exc)
+        if isinstance(unwrapped, StreamableHTTPError):
+            raise unwrapped from exc
+        raise
+

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -76,7 +76,6 @@ def _unwrap_exception(exc: BaseException) -> BaseException:
     return exc
 
 
-
 @dataclass
 class RequestContext:
     """Context for a request operation."""
@@ -247,7 +246,6 @@ class StreamableHTTPTransport:
                 logger.debug("GET stream error", exc_info=True)
                 attempt += 1
                 last_exc = exc
-
 
             if attempt >= MAX_RECONNECTION_ATTEMPTS:
                 logger.debug(f"GET stream max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
@@ -467,7 +465,6 @@ class StreamableHTTPTransport:
         except httpx2.HTTPError:
             logger.debug("SSE stream ended", exc_info=True)  # pragma: lax no cover
 
-
         # Stream ended without response - reconnect if we received an event with ID
         if last_event_id is not None:
             logger.info("SSE stream disconnected, reconnecting...")
@@ -553,7 +550,6 @@ class StreamableHTTPTransport:
             logger.debug(f"Reconnection failed: {e}")
             # Try to reconnect again if we still have an event ID
             await self._handle_reconnection(ctx, last_event_id, retry_interval_ms, attempt + 1)
-
 
     async def post_writer(
         self,
@@ -744,4 +740,3 @@ async def streamable_http_client(
         if isinstance(unwrapped, StreamableHTTPError):
             raise unwrapped from exc
         raise
-

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -1,6 +1,6 @@
 """Implements StreamableHTTP transport for MCP clients."""
 
-from __future__ import annotations as _annotations
+from __future__ import annotations
 
 import contextlib
 import logging

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2325,6 +2325,11 @@ async def test_streamable_http_client_reconnect_failure_propagates_error() -> No
     """
     client = AsyncMock(spec=httpx2.AsyncClient)
 
+    # Mock client.delete for session termination
+    mock_delete_response = AsyncMock(spec=httpx2.Response)
+    mock_delete_response.status_code = 204
+    client.delete.return_value = mock_delete_response
+
     # Mock post_writer requests:
     # 1. initialize request -> returns response with session ID
     # 2. notifications/initialized -> returns 202 Accepted

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2299,8 +2299,8 @@ async def test_reconnect_failure_propagates_error() -> None:
     # Create a context-aware stream writer (matches StreamWriter type alias)
     write_stream, read_stream = create_context_streams[SessionMessage | Exception](1)
 
-    # Mock client.sse to raise an exception
-    client.sse.side_effect = Exception("Connection refused")
+    # Mock client.sse to raise a connection error
+    client.sse.side_effect = httpx2.ConnectError("Connection refused")
 
     # Patch anyio.sleep to avoid waiting
     with patch("mcp.client.streamable_http.anyio.sleep", new_callable=AsyncMock) as mock_sleep:
@@ -2316,3 +2316,87 @@ async def test_reconnect_failure_propagates_error() -> None:
 
     await write_stream.aclose()
     await read_stream.aclose()
+
+
+@pytest.mark.anyio
+async def test_streamable_http_client_reconnect_failure_propagates_error() -> None:
+    """streamable_http_client context manager should propagate StreamableHTTPError
+    when the GET stream connection fails completely (max attempts exceeded).
+    """
+    client = AsyncMock(spec=httpx2.AsyncClient)
+
+    # Mock post_writer requests:
+    # 1. initialize request -> returns response with session ID
+    # 2. notifications/initialized -> returns 202 Accepted
+    mock_response = AsyncMock(spec=httpx2.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {
+        "content-type": "application/json",
+        "mcp-session-id": "test-session",
+    }
+    mock_response.aread.return_value = json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "serverInfo": {"name": "test-server", "version": "1.0"},
+        }
+    }).encode("utf-8")
+
+    mock_initialized_response = AsyncMock(spec=httpx2.Response)
+    mock_initialized_response.status_code = 202
+
+    # Use asynccontextmanager to mock client.stream
+    responses = [mock_response, mock_initialized_response]
+
+    @asynccontextmanager
+    async def mock_stream(*args: Any, **kwargs: Any):
+        yield responses.pop(0)
+
+    client.stream = mock_stream
+
+
+    # Mock client.sse to raise httpx2.HTTPError
+    client.sse.side_effect = httpx2.HTTPError("SSE connection refused")
+
+    # Patch anyio.sleep to avoid waiting during reconnect attempts
+    with patch("mcp.client.streamable_http.anyio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with pytest.raises(StreamableHTTPError) as exc_info:
+            with anyio.fail_after(5):
+                async with streamable_http_client("http://localhost:8000/mcp", http_client=client) as (read_stream, write_stream):
+                    # Send initialize message
+                    await write_stream.send(SessionMessage(
+                        types.JSONRPCRequest(
+                            jsonrpc="2.0",
+                            id=1,
+                            method="initialize",
+                            params={
+                                "protocolVersion": "2025-06-18",
+                                "capabilities": {},
+                                "clientInfo": {"name": "test-client", "version": "1.0"},
+                            },
+                        )
+                    ))
+
+                    # Receive the response
+                    await read_stream.receive()
+
+                    # Send notifications/initialized (which will trigger start_get_stream)
+                    await write_stream.send(SessionMessage(
+                        types.JSONRPCNotification(
+                            jsonrpc="2.0",
+                            method="notifications/initialized",
+                        )
+                    ))
+
+                    # Wait for the task group to fail
+                    event = anyio.Event()
+                    await event.wait()
+
+
+        assert "Failed to connect to GET stream" in str(exc_info.value)
+        assert client.sse.call_count == 2
+        mock_sleep.assert_called_once_with(1.0)
+
+

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2339,15 +2339,17 @@ async def test_streamable_http_client_reconnect_failure_propagates_error() -> No
         "content-type": "application/json",
         "mcp-session-id": "test-session",
     }
-    mock_response.aread.return_value = json.dumps({
-        "jsonrpc": "2.0",
-        "id": 1,
-        "result": {
-            "protocolVersion": "2025-06-18",
-            "capabilities": {},
-            "serverInfo": {"name": "test-server", "version": "1.0"},
+    mock_response.aread.return_value = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "serverInfo": {"name": "test-server", "version": "1.0"},
+            },
         }
-    }).encode("utf-8")
+    ).encode("utf-8")
 
     mock_initialized_response = AsyncMock(spec=httpx2.Response)
     mock_initialized_response.status_code = 202
@@ -2361,7 +2363,6 @@ async def test_streamable_http_client_reconnect_failure_propagates_error() -> No
 
     client.stream = mock_stream
 
-
     # Mock client.sse to raise httpx2.HTTPError
     client.sse.side_effect = httpx2.HTTPError("SSE connection refused")
 
@@ -2369,39 +2370,43 @@ async def test_streamable_http_client_reconnect_failure_propagates_error() -> No
     with patch("mcp.client.streamable_http.anyio.sleep", new_callable=AsyncMock) as mock_sleep:
         with pytest.raises(StreamableHTTPError) as exc_info:
             with anyio.fail_after(5):
-                async with streamable_http_client("http://localhost:8000/mcp", http_client=client) as (read_stream, write_stream):
+                async with streamable_http_client("http://localhost:8000/mcp", http_client=client) as (
+                    read_stream,
+                    write_stream,
+                ):
                     # Send initialize message
-                    await write_stream.send(SessionMessage(
-                        types.JSONRPCRequest(
-                            jsonrpc="2.0",
-                            id=1,
-                            method="initialize",
-                            params={
-                                "protocolVersion": "2025-06-18",
-                                "capabilities": {},
-                                "clientInfo": {"name": "test-client", "version": "1.0"},
-                            },
+                    await write_stream.send(
+                        SessionMessage(
+                            types.JSONRPCRequest(
+                                jsonrpc="2.0",
+                                id=1,
+                                method="initialize",
+                                params={
+                                    "protocolVersion": "2025-06-18",
+                                    "capabilities": {},
+                                    "clientInfo": {"name": "test-client", "version": "1.0"},
+                                },
+                            )
                         )
-                    ))
+                    )
 
                     # Receive the response
                     await read_stream.receive()
 
                     # Send notifications/initialized (which will trigger start_get_stream)
-                    await write_stream.send(SessionMessage(
-                        types.JSONRPCNotification(
-                            jsonrpc="2.0",
-                            method="notifications/initialized",
+                    await write_stream.send(
+                        SessionMessage(
+                            types.JSONRPCNotification(
+                                jsonrpc="2.0",
+                                method="notifications/initialized",
+                            )
                         )
-                    ))
+                    )
 
                     # Wait for the task group to fail
                     event = anyio.Event()
                     await event.wait()
 
-
         assert "Failed to connect to GET stream" in str(exc_info.value)
         assert client.sse.call_count == 2
         mock_sleep.assert_called_once_with(1.0)
-
-

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -2370,7 +2370,9 @@ async def test_streamable_http_client_reconnect_failure_propagates_error() -> No
     with patch("mcp.client.streamable_http.anyio.sleep", new_callable=AsyncMock) as mock_sleep:
         with pytest.raises(StreamableHTTPError) as exc_info:
             with anyio.fail_after(5):
-                async with streamable_http_client("http://localhost:8000/mcp", http_client=client) as (
+                async with streamable_http_client(
+                    "http://localhost:8000/mcp", http_client=client
+                ) as (  # pragma: no branch
                     read_stream,
                     write_stream,
                 ):

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -12,7 +12,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlparse
 
 import anyio
@@ -45,7 +45,11 @@ from starlette.types import Message, Scope
 from mcp import MCPError
 from mcp.client import ClientRequestContext
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import StreamableHTTPTransport, streamable_http_client
+from mcp.client.streamable_http import (
+    StreamableHTTPError,
+    StreamableHTTPTransport,
+    streamable_http_client,
+)
 from mcp.server import Server, ServerRequestContext
 from mcp.server.streamable_http import (
     GET_STREAM_KEY,
@@ -2283,3 +2287,32 @@ async def test_standalone_stream_teardown_between_dequeues_is_not_an_error(
     assert body_chunks[-1] == {"type": "http.response.body", "body": b"", "more_body": False}
     assert "Error in standalone SSE writer" not in caplog.text
     assert "Error in standalone SSE response" not in caplog.text
+
+
+@pytest.mark.anyio
+async def test_reconnect_failure_propagates_error() -> None:
+    """Client should raise StreamableHTTPError when reconnection fails completely."""
+    transport = StreamableHTTPTransport(url="http://localhost:8000/mcp")
+    transport.session_id = "test-session"
+    client = AsyncMock(spec=httpx2.AsyncClient)
+
+    # Create a context-aware stream writer (matches StreamWriter type alias)
+    write_stream, read_stream = create_context_streams[SessionMessage | Exception](1)
+
+    # Mock client.sse to raise an exception
+    client.sse.side_effect = Exception("Connection refused")
+
+    # Patch anyio.sleep to avoid waiting
+    with patch("mcp.client.streamable_http.anyio.sleep", new_callable=AsyncMock) as mock_sleep:
+        with pytest.raises(StreamableHTTPError) as exc_info:
+            await transport.handle_get_stream(client, write_stream)
+        assert "Failed to connect to GET stream" in str(exc_info.value)
+        # Should have attempted MAX_RECONNECTION_ATTEMPTS times (default is 2)
+        assert client.sse.call_count == 2
+        # Should have slept between attempts (attempts - 1 times)
+        assert mock_sleep.call_count == 1
+        # Verify it slept with the default delay (1000ms / 1000.0 = 1.0s)
+        mock_sleep.assert_called_once_with(1.0)
+
+    await write_stream.aclose()
+    await read_stream.aclose()


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Raise `StreamableHTTPError` on reconnection failure when the GET stream connection fails and exceeds `MAX_RECONNECTION_ATTEMPTS` instead of returning silently.

Currently, when the GET stream connection fails and exceeds `MAX_RECONNECTION_ATTEMPTS`, the transport receive loop returns silently. This prevents the failure from propagating out of the transport receive loop, causing downstream agents/sessions to hang rather than cleanly identifying the disconnection and reporting the failure.

Fixes https://github.com/google/adk-python/issues/2615.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Added [test_reconnect_failure_propagates_error](file:///Users/wukathy/Desktop/python-sdk/tests/shared/test_streamable_http.py#L2290) to [tests/shared/test_streamable_http.py](file:///Users/wukathy/Desktop/python-sdk/tests/shared/test_streamable_http.py) to assert that complete reconnection failure propagates the [StreamableHTTPError](file:///Users/wukathy/Desktop/python-sdk/src/mcp/client/streamable_http.py#L57).
- Executed `pytest` locally to verify all transport tests pass.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes. This corrects silent failures and hangs into expected transport exception propagation.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
