### PR TITLE
fix(server): generate tool output schema in serialization mode

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -126,7 +126,12 @@ class FuncMetadata(BaseModel):
         if isinstance(result, CallToolResult):
             if self.output_schema is not None:
                 assert self.output_model is not None, "Output model must be set if output schema is defined"
-                self.output_model.model_validate(result.structured_content)
+                validated = self.output_model.model_validate(result.structured_content)
+                # Normalize structured content the same way as ordinary return values, so
+                # computed fields and serialization aliases match the output schema.
+                return result.model_copy(
+                    update={"structured_content": validated.model_dump(mode="json", by_alias=True)}
+                )
             return result
 
         unstructured_content = _convert_to_content(result)

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -445,7 +445,7 @@ def _try_create_model_and_schema(
         # If we successfully created a model, try to get its schema
         # Use StrictJsonSchema to raise exceptions instead of warnings
         try:
-            schema = model.model_json_schema(schema_generator=StrictJsonSchema)
+            schema = model.model_json_schema(schema_generator=StrictJsonSchema, mode="serialization")
         except (
             PydanticUserError,
             TypeError,

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -127,7 +127,10 @@ class FuncMetadata(BaseModel):
     def model_post_init(self, context: Any, /) -> None:
         if self.output_model is not None and self.output_schema is None:
             # StrictJsonSchema raises instead of warning, so an unserializable return type fails construction.
-            schema = self._output_adapter(self.output_model).json_schema(schema_generator=StrictJsonSchema)
+            # Serialization mode: computed fields and serialization aliases are part of the dumped output.
+            schema = self._output_adapter(self.output_model).json_schema(
+                schema_generator=StrictJsonSchema, mode="serialization"
+            )
             self.output_schema = _inline_root_ref(schema)
 
     def _output_adapter(self, output_model: type[Any]) -> TypeAdapter[Any]:
@@ -203,7 +206,13 @@ class FuncMetadata(BaseModel):
         output_model = self.output_model if self.output_schema is not None else None
         if isinstance(result, CallToolResult):
             if output_model is not None and not result.is_error:
-                self._output_adapter(output_model).validate_python(result.structured_content)
+                adapter = self._output_adapter(output_model)
+                validated = adapter.validate_python(result.structured_content)
+                # Normalize structured content the same way as ordinary return values, so
+                # computed fields and serialization aliases match the output schema.
+                return result.model_copy(
+                    update={"structured_content": adapter.dump_python(validated, mode="json", by_alias=True)}
+                )
             return result
 
         unstructured_content = _convert_to_content(result)

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -884,6 +884,26 @@ def test_tool_call_result_annotated_is_structured_and_converted():
     assert isinstance(meta.convert_result(func_returning_annotated_tool_call_result()), CallToolResult)
 
 
+def test_tool_call_result_annotated_structured_content_is_normalized():
+    """A directly-returned CallToolResult has its structured_content normalized, so
+    serialization aliases match the declared output schema."""
+
+    class Person(BaseModel):
+        name: str = Field(serialization_alias="full_name")
+
+    def func_returning_annotated_tool_call_result() -> Annotated[CallToolResult, Person]:
+        return CallToolResult(content=[], structured_content={"name": "Brandon"})
+
+    meta = func_metadata(func_returning_annotated_tool_call_result)
+
+    assert meta.output_schema is not None
+    assert "full_name" in meta.output_schema["properties"]
+
+    converted = meta.convert_result(func_returning_annotated_tool_call_result())
+    assert isinstance(converted, CallToolResult)
+    assert converted.structured_content == {"full_name": "Brandon"}
+
+
 def test_tool_call_result_annotated_unioned_with_input_required_result_is_equivalent_to_the_bare_annotated_form():
     """Stripping `InputRequiredResult` makes the residual behave exactly as if it were the
     declared return annotation, including the `Annotated[CallToolResult, Model]` special case
@@ -1120,7 +1140,7 @@ def test_structured_output_computed_field():
 
         @computed_field
         @property
-        def doubled(self) -> int:  # pragma: no cover
+        def doubled(self) -> int:
             return self.value * 2
 
     def func_with_computed() -> ModelWithComputed:  # pragma: no cover

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -11,7 +11,7 @@ import annotated_types
 import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, InputRequiredResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from mcp.server.mcpserver.exceptions import InvalidSignature
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
@@ -1110,6 +1110,56 @@ def test_structured_output_aliases():
     assert "field_second" not in structured_content_defaults
     assert structured_content_defaults["first"] is None
     assert structured_content_defaults["second"] is None
+
+
+def test_structured_output_computed_field():
+    """A computed field is in the serialized output, so it must appear in the schema."""
+
+    class ModelWithComputed(BaseModel):
+        value: int
+
+        @computed_field
+        @property
+        def doubled(self) -> int:  # pragma: no cover
+            return self.value * 2
+
+    def func_with_computed() -> ModelWithComputed:  # pragma: no cover
+        return ModelWithComputed(value=3)
+
+    meta = func_metadata(func_with_computed)
+
+    assert meta.output_schema is not None
+    assert "doubled" in meta.output_schema["properties"]
+
+    converted = meta.convert_result(ModelWithComputed(value=3))
+    assert isinstance(converted, CallToolResult)
+    structured_content = converted.structured_content
+    assert structured_content is not None
+    assert structured_content == {"value": 3, "doubled": 6}
+    # Every serialized key must be advertised in the schema.
+    assert set(structured_content) <= set(meta.output_schema["properties"])
+
+
+def test_structured_output_serialization_alias():
+    """A serialization_alias changes the dumped key, so the schema must use it too."""
+
+    class ModelWithSerializationAlias(BaseModel):
+        value: int = Field(serialization_alias="the_value")
+
+    def func_with_serialization_alias() -> ModelWithSerializationAlias:  # pragma: no cover
+        return ModelWithSerializationAlias(value=7)
+
+    meta = func_metadata(func_with_serialization_alias)
+
+    assert meta.output_schema is not None
+    assert "the_value" in meta.output_schema["properties"]
+    assert "value" not in meta.output_schema["properties"]
+
+    converted = meta.convert_result(ModelWithSerializationAlias(value=7))
+    assert isinstance(converted, CallToolResult)
+    structured_content = converted.structured_content
+    assert structured_content is not None
+    assert structured_content == {"the_value": 7}
 
 
 def test_basemodel_reserved_names():

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -11,7 +11,7 @@ import annotated_types
 import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, ContentBlock, EmbeddedResource, InputRequiredResult, TextContent
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, computed_field
 from typing_extensions import NotRequired, ReadOnly, Required
 
 from mcp import MCPDeprecationWarning
@@ -1066,6 +1066,26 @@ def test_tool_call_result_annotated_is_structured_and_converted():
     assert isinstance(meta.convert_result(func_returning_annotated_tool_call_result()), CallToolResult)
 
 
+def test_tool_call_result_annotated_structured_content_is_normalized():
+    """A directly-returned CallToolResult has its structured_content normalized, so
+    serialization aliases match the declared output schema."""
+
+    class Person(BaseModel):
+        name: str = Field(serialization_alias="full_name")
+
+    def func_returning_annotated_tool_call_result() -> Annotated[CallToolResult, Person]:
+        return CallToolResult(content=[], structured_content={"name": "Brandon"})
+
+    meta = func_metadata(func_returning_annotated_tool_call_result)
+
+    assert meta.output_schema is not None
+    assert "full_name" in meta.output_schema["properties"]
+
+    converted = meta.convert_result(func_returning_annotated_tool_call_result())
+    assert isinstance(converted, CallToolResult)
+    assert converted.structured_content == {"full_name": "Brandon"}
+
+
 def test_tool_call_result_annotated_unioned_with_input_required_result_is_equivalent_to_the_bare_annotated_form():
     """Stripping `InputRequiredResult` makes the residual behave exactly as if it were the
     declared return annotation, including the `Annotated[CallToolResult, Model]` special case
@@ -1320,6 +1340,56 @@ def test_structured_output_aliases():
     assert "field_second" not in structured_content_defaults
     assert structured_content_defaults["first"] is None
     assert structured_content_defaults["second"] is None
+
+
+def test_structured_output_computed_field():
+    """A computed field is in the serialized output, so it must appear in the schema."""
+
+    class ModelWithComputed(BaseModel):
+        value: int
+
+        @computed_field
+        @property
+        def doubled(self) -> int:
+            return self.value * 2
+
+    def func_with_computed() -> ModelWithComputed:  # pragma: no cover
+        return ModelWithComputed(value=3)
+
+    meta = func_metadata(func_with_computed)
+
+    assert meta.output_schema is not None
+    assert "doubled" in meta.output_schema["properties"]
+
+    converted = meta.convert_result(ModelWithComputed(value=3))
+    assert isinstance(converted, CallToolResult)
+    structured_content = converted.structured_content
+    assert structured_content is not None
+    assert structured_content == {"value": 3, "doubled": 6}
+    # Every serialized key must be advertised in the schema.
+    assert set(structured_content) <= set(meta.output_schema["properties"])
+
+
+def test_structured_output_serialization_alias():
+    """A serialization_alias changes the dumped key, so the schema must use it too."""
+
+    class ModelWithSerializationAlias(BaseModel):
+        value: int = Field(serialization_alias="the_value")
+
+    def func_with_serialization_alias() -> ModelWithSerializationAlias:  # pragma: no cover
+        return ModelWithSerializationAlias(value=7)
+
+    meta = func_metadata(func_with_serialization_alias)
+
+    assert meta.output_schema is not None
+    assert "the_value" in meta.output_schema["properties"]
+    assert "value" not in meta.output_schema["properties"]
+
+    converted = meta.convert_result(ModelWithSerializationAlias(value=7))
+    assert isinstance(converted, CallToolResult)
+    structured_content = converted.structured_content
+    assert structured_content is not None
+    assert structured_content == {"the_value": 7}
 
 
 def test_basemodel_reserved_names():


### PR DESCRIPTION
Fixes #3100.

The tool output schema is generated with `model_json_schema()`, which defaults to validation mode, but structured content is serialized with `model_dump(mode="json", by_alias=True)` in `FuncMetadata.convert_result`. The two disagree for:

- `@computed_field`s — present in the serialized payload, absent from the schema.
- `serialization_alias` — the dumped key uses the serialization alias, but the schema advertises the validation name.

So a client validating structured content against the published `outputSchema` sees unexpected or misnamed properties.

Generate the output schema in serialization mode so it matches what the server actually sends. Added regression tests for the computed-field and serialization-alias cases (the existing `test_structured_output_aliases` only covers plain `alias=`, which agrees in both modes).