### PR TITLE
fix(server): forward tool args under the real parameter name, not the…

### DIFF
--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -99,9 +99,9 @@ class Tool(BaseModel):
         )
         parameters = func_arg_metadata.arg_model.model_json_schema(by_alias=True)
 
-        # Match `model_dump_one_level`'s kwarg keys (alias when present, else field name)
-        # so a by-name resolver param resolves to a key that exists at call time.
-        tool_arg_names = {field.alias or name for name, field in func_arg_metadata.arg_model.model_fields.items()}
+        # Match `model_dump_one_level`'s kwarg keys (the real parameter names) so a
+        # by-name resolver param resolves to a key that exists at call time.
+        tool_arg_names = set(func_arg_metadata.arg_model.param_names.values())
         resolver_plans = build_resolver_plans(resolved_params, tool_arg_names)
 
         return cls(

--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -105,9 +105,9 @@ class Tool(BaseModel):
         )
         parameters = func_arg_metadata.arg_model.model_json_schema(by_alias=True)
 
-        # Match `model_dump_one_level`'s kwarg keys (alias when present, else field name)
-        # so a by-name resolver param resolves to a key that exists at call time.
-        tool_arg_names = {field.alias or name for name, field in func_arg_metadata.arg_model.model_fields.items()}
+        # Match `model_dump_one_level`'s kwarg keys (the real parameter names) so a
+        # by-name resolver param resolves to a key that exists at call time.
+        tool_arg_names = set(func_arg_metadata.arg_model.param_names.values())
         resolver_plans = build_resolver_plans(resolved_params, tool_arg_names)
 
         return cls(

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import Awaitable, Callable, Sequence
 from itertools import chain
 from types import GenericAlias
-from typing import Annotated, Any, Union, cast, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, ClassVar, Union, cast, get_args, get_origin, get_type_hints
 
 import anyio
 import anyio.to_thread
@@ -47,17 +47,22 @@ class StrictJsonSchema(GenerateJsonSchema):
 class ArgModelBase(BaseModel):
     """A model representing the arguments to a function."""
 
+    # Maps each model field name to the real Python parameter name to forward it under.
+    # They differ for aliased parameters: our internal shadow-rename (field "field_schema"
+    # -> param "schema") and a user Field(alias=...) (field "city" stays the param name,
+    # the alias is only the wire name). field_info.alias alone can't tell the two apart.
+    param_names: ClassVar[dict[str, str]] = {}
+
     def model_dump_one_level(self) -> dict[str, Any]:
         """Return a dict of the model's fields, one level deep.
 
         That is, sub-models etc are not dumped - they are kept as Pydantic models.
         """
         kwargs: dict[str, Any] = {}
-        for field_name, field_info in self.__class__.model_fields.items():
-            value = getattr(self, field_name)
-            # Use the alias if it exists, otherwise use the field name
-            output_name = field_info.alias if field_info.alias else field_name
-            kwargs[output_name] = value
+        for field_name in self.__class__.model_fields:
+            # Forward under the real parameter name, not the schema alias - the alias is
+            # a wire name and isn't necessarily a valid kwarg for the underlying function.
+            kwargs[self.param_names.get(field_name, field_name)] = getattr(self, field_name)
         return kwargs
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -237,6 +242,7 @@ def func_metadata(
         raise InvalidSignature(f"Unable to evaluate type annotations for callable {func.__name__!r}") from e
     params = sig.parameters
     dynamic_pydantic_model_params: dict[str, Any] = {}
+    param_names: dict[str, str] = {}
     for param in params.values():
         if param.name.startswith("_"):  # pragma: no cover
             raise InvalidSignature(f"Parameter {param.name} of {func.__name__} cannot start with '_'")
@@ -258,6 +264,8 @@ def func_metadata(
             # Use a prefixed field name
             field_name = f"field_{field_name}"
 
+        param_names[field_name] = param.name
+
         if param.default is not inspect.Parameter.empty:
             dynamic_pydantic_model_params[field_name] = (
                 Annotated[(annotation, *field_metadata, Field(**field_kwargs))],
@@ -271,6 +279,7 @@ def func_metadata(
         __base__=ArgModelBase,
         **dynamic_pydantic_model_params,
     )
+    arguments_model.param_names = param_names
 
     if structured_output is False:
         return FuncMetadata(arg_model=arguments_model)

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -5,7 +5,7 @@ import sys
 from collections.abc import Awaitable, Callable, Sequence
 from itertools import chain
 from types import GenericAlias
-from typing import Annotated, Any, Union, cast, get_args, get_origin
+from typing import Annotated, Any, ClassVar, Union, cast, get_args, get_origin
 
 import anyio
 import anyio.to_thread
@@ -96,17 +96,22 @@ def _inline_root_ref(schema: dict[str, Any]) -> dict[str, Any]:
 class ArgModelBase(BaseModel):
     """A model representing the arguments to a function."""
 
+    # Maps each model field name to the real Python parameter name to forward it under.
+    # They differ for aliased parameters: our internal shadow-rename (field "field_schema"
+    # -> param "schema") and a user Field(alias=...) (field "city" stays the param name,
+    # the alias is only the wire name). field_info.alias alone can't tell the two apart.
+    param_names: ClassVar[dict[str, str]] = {}
+
     def model_dump_one_level(self) -> dict[str, Any]:
         """Return a dict of the model's fields, one level deep.
 
         That is, sub-models etc are not dumped - they are kept as Pydantic models.
         """
         kwargs: dict[str, Any] = {}
-        for field_name, field_info in self.__class__.model_fields.items():
-            value = getattr(self, field_name)
-            # Use the alias if it exists, otherwise use the field name
-            output_name = field_info.alias if field_info.alias else field_name
-            kwargs[output_name] = value
+        for field_name in self.__class__.model_fields:
+            # Forward under the real parameter name, not the schema alias - the alias is
+            # a wire name and isn't necessarily a valid kwarg for the underlying function.
+            kwargs[self.param_names.get(field_name, field_name)] = getattr(self, field_name)
         return kwargs
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -326,6 +331,7 @@ def func_metadata(
         raise InvalidSignature(f"Unable to evaluate type annotations for callable {func.__name__!r}") from e
     params = sig.parameters
     dynamic_pydantic_model_params: dict[str, Any] = {}
+    param_names: dict[str, str] = {}
     for param in params.values():
         if param.name.startswith("_"):  # pragma: no cover
             raise InvalidSignature(f"Parameter {param.name} of {func.__name__} cannot start with '_'")
@@ -347,6 +353,8 @@ def func_metadata(
             # Use a prefixed field name
             field_name = f"field_{field_name}"
 
+        param_names[field_name] = param.name
+
         if param.default is not inspect.Parameter.empty:
             dynamic_pydantic_model_params[field_name] = (
                 Annotated[(annotation, *field_metadata, Field(**field_kwargs))],
@@ -360,6 +368,7 @@ def func_metadata(
         __base__=ArgModelBase,
         **dynamic_pydantic_model_params,
     )
+    arguments_model.param_names = param_names
 
     if structured_output is False:
         return FuncMetadata(arg_model=arguments_model)

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1198,6 +1198,31 @@ async def test_basemodel_reserved_names_validation():
     assert dumped["normal_param"] == "test"
 
 
+@pytest.mark.anyio
+async def test_call_with_aliased_parameter():
+    """A parameter with an explicit Field alias is advertised under the alias in the
+    input schema but forwarded to the function under its real parameter name."""
+
+    def func_with_aliased_param(city: Annotated[str, Field(alias="location")]) -> str:
+        return f"weather in {city}"
+
+    meta = func_metadata(func_with_aliased_param)
+
+    # The input schema advertises the alias, not the parameter name.
+    schema = meta.arg_model.model_json_schema(by_alias=True)
+    assert "location" in schema["properties"]
+    assert "city" not in schema["properties"]
+
+    # A client sends the alias; the function must still be called with `city=`.
+    result = await meta.call_fn_with_arg_validation(
+        func_with_aliased_param,
+        fn_is_async=False,
+        arguments_to_validate={"location": "Paris"},
+        arguments_to_pass_directly=None,
+    )
+    assert result == "weather in Paris"
+
+
 def test_basemodel_reserved_names_with_json_preparsing():
     """Test that pre_parse_json works correctly with reserved parameter names"""
 

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1410,6 +1410,30 @@ async def test_basemodel_reserved_names_validation():
     assert dumped["normal_param"] == "test"
 
 
+@pytest.mark.anyio
+async def test_call_with_aliased_parameter():
+    """A parameter with an explicit Field alias is advertised under the alias in the
+    input schema but forwarded to the function under its real parameter name."""
+
+    def func_with_aliased_param(city: Annotated[str, Field(alias="location")]) -> str:
+        return f"weather in {city}"
+
+    meta = func_metadata(func_with_aliased_param)
+
+    # The input schema advertises the alias, not the parameter name.
+    schema = meta.arg_model.model_json_schema(by_alias=True)
+    assert "location" in schema["properties"]
+    assert "city" not in schema["properties"]
+
+    # A client sends the alias; the function must still be called with `city=`.
+    result = await meta.call_fn(
+        func_with_aliased_param,
+        fn_is_async=False,
+        arguments=meta.validate_arguments({"location": "Paris"}),
+    )
+    assert result == "weather in Paris"
+
+
 def test_basemodel_reserved_names_with_json_preparsing():
     """Test that pre_parse_json works correctly with reserved parameter names"""
 


### PR DESCRIPTION
Forward tool arguments to the underlying function under the real parameter name instead of the schema alias.

## Motivation and Context

A tool parameter with an explicit alias, e.g. `city: Annotated[str, Field(alias="location")]`, is advertised in the tool input schema as `location`, and clients send `location`. At call time `model_dump_one_level` forwarded the value under the alias, so the function was invoked as `fn(location=...)` and raised `TypeError: got an unexpected keyword argument 'location'`. Both sync and async tools are affected.

The root cause is that `field_info.alias` is used as the kwarg name, but the alias is a wire name, not necessarily a valid Python parameter. It happens to be correct for the internal shadow-rename case (a param named after a `BaseModel` attribute, e.g. `schema` -> field `field_schema` with `alias="schema"`), where the alias *is* the real param name — so the two cases are indistinguishable from `FieldInfo` alone.

The fix records each field's real Python parameter name at metadata-build time and forwards arguments under it. The shadow-rename case keeps working because its real name is recorded the same way. Resolver arg-name matching in `tools/base.py` reads the same map so by-name resolvers keep resolving.

## How Has This Been Tested?

Added a regression test (`test_call_with_aliased_parameter`) that fails before the change with the `TypeError` above and passes after. Repro:

```python
from typing import Annotated
from pydantic import Field
from mcp.server.mcpserver.utilities.func_metadata import func_metadata

def tool(city: Annotated[str, Field(alias="location")]) -> str:
    return city

meta = func_metadata(tool)
# input schema advertises "location"; a client sends {"location": "Paris"}
# -> TypeError: got an unexpected keyword argument 'location'
```

Full `tests/server/mcpserver/` suite passes locally (552 tests), along with ruff, pyright, and strict-no-cover.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
