### PR TITLE
fix: stop newline translation corrupting stdio framing on Windows

### DIFF
--- a/src/mcp/server/stdio.py
+++ b/src/mcp/server/stdio.py
@@ -41,7 +41,10 @@ async def stdio_server(stdin: anyio.AsyncFile[str] | None = None, stdout: anyio.
     if not stdin:
         stdin = anyio.wrap_file(TextIOWrapper(sys.stdin.buffer, encoding="utf-8", errors="replace"))
     if not stdout:
-        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8"))
+        # newline="" disables newline translation: without it, writing "\n" on
+        # Windows emits "\r\n", which breaks the newline-delimited JSON framing.
+        # stdin keeps universal-newline reading so CRLF from clients is tolerated.
+        stdout = anyio.wrap_file(TextIOWrapper(sys.stdout.buffer, encoding="utf-8", newline=""))
 
     read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](0)
     write_stream, write_stream_reader = create_context_streams[SessionMessage](0)

--- a/tests/server/test_stdio.py
+++ b/tests/server/test_stdio.py
@@ -105,6 +105,37 @@ async def test_stdio_server_invalid_utf8(monkeypatch: pytest.MonkeyPatch) -> Non
                 assert second.message == valid
 
 
+@pytest.mark.anyio
+async def test_stdio_server_default_stdout_writes_bare_lf(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default-wrapped stdout frames messages with bare "\\n", never "\\r\\n".
+
+    Regression lock for issue #2433: without newline="" the stdout wrapper
+    translates "\\n" to os.linesep on write, so Windows emitted "\\r\\n" and
+    corrupted the newline-delimited JSON framing. Asserted on the raw bytes so
+    the platform's newline translation, not the parsed result, is under test.
+    """
+
+    class _NonClosingBytesIO(io.BytesIO):
+        """Survives the wrapper's close-on-gc so the bytes stay inspectable."""
+
+        def close(self) -> None:
+            pass
+
+    raw_stdout = _NonClosingBytesIO()
+    monkeypatch.setattr(sys, "stdin", TextIOWrapper(io.BytesIO(), encoding="utf-8"))
+    monkeypatch.setattr(sys, "stdout", TextIOWrapper(raw_stdout, encoding="utf-8"))
+
+    with anyio.fail_after(5):
+        async with stdio_server() as (read_stream, write_stream):
+            await write_stream.send(SessionMessage(JSONRPCResponse(jsonrpc="2.0", id=1, result={})))
+            await write_stream.aclose()
+            await read_stream.aclose()
+
+    data = raw_stdout.getvalue()
+    assert data.endswith(b"}\n"), f"expected a bare-LF-terminated frame, got {data!r}"
+    assert b"\r" not in data, f"CR byte in stdout frame (Windows newline translation): {data!r}"
+
+
 class _GatedStdin(io.RawIOBase):
     """Raw stdin double: serves its frames, then blocks until released before EOF.
 


### PR DESCRIPTION
## Summary

Fixes #2433. Supersedes stale #2552 (credit to its author for the direction).

`stdio_server()` wraps `sys.stdout.buffer` in a `TextIOWrapper` with default newline handling, which translates `\n` to `os.linesep` on write. On Windows every outgoing frame is terminated with `\r\n`, breaking the newline-delimited JSON framing required by the spec.

## Change

`newline=""` on the stdout wrapper only. Write-side frames must be spec-exact (`\n`-delimited); stdin keeps universal-newline reading so CRLF from clients stays tolerated (liberal in what we accept).

## How Has This Been Tested?

Reproduced the bug natively on Windows 11 (Python 3.13, current `main`) with a raw-bytes client against a real stdio server subprocess: frames arrived as `b'...}\r\n'` before the fix, `b'...}\n'` after.

The new regression test asserts on the raw bytes written to stdout, so the platform's newline translation itself is under test. Verified red/green on native Windows: fails on `main` with `b'{"jsonrpc":"2.0","id":1,"result":{}}\r\n'`, passes with the fix. It runs on the `windows-latest` unit-test CI cell, which currently has no byte-level framing coverage (the test in #2552 asserted `endswith(b"\n")`, which cannot detect CRLF).

Local gate on Windows: full suite 5438 passed / 15 skipped / 1 xfailed, `ruff check` + `ruff format` clean, `pyright` (pinned 1.1.405) 0 errors.

## Breaking Changes

None. Output on POSIX platforms is byte-identical; Windows output changes from out-of-spec `\r\n` framing to the spec's `\n`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed