### PR TITLE
fix(server): respect Accept header q=0 (RFC 7231 "not acceptable")

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -77,19 +77,56 @@ SSEEvent = dict[str, Any]
 
 
 def check_accept_headers(request: Request) -> tuple[bool, bool]:
-    """Return (has_json, has_sse) for the request's Accept header, with RFC 7231 wildcard handling.
+    """Return (has_json, has_sse) for the request's Accept header, with RFC 7231 wildcard
+    and q-value handling.
 
     Supports wildcard media types per RFC 7231, section 5.3.2:
     - */* matches any media type
     - application/* matches any application/ subtype
     - text/* matches any text/ subtype
+
+    A media-range weighted q=0 is explicitly "not acceptable" per RFC 7231, section 5.3.1.
+    An explicit q=0 for a specific type (or its family wildcard) takes precedence over a
+    broader range that would otherwise accept it — e.g. "application/json;q=0, */*" still
+    rejects JSON even though */* is also present.
     """
     accept_header = request.headers.get("accept", "")
-    accept_types = [media_type.strip().split(";")[0].strip().lower() for media_type in accept_header.split(",")]
+    accepted: set[str] = set()
+    rejected: set[str] = set()
 
-    has_wildcard = "*/*" in accept_types
-    has_json = has_wildcard or any(t in (CONTENT_TYPE_JSON, "application/*") for t in accept_types)
-    has_sse = has_wildcard or any(t in (CONTENT_TYPE_SSE, "text/*") for t in accept_types)
+    for media_range in accept_header.split(","):
+        params = [p.strip() for p in media_range.split(";")]
+        media_type = params[0].lower()
+        if not media_type:
+            continue
+
+        q = 1.0
+        for param in params[1:]:
+            name, _, value = param.partition("=")
+            if name.strip().lower() == "q":
+                try:
+                    q = float(value.strip())
+                except ValueError:
+                    q = 1.0
+                break
+
+        (rejected if q <= 0 else accepted).add(media_type)
+
+    def is_acceptable(media_type: str, family_wildcard: str) -> bool:
+        # Most specific match wins: an exact media type overrides its family wildcard,
+        # which in turn overrides the global "*/*".
+        if media_type in accepted:
+            return True
+        if media_type in rejected:
+            return False
+        if family_wildcard in accepted:
+            return True
+        if family_wildcard in rejected:
+            return False
+        return "*/*" in accepted
+
+    has_json = is_acceptable(CONTENT_TYPE_JSON, "application/*")
+    has_sse = is_acceptable(CONTENT_TYPE_SSE, "text/*")
 
     return has_json, has_sse
 

--- a/tests/server/test_streamable_http_modern.py
+++ b/tests/server/test_streamable_http_modern.py
@@ -625,6 +625,55 @@ async def test_accept_wildcard_satisfies_both_response_modes(json_response: bool
     assert response.status_code == 200
 
 
+async def test_accept_q0_for_the_required_type_is_not_acceptable() -> None:
+    """RFC 7231 5.3.1: a media-range weighted q=0 is explicitly "not acceptable" -- a client
+    that sends `application/json;q=0` has ruled JSON out even though it's the only other type
+    on the line, so a JSON-mode request must get 406, not 200."""
+
+    async def list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+        return ListToolsResult(tools=[], ttl_ms=0, cache_scope="public")  # pragma: no cover
+
+    async with _asgi_client(
+        Server("test", on_list_tools=list_tools),
+        json_response=True,
+        accept="application/json;q=0, text/event-stream;q=1.0",
+    ) as http:
+        response = await http.post("/mcp", json=_list_tools_body(), headers={MCP_METHOD_HEADER: "tools/list"})
+    assert response.status_code == 406
+
+
+async def test_accept_q0_for_a_specific_type_overrides_a_present_wildcard() -> None:
+    """A specific "not acceptable" entry is more specific than `*/*` and must win: the client
+    is still rejecting JSON even though it also (redundantly) accepts everything."""
+
+    async def list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+        return ListToolsResult(tools=[], ttl_ms=0, cache_scope="public")  # pragma: no cover
+
+    async with _asgi_client(
+        Server("test", on_list_tools=list_tools),
+        json_response=True,
+        accept="application/json;q=0, */*",
+    ) as http:
+        response = await http.post("/mcp", json=_list_tools_body(), headers={MCP_METHOD_HEADER: "tools/list"})
+    assert response.status_code == 406
+
+
+async def test_accept_nonzero_q_for_the_required_type_is_still_acceptable() -> None:
+    """A low but nonzero weight is still a "yes" -- q only gates acceptability at 0, this SDK
+    doesn't rank multiple acceptable representations by preference."""
+
+    async def list_tools(ctx: ServerRequestContext, params: PaginatedRequestParams | None) -> ListToolsResult:
+        return ListToolsResult(tools=[], ttl_ms=0, cache_scope="public")
+
+    async with _asgi_client(
+        Server("test", on_list_tools=list_tools),
+        json_response=True,
+        accept="application/json;q=0.1",
+    ) as http:
+        response = await http.post("/mcp", json=_list_tools_body(), headers={MCP_METHOD_HEADER: "tools/list"})
+    assert response.status_code == 200
+
+
 async def test_late_notify_after_terminal_dropped() -> None:
     """SDK-defined: a `notify()` after the SSE sink has closed is silently dropped — the closed
     stream must not propagate as an exception out of the dispatch context."""


### PR DESCRIPTION
Fixes #3154

## What
`check_accept_headers()` stripped every Accept-header parameter after the media
type (`media_type.split(";")[0]`), so `application/json;q=0` — which per RFC 7231
§5.3.1 explicitly marks JSON as **not acceptable** — was parsed identically to
plain `application/json`. A client that explicitly ruled out a representation
could still receive it.

## Details
- Parses each media-range's `q` parameter (default 1.0 if absent/malformed).
- `q <= 0` moves the type from "accepted" to "rejected".
- A specific type's rejection takes precedence over a broader wildcard that
  would otherwise accept it (e.g. `application/json;q=0, */*` still rejects
  JSON) — most-specific-wins, consistent with RFC 7231 §5.3.2 precedence.
- Nonzero q values are unchanged: this SDK doesn't rank multiple acceptable
  representations by preference, it only gates on q=0 vs not.

## Testing
- `test_accept_q0_for_the_required_type_is_not_acceptable` — the exact example
  from the issue.
- `test_accept_q0_for_a_specific_type_overrides_a_present_wildcard` — specific
  rejection beats a present wildcard.
- `test_accept_nonzero_q_for_the_required_type_is_still_acceptable` — regression
  guard for nonzero q.
- `uv run pytest tests/server/`, `uv run ruff check .`, `uv run ruff format --check .`,
  `uv run pyright` all pass.

## Disclosure
I used AI (Claude) to help draft this fix and its tests; I've reviewed and
understand the change and I'm happy to answer questions about it.