### PR TITLE
fix(client): don't send client_id in token body under client_secret_basic

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -207,8 +207,11 @@ class OAuthContext:
             credentials = f"{encoded_id}:{encoded_secret}"
             encoded_credentials = base64.b64encode(credentials.encode()).decode()
             headers["Authorization"] = f"Basic {encoded_credentials}"
-            # Don't include client_secret in body for basic auth
-            data = {k: v for k, v in data.items() if k != "client_secret"}
+            # RFC 6749 §2.3: with HTTP Basic auth, client credentials must not also appear
+            # in the request body. Strict token endpoints (Keycloak, Okta in strict mode)
+            # reject a request that presents both the Authorization header and client_id
+            # in the body as two authentication methods at once.
+            data = {k: v for k, v in data.items() if k not in ("client_secret", "client_id")}
         elif auth_method == "client_secret_post" and self.client_info.client_id and self.client_info.client_secret:
             # Include client_id and client_secret in request body (RFC 6749 §2.3.1)
             data["client_id"] = self.client_info.client_id

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -680,7 +680,10 @@ class TestOAuthFallback:
         # client_secret should NOT be in body for basic auth
         content = request.content.decode()
         assert "client_secret=" not in content
-        assert "client_id=test%40client" in content  # client_id still in body
+        # RFC 6749 §2.3: with Basic auth, client_id must not appear in the body either --
+        # it's already presented via the Authorization header, and strict token endpoints
+        # reject a request that presents credentials both ways.
+        assert "client_id=" not in content
 
     @pytest.mark.anyio
     async def test_basic_auth_refresh_token(self, oauth_provider: OAuthClientProvider, valid_tokens: OAuthToken):
@@ -716,6 +719,8 @@ class TestOAuthFallback:
         # client_secret should NOT be in body
         content = request.content.decode()
         assert "client_secret=" not in content
+        # ...and neither should client_id, for the same RFC 6749 §2.3 reason as token exchange.
+        assert "client_id=" not in content
 
     @pytest.mark.anyio
     async def test_none_auth_method(self, oauth_provider: OAuthClientProvider):


### PR DESCRIPTION
Fixes #3138

## What
Under `token_endpoint_auth_method = client_secret_basic`, the OAuth client sends
credentials via `Authorization: Basic ...` — but `prepare_token_auth()` only
stripped `client_secret` from the request body, leaving `client_id` in. RFC 6749
§2.3 requires that with Basic auth, client credentials not also appear in the
body. Strict token endpoints (Keycloak, Okta in strict mode) reject this as two
authentication methods in a single request.

## Fix
One-line change: strip `client_id` alongside `client_secret` from the body when
`auth_method == "client_secret_basic"`.

## Testing
Two existing tests in `tests/client/test_auth.py` explicitly asserted the old
(buggy) behavior — `assert "client_id=test%40client" in content  # client_id
still in body`. Updated both to assert its absence instead, and added the same
check to the refresh-token test for symmetry.

`uv run pytest tests/client/`, `uv run ruff check .`, `uv run ruff format --check .`,
`uv run pyright` all pass.

## Disclosure
I used AI (Claude) to help draft this fix; I've reviewed and understand the
change and I'm happy to answer questions about it.