### PR TITLE
SEP-990 identity-assertion client also sends client_id in token body under client_secret_basic

### DIFF
--- a/src/mcp/client/auth/extensions/identity_assertion.py
+++ b/src/mcp/client/auth/extensions/identity_assertion.py
@@ -143,7 +143,6 @@ class IdentityAssertionOAuthProvider(httpx2.Auth):
         data: dict[str, str] = {
             "grant_type": JWT_BEARER_GRANT_TYPE,
             "assertion": assertion,
-            "client_id": self._client.client_id,
             "resource": self._resource,
         }
         if scope:
@@ -155,7 +154,10 @@ class IdentityAssertionOAuthProvider(httpx2.Auth):
             encoded_secret = quote(self._client.client_secret, safe="")
             credentials = base64.b64encode(f"{encoded_id}:{encoded_secret}".encode()).decode()
             headers["Authorization"] = f"Basic {credentials}"
+            # RFC 6749 section 2.3: client_id must not also appear in the body when it's
+            # already presented via the Authorization header.
         else:
+            data["client_id"] = self._client.client_id
             data["client_secret"] = self._client.client_secret
         return httpx2.Request("POST", self._token_endpoint, data=data, headers=headers)
 

--- a/tests/client/auth/extensions/test_identity_assertion.py
+++ b/tests/client/auth/extensions/test_identity_assertion.py
@@ -293,6 +293,8 @@ async def test_token_endpoint_error_surfaces_as_oauth_token_error() -> None:
 
 @pytest.mark.anyio
 async def test_client_secret_basic_sends_basic_header_not_body_secret() -> None:
+    """RFC 6749 §2.3: with Basic auth, neither client_secret nor client_id may also appear
+    in the body -- both are already presented via the Authorization header."""
     requests: list[httpx2.Request] = []
     auth = make_provider(token_endpoint_auth_method="client_secret_basic")
 
@@ -303,8 +305,28 @@ async def test_client_secret_basic_sends_basic_header_not_body_secret() -> None:
 
     [token_req] = [r for r in requests if r.url.path == "/token"]
     assert "client_secret" not in form(token_req)
+    assert "client_id" not in form(token_req)
     decoded = base64.b64decode(token_req.headers["Authorization"].removeprefix("Basic ")).decode()
     assert decoded == "test-client-id:test-client-secret"
+
+
+@pytest.mark.anyio
+async def test_client_secret_post_sends_client_id_and_secret_in_body() -> None:
+    """Sanity check / regression guard for the client_secret_basic fix above: the post method
+    is unaffected and still sends both client_id and client_secret in the body, not a header."""
+    requests: list[httpx2.Request] = []
+    auth = make_provider(token_endpoint_auth_method="client_secret_post")
+
+    async with httpx2.AsyncClient(
+        transport=mock_transport(requests, asm=asm_body(), token=token_body()), auth=auth
+    ) as http:
+        await http.post(f"{RS}/mcp")
+
+    [token_req] = [r for r in requests if r.url.path == "/token"]
+    assert "Authorization" not in token_req.headers
+    body = form(token_req)
+    assert body["client_id"] == "test-client-id"
+    assert body["client_secret"] == "test-client-secret"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

`IdentityAssertionOAuthProvider._build_token_request()` in
`src/mcp/client/auth/extensions/identity_assertion.py` has the same issue as #3138
(fixed for the main `OAuthContext.prepare_token_auth()`), in its own independent
implementation: `client_id` is unconditionally placed in the request body, and is
never removed when `token_endpoint_auth_method == "client_secret_basic"` — even
though it's already presented via the `Authorization: Basic` header at that point.

RFC 6749 §2.3 requires that with Basic auth, client credentials not also appear in
the body. Strict token endpoints (Keycloak, Okta in strict mode) reject a request
that presents credentials both ways.

## Where

```python
# src/mcp/client/auth/extensions/identity_assertion.py, _build_token_request()
data: dict[str, str] = {
    "grant_type": JWT_BEARER_GRANT_TYPE,
    "assertion": assertion,
    "client_id": self._client.client_id,  # <-- always present, never stripped
    "resource": self._resource,
}
...
if self._client.token_endpoint_auth_method == "client_secret_basic":
    ...
    headers["Authorization"] = f"Basic {credentials}"
    # client_id above is never removed from `data`
else:
    data["client_secret"] = self._client.client_secret
```

## Proposed fix

Move `client_id` into the `else` (client_secret_post) branch alongside
`client_secret`, so it's only added to the body for the post method — matching the
fix already applied to `OAuthContext.prepare_token_auth` for #3138.

I have a fix + tests ready and would like to submit a PR (disclosed: drafted with
AI assistance, reviewed and understood by me).