### PR TITLE
Remove Context.client_id

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -916,6 +916,27 @@ await ctx.log(level="info", data="hello")
 
 Positional calls (`await ctx.info("hello")`) are unaffected.
 
+### `Context.client_id` removed
+
+`Context.client_id` has been removed. It never returned an authenticated client identity: it echoed a non-standard `client_id` key from the request's `_meta`, which nothing in the SDK or the MCP spec populates, so it was `None` unless a caller injected `meta={"client_id": ...}` by hand. The name also collided with the OAuth `client_id`, which is what callers usually mean by "the client".
+
+If you were reading a custom `_meta` key, read it from the meta dict directly. If you want the authenticated OAuth client, use the access token:
+
+```python
+# Before (v1)
+client_id = ctx.client_id
+
+# After (v2) — the raw _meta key, if you were setting it yourself
+meta = ctx.request_context.meta
+client_id = meta.get("client_id") if meta else None
+
+# After (v2) — the authenticated OAuth client (usually what you want)
+from mcp.server.auth.middleware.auth_context import get_access_token
+
+token = get_access_token()
+client_id = token.client_id if token else None
+```
+
 ### `ProgressContext` and `progress()` context manager removed
 
 The `mcp.shared.progress` module (`ProgressContext`, `Progress`, and the `progress()` context manager) has been removed. This module had no real-world adoption — all users send progress notifications via `Context.report_progress()` or `session.send_progress_notification()` directly.

--- a/src/mcp/server/mcpserver/context.py
+++ b/src/mcp/server/mcpserver/context.py
@@ -54,7 +54,6 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
 
         # Get request info
         request_id = ctx.request_id
-        client_id = ctx.client_id
 
         return str(x)
     ```
@@ -274,16 +273,6 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
             logger=logger_name,
             related_request_id=self.request_id,
         )
-
-    # TODO(maxisbey): see if this is needed otherwise remove
-    @property
-    def client_id(self) -> str | None:
-        """Get the client ID if available.
-
-        Note: this reads from the MCP request's `_meta` params, not the OAuth
-        bearer token. For that, use `get_access_token().client_id`.
-        """
-        return self.request_context.meta.get("client_id") if self.request_context.meta else None  # pragma: no cover
 
     @property
     def headers(self) -> Mapping[str, str] | None:


### PR DESCRIPTION
Removes the `Context.client_id` property. It never returned an authenticated client identity: it echoed a non-standard `client_id` key from the request's `_meta`, which nothing in the SDK or the MCP spec populates, so it was `None` unless a caller injected `meta={"client_id": ...}` by hand. The name also collided with the OAuth `client_id`, which is what people usually mean by "the client" — see #373 for the recurring confusion.

## Motivation and Context

A leftover from the original FastMCP integration. It carried a `# pragma: no cover` because it had never been exercised, and a `TODO` to see if it was needed. It isn't: the meta path is reachable via `ctx.request_context.meta.get("client_id")`, and the authenticated client is `get_access_token().client_id`.

## How Has This Been Tested?

Existing suite; the removed line was the only untested one in the property. `docs/migration.md` gains a section with both replacements.

## Breaking Changes

Yes — `ctx.client_id` now raises `AttributeError`. Migration entry added under the `MCPServer` `Context` section:

- raw `_meta` key: `meta = ctx.request_context.meta; meta.get("client_id") if meta else None`
- authenticated OAuth client: `get_access_token().client_id`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
