### PR TITLE
Serve v2 docs at the site root, with permanent per-major paths

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,8 +3,10 @@ name: Deploy Docs
 on:
   push:
     branches:
+      # main is the sole deployer of the combined site (v2 at / and /v2/, v1.x
+      # at /v1/); the v1.x branch has no deploy workflow. A v1.x docs change is
+      # published by the next main deploy or a manual workflow_dispatch here.
       - main
-      - v1.x
     paths:
       - docs/**
       # docs pages include their code blocks from these files via `--8<--`, so a
@@ -48,7 +50,7 @@ jobs:
           enable-cache: true
           version: 0.9.5
 
-      - name: Build combined docs (v1.x at /, main at /v2/)
+      - name: Build combined docs (main at / and /v2/, v1.x at /v1/)
         run: bash scripts/build-docs.sh site
 
       - name: Configure Pages

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # MCP Python SDK
 
-!!! info "You are viewing the in-development v2 documentation"
-    For the current stable release, see the [v1.x documentation](https://py.sdk.modelcontextprotocol.io/).
+!!! info "You are viewing the v2 documentation"
+    The v1.x documentation is at [/v1/](https://py.sdk.modelcontextprotocol.io/v1/).
     New to v2, or coming from v1? **[What's new in v2](whats-new.md)** is the five-minute tour of what changed.
     Trying v2? [Tell us what you find](https://github.com/modelcontextprotocol/python-sdk/issues/new?template=v2-feedback.yaml) — it is the most useful thing you can do for the SDK right now.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: The official Python SDK for the Model Context Protocol
 repo_name: modelcontextprotocol/python-sdk
 repo_url: https://github.com/modelcontextprotocol/python-sdk
 edit_uri: edit/main/docs/
-site_url: https://py.sdk.modelcontextprotocol.io/v2/
+site_url: https://py.sdk.modelcontextprotocol.io/
 
 # TODO(Marcelo): Add Anthropic copyright?
 # copyright: © Model Context Protocol 2025 to present

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://modelcontextprotocol.io"
-Documentation = "https://py.sdk.modelcontextprotocol.io/v2/"
+Documentation = "https://py.sdk.modelcontextprotocol.io/"
 Repository = "https://github.com/modelcontextprotocol/python-sdk"
 Issues = "https://github.com/modelcontextprotocol/python-sdk/issues"
 

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -2,16 +2,20 @@
 #
 # Build combined v1 + v2 documentation for GitHub Pages.
 #
-# v1 docs (from the v1.x branch) are placed at the site root.
-# v2 docs (from main) are placed under /v2/.
+# The current major (v2, from main) is placed at the site root and mirrored
+# under /v2/; the v1 maintenance line (from the v1.x branch) is placed under
+# /v1/. Per-major paths are permanent: /v2/ is a byte-identical copy of the
+# root so that /v2/... links keep resolving after a future major takes the
+# root, the way /v1/... does for v1 today.
 #
 # The two lines use different toolchains: v1.x still builds with MkDocs, while
 # main builds with Zensical (which needs a pre-build step to materialise the API
 # reference and a post-build step for llms.txt — see scripts/docs/). Each branch
-# is fetched fresh from origin and built with its own synced `docs` group, so
-# the output is identical regardless of which branch triggered the workflow.
-# This script is intended to run in CI; for a local v2 preview use
-# `scripts/serve-docs.sh`.
+# is fetched fresh from origin and built with its own synced `docs` group. Only
+# main deploys the combined site (the v1.x branch carries no deploy workflow), so
+# a v1.x docs change goes live on the next main deploy or a manual
+# `workflow_dispatch` of deploy-docs.yml. This script is intended to run in CI;
+# for a local v2 preview use `scripts/serve-docs.sh`.
 #
 # Usage:
 #   scripts/build-docs.sh [output-dir]
@@ -50,6 +54,9 @@ build_site() {
     fi
 }
 
+# Fetch a branch fresh from origin, build its docs, and copy the result to
+# `dest`. The built tree stays in `worktree/site` afterwards so a caller can
+# mirror it to a second destination.
 build_branch() {
     local branch="$1" worktree="$2" dest="$3"
 
@@ -70,7 +77,12 @@ build_branch() {
 
 rm -rf "${OUTPUT_DIR:?}"/*
 
-build_branch v1.x "$V1_WORKTREE" "$OUTPUT_DIR"
-build_branch main "$V2_WORKTREE" "$OUTPUT_DIR/v2"
+# v2 (main) at the root, then mirrored to /v2/ from the same build, then v1
+# under /v1/. The mirror is copied from the worktree's build directory rather
+# than from the root so it never picks up the /v1/ tree.
+build_branch main "$V2_WORKTREE" "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/v2"
+cp -a "$V2_WORKTREE/site/." "$OUTPUT_DIR/v2/"
+build_branch v1.x "$V1_WORKTREE" "$OUTPUT_DIR/v1"
 
 echo "=== Combined docs built at $OUTPUT_DIR ==="

--- a/src/mcp-types/pyproject.toml
+++ b/src/mcp-types/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://modelcontextprotocol.io"
-Documentation = "https://py.sdk.modelcontextprotocol.io/v2/"
+Documentation = "https://py.sdk.modelcontextprotocol.io/"
 Repository = "https://github.com/modelcontextprotocol/python-sdk"
 Issues = "https://github.com/modelcontextprotocol/python-sdk/issues"
 


### PR DESCRIPTION
The combined docs site currently serves the v1.x docs at the root and main's v2 docs under `/v2/`. For the v2 stable release this flips the layout: main's build is served at the root and mirrored under `/v2/`, and the v1.x maintenance docs are built under `/v1/`. Per-major paths are meant to be permanent, so every existing `/v2/...` link keeps resolving, and `/v1/...` will likewise keep resolving after a future major takes the root.

## Motivation and Context

v2 becomes the stable line, so the site root should serve the current docs. Mirroring `/v2/` as a byte copy of the same build (rather than deleting or redirecting it) means nothing already published breaks: release notes, package metadata, and external links that point at `/v2/...` still land on real pages.

Changes:

- `scripts/build-docs.sh` builds main once into the root and copies the same tree to `/v2/`, then builds v1.x under `/v1/`.
- `mkdocs.yml` `site_url` and both packages' `Documentation` URLs point at the root as the canonical location.
- The Deploy Docs workflow drops `v1.x` from its push triggers: main is the sole deployer of the combined site (the v1.x branch's own deploy workflow is removed in #3177), so a v1.x docs change publishes on the next main deploy or a manual `workflow_dispatch`.

Merge order for release day: this PR first, then #3177 (retires v1.x's own deploy and moves its `site_url` to `/v1/`), then a manual Deploy Docs dispatch on main so `/v1/` rebuilds with its new `site_url`, then #3178 (the stable README/docs flip) last before the tag.

## How Has This Been Tested?

Ran `scripts/build-docs.sh` into a scratch directory: the root serves the v2 build and `/v2/` is byte-identical to it (`diff -rq` reports zero differences across 227 files), and a second run into the populated directory rebuilds cleanly. The combined layout is exercised only at deploy time (PR CI builds the v2 site alone), so the first Deploy Docs run after merge is the confirming run for `/v1/`; watch it to green.

## Breaking Changes

None for SDK users. For docs URLs: v1 pages previously at the root move to `/v1/...`, so external deep links to the old v1 root paths will 404 (accepted); v2 pages gain a canonical root URL and keep working under `/v2/`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## AI disclosure

AI assistance was used to implement and validate this change; I reviewed the result and take responsibility for it.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
