### PR TITLE
Lengthen the demo signing keys in the identity-assertion examples

### DIFF
--- a/docs_src/identity_assertion/tutorial001.py
+++ b/docs_src/identity_assertion/tutorial001.py
@@ -9,7 +9,7 @@ from mcp.client.auth.extensions.identity_assertion import IdentityAssertionOAuth
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
-IDP_SIGNING_KEY = "the-enterprise-idp-signing-key"
+IDP_SIGNING_KEY = "the-enterprise-idp-signing-key-for-this-demo"
 
 
 class InMemoryTokenStorage:

--- a/docs_src/identity_assertion/tutorial002.py
+++ b/docs_src/identity_assertion/tutorial002.py
@@ -21,7 +21,7 @@ from mcp.shared.auth import JWT_BEARER_GRANT_TYPE, OAuthClientInformationFull, O
 ISSUER = "https://auth.example.com/"
 MCP_SERVER = "http://localhost:8001/mcp"
 IDP_ISSUER = "https://idp.example.com"
-IDP_SIGNING_KEY = "the-enterprise-idp-signing-key"
+IDP_SIGNING_KEY = "the-enterprise-idp-signing-key-for-this-demo"
 
 REGISTERED_CLIENTS = {
     "finance-agent": OAuthClientInformationFull(

--- a/examples/stories/identity_assertion/idp.py
+++ b/examples/stories/identity_assertion/idp.py
@@ -14,7 +14,7 @@ import jwt
 IDP_ISSUER = "https://idp.example.com"
 # Demo only: a real IdP signs with its private key and the authorization server verifies the
 # signature against the IdP's published JWKS. A shared HMAC secret keeps this story self-contained.
-IDP_SIGNING_KEY = "demo-idp-signing-key"
+IDP_SIGNING_KEY = "the-demo-idp-signing-key-for-this-story"
 
 
 def issue_id_jag(*, subject: str, client_id: str, audience: str, resource: str, scope: str) -> str:


### PR DESCRIPTION
The identity-assertion tutorial and its example story signed their demo ID-JAG tokens with HMAC keys of 30 and 20 bytes. PyJWT 2.11+ warns when an HS256 key is shorter than the 32-byte minimum from RFC 7518, and `pyjwt` is uncapped in our dependencies, so a fresh install already emitted `InsecureKeyLengthWarning` from the shipped example. The three demo keys are now at least 32 bytes.

## Motivation and Context

The examples should run clean on a default install. It also keeps the test suite green on the next lockfile refresh: with warnings-as-errors, the current keys turn nine identity-assertion tests red under pyjwt 2.13.

## How Has This Been Tested?

Ran the identity-assertion docs tests and the example story against pyjwt 2.13: all 15 pass with the lengthened keys (nine fail before the change).

## Breaking Changes

None. Demo constants only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## AI disclosure

AI assistance was used to find, implement, and validate this change; I reviewed the result and take responsibility for it.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
