### PR TITLE
Repin conformance harness to the published 0.2.0-alpha.10

### DIFF
--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -12,9 +12,9 @@
 
 client:
   # SEP-1932 (DPoP): the SDK's OAuth client does not implement DPoP proofs.
-  # These scenarios are new in the da56f663 referee pin. The entries are
-  # per-check (conformance #406) because both scenarios pass their
-  # non-DPoP checks (discovery, token acquisition, request flow) live.
+  # The entries are per-check (conformance #406) because both scenarios
+  # pass their non-DPoP checks (discovery, token acquisition, request
+  # flow) live.
   - auth/dpop:sep-1932-client-token-request-proof
   - auth/dpop:sep-1932-client-dpop-auth-scheme
   - auth/dpop:sep-1932-client-fresh-proof
@@ -25,8 +25,7 @@ client:
   - auth/dpop-nonce:sep-1932-client-rs-nonce
   # Workload identity federation: the OAuth client does not implement the
   # urn:ietf:params:oauth:grant-type:jwt-bearer grant (it answers with
-  # authorization_code). Also new in the da56f663 referee pin; per-check for
-  # the same reason.
+  # authorization_code). Per-check for the same reason.
   - auth/wif-jwt-bearer:wif-grant-type
 
 server:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,23 +15,9 @@ permissions:
 
 env:
   # Pinned conformance harness package spec (passed verbatim to `npx --yes`).
-  # Use a published version, e.g. @modelcontextprotocol/conformance@0.2.0-alpha.7.
   # Bump deliberately and reconcile both
   # .github/actions/conformance/expected-failures*.yml files in the same change.
-  #
-  # Temporarily pinned to the pkg.pr.new build of conformance main@da56f663,
-  # which includes #403 (sep-2575 checks flipped to the post-spec-#3002 shape:
-  # clientInfo optional on requests, serverInfo in result _meta instead of the
-  # discover body) and #406 (per-check expected-failures granularity) — the
-  # last published npm release (0.2.0-alpha.9) still enforces the pre-#3002
-  # shape. Pinned by commit SHA so the tarball cannot move under us;
-  # CONFORMANCE_PKG_SHA256 pins the bytes and the fetch-and-verify step below
-  # downloads, checks the digest, and repoints CONFORMANCE_PKG at the
-  # verified local copy. Repin to the next published @modelcontextprotocol/
-  # conformance release (>=0.2.0-alpha.10) once it ships, then drop
-  # CONFORMANCE_PKG_SHA256 and the fetch-and-verify steps.
-  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@da56f663"
-  CONFORMANCE_PKG_SHA256: "bbc94678033071df4bc9851ce2054f9dff918f4501661d1d60e2d09d8c515e6d"
+  CONFORMANCE_PKG: "@modelcontextprotocol/conformance@0.2.0-alpha.10"
 
 jobs:
   server-conformance:
@@ -47,19 +33,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - name: Fetch and verify conformance harness
-        # Only when CONFORMANCE_PKG is a URL: download, check the recorded
-        # sha256, and re-point CONFORMANCE_PKG at the verified local tarball.
-        # When CONFORMANCE_PKG is a registry spec, this step is a no-op (npm's
-        # own integrity check applies).
-        run: |
-          case "$CONFORMANCE_PKG" in
-            https://*)
-              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
-              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
-              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
-              ;;
-          esac
       - run: uv sync --frozen --all-extras --package mcp-everything-server
       - name: Run server conformance (active suite)
         run: >-
@@ -119,19 +92,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - name: Fetch and verify conformance harness
-        # Only when CONFORMANCE_PKG is a URL: download, check the recorded
-        # sha256, and re-point CONFORMANCE_PKG at the verified local tarball.
-        # When CONFORMANCE_PKG is a registry spec, this step is a no-op (npm's
-        # own integrity check applies).
-        run: |
-          case "$CONFORMANCE_PKG" in
-            https://*)
-              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
-              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
-              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
-              ;;
-          esac
       # --compile-bytecode: without it, ~40 concurrently spawned interpreters
       # race to byte-compile site-packages during the timing-sensitive window.
       - run: uv sync --frozen --all-extras --package mcp --compile-bytecode


### PR DESCRIPTION
Repins the conformance harness from the temporary pkg.pr.new build of `main@da56f663` to the published `@modelcontextprotocol/conformance@0.2.0-alpha.10`, and drops the sha256 fetch-and-verify steps that only the tarball URL needed.

## Motivation and Context
The pkg.pr.new pin was a stopgap until an npm release carrying [conformance #403](https://github.com/modelcontextprotocol/conformance/pull/403) (sep-2575 checks aligned with spec #3002) and [#406](https://github.com/modelcontextprotocol/conformance/pull/406) (per-check expected-failures granularity) shipped. `0.2.0-alpha.10` is now on npm (the `alpha` dist-tag) with both, so `CONFORMANCE_PKG` can go back to a plain registry spec — npm's own integrity check replaces the recorded digest.

The release adds two commits beyond the previous pin ([conformance #409](https://github.com/modelcontextprotocol/conformance/pull/409), [#383](https://github.com/modelcontextprotocol/conformance/pull/383)); neither changes results against this SDK, so both `expected-failures*.yml` baselines are unchanged apart from comment wording.

## How Has This Been Tested?
Ran all six CI legs locally against the `0.2.0-alpha.10` tarball (server active/draft/2026-07-28/all, client all/2026-07-28) — every leg passes with the existing baselines and no stale entries.

## Breaking Changes
None; CI-only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] CI

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed