### PR TITLE
ci: repin conformance harness to published 0.2.0-alpha.10

### DIFF
--- a/.github/actions/conformance/expected-failures.yml
+++ b/.github/actions/conformance/expected-failures.yml
@@ -12,7 +12,7 @@
 
 client:
   # SEP-1932 (DPoP): the SDK's OAuth client does not implement DPoP proofs.
-  # These scenarios are new in the da56f663 referee pin. The entries are
+  # These scenarios are new in the 0.2.0-alpha.10 referee pin. The entries are
   # per-check (conformance #406) because both scenarios pass their
   # non-DPoP checks (discovery, token acquisition, request flow) live.
   - auth/dpop:sep-1932-client-token-request-proof
@@ -25,7 +25,7 @@ client:
   - auth/dpop-nonce:sep-1932-client-rs-nonce
   # Workload identity federation: the OAuth client does not implement the
   # urn:ietf:params:oauth:grant-type:jwt-bearer grant (it answers with
-  # authorization_code). Also new in the da56f663 referee pin; per-check for
+  # authorization_code). Also new in the 0.2.0-alpha.10 referee pin; per-check for
   # the same reason.
   - auth/wif-jwt-bearer:wif-grant-type
 

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -15,10 +15,15 @@ permissions:
 
 env:
   # Pinned conformance harness package spec (passed verbatim to `npx --yes`).
-  # Use a published version, e.g. @modelcontextprotocol/conformance@0.2.0-alpha.7.
-  # Bump deliberately and reconcile both
-  # .github/actions/conformance/expected-failures*.yml files in the same change.
-  CONFORMANCE_PKG: "@modelcontextprotocol/conformance@0.2.0-alpha.10"
+  # Pinned to the published release tarball by registry URL, with
+  # CONFORMANCE_PKG_SHA256 pinning the bytes (registry version specs and
+  # dist-tags are movable; the digest is not) — the fetch-and-verify step
+  # below downloads, checks the digest, and repoints CONFORMANCE_PKG at the
+  # verified local copy. Bump deliberately: update both values and reconcile
+  # both .github/actions/conformance/expected-failures*.yml files in the same
+  # change.
+  CONFORMANCE_PKG: "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.2.0-alpha.10.tgz"
+  CONFORMANCE_PKG_SHA256: "fd3795fd3f55ee7c3395710282c3f9739ec8bffe98898bd36eca0c142e2a4234"
 
 jobs:
   server-conformance:
@@ -34,6 +39,19 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+      - name: Fetch and verify conformance harness
+        # Only when CONFORMANCE_PKG is a URL: download, check the recorded
+        # sha256, and re-point CONFORMANCE_PKG at the verified local tarball.
+        # When CONFORMANCE_PKG is a registry spec, this step is a no-op (npm's
+        # own integrity check applies).
+        run: |
+          case "$CONFORMANCE_PKG" in
+            https://*)
+              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
+              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
+              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
+              ;;
+          esac
       - run: uv sync --frozen --all-extras --package mcp-everything-server
       - name: Run server conformance (active suite)
         run: >-
@@ -93,6 +111,21 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+      - name: Fetch and verify conformance harness
+        # Only when CONFORMANCE_PKG is a URL: download, check the recorded
+        # sha256, and re-point CONFORMANCE_PKG at the verified local tarball.
+        # When CONFORMANCE_PKG is a registry spec, this step is a no-op (npm's
+        # own integrity check applies).
+        run: |
+          case "$CONFORMANCE_PKG" in
+            https://*)
+              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
+              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
+              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
+              ;;
+          esac
+      # --compile-bytecode: without it, ~40 concurrently spawned interpreters
+      # race to byte-compile site-packages during the timing-sensitive window.
       - run: uv sync --frozen --all-extras --package mcp --compile-bytecode
       - name: Pre-compile bytecode (editable sources)
         run: uv run --frozen python -m compileall -q src .github/actions/conformance

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,20 +18,7 @@ env:
   # Use a published version, e.g. @modelcontextprotocol/conformance@0.2.0-alpha.7.
   # Bump deliberately and reconcile both
   # .github/actions/conformance/expected-failures*.yml files in the same change.
-  #
-  # Temporarily pinned to the pkg.pr.new build of conformance main@da56f663,
-  # which includes #403 (sep-2575 checks flipped to the post-spec-#3002 shape:
-  # clientInfo optional on requests, serverInfo in result _meta instead of the
-  # discover body) and #406 (per-check expected-failures granularity) — the
-  # last published npm release (0.2.0-alpha.9) still enforces the pre-#3002
-  # shape. Pinned by commit SHA so the tarball cannot move under us;
-  # CONFORMANCE_PKG_SHA256 pins the bytes and the fetch-and-verify step below
-  # downloads, checks the digest, and repoints CONFORMANCE_PKG at the
-  # verified local copy. Repin to the next published @modelcontextprotocol/
-  # conformance release (>=0.2.0-alpha.10) once it ships, then drop
-  # CONFORMANCE_PKG_SHA256 and the fetch-and-verify steps.
-  CONFORMANCE_PKG: "https://pkg.pr.new/@modelcontextprotocol/conformance@da56f663"
-  CONFORMANCE_PKG_SHA256: "bbc94678033071df4bc9851ce2054f9dff918f4501661d1d60e2d09d8c515e6d"
+  CONFORMANCE_PKG: "@modelcontextprotocol/conformance@0.2.0-alpha.10"
 
 jobs:
   server-conformance:
@@ -47,19 +34,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - name: Fetch and verify conformance harness
-        # Only when CONFORMANCE_PKG is a URL: download, check the recorded
-        # sha256, and re-point CONFORMANCE_PKG at the verified local tarball.
-        # When CONFORMANCE_PKG is a registry spec, this step is a no-op (npm's
-        # own integrity check applies).
-        run: |
-          case "$CONFORMANCE_PKG" in
-            https://*)
-              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
-              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
-              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
-              ;;
-          esac
       - run: uv sync --frozen --all-extras --package mcp-everything-server
       - name: Run server conformance (active suite)
         run: >-
@@ -119,21 +93,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - name: Fetch and verify conformance harness
-        # Only when CONFORMANCE_PKG is a URL: download, check the recorded
-        # sha256, and re-point CONFORMANCE_PKG at the verified local tarball.
-        # When CONFORMANCE_PKG is a registry spec, this step is a no-op (npm's
-        # own integrity check applies).
-        run: |
-          case "$CONFORMANCE_PKG" in
-            https://*)
-              curl -fsSL "$CONFORMANCE_PKG" -o /tmp/conformance.tgz
-              echo "$CONFORMANCE_PKG_SHA256  /tmp/conformance.tgz" | sha256sum -c -
-              echo "CONFORMANCE_PKG=file:/tmp/conformance.tgz" >> "$GITHUB_ENV"
-              ;;
-          esac
-      # --compile-bytecode: without it, ~40 concurrently spawned interpreters
-      # race to byte-compile site-packages during the timing-sensitive window.
       - run: uv sync --frozen --all-extras --package mcp --compile-bytecode
       - name: Pre-compile bytecode (editable sources)
         run: uv run --frozen python -m compileall -q src .github/actions/conformance


### PR DESCRIPTION
Repins the conformance harness to the published `0.2.0-alpha.10` release, which contains the sep-2575 checks asserting the final spec [#3002](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002) discover shape (conformance [#403](https://github.com/modelcontextprotocol/conformance/pull/403)) and per-check expected-failures granularity ([#406](https://github.com/modelcontextprotocol/conformance/pull/406)) that the previous temporary pkg.pr.new pin (`main@da56f663`) existed to pick up early — plus [#409](https://github.com/modelcontextprotocol/conformance/pull/409), a client request-metadata scenario fix.

The pin stays in the tarball-URL + `CONFORMANCE_PKG_SHA256` form (registry version specs and dist-tags are movable; the digest is not), now pointing at the npm registry tarball for the published release. The fetch-and-verify step is unchanged.

Expected-failures comments now name the alpha.10 pin instead of the commit SHA; no baseline entry changes.

All six CI legs (server active/draft/2026/all, client all/2026) pass locally against alpha.10, including the server active leg run against the digest-verified local tarball via the same `file:` repoint the workflow step performs.