### PR TITLE
docs: fix off-by-one hl_lines in apps.md

### DIFF
--- a/docs/advanced/apps.md
+++ b/docs/advanced/apps.md
@@ -20,7 +20,7 @@ then come back.
 
 ## A clock with a face
 
-```python title="server.py" hl_lines="18 21 29 31"
+```python title="server.py" hl_lines="19 22 30 32"
 --8<-- "docs_src/apps/tutorial001.py"
 ```
 
@@ -51,7 +51,7 @@ The model reads `content`; the iframe is for humans. A UI-capable host still fee
 the text result to the model, and a text-only client gets *only* that. So the
 canonical pattern is one tool, two answers. Look at `get_time` again:
 
-```python title="server.py" hl_lines="22-26"
+```python title="server.py" hl_lines="23-27"
 --8<-- "docs_src/apps/tutorial001.py"
 ```
 


### PR DESCRIPTION
#3034 added an import line to `docs_src/apps/tutorial001.py`, which shifted the highlighted lines in both `apps.md` snippets that include it — the first block was highlighting four blank lines instead of the "four moves" the prose walks through. Bumps both specs by one.

Flagged in https://github.com/modelcontextprotocol/python-sdk/pull/3190#discussion_r3661479643 (the second block wasn't mentioned there but has the same shift).