### PR TITLE
Remove unused mcpserver.exceptions.ValidationError

### DIFF
--- a/src/mcp/server/mcpserver/exceptions.py
+++ b/src/mcp/server/mcpserver/exceptions.py
@@ -5,10 +5,6 @@ class MCPServerError(Exception):
     """Base error for MCPServer."""
 
 
-class ValidationError(MCPServerError):
-    """Error in validating parameters or return values."""
-
-
 class ResourceError(MCPServerError):
     """Error in resource operations."""
 


### PR DESCRIPTION
Deletes `ValidationError` from `mcp.server.mcpserver.exceptions`.

## Motivation and Context
It was never raised — not in v1's `fastmcp/exceptions.py` and not in v2 — and nothing in the SDK imports it. All it does is shadow `pydantic.ValidationError` for anyone who imports it.

## How Has This Been Tested?
Grep for references across `src/`, `tests/`, `examples/`, `docs/`; the only hit was the definition itself. ruff + pyright pass.

## Breaking Changes
Only for code importing a symbol the SDK never raised.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed