### PR TITLE
Remove unused StreamableHTTPTransport.get_session_id()

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2110,7 +2110,7 @@ Client-side stream resumption is also unchanged: the transport reconnects a drop
 
 The `get_session_id` callback (third element of the returned tuple) has been removed from `streamable_http_client`. The function now returns a 2-tuple `(read_stream, write_stream)` instead of a 3-tuple.
 
-The `GetSessionIdCallback` type alias is gone as well, so `from mcp.client.streamable_http import GetSessionIdCallback` now raises `ImportError`. Drop the annotation, or inline `Callable[[], str | None]` if your own wrapper code still needs the type.
+The `GetSessionIdCallback` type alias is gone as well, so `from mcp.client.streamable_http import GetSessionIdCallback` now raises `ImportError`. Drop the annotation, or inline `Callable[[], str | None]` if your own wrapper code still needs the type. The `StreamableHTTPTransport.get_session_id()` method that backed the callback is removed too.
 
 If you need to capture the session ID (e.g., for session resumption testing), you can use httpx2 event hooks to capture it from the response headers:
 

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -635,15 +635,7 @@ class StreamableHTTPTransport:
         except Exception as exc:  # pragma: no cover
             logger.warning(f"Session termination failed: {exc}")
 
-    # TODO(Marcelo): Check the TODO below, and cover this with tests if necessary.
-    def get_session_id(self) -> str | None:
-        """Get the current session ID."""
-        return self.session_id  # pragma: no cover
 
-
-# TODO(Marcelo): I've dropped the `get_session_id` callback because it breaks the Transport protocol. Is that needed?
-# It's a completely wrong abstraction, so removal is a good idea. But if we need the client to find the session ID,
-# we should think about a better way to do it. I believe we can achieve it with other means.
 @asynccontextmanager
 async def streamable_http_client(
     url: str,


### PR DESCRIPTION
Removes the dead `StreamableHTTPTransport.get_session_id()` method from the client streamable HTTP transport, along with the two stale `TODO(Marcelo)` comments about it.

## Motivation and Context

The method existed to back the `get_session_id` callback that v1's `streamable_http_client` yielded as the third tuple element. That callback was already removed on `main` (documented in `docs/migration.md`), which left the getter with no callers in `src/`, `tests/`, or `examples/` (it was `# pragma: no cover`) and no way to reach a transport instance through the public entry point anyway — `streamable_http_client` yields only the two streams.

The `session_id` attribute the getter wrapped is unchanged; it's the transport's own working state (header stamping, GET/DELETE gating, terminate-on-close).

## How Has This Been Tested?

Existing client streamable HTTP tests pass. Also drove `streamable_http_client` end-to-end against a real `MCPServer` streamable HTTP app on a local port (initialize → tool call → DELETE on close) to confirm the client path is unaffected.

## Breaking Changes

`StreamableHTTPTransport.get_session_id()` no longer exists. This was public in v1, so the removal is added to the existing "`get_session_id` callback removed from `streamable_http_client`" section of `docs/migration.md`, which already points users at httpx2 event hooks for capturing the session ID.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

No pragmas or type-ignores added; the removal drops one `# pragma: no cover`.