### PR TITLE
Add missing add_resource_template() to MCPServer

### DIFF
--- a/src/mcp/server/mcpserver/resources/resource_manager.py
+++ b/src/mcp/server/mcpserver/resources/resource_manager.py
@@ -57,6 +57,18 @@ class ResourceManager:
         self._resources[str(resource.uri)] = resource
         return resource
 
+    def add_resource_template(self, template: ResourceTemplate) -> ResourceTemplate:
+        """Add a resource template to the manager.
+
+        Args:
+            template: A ResourceTemplate instance to add.
+
+        Returns:
+            The added resource template.
+        """
+        self._templates[template.uri_template] = template
+        return template
+
     def add_template(
         self,
         fn: Callable[..., Any],
@@ -83,8 +95,7 @@ class ResourceManager:
             meta=meta,
             security=security,
         )
-        self._templates[template.uri_template] = template
-        return template
+        return self.add_resource_template(template)
 
     async def get_resource(
         self, uri: AnyUrl | str, context: Context[LifespanContextT, RequestT]

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -79,6 +79,7 @@ from mcp.server.mcpserver.resources import (
     Resource,
     ResourceManager,
     ResourceSecurity,
+    ResourceTemplate,
 )
 from mcp.server.mcpserver.tools import Tool, ToolManager
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
@@ -729,6 +730,14 @@ class MCPServer(Generic[LifespanResultT]):
         """
         self._resource_manager.add_resource(resource)
 
+    def add_resource_template(self, template: ResourceTemplate) -> None:
+        """Add a resource template to the server.
+
+        Args:
+            template: A ResourceTemplate instance to add
+        """
+        self._resource_manager.add_resource_template(template)
+
     def resource(
         self,
         uri: str,
@@ -846,7 +855,7 @@ class MCPServer(Generic[LifespanResultT]):
                     )
 
                 # Register as template
-                self._resource_manager.add_template(
+                template = ResourceTemplate.from_function(
                     fn=fn,
                     uri_template=uri,
                     name=name,
@@ -858,6 +867,7 @@ class MCPServer(Generic[LifespanResultT]):
                     security=security if security is not None else self._resource_security,
                     meta=meta,
                 )
+                self._resource_manager.add_resource_template(template)
             else:
                 if func_params:
                     raise ValueError(

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1004,6 +1004,18 @@ class TestServerResourceTemplates:
                 )
             )
 
+    async def test_add_resource_template(self):
+        """Test that a resource template can be added without using the @resource decorator."""
+        from mcp.server.mcpserver.resources import ResourceTemplate
+
+        mcp = MCPServer()
+
+        def get_data(param: str) -> str:  # type: ignore  # pragma: no cover
+            return "Data"
+
+        template = ResourceTemplate.from_function(get_data, "resource://{param}")
+        mcp.add_resource_template(template)
+
 
 class TestServerResourceMetadata:
     """Test MCPServer @resource decorator meta parameter for list operations.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Add the missing `add_resource_template()` method to `MCPServer` and `ResourceManager` to manage resource template implementations manually and independently without using the `@mcp.resource` decorator.

Note that this PR leaves `add_template()` in place to maintain backward compatibility.

Fixes #3333.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
n/a

## Breaking Changes
Non-breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
