### PR TITLE
Link the released 2026-07-28 spec and point migrators at /v1/

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </div>
 
 > [!NOTE]
-> **This is v2 of the MCP Python SDK, the current stable release line.** It is a major rework of the SDK, both to support the [2026-07-28 MCP specification](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) (and every earlier revision) and to fix long-standing architectural issues. Coming from v1? See [What's new in v2](https://py.sdk.modelcontextprotocol.io/whats-new/) for the tour of what changed and the [migration guide](https://py.sdk.modelcontextprotocol.io/migration/) for every breaking change.
+> **This is v2 of the MCP Python SDK, the current stable release line.** It is a major rework of the SDK, both to support the [2026-07-28 MCP specification](https://modelcontextprotocol.io/specification/2026-07-28) (and every earlier revision) and to fix long-standing architectural issues. Coming from v1? See [What's new in v2](https://py.sdk.modelcontextprotocol.io/whats-new/) for the tour of what changed and the [migration guide](https://py.sdk.modelcontextprotocol.io/migration/) for every breaking change.
 >
 > **Not ready to migrate?** v1.x lives on the [`v1.x` branch](https://github.com/modelcontextprotocol/python-sdk/tree/v1.x), continues to receive critical bug fixes and security patches, and is documented at <https://py.sdk.modelcontextprotocol.io/v1/>. Since `pip install mcp` now installs 2.x, keep a `<2` upper bound on your requirement (for example `mcp>=1.28,<2`) until you've migrated.
 >

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2877,3 +2877,6 @@ If you encounter issues during migration:
 1. Check the [API Reference](api/mcp/index.md) for updated method signatures
 2. Review the [examples](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples) for updated usage patterns
 3. Open an issue on [GitHub](https://github.com/modelcontextprotocol/python-sdk/issues) if you find a bug or need further assistance
+
+Not ready to migrate yet? The v1.x maintenance line keeps receiving critical bug fixes and security
+patches; its documentation is at [/v1/](https://py.sdk.modelcontextprotocol.io/v1/).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,11 @@ This guide covers the breaking changes introduced in v2 of the MCP Python SDK an
 
 Version 2 of the MCP Python SDK introduces several breaking changes to improve the API, align with the MCP specification, and provide better type safety.
 
+!!! note "Not ready to migrate yet?"
+    The v1.x maintenance line keeps receiving critical bug fixes and security patches, and its
+    documentation is at [/v1/](https://py.sdk.modelcontextprotocol.io/v1/). If your package depends
+    on `mcp`, keep a `<2` upper bound until you've migrated.
+
 ## Find your changes
 
 Every section heading below names the API it affects, so searching this page for the symbol your code uses is the fastest route to the change that broke it. The guide lists changes only: an SDK API not mentioned here behaves as it did in v1, and the "what did not change" summaries — [`MCPServer`](#what-is-unchanged-on-mcpserver), [lowlevel `Server`](#lowlevel-server-what-did-not-change), and [auth](#unchanged-auth-surfaces) — spell out the surfaces most migrators stop to check.
@@ -2877,6 +2882,3 @@ If you encounter issues during migration:
 1. Check the [API Reference](api/mcp/index.md) for updated method signatures
 2. Review the [examples](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples) for updated usage patterns
 3. Open an issue on [GitHub](https://github.com/modelcontextprotocol/python-sdk/issues) if you find a bug or need further assistance
-
-Not ready to migrate yet? The v1.x maintenance line keeps receiving critical bug fixes and security
-patches; its documentation is at [/v1/](https://py.sdk.modelcontextprotocol.io/v1/).


### PR DESCRIPTION
Two small link fixes in the v2-facing docs.

## Motivation and Context

The README banner linked the spec's release-candidate blog post; the 2026-07-28 specification is published now, so link it directly. The migration guide's "Need Help?" section also gets the same pointer to the v1.x maintenance-line docs (`/v1/`) that `index.md` and `whats-new.md` already carry.

## How Has This Been Tested?

Link targets checked (spec URL returns 200).

## Breaking Changes

None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
