### PR TITLE
fix(mcpserver): omit unreturned TypedDict keys from structuredContent

### DIFF
--- a/docs/servers/structured-output.md
+++ b/docs/servers/structured-output.md
@@ -102,6 +102,11 @@ Not every shape deserves a class. A `TypedDict` produces the same schema:
 
 A `TypedDict` is a plain `dict` at runtime, so that is what you build and return. The schema, the validation, and `structured_content` are identical to the `BaseModel` version (minus the descriptions, which `TypedDict` has no place for).
 
+A key marked `NotRequired` (or any key at all under `total=False`) follows `TypedDict` semantics: if your tool leaves it out of the returned dict, it is **absent** from `structured_content` rather than present as `null`. That matches the published `outputSchema`, which declares those properties with their own type and simply omits them from `required`.
+
+!!! note
+    Below Python 3.12, import `TypedDict` from `typing_extensions` rather than `typing` whenever you use `NotRequired` — pydantic needs the `typing_extensions` variant to see the qualifier.
+
 ## A dataclass
 
 Dataclasses work too, and so does any ordinary class whose attributes have type hints. The SDK builds a Pydantic model out of the annotations behind the scenes.

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -139,7 +139,11 @@ class FuncMetadata(BaseModel):
 
         assert self.output_model is not None, "Output model must be set if output schema is defined"
         validated = self.output_model.model_validate(result)
-        structured_content = validated.model_dump(mode="json", by_alias=True)
+        # A TypedDict's non-required keys are absent, not null, when the tool omits
+        # them -- and the published outputSchema declares them non-nullable, so
+        # emitting nulls would violate the server's own schema.
+        exclude_unset = issubclass(self.output_model, _TypedDictOutputModel)
+        structured_content = validated.model_dump(mode="json", by_alias=True, exclude_unset=exclude_unset)
 
         return CallToolResult(content=unstructured_content, structured_content=structured_content)
 
@@ -494,6 +498,17 @@ def _create_model_from_class(cls: type[Any], type_hints: dict[str, Any]) -> type
     return create_model(cls.__name__, __config__=ConfigDict(from_attributes=True), **model_fields)
 
 
+class _TypedDictOutputModel(BaseModel):
+    """Base for output models generated from a TypedDict return annotation.
+
+    Non-required TypedDict keys are given a `None` default so they are optional on
+    the generated model, but `None` is not a valid value for their declared type and
+    the published `outputSchema` does not accept it. Dumping such a model has to
+    honour TypedDict semantics -- a key the tool did not return stays absent rather
+    than becoming an explicit null -- so `convert_result` keys off this base class.
+    """
+
+
 def _create_model_from_typeddict(td_type: type[Any]) -> type[BaseModel]:
     """Create a Pydantic model from a TypedDict.
 
@@ -507,12 +522,13 @@ def _create_model_from_typeddict(td_type: type[Any]) -> type[BaseModel]:
         if field_name not in required_keys:
             # For optional TypedDict fields, set default=None
             # This makes them not required in the Pydantic model
-            # The model should use exclude_unset=True when dumping to get TypedDict semantics
+            # Dumped with exclude_unset=True (see `_TypedDictOutputModel`) so an
+            # omitted key stays omitted instead of serializing as null
             model_fields[field_name] = (field_type, None)
         else:
             model_fields[field_name] = field_type
 
-    return create_model(td_type.__name__, **model_fields)
+    return create_model(td_type.__name__, __base__=_TypedDictOutputModel, **model_fields)
 
 
 def _create_wrapped_model(func_name: str, annotation: Any) -> type[BaseModel]:

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import Awaitable, Callable, Sequence
 from itertools import chain
 from types import GenericAlias
-from typing import Annotated, Any, Union, cast, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, Union, cast, get_args, get_origin
 
 import anyio
 import anyio.to_thread
@@ -13,7 +13,7 @@ from mcp_types import CallToolResult, ContentBlock, InputRequiredResult, TextCon
 from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, WithJsonSchema, create_model
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaWarningKind
-from typing_extensions import is_typeddict
+from typing_extensions import get_type_hints, is_typeddict
 from typing_inspection.introspection import (
     UNKNOWN,
     AnnotationSource,
@@ -514,6 +514,9 @@ def _create_model_from_typeddict(td_type: type[Any]) -> type[BaseModel]:
 
     The created model will have the same name and fields as the TypedDict.
     """
+    # `typing_extensions.get_type_hints` strips the `Required`/`NotRequired` qualifier on
+    # every supported version; `typing.get_type_hints` only does so from 3.11, and below
+    # that the bare qualifier reaches `create_model`, which pydantic rejects outright.
     type_hints = get_type_hints(td_type)
     required_keys = getattr(td_type, "__required_keys__", set(type_hints.keys()))
 

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -5,7 +5,7 @@
 # pyright: reportUnknownLambdaType=false
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Any, Final, NamedTuple, NotRequired, TypedDict
+from typing import Annotated, Any, Final, NamedTuple, TypedDict
 
 import annotated_types
 import jsonschema
@@ -13,6 +13,7 @@ import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, InputRequiredResult
 from pydantic import BaseModel, Field
+from typing_extensions import NotRequired
 
 from mcp.server.mcpserver.exceptions import InvalidSignature
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -5,7 +5,7 @@
 # pyright: reportUnknownLambdaType=false
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Any, Final, NamedTuple, TypedDict
+from typing import Annotated, Any, Final, NamedTuple
 
 import annotated_types
 import jsonschema
@@ -13,7 +13,10 @@ import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, InputRequiredResult
 from pydantic import BaseModel, Field
-from typing_extensions import NotRequired
+
+# Pydantic requires `typing_extensions.TypedDict` (not `typing.TypedDict`) below 3.12,
+# otherwise a `NotRequired` qualifier is rejected as invalid in the context it is defined.
+from typing_extensions import NotRequired, TypedDict
 
 from mcp.server.mcpserver.exceptions import InvalidSignature
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -12,7 +12,7 @@ import jsonschema
 import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, InputRequiredResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 # Pydantic requires `typing_extensions.TypedDict` (not `typing.TypedDict`) below 3.12,
 # otherwise a `NotRequired` qualifier is rejected as invalid in the context it is defined.
@@ -874,6 +874,91 @@ def test_total_false_typeddict_output_omits_every_unreturned_key():
     assert result.structured_content == {}
     assert meta.output_schema is not None
     jsonschema.validate(instance=result.structured_content, schema=meta.output_schema)
+
+
+def test_nested_typeddict_output_omits_keys_the_tool_did_not_return():
+    """The omission rule reaches a TypedDict nested inside another one.
+
+    SDK-defined: only the top-level return annotation becomes the output model, so a
+    nested TypedDict is serialized by pydantic rather than by `convert_result`. Pins
+    that an inner non-required key is still absent instead of null.
+    """
+
+    class Address(TypedDict):
+        city: str
+        postcode: NotRequired[str]
+
+    class Contact(TypedDict):
+        name: str
+        address: Address
+        phone: NotRequired[str]
+
+    def get_contact() -> Contact:
+        return {"name": "Dave", "address": {"city": "Berlin"}}
+
+    meta = func_metadata(get_contact)
+    result = meta.convert_result(get_contact())
+
+    assert isinstance(result, CallToolResult)
+    assert result.structured_content == {"name": "Dave", "address": {"city": "Berlin"}}
+    assert meta.output_schema is not None
+    jsonschema.validate(instance=result.structured_content, schema=meta.output_schema)
+
+
+def test_typeddict_output_distinguishes_an_explicit_none_from_an_unset_key():
+    """A key the tool set to `None` is kept; the same key left out stays absent.
+
+    SDK-defined: `exclude_unset` keys off what the tool actually returned, not off the
+    value, so a nullable key carries a deliberate `null` through while an omitted one
+    does not appear at all. Guards against a fix that strips every falsy value.
+    """
+
+    class Profile(TypedDict):
+        name: str
+        age: NotRequired[int | None]
+
+    def get_profile() -> Profile:
+        return {"name": "Dave", "age": None}
+
+    meta = func_metadata(get_profile)
+    assert meta.output_schema is not None
+
+    explicit_null = meta.convert_result(get_profile())
+    assert isinstance(explicit_null, CallToolResult)
+    assert explicit_null.structured_content == {"name": "Dave", "age": None}
+    jsonschema.validate(instance=explicit_null.structured_content, schema=meta.output_schema)
+
+    unset = meta.convert_result({"name": "Dave"})
+    assert isinstance(unset, CallToolResult)
+    assert unset.structured_content == {"name": "Dave"}
+    jsonschema.validate(instance=unset.structured_content, schema=meta.output_schema)
+
+
+def test_typeddict_output_rejects_a_none_its_schema_does_not_allow():
+    """`None` on a non-nullable key is refused rather than serialized.
+
+    SDK-defined: the `None` default that makes a non-required key optional on the
+    generated model is not a value the key accepts, so returning one fails validation
+    instead of emitting content the published outputSchema rejects.
+    """
+
+    class Person(TypedDict):
+        name: str
+        age: NotRequired[int]
+
+    def get_person() -> Person:
+        return {"name": "Dave"}
+
+    meta = func_metadata(get_person)
+
+    # Leaving the key out is the supported way to say "no age"...
+    omitted = meta.convert_result(get_person())
+    assert isinstance(omitted, CallToolResult)
+    assert omitted.structured_content == {"name": "Dave"}
+
+    # ...whereas handing back an explicit `None` is not a value `int` accepts.
+    with pytest.raises(ValidationError):
+        meta.convert_result({"name": "Dave", "age": None})
 
 
 def test_structured_output_ordinary_class():

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -5,9 +5,10 @@
 # pyright: reportUnknownLambdaType=false
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Any, Final, NamedTuple, TypedDict
+from typing import Annotated, Any, Final, NamedTuple, NotRequired, TypedDict
 
 import annotated_types
+import jsonschema
 import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, InputRequiredResult
@@ -809,6 +810,66 @@ def test_structured_output_typeddict():
         "required": ["name", "age", "email"],
         "title": "PersonTypedDictRequired",
     }
+
+
+def test_typeddict_output_omits_keys_the_tool_did_not_return():
+    """A non-required TypedDict key the tool omits stays absent from structuredContent.
+
+    SDK-defined: those keys carry a `None` default so they are optional on the generated
+    model, but the published outputSchema declares them non-nullable, so serializing them
+    as explicit nulls would make every such tool emit content violating the server's own
+    schema (and a conforming client reject the call).
+    """
+
+    class Person(TypedDict):
+        name: str
+        age: NotRequired[int]
+        nickname: NotRequired[str]
+
+    def get_person() -> Person:
+        return {"name": "Dave"}
+
+    meta = func_metadata(get_person)
+    # Call the real function rather than restating its return value: the existing
+    # tests in this file never invoke the tool body, which is why this went unnoticed.
+    result = meta.convert_result(get_person())
+
+    assert isinstance(result, CallToolResult)
+    assert result.structured_content == {"name": "Dave"}
+
+    # The load-bearing assertion: the payload has to satisfy the schema this same
+    # metadata published, which is the contract a client validates against.
+    assert meta.output_schema is not None
+    jsonschema.validate(instance=result.structured_content, schema=meta.output_schema)
+
+    # A key the tool DOES return still travels, including a falsy one.
+    both = meta.convert_result({"name": "Dave", "age": 0})
+    assert isinstance(both, CallToolResult)
+    assert both.structured_content == {"name": "Dave", "age": 0}
+    jsonschema.validate(instance=both.structured_content, schema=meta.output_schema)
+
+
+def test_total_false_typeddict_output_omits_every_unreturned_key():
+    """`total=False` makes every key non-required, so an empty return stays empty.
+
+    SDK-defined: pins the degenerate case, where the old behaviour turned `{}` into a
+    payload of nothing but nulls.
+    """
+
+    class Partial(TypedDict, total=False):
+        name: str
+        age: int
+
+    def get_partial() -> Partial:
+        return {}
+
+    meta = func_metadata(get_partial)
+    result = meta.convert_result(get_partial())
+
+    assert isinstance(result, CallToolResult)
+    assert result.structured_content == {}
+    assert meta.output_schema is not None
+    jsonschema.validate(instance=result.structured_content, schema=meta.output_schema)
 
 
 def test_structured_output_ordinary_class():


### PR DESCRIPTION
Fixes #3224

## Problem

A tool returning a `TypedDict` with `NotRequired` keys (or `total=False`) publishes an
`outputSchema` declaring those properties **non-nullable**, while `convert_result` materialises
every key the tool did not return as an explicit `null`. The response violates the schema the
same server advertised, so a conforming client rejects the call — including this SDK's own:

```
RuntimeError: Invalid structured content returned by tool get_person: None is not of type 'string'
```

Those tools are therefore unusable, though TypedDict is one of the documented structured-output
return shapes. `structuredContent` and the unstructured text block also disagreed, so a client
skipping validation saw two different answers.

## Solution

`_create_model_from_typeddict` gives non-required keys a `None` default to make them optional on
the generated model. The file's own comment already said such a model *"should use
`exclude_unset=True` when dumping to get TypedDict semantics"* — nothing did. This marks those
models with a private base class (`_TypedDictOutputModel`) and honours it in `convert_result`, so
a key the tool omitted stays omitted.

Two deliberate choices:

- **Scoped to TypedDict-derived models.** Applying `exclude_unset` to every output shape would
  change payloads for `BaseModel`, dataclass and wrapped (`{"result": ...}`) returns, where
  emitting defaults is correct. The marker base class keeps the blast radius to exactly the
  shape that is broken, and avoids threading another value out of
  `_try_create_model_and_schema` alongside `wrap_output`.
- **The published `outputSchema` is unchanged.** Widening the annotation to `field_type | None`
  would make the null legal, but `absent` and `null` are not the same thing for `NotRequired`,
  and it would alter the wire format of every existing TypedDict tool. Because only the dump
  side changes, no existing expectation moves — including
  `test_structured_output_typeddict`, which hard-codes the current schema.

The `default: null` still present in the schema is now cosmetic (`default` does not constrain
instances). Happy to strip it in a follow-up if you would rather the schema not advertise a
default it can never legally take.

## A second, pre-existing bug this uncovered: `NotRequired` is unusable on Python 3.10

Tracked separately in #3227.

Adding a test that actually *builds* a `NotRequired` TypedDict surfaced a separate defect. On
Python 3.10 the tool does not merely return bad content — it cannot be registered at all:

```
pydantic.errors.PydanticForbiddenQualifier: The annotation 'NotRequired[int]' contains the
'typing.NotRequired' type qualifier, which is invalid in the context it is defined.
```

`typing.get_type_hints` only strips the `Required`/`NotRequired` qualifier from 3.11 onwards, so
below that the bare qualifier reaches `create_model` and pydantic rejects it. `func_metadata()`
raises, so the failure lands at decoration time, before the tool can ever be called.

**This predates this branch.** I confirmed it by running the same reproducer against unmodified
`main` (`a4f4ccd0`) in a separate worktree — identical crash. It is not introduced here; it is
simply the first time the suite exercises the path, since `test_structured_output_typeddict` uses
all-required keys and never instantiates the annotation.

The fix is one import: `typing_extensions.get_type_hints` strips the qualifier on **every**
supported version, so there is no version branch. That matters here — a `sys.version_info` branch
would be one-sided on whichever interpreter is measuring, and coverage runs at
`fail_under = 100` independently on all five.

Say the word if you would rather have this as its own PR and I will split it out; I kept them
together because the new tests cannot pass on 3.10 without it, so landing them separately would
knowingly leave `main` red on a supported version.

## How to test

```bash
uv sync --frozen --all-extras --dev
uv run --frozen pytest tests/server/mcpserver/test_func_metadata.py -q
uv run --frozen --python 3.10 --all-extras --dev pytest -q -n auto   # the version that was broken
./scripts/test          # coverage + strict-no-cover
```

Verified on this branch:

- **Python 3.10 specifically** → **5582 passed**, 10 skipped, 1 xfailed. I ran the whole suite on a
  real 3.10 interpreter rather than trusting the default one; an earlier revision of this branch
  passed locally and still broke all four 3.10 jobs, which is what led to the section above.
- `./scripts/test` → **5582 passed**, `TOTAL 49631 Stmts 0 Miss 3922 Branch 0 BrPart 100.00%`,
  `strict-no-cover` clean
- `uv run --frozen ruff check .` / `ruff format --check .` → clean
- `uv run --frozen pyright --pythonversion 3.10` → the only 2 errors are pre-existing and unrelated
  (`tests/transports/stdio/test_lifecycle.py` uses `os.waitid`, which does not exist on macOS)
- `markdownlint` with the repo's own config → clean, and clean on `main` too

Red-before/green-after was verified rather than assumed — with `git stash push -- src/` (tests
kept, fix removed) both new tests fail on the injected nulls:

```
Left contains 2 more items:
{'age': None, 'name': None}
Full diff:
- {}
+ {...}
```

End-to-end through a real `Client(MCPServer(...))`, the reproducer in the issue goes from
`RuntimeError: Invalid structured content ...` to `structuredContent: {'name': 'Dave'}`, matching
the text block.

## Tests added

Two cases in `tests/server/mcpserver/test_func_metadata.py`:

- `test_typeddict_output_omits_keys_the_tool_did_not_return` — an omitted `NotRequired` key is
  absent, a returned one still travels (including a falsy `0`)
- `test_total_false_typeddict_output_omits_every_unreturned_key` — the degenerate `total=False`
  case, where the old behaviour turned `{}` into a payload of nothing but nulls

Both assert the payload against `meta.output_schema` with `jsonschema.validate`, so they pin the
actual contract — *structuredContent must satisfy the schema this server published* — rather than
just a dict shape.

They also **call the tool function** instead of restating its return value, and add no
`# pragma: no cover`. That is the point: the existing tests for this shape never invoke the tool
body, which is why the bug survived — and building the annotation for real is what exposed the
3.10 crash as well.

The test module now takes `TypedDict` from `typing_extensions`, which pydantic requires below 3.12
for a `NotRequired` qualifier to be honoured.

## Docs

Per `AGENTS.md` ("update the relevant page(s) under `docs/` in the same PR"),
`docs/servers/structured-output.md` said a `TypedDict`'s `structured_content` was "identical to the
`BaseModel` version". That is no longer true for omitted keys, so the `TypedDict` section now states
the omission rule and notes the `typing_extensions` import requirement below 3.12.

## Disclosure

Written with AI assistance (Claude Code). Filed by me as the human contributor -- I own this
change and will answer any questions on the implementation or the trade-offs above.