### PR TITLE
fix(server): discard a session whose establishing request was refused

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -793,7 +793,7 @@ class StreamableHTTPServerTransport:
             await response(request.scope, request.receive, send)
             return
 
-        if not await self._validate_request_headers(request, send):  # pragma: no cover
+        if not await self._validate_request_headers(request, send):
             return
 
         await self.terminate()

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -352,8 +352,30 @@ class StreamableHTTPSessionManager:
                 # Start the server task
                 await self._task_group.start(run_server)
 
+                # The session above is provisional: every validation (Host, Accept,
+                # Content-Type, JSON parse, JSON-RPC shape, "Missing session ID")
+                # lives inside `handle_request`, so it runs only now. If the request
+                # that was meant to establish this session is refused, the session
+                # must not survive it -- otherwise a rejected request leaves live
+                # state behind and hands the caller a usable session id.
+                establishing_status: int | None = None
+
+                async def send_tracking_status(message: Message) -> None:
+                    nonlocal establishing_status
+                    if message["type"] == "http.response.start":
+                        establishing_status = message["status"]
+                    await send(message)
+
                 # Handle the HTTP request and return the response
-                await http_transport.handle_request(scope, receive, send)
+                await http_transport.handle_request(scope, receive, send_tracking_status)
+
+                if establishing_status is not None and establishing_status >= 400:
+                    logger.debug(
+                        f"Discarding session {new_session_id}: establishing request returned {establishing_status}"
+                    )
+                    self._server_instances.pop(new_session_id, None)
+                    self._session_owners.pop(new_session_id, None)
+                    await http_transport.terminate()
         else:
             # Unknown or expired session ID - return 404 per MCP spec
             # TODO(L62): Align error code once spec clarifies

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -14,7 +14,7 @@ from mcp_types import DEFAULT_NEGOTIATED_VERSION, INVALID_REQUEST, ErrorData, JS
 from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.types import Receive, Scope, Send
+from starlette.types import Message, Receive, Scope, Send
 
 from mcp.server._streamable_http_modern import handle_modern_request
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser, AuthorizationContext, authorization_context

--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -355,8 +355,30 @@ class StreamableHTTPSessionManager:
                 # Start the server task
                 await self._task_group.start(run_server)
 
+                # The session above is provisional: every validation (Host, Accept,
+                # Content-Type, JSON parse, JSON-RPC shape, "Missing session ID")
+                # lives inside `handle_request`, so it runs only now. If the request
+                # that was meant to establish this session is refused, the session
+                # must not survive it -- otherwise a rejected request leaves live
+                # state behind and hands the caller a usable session id.
+                establishing_status: int | None = None
+
+                async def send_tracking_status(message: Message) -> None:
+                    nonlocal establishing_status
+                    if message["type"] == "http.response.start":
+                        establishing_status = message["status"]
+                    await send(message)
+
                 # Handle the HTTP request and return the response
-                await http_transport.handle_request(scope, receive, send)
+                await http_transport.handle_request(scope, receive, send_tracking_status)
+
+                if establishing_status is not None and establishing_status >= 400:
+                    logger.debug(
+                        f"Discarding session {new_session_id}: establishing request returned {establishing_status}"
+                    )
+                    self._server_instances.pop(new_session_id, None)
+                    self._session_owners.pop(new_session_id, None)
+                    await http_transport.terminate()
         else:
             # Unknown or expired session ID - return 404 per MCP spec
             # TODO(L62): Align error code once spec clarifies

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -3,14 +3,15 @@
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Final
 from unittest.mock import AsyncMock, patch
 
 import anyio
 import httpx2
 import pytest
 from mcp_types import INVALID_REQUEST, ListToolsResult, PaginatedRequestParams
-from starlette.types import Message, Scope
+from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS
+from starlette.types import Message, Receive, Scope, Send
 
 from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
@@ -19,6 +20,19 @@ from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from mcp.server.auth.provider import AccessToken
 from mcp.server.streamable_http import MCP_SESSION_ID_HEADER, StreamableHTTPServerTransport
 from mcp.server.streamable_http_manager import DEFAULT_MAX_REQUEST_BODY_SIZE, StreamableHTTPSessionManager
+
+_INITIALIZE_BODY: Final[bytes] = json.dumps(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": HANDSHAKE_PROTOCOL_VERSIONS[-1],
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1.0"},
+        },
+    }
+).encode()
 
 
 @pytest.mark.anyio
@@ -140,6 +154,140 @@ async def test_oversized_streamed_body_is_rejected_before_session_creation(
 
     response_start = next(message for message in sent_messages if message["type"] == "http.response.start")
     assert response_start["status"] == 413
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "headers", "body", "expected_status"),
+    [
+        pytest.param(
+            "POST",
+            [(b"content-type", b"application/json"), (b"accept", b"application/json, text/event-stream")],
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}).encode(),
+            400,
+            id="post-that-is-not-initialize",
+        ),
+        pytest.param(
+            "POST",
+            [(b"content-type", b"application/json"), (b"accept", b"application/json, text/event-stream")],
+            b"{not valid json",
+            400,
+            id="post-with-malformed-body",
+        ),
+        pytest.param(
+            "POST",
+            [(b"content-type", b"application/json"), (b"accept", b"text/plain")],
+            _INITIALIZE_BODY,
+            406,
+            id="post-with-unacceptable-accept",
+        ),
+        pytest.param("GET", [(b"accept", b"text/event-stream")], b"", 400, id="get-without-session"),
+        pytest.param("DELETE", [], b"", 400, id="delete-without-session"),
+    ],
+)
+async def test_refused_request_leaves_no_session_behind(
+    method: str, headers: list[tuple[bytes, bytes]], body: bytes, expected_status: int
+) -> None:
+    """SDK-defined: a request the transport refuses must not leave a registered session behind.
+
+    The session is minted before any validation runs -- Host, Accept, Content-Type, JSON parse,
+    JSON-RPC shape and the "Missing session ID" check all live downstream in the transport -- so a
+    refusal has to undo it. Otherwise a rejected request grows `_server_instances` forever and hands
+    the caller a session id that later requests can still use.
+
+    This is the same property the suite already asserts by name for the 413 path in
+    `test_oversized_content_length_is_rejected_before_body_read_or_session_creation`.
+    """
+    manager = StreamableHTTPSessionManager(app=Server("test-refused-request"))
+    sent_messages: list[Message] = []
+
+    async def mock_send(message: Message) -> None:
+        sent_messages.append(message)
+
+    async def mock_receive() -> Message:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    scope: Scope = {"type": "http", "method": method, "path": "/mcp", "headers": headers}
+
+    async with manager.run():
+        await manager.handle_request(scope, mock_receive, mock_send)
+
+        response_start = next(msg for msg in sent_messages if msg["type"] == "http.response.start")
+        assert response_start["status"] == expected_status
+        assert manager._server_instances == {}
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_while_streaming_request_body_is_replayed() -> None:
+    """SDK-defined: raw ASGI is required to prove a disconnect before body completion reaches the transport."""
+    disconnect: Message = {"type": "http.disconnect"}
+    request_messages: Iterator[Message] = iter(
+        [{"type": "http.request", "body": b"1234", "more_body": True}, disconnect]
+    )
+    received_messages: list[Message] = []
+
+    async def receive() -> Message:
+        return next(request_messages)
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        received_messages.append(await receive())
+        received_messages.append(await receive())
+
+    scope: Scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": []}
+    middleware = RequestBodyLimitMiddleware(app, max_body_size=8)
+
+    await middleware(scope, receive, AsyncMock())
+
+    assert received_messages == [
+        {"type": "http.request", "body": b"1234", "more_body": True},
+        disconnect,
+    ]
+
+
+@pytest.mark.anyio
+async def test_client_disconnect_before_request_body_is_replayed() -> None:
+    """SDK-defined: raw ASGI proves a disconnect before the first body message reaches the transport."""
+    disconnect: Message = {"type": "http.disconnect"}
+    received_messages: list[Message] = []
+
+    async def receive() -> Message:
+        return disconnect
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        received_messages.append(await receive())
+
+    scope: Scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": []}
+    middleware = RequestBodyLimitMiddleware(app, max_body_size=8)
+
+    await middleware(scope, receive, AsyncMock())
+
+    assert received_messages == [disconnect]
+
+
+@pytest.mark.anyio
+async def test_request_body_chunks_are_replayed_as_one_message() -> None:
+    """SDK-defined: raw ASGI proves chunk overhead is discarded before the body reaches the transport."""
+    request_messages: Iterator[Message] = iter(
+        [
+            {"type": "http.request", "body": b"12", "more_body": True},
+            {"type": "http.request", "body": b"34", "more_body": True},
+            {"type": "http.request", "body": b"56", "more_body": False},
+        ]
+    )
+    received_messages: list[Message] = []
+
+    async def receive() -> Message:
+        return next(request_messages)
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        received_messages.append(await receive())
+
+    scope: Scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": []}
+    middleware = RequestBodyLimitMiddleware(app, max_body_size=8)
+
+    await middleware(scope, receive, AsyncMock())
+
+    assert received_messages == [{"type": "http.request", "body": b"123456", "more_body": False}]
 
 
 def test_request_body_limit_defaults_to_four_mib() -> None:
@@ -436,34 +584,12 @@ async def test_idle_session_is_reaped(caplog: pytest.LogCaptureFixture, request:
     caplog.set_level(logging.INFO, logger=streamable_http_manager.__name__)
 
     async with manager.run():
-        sent_messages: list[Message] = []
+        # Establish the session with a real `initialize`: a request the transport refuses no
+        # longer leaves a session behind, so there would be nothing for the reaper to reap.
+        session_id = await _open_session(manager, None)
 
-        async def mock_send(message: Message):
-            sent_messages.append(message)
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "path": "/mcp",
-            "headers": [(b"content-type", b"application/json")],
-        }
-
-        async def mock_receive():
+        async def mock_receive() -> Message:
             return {"type": "http.request", "body": b"", "more_body": False}
-
-        await manager.handle_request(scope, mock_receive, mock_send)
-
-        session_id = None
-        for msg in sent_messages:  # pragma: no branch
-            if msg["type"] == "http.response.start":  # pragma: no branch
-                for header_name, header_value in msg.get("headers", []):  # pragma: no branch
-                    if header_name.decode().lower() == MCP_SESSION_ID_HEADER.lower():
-                        session_id = header_value.decode()
-                        break
-                if session_id:  # pragma: no branch
-                    break
-
-        assert session_id is not None, "Session ID not found in response headers"
 
         # Wait for the 50ms idle timeout to fire and the session to be unregistered. Re-requesting
         # the session to poll for the 404 would push its idle deadline forward and keep it alive.
@@ -536,18 +662,31 @@ def _request_scope(
 
 
 async def _open_session(manager: StreamableHTTPSessionManager, user: AuthenticatedUser | None) -> str:
-    """Create a new session as `user` and return its session ID."""
+    """Create a new session as `user` and return its session ID.
+
+    Establishes the session the way a real client does, with an `initialize` request, because
+    a request the transport refuses no longer leaves a session behind. The reply is an SSE
+    stream, so the body is followed by a disconnect: that ends the stream and lets
+    `handle_request` return, while the session itself lives on in the manager's task group.
+    """
     sent_messages: list[Message] = []
+    body_sent = False
 
     async def mock_send(message: Message) -> None:
         sent_messages.append(message)
 
     async def mock_receive() -> Message:
-        return {"type": "http.request", "body": b"", "more_body": False}
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.disconnect"}
+        body_sent = True
+        return {"type": "http.request", "body": _INITIALIZE_BODY, "more_body": False}
 
-    await manager.handle_request(_request_scope(user=user), mock_receive, mock_send)
+    with anyio.fail_after(5):
+        await manager.handle_request(_request_scope(user=user), mock_receive, mock_send)
 
     response_start = next(msg for msg in sent_messages if msg["type"] == "http.response.start")
+    assert response_start["status"] == 200, f"initialize was refused with {response_start['status']}"
     headers = dict(response_start.get("headers", []))
     return headers[MCP_SESSION_ID_HEADER.encode()].decode()
 

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -11,7 +11,7 @@ import httpx2
 import pytest
 from mcp_types import INVALID_REQUEST, ListToolsResult, PaginatedRequestParams
 from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS
-from starlette.types import Message, Receive, Scope, Send
+from starlette.types import Message, Scope
 
 from mcp import Client
 from mcp.client.streamable_http import streamable_http_client
@@ -225,76 +225,50 @@ async def test_refused_request_leaves_no_session_behind(
 
 
 @pytest.mark.anyio
-async def test_client_disconnect_while_streaming_request_body_is_replayed() -> None:
-    """SDK-defined: raw ASGI is required to prove a disconnect before body completion reaches the transport."""
-    disconnect: Message = {"type": "http.disconnect"}
-    request_messages: Iterator[Message] = iter(
-        [{"type": "http.request", "body": b"1234", "more_body": True}, disconnect]
-    )
-    received_messages: list[Message] = []
+@pytest.mark.parametrize(
+    ("body_messages", "test_id"),
+    [
+        pytest.param(
+            [{"type": "http.request", "body": _INITIALIZE_BODY[:10], "more_body": True}, {"type": "http.disconnect"}],
+            "disconnect-mid-body",
+            id="disconnect-mid-body",
+        ),
+        pytest.param([{"type": "http.disconnect"}], "disconnect-before-body", id="disconnect-before-body"),
+    ],
+)
+async def test_client_disconnect_leaves_no_session_behind(body_messages: list[Message], test_id: str) -> None:
+    """SDK-defined: a client that vanishes mid-establishment must not leave a registered session behind.
 
-    async def receive() -> Message:
-        return next(request_messages)
+    `Request.body()` raises `ClientDisconnect` when the stream ends on `http.disconnect`, so this
+    never reaches the refusal paths above. `_handle_post_request` converts it into a 500 instead of
+    letting it escape, which is why keying the discard off the response status covers this too: 500
+    is not a validation refusal and an enumerated list of them would have missed it.
 
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        received_messages.append(await receive())
-        received_messages.append(await receive())
+    Reported by @keeltrace on #3229.
+    """
+    manager = StreamableHTTPSessionManager(app=Server("test-client-disconnect"))
+    sent_messages: list[Message] = []
+    messages = iter(body_messages)
 
-    scope: Scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": []}
-    middleware = RequestBodyLimitMiddleware(app, max_body_size=8)
+    async def mock_send(message: Message) -> None:
+        sent_messages.append(message)
 
-    await middleware(scope, receive, AsyncMock())
+    async def mock_receive() -> Message:
+        return next(messages)
 
-    assert received_messages == [
-        {"type": "http.request", "body": b"1234", "more_body": True},
-        disconnect,
-    ]
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [(b"content-type", b"application/json"), (b"accept", b"application/json, text/event-stream")],
+    }
 
+    async with manager.run():
+        await manager.handle_request(scope, mock_receive, mock_send)
 
-@pytest.mark.anyio
-async def test_client_disconnect_before_request_body_is_replayed() -> None:
-    """SDK-defined: raw ASGI proves a disconnect before the first body message reaches the transport."""
-    disconnect: Message = {"type": "http.disconnect"}
-    received_messages: list[Message] = []
-
-    async def receive() -> Message:
-        return disconnect
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        received_messages.append(await receive())
-
-    scope: Scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": []}
-    middleware = RequestBodyLimitMiddleware(app, max_body_size=8)
-
-    await middleware(scope, receive, AsyncMock())
-
-    assert received_messages == [disconnect]
-
-
-@pytest.mark.anyio
-async def test_request_body_chunks_are_replayed_as_one_message() -> None:
-    """SDK-defined: raw ASGI proves chunk overhead is discarded before the body reaches the transport."""
-    request_messages: Iterator[Message] = iter(
-        [
-            {"type": "http.request", "body": b"12", "more_body": True},
-            {"type": "http.request", "body": b"34", "more_body": True},
-            {"type": "http.request", "body": b"56", "more_body": False},
-        ]
-    )
-    received_messages: list[Message] = []
-
-    async def receive() -> Message:
-        return next(request_messages)
-
-    async def app(scope: Scope, receive: Receive, send: Send) -> None:
-        received_messages.append(await receive())
-
-    scope: Scope = {"type": "http", "method": "POST", "path": "/mcp", "headers": []}
-    middleware = RequestBodyLimitMiddleware(app, max_body_size=8)
-
-    await middleware(scope, receive, AsyncMock())
-
-    assert received_messages == [{"type": "http.request", "body": b"123456", "more_body": False}]
+        response_start = next(msg for msg in sent_messages if msg["type"] == "http.response.start")
+        assert response_start["status"] == 500
+        assert manager._server_instances == {}
 
 
 def test_request_body_limit_defaults_to_four_mib() -> None:

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -3,13 +3,14 @@
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Final
 from unittest.mock import AsyncMock, patch
 
 import anyio
 import httpx2
 import pytest
 from mcp_types import INVALID_REQUEST, ListToolsResult, PaginatedRequestParams
+from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS
 from starlette.types import Message, Receive, Scope, Send
 
 from mcp import Client
@@ -23,6 +24,19 @@ from mcp.server.streamable_http_manager import (
     RequestBodyLimitMiddleware,
     StreamableHTTPSessionManager,
 )
+
+_INITIALIZE_BODY: Final[bytes] = json.dumps(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": HANDSHAKE_PROTOCOL_VERSIONS[-1],
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "1.0"},
+        },
+    }
+).encode()
 
 
 @pytest.mark.anyio
@@ -144,6 +158,67 @@ async def test_oversized_streamed_body_is_rejected_before_session_creation(
 
     response_start = next(message for message in sent_messages if message["type"] == "http.response.start")
     assert response_start["status"] == 413
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "headers", "body", "expected_status"),
+    [
+        pytest.param(
+            "POST",
+            [(b"content-type", b"application/json"), (b"accept", b"application/json, text/event-stream")],
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}).encode(),
+            400,
+            id="post-that-is-not-initialize",
+        ),
+        pytest.param(
+            "POST",
+            [(b"content-type", b"application/json"), (b"accept", b"application/json, text/event-stream")],
+            b"{not valid json",
+            400,
+            id="post-with-malformed-body",
+        ),
+        pytest.param(
+            "POST",
+            [(b"content-type", b"application/json"), (b"accept", b"text/plain")],
+            _INITIALIZE_BODY,
+            406,
+            id="post-with-unacceptable-accept",
+        ),
+        pytest.param("GET", [(b"accept", b"text/event-stream")], b"", 400, id="get-without-session"),
+        pytest.param("DELETE", [], b"", 400, id="delete-without-session"),
+    ],
+)
+async def test_refused_request_leaves_no_session_behind(
+    method: str, headers: list[tuple[bytes, bytes]], body: bytes, expected_status: int
+) -> None:
+    """SDK-defined: a request the transport refuses must not leave a registered session behind.
+
+    The session is minted before any validation runs -- Host, Accept, Content-Type, JSON parse,
+    JSON-RPC shape and the "Missing session ID" check all live downstream in the transport -- so a
+    refusal has to undo it. Otherwise a rejected request grows `_server_instances` forever and hands
+    the caller a session id that later requests can still use.
+
+    This is the same property the suite already asserts by name for the 413 path in
+    `test_oversized_content_length_is_rejected_before_body_read_or_session_creation`.
+    """
+    manager = StreamableHTTPSessionManager(app=Server("test-refused-request"))
+    sent_messages: list[Message] = []
+
+    async def mock_send(message: Message) -> None:
+        sent_messages.append(message)
+
+    async def mock_receive() -> Message:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    scope: Scope = {"type": "http", "method": method, "path": "/mcp", "headers": headers}
+
+    async with manager.run():
+        await manager.handle_request(scope, mock_receive, mock_send)
+
+        response_start = next(msg for msg in sent_messages if msg["type"] == "http.response.start")
+        assert response_start["status"] == expected_status
+        assert manager._server_instances == {}
 
 
 @pytest.mark.anyio
@@ -513,34 +588,12 @@ async def test_idle_session_is_reaped(caplog: pytest.LogCaptureFixture, request:
     caplog.set_level(logging.INFO, logger=streamable_http_manager.__name__)
 
     async with manager.run():
-        sent_messages: list[Message] = []
+        # Establish the session with a real `initialize`: a request the transport refuses no
+        # longer leaves a session behind, so there would be nothing for the reaper to reap.
+        session_id = await _open_session(manager, None)
 
-        async def mock_send(message: Message):
-            sent_messages.append(message)
-
-        scope = {
-            "type": "http",
-            "method": "POST",
-            "path": "/mcp",
-            "headers": [(b"content-type", b"application/json")],
-        }
-
-        async def mock_receive():
+        async def mock_receive() -> Message:
             return {"type": "http.request", "body": b"", "more_body": False}
-
-        await manager.handle_request(scope, mock_receive, mock_send)
-
-        session_id = None
-        for msg in sent_messages:  # pragma: no branch
-            if msg["type"] == "http.response.start":  # pragma: no branch
-                for header_name, header_value in msg.get("headers", []):  # pragma: no branch
-                    if header_name.decode().lower() == MCP_SESSION_ID_HEADER.lower():
-                        session_id = header_value.decode()
-                        break
-                if session_id:  # pragma: no branch
-                    break
-
-        assert session_id is not None, "Session ID not found in response headers"
 
         # Wait for the 50ms idle timeout to fire and the session to be unregistered. Re-requesting
         # the session to poll for the 404 would push its idle deadline forward and keep it alive.
@@ -613,18 +666,31 @@ def _request_scope(
 
 
 async def _open_session(manager: StreamableHTTPSessionManager, user: AuthenticatedUser | None) -> str:
-    """Create a new session as `user` and return its session ID."""
+    """Create a new session as `user` and return its session ID.
+
+    Establishes the session the way a real client does, with an `initialize` request, because
+    a request the transport refuses no longer leaves a session behind. The reply is an SSE
+    stream, so the body is followed by a disconnect: that ends the stream and lets
+    `handle_request` return, while the session itself lives on in the manager's task group.
+    """
     sent_messages: list[Message] = []
+    body_sent = False
 
     async def mock_send(message: Message) -> None:
         sent_messages.append(message)
 
     async def mock_receive() -> Message:
-        return {"type": "http.request", "body": b"", "more_body": False}
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.disconnect"}
+        body_sent = True
+        return {"type": "http.request", "body": _INITIALIZE_BODY, "more_body": False}
 
-    await manager.handle_request(_request_scope(user=user), mock_receive, mock_send)
+    with anyio.fail_after(5):
+        await manager.handle_request(_request_scope(user=user), mock_receive, mock_send)
 
     response_start = next(msg for msg in sent_messages if msg["type"] == "http.response.start")
+    assert response_start["status"] == 200, f"initialize was refused with {response_start['status']}"
     headers = dict(response_start.get("headers", []))
     return headers[MCP_SESSION_ID_HEADER.encode()].decode()
 

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -183,6 +183,8 @@ async def test_oversized_streamed_body_is_rejected_before_session_creation(
         ),
         pytest.param("GET", [(b"accept", b"text/event-stream")], b"", 400, id="get-without-session"),
         pytest.param("DELETE", [], b"", 400, id="delete-without-session"),
+        pytest.param("HEAD", [], b"", 405, id="head-is-not-implemented"),
+        pytest.param("OPTIONS", [], b"", 405, id="options-is-not-implemented"),
     ],
 )
 async def test_refused_request_leaves_no_session_behind(
@@ -194,6 +196,11 @@ async def test_refused_request_leaves_no_session_behind(
     JSON-RPC shape and the "Missing session ID" check all live downstream in the transport -- so a
     refusal has to undo it. Otherwise a rejected request grows `_server_instances` forever and hands
     the caller a session id that later requests can still use.
+
+    The property is method-independent: a method the transport does not implement at all is refused
+    by `_handle_unsupported_request`, which also runs downstream of registration and also echoes the
+    session id back. That is why the discard keys off the response status rather than an enumerated
+    list of validation failures.
 
     This is the same property the suite already asserts by name for the 413 path in
     `test_oversized_content_length_is_rejected_before_body_read_or_session_creation`.

--- a/tests/server/test_streamable_http_router.py
+++ b/tests/server/test_streamable_http_router.py
@@ -1,5 +1,7 @@
 """Regression coverage for the StreamableHTTP per-session response router."""
 
+import logging
+
 import anyio
 import pytest
 from mcp_types import JSONRPCMessage, JSONRPCResponse
@@ -141,3 +143,23 @@ async def test_json_post_answers_500_when_session_terminates_mid_request() -> No
 
     assert post.sent[0]["type"] == "http.response.start"
     assert post.sent[0]["status"] == 500
+
+
+@pytest.mark.anyio
+async def test_router_reports_a_stream_closure_it_did_not_cause(caplog: pytest.LogCaptureFixture) -> None:
+    """A stream closed without terminating the transport is an anomaly, not a clean shutdown.
+
+    `terminate()` closes these streams deliberately and the router says so at debug level.
+    Anything else closing them is unexplained, so the router must surface it at exception
+    level instead of swallowing it as a normal end-of-stream.
+    """
+    transport = StreamableHTTPServerTransport(mcp_session_id="sid", is_json_response_enabled=True)
+    caplog.set_level(logging.ERROR, logger="mcp.server.streamable_http")
+
+    async with transport.connect():
+        assert not transport.is_terminated
+        # Close the stream the router is iterating without going through terminate().
+        assert transport._write_stream_reader is not None
+        await transport._write_stream_reader.aclose()
+
+    assert "Unexpected closure of read stream in message router" in caplog.text


### PR DESCRIPTION
Fixes #3228

## Problem

A stateful streamable-HTTP session is minted, registered in `_server_instances` and given a
running task **before the request is validated**. Every check — Host / DNS-rebinding, `Accept`,
`Content-Type`, JSON parse, JSON-RPC shape, and the "Missing session ID" check for non-`initialize`
POSTs — lives downstream in the transport, so it runs only after the session already exists.

Every request the server itself refuses therefore left a live, non-terminated session behind, and
nothing reclaimed it: `session_idle_timeout` defaults to `None` and is not reachable from
`streamable_http_app()` (#2455). A refused `406` also handed back a usable `Mcp-Session-Id`, and a
follow-up request on that never-initialized id was served `200`.

## Solution

Track the status of the response to the establishing request; if it is `>= 400`, drop the session
and terminate the transport.

Chosen over the alternative — "only a POST carrying `initialize` may establish a session" — because
that requires the manager to peek the body, which currently lives in the transport
(`is_initialization_request`). This shape needs no body parsing and closes the same vectors. If you
would rather have the stricter shape, say so and I will rewrite it; it would also subsume #3129.

## Scope: correctness, not a DoS fix

Worth stating plainly, because an earlier draft of my own report got this wrong. This does **not**
close an availability hole: on the same no-auth server, 200 *valid* `initialize` requests create 200
sessions, so unbounded session growth is already reachable with entirely legitimate traffic. The
real gap there is the absence of a session cap plus an unreachable idle reaper, which is #2455 and
is untouched here.

What this fixes is that the server contradicts itself — requests it refuses leave state behind, a
`421` from the default-on DNS-rebinding protection creates a session anyway, and a refusal returns a
working session handle.

## How to test

```bash
uv sync --frozen --all-extras --dev
uv run --frozen pytest tests/server/test_streamable_http_manager.py tests/server/test_streamable_http_router.py -q
uv run --frozen --python 3.10 --all-extras --dev pytest -q -n auto
./scripts/test          # coverage + strict-no-cover
```

Verified on this branch:

- `./scripts/test` → **100.00%**, `TOTAL 49628 Stmts 0 Miss 3920 Branch 0 BrPart`, `strict-no-cover` clean
- Full suite on a real **Python 3.10** interpreter → **5586 passed**, 10 skipped, 1 xfailed
- `ruff check` / `ruff format --check` → clean
- `pyright --pythonversion 3.10` → the only 2 errors are pre-existing and unrelated
  (`tests/transports/stdio/test_lifecycle.py` uses `os.waitid`, absent on macOS)

Against a default-configured server, every session-less vector before and after:

| vector | status | before | after |
|---|---|---|---|
| `GET` no session id | 400 | leaked | 0 |
| `DELETE` no session id | 400 | leaked | 0 |
| `POST` non-`initialize` | 400 | leaked | 0 |
| `POST` malformed body | 400 | leaked | 0 |
| `POST` bad `Accept` | 406 | leaked | 0 |
| `GET` bad `Host` (421) | 421 | leaked | 0 |

A legitimate `initialize` still returns `200` with a session header, and a follow-up `tools/list` on
that session is still served `200`.

## Tests

`test_refused_request_leaves_no_session_behind` — five parametrized vectors, each asserting the
status *and* `manager._server_instances == {}`. Red before this change (all five fail), green after.
It pins the same property the suite already asserts by name for the `413` path in
`test_oversized_content_length_is_rejected_before_body_read_or_session_creation`.

`test_router_reports_a_stream_closure_it_did_not_cause` — covers the router's "unexpected closure"
branch. Worth explaining: that branch was previously reached only *incidentally*, by leaked sessions
whose streams closed at teardown without ever being terminated. Now that refused sessions are
terminated properly, nothing reaches it by accident, so it gets a deliberate test instead of losing
coverage.

## A note on the existing test helper

`_open_session` previously obtained a session **via a request the transport rejects** — it POSTed an
empty body, was answered `400`/`406`, and used the session id that came back anyway. Eight tests
depended on that, so they fail against any correct fix.

It now performs a real `initialize`. The reply is an SSE stream, so the body is followed by an
`http.disconnect`, which ends the stream and lets `handle_request` return while the session lives on
in the manager's task group. `test_idle_session_is_reaped` was building its session the same way and
is switched over too.

That the suite encoded the buggy behaviour as *the way to obtain a session* is plausibly why this
went unnoticed.

## Incidental

- Removes a stale `# pragma: no cover` on the DELETE header-validation path, now covered by the new
  parametrized test.
- Removes four `# pragma: no branch` markers made unnecessary by the rewritten helper.
- No new `# pragma`, `# type: ignore`, or `# noqa` anywhere in the diff.

## Disclosure

Written with AI assistance (Claude Code). Filed by me as the human contributor — I own this change
and will answer any questions on the implementation or the trade-offs above.
