### PR TITLE
feat(mcpserver): expose public get_tool(name) on MCPServer

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -607,6 +607,20 @@ class MCPServer(Generic[LifespanResultT]):
             structured_output=structured_output,
         )
 
+    def get_tool(self, name: str) -> Tool | None:
+        """Get a registered tool by name.
+
+        Returns the tool registration (including its mutable `parameters` JSON schema)
+        so callers can inspect or update a tool without reaching into `_tool_manager`.
+
+        Args:
+            name: The name of the tool to look up
+
+        Returns:
+            The registered tool, or `None` if no tool with that name exists
+        """
+        return self._tool_manager.get_tool(name)
+
     def remove_tool(self, name: str) -> None:
         """Remove a tool from the server by name.
 

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -2348,6 +2348,39 @@ def test_remove_prompt_removes_and_unknown_name_raises() -> None:
         mcp.remove_prompt("greeting")
 
 
+def test_get_tool_returns_registered_tool_or_none() -> None:
+    """SDK-defined: public get_tool completes add/remove without using _tool_manager."""
+    mcp = MCPServer()
+
+    def echo(text: str) -> str:  # pragma: no cover
+        return text
+
+    mcp.add_tool(echo)
+    tool = mcp.get_tool("echo")
+    assert tool is not None
+    assert tool.name == "echo"
+    assert mcp.get_tool("missing") is None
+
+
+def test_get_tool_exposes_mutable_parameters_for_schema_updates() -> None:
+    """SDK-defined: callers can update a tool's inputSchema via get_tool after registration."""
+    mcp = MCPServer()
+
+    def act(action: str) -> str:  # pragma: no cover
+        return action
+
+    mcp.add_tool(act)
+    tool = mcp.get_tool("act")
+    assert tool is not None
+    tool.parameters = {
+        "type": "object",
+        "properties": {"action": {"type": "string", "const": "ping"}},
+        "required": ["action"],
+    }
+    assert mcp.get_tool("act") is tool
+    assert tool.parameters["properties"]["action"]["const"] == "ping"
+
+
 @pytest.mark.anyio
 async def test_middleware_kwarg_and_property_share_the_low_level_chain() -> None:
     """SDK-defined: `MCPServer(middleware=[...])` appends to the low-level chain after


### PR DESCRIPTION
## Summary

Adds a public `MCPServer.get_tool(name) -> Tool | None` that delegates to the existing `ToolManager.get_tool`, so callers can look up a registered tool without using the private `_tool_manager`.

This completes the public tool registration surface next to `add_tool()` / `remove_tool()`.

**Use case (from #3162):** after registration, update a tool's `inputSchema` (e.g. attach `oneOf` / discriminated action schemas) via the returned tool's mutable `parameters` dict.

```python
tool = mcp.get_tool("act")
if tool is not None:
    tool.parameters = {...}  # advertised on tools/list
```

Fixes #3162

## Notes on issue discussion

Maintainer asked whether customizing `inputSchema` at registration time would be enough. This PR still implements the issue's proposed API (`get_tool`) because:

1. It is the minimal CRUD completion (`add` / `get` / `remove`)
2. It enables post-registration inspection and mutation without new registration kwargs
3. An optional `input_schema=` override on `add_tool` / `@tool` remains a possible follow-up and is orthogonal

## Test plan

- [x] `test_get_tool_returns_registered_tool_or_none`
- [x] `test_get_tool_exposes_mutable_parameters_for_schema_updates`
- [x] Neighboring `TestServerTools` add/remove tests still pass
- [x] `ruff` + `pyright` clean on touched files

```bash
uv run --frozen pytest \
  tests/server/mcpserver/test_server.py::test_get_tool_returns_registered_tool_or_none \
  tests/server/mcpserver/test_server.py::test_get_tool_exposes_mutable_parameters_for_schema_updates \
  -q
```

## AI disclosure

Assisted by AI (Grok / Cursor) for implementation and tests; human-reviewed before submit.