### PR TITLE
Discover auth-server metadata before eager token refresh

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -577,6 +577,64 @@ class OAuthClientProvider(httpx2.Auth):
         if not check_resource_allowed(requested_resource=default_resource, configured_resource=prm_resource):
             raise OAuthFlowError(f"Protected resource {prm_resource} does not match expected {default_resource}")
 
+    async def _discover_oauth_metadata(self) -> AsyncGenerator[httpx2.Request, httpx2.Response]:
+        """Discover authorization server metadata and populate the context.
+
+        Yields the discovery requests so they run through the outer httpx auth flow
+        (no side-channel client). This is pure discovery: it fills in
+        ``protected_resource_metadata`` / ``auth_server_url`` / ``oauth_metadata`` and
+        does not register clients or mutate stored credentials. Used to populate the
+        token endpoint before an eager refresh, and available for the 401 path.
+        """
+        # Protected resource metadata -> authorization server URL. Best-effort: legacy
+        # servers without PRM fall through to the origin well-known in the ASM step.
+        if self.context.auth_server_url is None:
+            for url in build_protected_resource_metadata_discovery_urls(None, self.context.server_url):
+                prm = await handle_protected_resource_response((yield create_oauth_metadata_request(url)))
+                if prm:
+                    await self._validate_resource_match(prm)
+                    self.context.protected_resource_metadata = prm
+                    self.context.auth_server_url = str(prm.authorization_servers[0])
+                    break
+
+        # Authorization server metadata -> token / authorization / registration endpoints.
+        for url in build_oauth_authorization_server_metadata_discovery_urls(
+            self.context.auth_server_url, self.context.server_url
+        ):
+            ok, asm = await handle_auth_metadata_response((yield create_oauth_metadata_request(url)))
+            if not ok:
+                break
+            if asm:
+                if self.context.auth_server_url is not None:
+                    validate_metadata_issuer(asm, self.context.auth_server_url)
+                self.context.oauth_metadata = asm
+                break
+
+    async def _refresh_with_discovery(self) -> AsyncGenerator[httpx2.Request, httpx2.Response]:
+        """Eager token refresh that discovers authorization-server metadata first when
+        it is not yet known.
+
+        The token endpoint comes from the AS metadata. On a cold start (e.g. reusing a
+        stored refresh token before any 401) that metadata has not been discovered, so
+        ``_refresh_token`` would fall back to ``{origin}/token`` — dropping any issuer
+        path and 404ing on servers whose token endpoint lives under a path. Yields the
+        discovery and refresh requests so they run through the outer httpx auth flow.
+        """
+        if self.context.oauth_metadata is None:
+            discovery = self._discover_oauth_metadata()
+            discovery_request = await discovery.asend(None)
+            while True:
+                discovery_response = yield discovery_request
+                try:
+                    discovery_request = await discovery.asend(discovery_response)
+                except StopAsyncIteration:
+                    break
+
+        refresh_response = yield await self._refresh_token()
+        if not await self._handle_refresh_response(refresh_response):
+            # Refresh failed, need full re-authentication
+            self._initialized = False
+
     async def async_auth_flow(self, request: httpx2.Request) -> AsyncGenerator[httpx2.Request, httpx2.Response]:
         """httpx2 auth flow integration."""
         async with self.context.lock:
@@ -587,13 +645,17 @@ class OAuthClientProvider(httpx2.Auth):
             self.context.protocol_version = request.headers.get(MCP_PROTOCOL_VERSION_HEADER)
 
             if not self.context.is_token_valid() and self.context.can_refresh_token():
-                # Try to refresh token
-                refresh_request = await self._refresh_token()
-                refresh_response = yield refresh_request
-
-                if not await self._handle_refresh_response(refresh_response):
-                    # Refresh failed, need full re-authentication
-                    self._initialized = False
+                # Refresh the token, discovering authorization-server metadata first when
+                # it is not yet known (see _refresh_with_discovery). Driven here so its
+                # requests run through this httpx auth flow, not a side-channel client.
+                refresh_flow = self._refresh_with_discovery()
+                refresh_request = await refresh_flow.asend(None)
+                while True:
+                    refresh_response = yield refresh_request
+                    try:
+                        refresh_request = await refresh_flow.asend(refresh_response)
+                    except StopAsyncIteration:
+                        break
 
             if self.context.is_token_valid():
                 self._add_auth_header(request)

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -3253,3 +3253,60 @@ async def test_issuer_is_stamped_when_same_origin_fallback_register_is_on_the_di
         await auth_flow.asend(httpx2.Response(200, request=final_req))
     except StopAsyncIteration:
         pass
+
+
+@pytest.mark.anyio
+async def test_eager_refresh_discovers_token_endpoint_before_refreshing(
+    oauth_provider: OAuthClientProvider, valid_tokens: OAuthToken
+):
+    """Regression: on a cold start (cached expired token, no prior discovery) the
+    eager refresh must discover authorization-server metadata first, so it targets
+    the real token endpoint instead of the ``{origin}/token`` fallback. That
+    fallback drops any issuer path and 404s on servers whose token endpoint lives
+    under a path, which silently clears tokens and forces interactive re-auth.
+    """
+    oauth_provider.context.current_tokens = valid_tokens
+    oauth_provider.context.token_expiry_time = time.time() - 100  # expired
+    oauth_provider.context.client_info = OAuthClientInformationFull(
+        client_id="test_client",
+        redirect_uris=[AnyUrl("http://localhost:3030/callback")],
+        token_endpoint_auth_method="none",
+    )
+    oauth_provider._initialized = True
+    assert oauth_provider.context.oauth_metadata is None
+
+    test_request = httpx2.Request("GET", "https://api.example.com/v1/mcp")
+    auth_flow = oauth_provider.async_auth_flow(test_request)
+
+    # 1) protected-resource metadata discovery
+    prm_request = await auth_flow.__anext__()
+    assert "oauth-protected-resource" in str(prm_request.url)
+    prm_response = httpx2.Response(
+        200,
+        content=(
+            b'{"resource": "https://api.example.com/v1/mcp", "authorization_servers": ["https://auth.example.com"]}'
+        ),
+        request=prm_request,
+    )
+
+    # 2) authorization-server metadata whose token endpoint is NOT {origin}/token
+    asm_request = await auth_flow.asend(prm_response)
+    assert "oauth-authorization-server" in str(asm_request.url)
+    asm_response = httpx2.Response(
+        200,
+        content=(
+            b'{"issuer": "https://auth.example.com", '
+            b'"authorization_endpoint": "https://auth.example.com/oauth2/authorize", '
+            b'"token_endpoint": "https://auth.example.com/oauth2/api/v1/token"}'
+        ),
+        request=asm_request,
+    )
+
+    # 3) the refresh must target the discovered token endpoint, not the fallback
+    refresh_request = await auth_flow.asend(asm_response)
+    assert refresh_request.method == "POST"
+    assert str(refresh_request.url) == "https://auth.example.com/oauth2/api/v1/token"
+    assert str(refresh_request.url) != "https://api.example.com/token"
+    assert "grant_type=refresh_token" in refresh_request.content.decode()
+
+    await auth_flow.aclose()


### PR DESCRIPTION
On a cold start with a cached-but-expired token (reusing a stored refresh token before any 401), `async_auth_flow` refreshed before discovery ran, so `oauth_metadata` was `None` and `_refresh_token` fell back to `{origin}/token`. That drops any issuer path and 404s on servers whose token endpoint lives under a path (e.g. `.../oauth2/api/v1/token`) — the refresh fails, tokens are cleared, and the client is forced into interactive re-auth it may not be able to complete. Discover AS metadata before the eager refresh.

Adds `_discover_oauth_metadata` (pure discovery, driven through the auth flow) and `_refresh_with_discovery`, plus a regression test.

Fixes #3240

## Motivation and Context
Hit this against a hosted MCP server whose authorization server isn't at the resource origin (token endpoint `https://host/oauth2/api/v1/token`, not `https://host/token`). A headless client with cached tokens disconnects every time the short-lived access token expires: on reconnect the eager refresh at the top of `async_auth_flow` runs before any 401/discovery, `oauth_metadata is None`, and `_refresh_token` uses `urljoin(get_authorization_base_url(server_url), "/token")` → `{scheme}://{netloc}/token` → 404 → `_handle_refresh_response` clears the tokens → the flow drops to interactive auth a background client can't complete.

The same path-stripping fallback exists in `_get_token_endpoint`, `_perform_authorization_code_grant` (`/authorize`) and DCR (`/register`), but those run inside the 401 branch after discovery, so metadata is already populated there — refresh is the one that fires before discovery, which is why it's the acute, silent case. This PR fixes the refresh path; the other fallbacks are left as-is.

## How Has This Been Tested?
- New regression test in `tests/client/test_auth.py`: cold start with an expired-but-refreshable token and no prior discovery, against an AS whose `token_endpoint` is under a path; asserts the refresh request targets the discovered endpoint, not `{origin}/token`.
- `uv run pytest tests/client/test_auth.py` → 141 passed, 1 xfailed. `uv run ruff check` / `ruff format --check` clean.
- Reproduced the original break and confirmed the fix end-to-end against a real hosted MCP server (Interactive Brokers) whose token endpoint lives under `/oauth2/...`.

## Breaking Changes
None. On a cold start with no cached metadata the eager refresh now issues discovery requests before the refresh; once metadata is known it's a no-op, so the fast path (already-valid or already-discovered) is unchanged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
`_discover_oauth_metadata` is a pure-discovery async generator (PRM → AS metadata) that yields its requests through the outer httpx auth flow — noside-channel client — and only populates `protected_resource_metadata` / `auth_server_url` / `oauth_metadata`. `_refresh_with_discovery` wraps it + the existing refresh so `async_auth_flow` drives one sub-flow and stays under the module's complexity cap. It reuses the existing `build_*_discovery_urls` /`handle_*_response` / `validate_metadata_issuer` helpers, so discovery behaves exactly like the 401 path.