### PR TITLE
Read UTF-8 test fixtures with explicit encoding

### DIFF
--- a/tests/examples/conftest.py
+++ b/tests/examples/conftest.py
@@ -38,7 +38,7 @@ else:  # pragma: lax no cover
 STORIES_DIR = Path(stories.__file__).parent
 BASE_URL = "http://127.0.0.1:8000"
 
-MANIFEST = tomllib.loads((STORIES_DIR / "manifest.toml").read_text())
+MANIFEST = tomllib.loads((STORIES_DIR / "manifest.toml").read_text(encoding="utf-8"))
 DEFAULTS: dict[str, Any] = MANIFEST["defaults"]
 STORIES: dict[str, dict[str, Any]] = MANIFEST["story"]
 

--- a/tests/examples/test_story_shape.py
+++ b/tests/examples/test_story_shape.py
@@ -27,7 +27,7 @@ _LOWLEVEL_STORIES = [name for name in sorted(STORIES) if story_cfg(name)["lowlev
 
 def _parse(path: Path) -> ast.Module:
     """Parse ``path`` into an AST module."""
-    return ast.parse(path.read_text(), filename=str(path))
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
 
 
 def _resolve(node: ast.ImportFrom, package: str) -> str:


### PR DESCRIPTION
## Summary

Fixes #3244.

Two `Path.read_text()` calls in `tests/examples` omit the `encoding` argument, so they decode with the locale preferred encoding - on Windows that is the ANSI code page. On non-Western-locale Windows (e.g. Chinese locale, cp936/GBK) this raises `UnicodeDecodeError`: `tests/examples/conftest.py:41` fails at collection (8 collection errors blocking the whole directory) and `tests/examples/test_story_shape.py:30` fails ~70 parametrized tests. CI's `windows-latest` uses cp1252, which happens to decode the same bytes without raising, so this only reproduces on non-Western locales.

Both files being read (`manifest.toml`, story sources) are UTF-8 - TOML is UTF-8 by specification - so this passes `encoding=utf-8` explicitly at both call sites.

## Test plan

- Before: `uv run pytest tests -n auto` on Chinese-locale Windows 10 (cp936): 70 failed, 8 collection errors.
- After: full suite green on the same machine: 5574 passed, 16 skipped, 1 xfailed.

## Disclosure

This fix was prepared with AI assistance (Claude Code); I have reviewed and verified the change myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)