### PR TITLE
fix: record JSON-RPC errors on client OpenTelemetry spans

### DIFF
--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -32,7 +32,7 @@ from mcp_types import (
     ProgressToken,
     RequestId,
 )
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, StatusCode
 from pydantic import ValidationError
 from typing_extensions import TypeVar
 
@@ -385,7 +385,7 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                 span_name,
                 kind=SpanKind.CLIENT,
                 attributes={"mcp.method.name": method, "jsonrpc.request.id": str(request_id)},
-            ):
+            ) as span:
                 # SEP-414: inject W3C trace context; `_meta` stays on the wire even with a no-op tracer.
                 inject_trace_context(out_meta)
                 msg = JSONRPCRequest(jsonrpc="2.0", id=request_id, method=method, params=out_params)
@@ -401,6 +401,11 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                 with anyio.fail_after(opts.get("timeout")):
                     timeout_armed = True
                     outcome = await receive.receive()
+                if isinstance(outcome, ErrorData):
+                    span.set_attributes(
+                        {"error.type": str(outcome.code), "rpc.response.status_code": str(outcome.code)}
+                    )
+                    span.set_status(StatusCode.ERROR, outcome.message)
         except TimeoutError:
             if not timeout_armed:
                 # `fail_after` arms only after the write, so this TimeoutError is the

--- a/tests/server/test_otel.py
+++ b/tests/server/test_otel.py
@@ -71,6 +71,29 @@ async def test_emits_server_span_with_method_and_target(server: SrvT, spans: Spa
 
 
 @pytest.mark.anyio
+async def test_client_span_records_jsonrpc_error(server: SrvT, spans: SpanCapture):
+    """A JSON-RPC error marks the client span while preserving the MCPError contract."""
+
+    async def failing(ctx: Ctx, params: PaginatedRequestParams | None) -> Any:
+        raise MCPError(code=INVALID_PARAMS, message="forced failure")
+
+    server.add_request_handler("resources/list", PaginatedRequestParams, failing)
+    async with connected_runner(server) as (client, _):
+        spans.clear()
+        with pytest.raises(MCPError) as exc:
+            await client.send_raw_request("resources/list", None)
+
+    assert exc.value.error.code == INVALID_PARAMS
+    [span] = [s for s in spans.finished() if s.kind == SpanKind.CLIENT]
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.status.description == "forced failure"
+    assert span.attributes is not None
+    assert span.attributes["error.type"] == str(INVALID_PARAMS)
+    assert span.attributes["rpc.response.status_code"] == str(INVALID_PARAMS)
+    assert not [event for event in span.events if event.name == "exception"]
+
+
+@pytest.mark.anyio
 async def test_tool_error_dict_result_sets_error_type(server: SrvT, spans: SpanCapture):
     async def err_tool(ctx: Ctx, params: CallToolRequestParams) -> dict[str, Any]:
         return {"content": [], "isError": True}


### PR DESCRIPTION
## Summary

Fixes #3174.

When the MCP peer returns a JSON-RPC error, `send_raw_request()` receives the
`ErrorData` while the client OpenTelemetry span is active, but the span closes
before that response is converted to `MCPError`. Failed requests therefore look
like normal exits in client telemetry.

## Changes

This change:

- records `StatusCode.ERROR`, the JSON-RPC message, `error.type`, and
  `rpc.response.status_code` on the active client span;
- preserves the existing `ErrorData` to `MCPError` conversion and its public
  exception contract; and
- adds an in-memory regression test covering the client span and error code.

The scope is limited to client telemetry. Wire messages, request correlation,
timeouts, cancellation, connection-close handling, and handler exception
behavior are unchanged.

## Verification

```bash
./scripts/test
uv run --frozen ruff check src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py
uv run --frozen ruff format --check src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py
uv run --frozen pyright src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py
```

- `./scripts/test` (5581 passed, 10 skipped, 1 xfailed; 100% coverage)
- `uv run --frozen ruff check src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py`
- `uv run --frozen ruff format --check src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py`
- `uv run --frozen pyright src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py`

The changed files pass Pyright. A full macOS Pyright run also reports two
pre-existing `os.waitid` typing errors in
`tests/transports/stdio/test_lifecycle.py:234`, which is outside this diff.

AI assistance was used to help analyze and implement this change; I reviewed
the source and tests, reran the reproduction and verification, and take
responsibility for the contribution.
