### PR TITLE
fix(server): handle POST body disconnects gracefully

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -36,7 +36,7 @@ from mcp_types import (
 from mcp_types.version import is_version_at_least
 from pydantic import ValidationError
 from sse_starlette import EventSourceResponse
-from starlette.requests import Request
+from starlette.requests import ClientDisconnect, Request
 from starlette.responses import Response
 from starlette.types import Receive, Scope, Send
 
@@ -534,7 +534,11 @@ class StreamableHTTPServerTransport:
                 return
 
             # Parse the body - only read it once
-            body = await request.body()
+            try:
+                body = await request.body()
+            except ClientDisconnect:
+                logger.debug("Client disconnected while sending POST request body")
+                return
 
             try:
                 raw_message = pydantic_core.from_json(body)

--- a/tests/server/test_streamable_http_router.py
+++ b/tests/server/test_streamable_http_router.py
@@ -1,5 +1,7 @@
 """Regression coverage for the StreamableHTTP per-session response router."""
 
+import logging
+
 import anyio
 import pytest
 from mcp_types import JSONRPCMessage, JSONRPCResponse
@@ -14,6 +16,7 @@ from mcp.server.streamable_http import (
     StreamableHTTPServerTransport,
     StreamId,
 )
+from mcp.shared._context_streams import create_context_streams
 from mcp.shared.message import SessionMessage
 
 
@@ -42,6 +45,44 @@ class _AsgiPost:
 
     async def send(self, message: Message) -> None:
         self.sent.append(message)
+
+
+class _AsgiDisconnect(_AsgiPost):
+    """A POST whose body stream disconnects before the declared body is complete."""
+
+    async def receive(self) -> Message:
+        if not self._body_sent:
+            self._body_sent = True
+            return {"type": "http.request", "body": self._body, "more_body": True}
+        return {"type": "http.disconnect"}
+
+
+@pytest.mark.anyio
+async def test_post_client_disconnect_is_not_reported_as_server_error(caplog: pytest.LogCaptureFixture) -> None:
+    transport = StreamableHTTPServerTransport(mcp_session_id=None)
+    post = _AsgiDisconnect(
+        b'{"jsonrpc":"2.0",',
+        [
+            (b"accept", b"application/json, text/event-stream"),
+            (b"content-type", b"application/json"),
+        ],
+    )
+    read_stream_writer, read_stream = create_context_streams[SessionMessage | Exception](1)
+    transport._read_stream_writer = read_stream_writer
+
+    try:
+        with caplog.at_level(logging.ERROR, logger="mcp.server.streamable_http"):
+            await transport.handle_request(post.scope, post.receive, post.send)
+
+        await read_stream_writer.aclose()
+        with pytest.raises(anyio.EndOfStream):
+            await read_stream.receive()
+    finally:
+        await read_stream_writer.aclose()
+        await read_stream.aclose()
+
+    assert post.sent == []
+    assert not caplog.records
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- handle Starlette `ClientDisconnect` while reading a Streamable HTTP POST body as a normal client-side event
- return without attempting to send an HTTP 500 response to a client that has already disconnected
- keep the disconnect out of the internal session stream because no JSON-RPC message was parsed or dispatched
- add direct ASGI regression coverage for the partial-body disconnect path

Fixes #1648.

## Verification

- `uv run --frozen pytest tests/server/test_streamable_http_router.py -q` (4 passed)
- `uv run --frozen ruff check src/mcp/server/streamable_http.py tests/server/test_streamable_http_router.py`
- `uv run --frozen ruff format --check src/mcp/server/streamable_http.py tests/server/test_streamable_http_router.py`
- `uv run --frozen pyright src/mcp/server/streamable_http.py tests/server/test_streamable_http_router.py` (0 errors)

The full `scripts/test -n 0` run collected 5,592 tests but could not complete on this Windows host because unrelated stdio interaction tests were unable to spawn child Python processes (`PermissionError: [WinError 5]`).

AI assistance was used during investigation and implementation. I reviewed the final diff and take responsibility for the change.