### PR TITLE
fix(server): normalize experimental capability to {} in get_capabilities

### DIFF
--- a/src/mcp/server/lowlevel/server.py
+++ b/src/mcp/server/lowlevel/server.py
@@ -575,6 +575,11 @@ class Server(Generic[LifespanResultT]):
         handshake-era derivation applies unchanged.
         """
         notification_options = notification_options or NotificationOptions()
+        # Normalized here rather than only at the create_initialization_options()
+        # call site, so server/discover (which calls this directly with no
+        # experimental_capabilities argument) reports {} instead of None for the
+        # same unconfigured server.
+        experimental_capabilities = experimental_capabilities or {}
         prompts_capability = None
         resources_capability = None
         tools_capability = None

--- a/tests/server/lowlevel/test_server_discover.py
+++ b/tests/server/lowlevel/test_server_discover.py
@@ -181,6 +181,27 @@ async def test_capabilities_derived_from_registered_handlers() -> None:
 
 
 @pytest.mark.anyio
+async def test_experimental_capability_is_empty_dict_not_none_when_unset() -> None:
+    """SDK-defined: an unconfigured server's `experimental` capability is `{}`
+    on both discovery paths, matching `create_initialization_options()`.
+
+    `get_capabilities()` used to leave `experimental` at its own parameter
+    default (`None`) unless the caller normalized it first;
+    `create_initialization_options()` did that normalization, but
+    `server/discover` calls `get_capabilities()` directly and did not - so the
+    same unconfigured server reported `{}` via `initialize` and `None` via
+    `server/discover`. See https://github.com/modelcontextprotocol/python-sdk/issues/3254
+    """
+    server = Server("cap-server")
+
+    legacy_capabilities = server.create_initialization_options().capabilities
+    discovered = await _discover(server)
+
+    assert legacy_capabilities.experimental == {}
+    assert discovered.capabilities.experimental == {}
+
+
+@pytest.mark.anyio
 async def test_discover_result_defaults_to_immediately_stale_private_cache() -> None:
     """SDK-defined: `DiscoverResult` is cacheable; the auto-derived handler
     relies on the model defaults (immediately-stale, private)."""


### PR DESCRIPTION
Fixes #3254

## What's broken

An unconfigured `Server` reports its `experimental` capability differently depending on which discovery path answers:

- `initialize` (via `create_initialization_options()`): `experimental == {}`, field present on the wire.
- `server/discover` (calls `get_capabilities()` directly): `experimental is None`, field omitted from the wire dump.

That's client-visible: `.get(...)` works on the legacy value and raises on the modern one, and `is not None` checks flip meaning depending on which path answered. Same server, same lack of configuration, two different answers.

## Why

`create_initialization_options()` was the only caller that normalized a missing `experimental_capabilities` argument to `{}` before handing it to `get_capabilities()`. `get_capabilities()` itself just used its own parameter default (`None`) whenever a caller didn't do that normalization first — and `server/discover`'s internal handler calls `get_capabilities(protocol_version=ctx.protocol_version)` with nothing for `experimental_capabilities`, so it fell straight through to `None`.

## The fix

One line: move the normalization into `get_capabilities()` itself, right next to the existing `notification_options = notification_options or NotificationOptions()` fallback that already does the same job for a sibling parameter. Now every caller gets `{}` unless it explicitly passes something else, regardless of which path calls it.

## How I checked it

Ran the exact repro from the issue against both trees:

```
# main
legacy {} True
modern None False

# this branch
legacy {} True
modern {} True
```

Added a test in `tests/server/lowlevel/test_server_discover.py` (the file that already exercises `get_capabilities()` via the discover path) asserting both `create_initialization_options()` and `server/discover` report `experimental == {}` for the same unconfigured server. It fails on `main` with `assert None == {}` and passes with this change.

`ruff format`/`ruff check`/`pyright` are all clean. Ran the full `tests/server/` suite (1213 tests) and it passes. I didn't run the complete coverage/strict-no-cover gate across the whole repo, but confirmed the new line is exercised (not in `coverage report`'s missing-lines list) when running the affected test files.

## Type

🐛 Bug Fix

## Disclosure

An AI coding agent helped me write this. I read the SDK's fallback pattern in `get_capabilities()`, picked the one-line fix that matches it, reproduced the issue's exact repro on both trees myself, and can walk through any part of this change.
