### PR TITLE
fix(client): bound empty GET stream retries

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -214,7 +214,9 @@ class StreamableHTTPTransport:
                     event_source.response.raise_for_status()
                     logger.debug("GET SSE connection established")
 
+                    saw_event = False
                     async for sse in event_source:
+                        saw_event = True
                         # Track last event ID for reconnection
                         if sse.id:
                             last_event_id = sse.id
@@ -224,8 +226,9 @@ class StreamableHTTPTransport:
 
                         await self._handle_sse_event(sse, read_stream_writer)
 
-                    # Stream ended normally (server closed) - reset attempt counter
-                    attempt = 0
+                    # A clean stream close is retryable only when the server sent an event.
+                    # An empty stream is a terminated endpoint, so count it against the retry budget.
+                    attempt = 0 if saw_event else attempt + 1
 
             except Exception:
                 logger.debug("GET stream error", exc_info=True)

--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -234,7 +234,7 @@ class StreamableHTTPTransport:
                 logger.debug("GET stream error", exc_info=True)
                 attempt += 1
 
-            if attempt >= MAX_RECONNECTION_ATTEMPTS:  # pragma: no cover
+            if attempt >= MAX_RECONNECTION_ATTEMPTS:
                 logger.debug(f"GET stream max reconnection attempts ({MAX_RECONNECTION_ATTEMPTS}) exceeded")
                 return
 

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -737,6 +737,31 @@ async def test_exhausted_reconnection_attempts_resolve_the_request_with_an_error
 
 
 @pytest.mark.anyio
+async def test_empty_get_stream_exhausts_reconnection_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty, cleanly closed GET stream must not reset the reconnection budget."""
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, content=b"")
+
+    async def no_sleep(_delay: float) -> None:
+        pass
+
+    monkeypatch.setattr("mcp.client.streamable_http.anyio.sleep", no_sleep)
+    transport = StreamableHTTPTransport("http://test/mcp")
+    transport.session_id = "session-1"
+    send, receive = create_context_streams[SessionMessage | Exception](0)
+
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as http:
+        await transport.handle_get_stream(http, send)
+
+    assert len(requests) == MAX_RECONNECTION_ATTEMPTS
+    send.close()
+    receive.close()
+
+
+@pytest.mark.anyio
 async def test_resolving_an_abandoned_request_after_the_reader_closed_is_contained() -> None:
     """Teardown race: a stream dying after the reader closed resolves best-effort and must not crash."""
     transport = StreamableHTTPTransport("http://test/mcp")

--- a/tests/client/test_streamable_http.py
+++ b/tests/client/test_streamable_http.py
@@ -754,7 +754,8 @@ async def test_empty_get_stream_exhausts_reconnection_attempts(monkeypatch: pyte
     send, receive = create_context_streams[SessionMessage | Exception](0)
 
     async with httpx2.AsyncClient(transport=httpx2.MockTransport(handler)) as http:
-        await transport.handle_get_stream(http, send)
+        with anyio.fail_after(5):
+            await transport.handle_get_stream(http, send)
 
     assert len(requests) == MAX_RECONNECTION_ATTEMPTS
     send.close()


### PR DESCRIPTION
## Problem

`StreamableHTTPTransport.handle_get_stream()` can reconnect forever when a server returns a valid empty SSE stream and closes it cleanly. The loop's `MAX_RECONNECTION_ATTEMPTS` bound is never reached because every empty close resets the attempt counter.

## Root Cause

The transport treated every normal SSE iterator completion as a productive stream, even when no SSE event had been received.

## Solution

Track whether the stream delivered an event. Reset the retry counter only after a productive stream; count an empty clean close against the existing retry budget.

## Changes

- Bound empty GET/SSE stream retries at `MAX_RECONNECTION_ATTEMPTS`.
- Preserve existing retry reset behavior for streams that deliver events.
- Add a regression test with an empty `200 text/event-stream` response.

## Testing

- Baseline: existing header and exhausted-reconnection tests ? 9 passed.
- `PYTHONPATH=src;. py -3 -m pytest --import-mode=importlib tests/client/test_streamable_http.py -q` ? 29 passed.
- `py -3 -m ruff format --check src/mcp/client/streamable_http.py tests/client/test_streamable_http.py` ? passed.
- `py -3 -m ruff check src/mcp/client/streamable_http.py tests/client/test_streamable_http.py` ? passed.
- `py -3 -m pyright --pythonpath D:\Python310\python.exe src/mcp/client/streamable_http.py tests/client/test_streamable_http.py` ? passed.
- `git diff --check` ? passed.

## Compatibility / Risk

This only changes behavior for a cleanly closed stream that delivered zero events. Productive SSE streams continue to reset the retry budget and reconnect as before. The change prevents unbounded background polling against endpoints that terminate without sending data.

## Notes for Reviewer

The regression uses the real transport with `httpx2.MockTransport`, a valid empty SSE response, and a patched zero-delay sleep; it asserts exactly the configured retry budget is consumed.

## Linked Issue

Fixes #3257
