### PR TITLE
fix(auth): preserve root protected resource URI

### DIFF
--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,4 +1,5 @@
 from typing import Any, Literal, cast
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -256,3 +257,19 @@ class ProtectedResourceMetadata(BaseModel):
     dpop_signing_alg_values_supported: list[str] | None = None
     # dpop_bound_access_tokens_required default is False, but omitted here for clarity
     dpop_bound_access_tokens_required: bool | None = None
+
+    @field_validator("resource", mode="before")
+    @classmethod
+    def _preserve_empty_resource_path(cls, value: object) -> object:
+        """Keep the RFC 9728 root resource URI free of a synthetic slash.
+
+        ``AnyHttpUrl`` normalizes ``https://example.com`` to
+        ``https://example.com/`` before the model's ``url_preserve_empty_path``
+        setting can preserve the distinction. This is especially visible when
+        the value arrives as an already-validated ``AnyHttpUrl`` from the
+        server settings.
+        """
+        parsed = urlsplit(str(value))
+        if parsed.path == "/":
+            return urlunsplit(parsed._replace(path=""))
+        return value

--- a/tests/server/auth/test_protected_resource.py
+++ b/tests/server/auth/test_protected_resource.py
@@ -98,7 +98,7 @@ async def test_metadata_endpoint_without_path(root_resource_client: httpx2.Async
     assert response.status_code == 200
     assert response.json() == snapshot(
         {
-            "resource": "https://example.com/",
+            "resource": "https://example.com",
             "authorization_servers": ["https://auth.example.com/"],
             "scopes_supported": ["read"],
             "resource_name": "Root Resource",

--- a/tests/shared/test_auth.py
+++ b/tests/shared/test_auth.py
@@ -1,9 +1,15 @@
 """Tests for OAuth 2.0 shared code."""
 
 import pytest
-from pydantic import AnyUrl, ValidationError
+from pydantic import AnyHttpUrl, AnyUrl, ValidationError
 
-from mcp.shared.auth import InvalidRedirectUriError, OAuthClientInformationFull, OAuthClientMetadata, OAuthMetadata
+from mcp.shared.auth import (
+    InvalidRedirectUriError,
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+    ProtectedResourceMetadata,
+)
 
 
 def test_oauth():
@@ -107,6 +113,27 @@ def test_valid_url_passes_through_unchanged():
     }
     metadata = OAuthClientMetadata.model_validate(data)
     assert str(metadata.client_uri) == "https://udemy.com/"
+
+
+def test_protected_resource_metadata_preserves_empty_root_path():
+    metadata = ProtectedResourceMetadata.model_validate(
+        {
+            "resource": "https://example.com",
+            "authorization_servers": ["https://auth.example.com"],
+        }
+    )
+
+    assert str(metadata.resource) == "https://example.com"
+    assert '"resource":"https://example.com"' in metadata.model_dump_json()
+
+
+def test_protected_resource_metadata_strips_normalized_root_path():
+    metadata = ProtectedResourceMetadata(
+        resource=AnyHttpUrl("https://example.com"),
+        authorization_servers=[AnyHttpUrl("https://auth.example.com")],
+    )
+
+    assert str(metadata.resource) == "https://example.com"
 
 
 def test_information_full_inherits_coercion():


### PR DESCRIPTION
## Problem

`ProtectedResourceMetadata.resource` can be serialized with a synthetic trailing slash when a root resource URL is supplied as an already-validated `AnyHttpUrl`. This changes `https://example.com` to `https://example.com/` and can break strict RFC 9728 resource matching.

## Root Cause

`AnyHttpUrl` normalizes an empty URL path to `/` before `ProtectedResourceMetadata`'s `url_preserve_empty_path` model setting can preserve the original spelling. The server auth settings pass an already-validated URL object into the metadata model.

## Solution

Normalize only the root path in a `ProtectedResourceMetadata` pre-validator, removing the synthetic slash before `AnyHttpUrl` validation. Non-root paths and URL validation remain unchanged.

## Changes

- Preserve an empty root path for `ProtectedResourceMetadata.resource`.
- Add regression coverage for raw metadata input and an already-normalized URL object.

## Testing

- `py -m pytest tests/shared/test_auth.py -q` — 43 passed.
- `py -m pytest tests/shared/test_auth_utils.py tests/shared/test_auth.py -q` — 58 passed.
- `py -m pytest tests/client/test_auth.py -q` — 140 passed, 1 xfailed.
- `py -m ruff format --check src/mcp/shared/auth.py tests/shared/test_auth.py` — passed.
- `py -m ruff check src/mcp/shared/auth.py tests/shared/test_auth.py` — passed.
- `git diff --check` — passed.

## Compatibility/Risk

The public field type remains `AnyHttpUrl`. Only a root-path slash synthesized by URL normalization is removed; non-root paths, query strings, and validation behavior are unchanged.

## Notes for Reviewer

Pyright could not be run with the repository's configured `.venv` because this incremental worktree does not contain that environment. A separate available environment reported no source-file diagnostics but reported unrelated baseline test typing diagnostics; this is explicitly unverified locally.

## Linked Issue

Closes #2883
