### PR TITLE
fix(auth): recover expired dynamic client registrations

### DIFF
--- a/docs_src/identity_assertion/tutorial001.py
+++ b/docs_src/identity_assertion/tutorial001.py
@@ -20,13 +20,13 @@ class InMemoryTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self.tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self.client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self.client_info = client_info
 
 

--- a/docs_src/oauth_clients/tutorial001.py
+++ b/docs_src/oauth_clients/tutorial001.py
@@ -17,13 +17,13 @@ class InMemoryTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self.tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self.client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self.client_info = client_info
 
 

--- a/docs_src/oauth_clients/tutorial002.py
+++ b/docs_src/oauth_clients/tutorial002.py
@@ -14,13 +14,13 @@ class InMemoryTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self.tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self.client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self.client_info = client_info
 
 

--- a/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
+++ b/examples/clients/simple-auth-client/mcp_simple_auth_client/main.py
@@ -37,13 +37,13 @@ class InMemoryTokenStorage(TokenStorage):
     async def get_tokens(self) -> OAuthToken | None:
         return self._tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self._tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self._client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self._client_info = client_info
 
 

--- a/examples/snippets/clients/identity_assertion_client.py
+++ b/examples/snippets/clients/identity_assertion_client.py
@@ -34,13 +34,13 @@ class InMemoryTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self.tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self.client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self.client_info = client_info
 
 

--- a/examples/snippets/clients/oauth_client.py
+++ b/examples/snippets/clients/oauth_client.py
@@ -29,7 +29,7 @@ class InMemoryTokenStorage(TokenStorage):
         """Get stored tokens."""
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         """Store tokens."""
         self.tokens = tokens
 
@@ -37,7 +37,7 @@ class InMemoryTokenStorage(TokenStorage):
         """Get stored client information."""
         return self.client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         """Store client information."""
         self.client_info = client_info
 

--- a/examples/stories/_shared/auth.py
+++ b/examples/stories/_shared/auth.py
@@ -38,13 +38,13 @@ class InMemoryTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self.tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self.client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self.client_info = client_info
 
 

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -5,6 +5,7 @@ Implements authorization code flow with PKCE and automatic token refresh.
 
 import base64
 import hashlib
+import json
 import logging
 import secrets
 import string
@@ -109,6 +110,21 @@ def check_registration_usable(client_info: OAuthClientInformationFull) -> None:
         )
 
 
+def _is_expired_client_secret(client_info: OAuthClientInformationFull) -> bool:
+    """Return whether a stored registration reports an expired client secret."""
+    expires_at = client_info.client_secret_expires_at
+    return expires_at is not None and expires_at != 0 and expires_at <= int(time.time())
+
+
+def _is_invalid_client_response(body: bytes) -> bool:
+    """Identify RFC 6749 ``invalid_client`` responses independent of HTTP status."""
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    return isinstance(payload, dict) and payload.get("error") == "invalid_client"
+
+
 class PKCEParameters(BaseModel):
     """PKCE (Proof Key for Code Exchange) parameters."""
 
@@ -131,16 +147,16 @@ class TokenStorage(Protocol):
         """Get stored tokens."""
         ...
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
-        """Store tokens."""
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
+        """Store tokens, or clear them when ``tokens`` is ``None``."""
         ...
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         """Get stored client information."""
         ...
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
-        """Store client information."""
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
+        """Store client information, or clear it when ``client_info`` is ``None``."""
         ...
 
 
@@ -468,6 +484,8 @@ class OAuthClientProvider(httpx2.Auth):
         """Handle token exchange response."""
         if response.status_code not in {200, 201}:
             body = await response.aread()
+            if _is_invalid_client_response(body):
+                await self._clear_stored_credentials()
             body_text = body.decode("utf-8")
             raise OAuthTokenError(f"Token exchange failed ({response.status_code}): {body_text}")
 
@@ -519,8 +537,12 @@ class OAuthClientProvider(httpx2.Auth):
     async def _handle_refresh_response(self, response: httpx2.Response) -> bool:
         """Handle token refresh response. Returns True if successful."""
         if response.status_code != 200:
+            body = await response.aread()
             logger.warning(f"Token refresh failed: {response.status_code}")
-            self.context.clear_tokens()
+            if _is_invalid_client_response(body):
+                await self._clear_stored_credentials()
+            else:
+                self.context.clear_tokens()
             return False
 
         try:
@@ -551,7 +573,17 @@ class OAuthClientProvider(httpx2.Auth):
         """Load stored tokens and client info."""
         self.context.current_tokens = await self.context.storage.get_tokens()
         self.context.client_info = await self.context.storage.get_client_info()
+        if self.context.client_info and _is_expired_client_secret(self.context.client_info):
+            logger.info("Stored client registration has expired; clearing credentials and re-registering")
+            await self._clear_stored_credentials()
         self._initialized = True
+
+    async def _clear_stored_credentials(self) -> None:
+        """Clear the in-memory and persisted credentials bound to a client registration."""
+        self.context.client_info = None
+        self.context.clear_tokens()
+        await self.context.storage.set_client_info(None)
+        await self.context.storage.set_tokens(None)
 
     def _add_auth_header(self, request: httpx2.Request) -> None:
         """Add authorization header to request if we have valid tokens."""

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -12,7 +12,7 @@ import string
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Any, Protocol, get_args
+from typing import Any, Protocol, cast, get_args
 from urllib.parse import quote, urlencode, urljoin, urlparse
 
 import anyio
@@ -122,7 +122,7 @@ def _is_invalid_client_response(body: bytes) -> bool:
         payload: Any = json.loads(body)
     except (json.JSONDecodeError, UnicodeDecodeError):
         return False
-    return isinstance(payload, dict) and payload.get("error") == "invalid_client"
+    return isinstance(payload, dict) and cast(dict[str, Any], payload).get("error") == "invalid_client"
 
 
 class PKCEParameters(BaseModel):

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -119,7 +119,7 @@ def _is_expired_client_secret(client_info: OAuthClientInformationFull) -> bool:
 def _is_invalid_client_response(body: bytes) -> bool:
     """Identify RFC 6749 ``invalid_client`` responses independent of HTTP status."""
     try:
-        payload = json.loads(body)
+        payload: Any = json.loads(body)
     except (json.JSONDecodeError, UnicodeDecodeError):
         return False
     return isinstance(payload, dict) and payload.get("error") == "invalid_client"

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -27,13 +27,13 @@ class MockTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self._tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:  # pragma: no cover
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:  # pragma: no cover
         self._tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:  # pragma: no cover
         return self._client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:  # pragma: no cover
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:  # pragma: no cover
         self._client_info = client_info
 
 

--- a/tests/client/auth/extensions/test_identity_assertion.py
+++ b/tests/client/auth/extensions/test_identity_assertion.py
@@ -29,13 +29,13 @@ class InMemoryStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self.tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         raise NotImplementedError
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         raise NotImplementedError
 
 

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -13,6 +13,7 @@ from pydantic import AnyHttpUrl, AnyUrl
 
 from mcp.client.auth import OAuthClientProvider, PKCEParameters
 from mcp.client.auth.exceptions import OAuthFlowError, OAuthRegistrationError, OAuthTokenError
+from mcp.client.auth.oauth2 import _is_invalid_client_response
 from mcp.client.auth.utils import (
     build_oauth_authorization_server_metadata_discovery_urls,
     build_protected_resource_metadata_discovery_urls,
@@ -76,6 +77,20 @@ def client_metadata():
         redirect_uris=[AnyUrl("http://localhost:3030/callback")],
         scope="read write",
     )
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (b"not json", False),
+        (b"\xff", False),
+        (b"[]", False),
+        (b'{"error": "invalid_grant"}', False),
+        (b'{"error": "invalid_client"}', True),
+    ],
+)
+def test_invalid_client_response_detection(body: bytes, expected: bool) -> None:
+    assert _is_invalid_client_response(body) is expected
 
 
 @pytest.fixture

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -53,13 +53,13 @@ class MockTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self._tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self._tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self._client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self._client_info = client_info
 
 
@@ -263,6 +263,26 @@ class TestOAuthContext:
         # Verify cleared
         assert context.current_tokens is None
         assert context.token_expiry_time is None
+
+    @pytest.mark.anyio
+    async def test_initialize_discards_expired_client_registration(
+        self, oauth_provider: OAuthClientProvider, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
+    ):
+        expired_client = OAuthClientInformationFull(
+            client_id="expired-client",
+            client_secret="expired-secret",
+            client_secret_expires_at=int(time.time()) - 1,
+            redirect_uris=[AnyUrl("http://localhost:3030/callback")],
+        )
+        await mock_storage.set_client_info(expired_client)
+        await mock_storage.set_tokens(valid_tokens)
+
+        await oauth_provider._initialize()
+
+        assert oauth_provider.context.client_info is None
+        assert oauth_provider.context.current_tokens is None
+        assert await mock_storage.get_client_info() is None
+        assert await mock_storage.get_tokens() is None
 
 
 class TestOAuthFlow:
@@ -2956,6 +2976,34 @@ async def test_handle_token_response_raises_on_non_2xx_with_body(oauth_provider:
 
 
 @pytest.mark.anyio
+async def test_handle_token_response_invalid_client_clears_stored_credentials(
+    oauth_provider: OAuthClientProvider, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
+):
+    client_info = OAuthClientInformationFull(
+        client_id="stale-client",
+        client_secret="stale-secret",
+        redirect_uris=[AnyUrl("http://localhost:3030/callback")],
+    )
+    oauth_provider.context.client_info = client_info
+    oauth_provider.context.current_tokens = valid_tokens
+    await mock_storage.set_client_info(client_info)
+    await mock_storage.set_tokens(valid_tokens)
+    response = httpx2.Response(
+        401,
+        json={"error": "invalid_client"},
+        request=httpx2.Request("POST", "https://auth.example.com/token"),
+    )
+
+    with pytest.raises(OAuthTokenError, match=r"Token exchange failed \(401\).*invalid_client"):
+        await oauth_provider._handle_token_response(response)
+
+    assert oauth_provider.context.client_info is None
+    assert oauth_provider.context.current_tokens is None
+    assert await mock_storage.get_client_info() is None
+    assert await mock_storage.get_tokens() is None
+
+
+@pytest.mark.anyio
 async def test_handle_refresh_response_carries_prior_scope_and_refresh_token_when_omitted(
     oauth_provider: OAuthClientProvider, mock_storage: MockTokenStorage
 ):
@@ -3005,6 +3053,34 @@ async def test_handle_refresh_response_adopts_rotated_refresh_token_when_returne
     stored = await mock_storage.get_tokens()
     assert stored is not None
     assert stored.refresh_token == "rotated"
+
+
+@pytest.mark.anyio
+async def test_handle_refresh_response_invalid_client_clears_stored_credentials(
+    oauth_provider: OAuthClientProvider, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
+):
+    client_info = OAuthClientInformationFull(
+        client_id="stale-client",
+        client_secret="stale-secret",
+        redirect_uris=[AnyUrl("http://localhost:3030/callback")],
+    )
+    oauth_provider.context.client_info = client_info
+    oauth_provider.context.current_tokens = valid_tokens
+    await mock_storage.set_client_info(client_info)
+    await mock_storage.set_tokens(valid_tokens)
+    response = httpx2.Response(
+        400,
+        json={"error": "invalid_client"},
+        request=httpx2.Request("POST", "https://auth.example.com/token"),
+    )
+
+    ok = await oauth_provider._handle_refresh_response(response)
+
+    assert ok is False
+    assert oauth_provider.context.client_info is None
+    assert oauth_provider.context.current_tokens is None
+    assert await mock_storage.get_client_info() is None
+    assert await mock_storage.get_tokens() is None
 
 
 @pytest.mark.anyio

--- a/tests/client/test_scope_bug_1630.py
+++ b/tests/client/test_scope_bug_1630.py
@@ -29,13 +29,13 @@ class MockTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self._tokens  # pragma: no cover
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self._tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self._client_info  # pragma: no cover
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self._client_info = client_info  # pragma: no cover
 
 

--- a/tests/interaction/auth/_harness.py
+++ b/tests/interaction/auth/_harness.py
@@ -116,13 +116,13 @@ class InMemoryTokenStorage:
     async def get_tokens(self) -> OAuthToken | None:
         return self.tokens
 
-    async def set_tokens(self, tokens: OAuthToken) -> None:
+    async def set_tokens(self, tokens: OAuthToken | None) -> None:
         self.tokens = tokens
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         return self.client_info
 
-    async def set_client_info(self, client_info: OAuthClientInformationFull) -> None:
+    async def set_client_info(self, client_info: OAuthClientInformationFull | None) -> None:
         self.client_info = client_info
 
 


### PR DESCRIPTION
## Problem

An OAuth client can remain permanently stuck after a dynamically registered client secret expires. The stored registration is reused, and token endpoint `invalid_client` responses are treated as ordinary failures, so re-authorization retries with the same dead credentials.

## Root Cause

`OAuthClientProvider` loaded `client_secret_expires_at` but never used it. The token storage protocol also had no way to clear the persisted client registration or tokens when the authorization server rejected the client credentials.

## Solution

Treat a non-zero, past `client_secret_expires_at` as an unusable stored registration and clear it before the next flow. Also detect `invalid_client` from the response body regardless of whether the authorization server uses HTTP 400 or 401, clear the bound credentials, and allow the next flow to register again.

## Changes

- Allow `TokenStorage` setters to receive `None` to clear stored tokens or client information.
- Clear expired registrations during provider initialization.
- Clear persisted registration and tokens on `invalid_client` during token exchange or refresh.
- Add regression coverage for proactive expiry, authorization-code exchange failures, and refresh failures.

## Testing

- `py -m pytest tests/client/test_auth.py tests/client/test_scope_bug_1630.py tests/client/auth/extensions/test_client_credentials.py tests/client/auth/extensions/test_identity_assertion.py -q` — 172 passed, 1 xfailed.
- `py -m ruff format --check src/mcp/client/auth/oauth2.py tests/client/test_auth.py tests/client/test_scope_bug_1630.py tests/client/auth/extensions/test_client_credentials.py tests/client/auth/extensions/test_identity_assertion.py` — passed.
- `py -m ruff check src/mcp/client/auth/oauth2.py tests/client/test_auth.py tests/client/test_scope_bug_1630.py tests/client/auth/extensions/test_client_credentials.py tests/client/auth/extensions/test_identity_assertion.py` — passed.
- `git diff --check` — passed.

## Compatibility/Risk

This changes the `TokenStorage` setter contract so storage implementations must treat `None` as deletion. The runtime behavior is limited to expired or server-rejected registrations; valid registrations and non-`invalid_client` failures retain their existing flow.

## Notes for Reviewer

Pyright is unverified locally because the incremental worktree has no repository `.venv`. An alternate environment had mismatched `mcp_types`, `httpx2`, and project dependency versions and reported broad pre-existing import/type diagnostics; those results are not presented as a passing typecheck.

## Linked Issue

Closes #3256
