### PR TITLE
fix: log exceptions in tool calls at ERROR level

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -421,6 +421,7 @@ class MCPServer(Generic[LifespanResultT]):
         except MCPError:
             raise
         except Exception as e:
+            logger.exception(f"Error calling tool {params.name}")
             return CallToolResult(content=[TextContent(type="text", text=str(e))], is_error=True)
 
     async def _handle_list_resources(

--- a/tests/interaction/mcpserver/test_tools.py
+++ b/tests/interaction/mcpserver/test_tools.py
@@ -119,6 +119,32 @@ async def test_call_tool_tool_error_becomes_error_result(connect: Connect, unsta
     )
 
 
+@requirement("mcpserver:tool:handler-throws")
+async def test_call_tool_exception_is_logged_server_side(
+    connect: Connect, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A tool exception is logged at ERROR level on the server so operators can diagnose failures.
+
+    The is_error result reaches the client, but without server-side logging the root cause is
+    invisible in server logs. This test asserts the log record is emitted alongside the result.
+    """
+    mcp = MCPServer("errors")
+
+    @mcp.tool()
+    def boom() -> str:
+        raise RuntimeError("something went wrong")
+
+    with caplog.at_level(logging.ERROR, logger="mcp.server.mcpserver.server"):
+        async with connect(mcp) as client:
+            result = await client.call_tool("boom", {})
+
+    assert result.is_error is True
+    assert any(
+        rec.levelno == logging.ERROR and "boom" in rec.message
+        for rec in caplog.records
+    )
+
+
 @requirement("mcpserver:tool:unknown-name")
 async def test_call_tool_unknown_name_returns_error_result(connect: Connect, unstamped: Unstamp) -> None:
     """Calling a tool name that was never registered is reported as an is_error result.


### PR DESCRIPTION
## Summary

Fixes #3266.

`_handle_call_tool` silently converts all exceptions into `CallToolResult(is_error=True)` without any server-side logging, making tool failures invisible in server logs. The existing resource and prompt handlers both call `logger.exception()` before handling the error — this PR applies the same pattern to tool calls.

**Before:** A tool raising `ValueError("something went wrong")` returns an `is_error` result to the client with no trace in server logs.

**After:** The same exception is logged at `ERROR` level (with full traceback via `logger.exception`) before the `is_error` result is returned.

## Change

`src/mcp/server/mcpserver/server.py` — one line added in `_handle_call_tool`:

```python
except Exception as e:
    logger.exception(f"Error calling tool {params.name}")  # ← added
    return CallToolResult(content=[TextContent(type="text", text=str(e))], is_error=True)
```

This mirrors the pattern in `_handle_read_resource` (line 566) and `_handle_get_prompt` (line 1296).

## Test

Added `test_call_tool_exception_is_logged_server_side` to `tests/interaction/mcpserver/test_tools.py`. It asserts that when a tool raises an exception, a log record at `ERROR` level containing the tool name is emitted by `mcp.server.mcpserver.server`.