### PR TITLE
Bump conformance harness to 0.2.0-alpha.11

### DIFF
--- a/.github/actions/conformance/client.py
+++ b/.github/actions/conformance/client.py
@@ -11,16 +11,18 @@ Contract:
       --spec-version is omitted the harness picks per-scenario (LATEST_SPEC_VERSION
       for active scenarios, DRAFT_PROTOCOL_VERSION for draft-only ones).
     - Server URL as last CLI argument (sys.argv[1])
-    - Must exit 0 within 30 seconds
+    - Must exit 0 within the harness --timeout (CI passes 60s; the default is 30s)
 
 Scenarios:
     initialize                              - Connect, initialize, list tools, close
     tools_call                              - Connect, call add_numbers(a=5, b=3), close
     sse-retry                               - Connect, call test_reconnection, close
     json-schema-ref-no-deref                - Connect, list tools (no $ref deref)
+    json-schema-2020-12-preservation        - List tools, echo the focal inputSchema back verbatim
     request-metadata                        - Connect with all callbacks; client stamps _meta
     http-standard-headers                   - Connect, call a tool (Mcp-* headers checked)
     http-invalid-tool-headers               - List tools, call every surfaced tool (x-mcp-header filter)
+    http-custom-headers                     - Replay the harness's toolCalls (x-mcp-header -> Mcp-Param-*)
     elicitation-sep1034-client-defaults     - Elicitation with default accept callback
     sep-2322-client-request-state           - Drive the MRTR auto-loop (SEP-2322)
     auth/client-credentials-jwt             - Client credentials with private_key_jwt
@@ -250,6 +252,21 @@ async def run_json_schema_ref_no_deref(server_url: str) -> None:
     """
     async with Client(server_url, mode="legacy") as client:
         await client.list_tools()
+
+
+@register("json-schema-2020-12-preservation")
+async def run_json_schema_2020_12_preservation(server_url: str) -> None:
+    """List tools, then echo the focal tool's inputSchema back verbatim (SEP-1613 / SEP-2106).
+
+    The harness diffs what the client round-trips through `json_schema_echo` against its
+    fixture to detect 2020-12 keywords ($schema, $defs, $anchor, additionalProperties,
+    allOf/anyOf, if/then/else) being stripped while parsing tools/list. Unlike
+    json-schema-ref-no-deref, this mock is version-aware, so client_mode() applies.
+    """
+    async with Client(server_url, mode=client_mode()) as client:
+        listed = await client.list_tools()
+        focal = next(tool for tool in listed.tools if tool.name == "json_schema_2020_12_tool")
+        await client.call_tool("json_schema_echo", {"schema": focal.input_schema})
 
 
 @register("tools_call")

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -17,7 +17,7 @@ env:
   # Pinned conformance harness package spec (passed verbatim to `npx --yes`).
   # Bump deliberately and reconcile both
   # .github/actions/conformance/expected-failures*.yml files in the same change.
-  CONFORMANCE_PKG: "@modelcontextprotocol/conformance@0.2.0-alpha.10"
+  CONFORMANCE_PKG: "@modelcontextprotocol/conformance@0.2.0-alpha.11"
 
 jobs:
   server-conformance:


### PR DESCRIPTION
Bumps the pinned conformance harness from `0.2.0-alpha.10` to [`0.2.0-alpha.11`](https://github.com/modelcontextprotocol/conformance/pull/448) and adds the one client fixture handler the new release needs.

## Motivation and Context

alpha.11 is the harness the current SDK tier round is scored with. Relative to alpha.10 it adds JSON-schema validation of every wire message ([conformance#399](https://github.com/modelcontextprotocol/conformance/pull/399)), a `server-session-lifecycle` scenario ([#322](https://github.com/modelcontextprotocol/conformance/pull/322)), a best-effort `DELETE` after each stateful server scenario ([#316](https://github.com/modelcontextprotocol/conformance/pull/316)), a frozen `--requirements <revision>` mode ([#447](https://github.com/modelcontextprotocol/conformance/pull/447)), and one new client scenario, `json-schema-2020-12-preservation` ([#335](https://github.com/modelcontextprotocol/conformance/pull/335)).

Only the last one needs a change here. The scenario lists tools and expects the client to echo the focal tool's `inputSchema` back through `json_schema_echo`, so the harness can detect 2020-12 keywords (`$schema`, `$defs`, `$anchor`, `additionalProperties`, `allOf`/`anyOf`, `if`/`then`/`else`) being stripped in transit. `client.py` had no handler, so both client legs failed with "Unknown scenario". With the handler it passes 9/9 (including the new `wire-schema-valid` check) at the default, 2025-11-25 and 2026-07-28 wires — `Tool.input_schema` is a plain dict, nothing is dropped.

No baseline entries change. The nine `tasks-*` server entries and the nine per-check DPoP/WIF client entries fail check-for-check as before; `tasks-status-notifications` still emits no checks and stays out.

Also fixes two bits of docstring drift in `client.py` (the exit budget is the harness `--timeout`, and `http-custom-headers` was missing from the scenario list).

## How Has This Been Tested?

All six CI legs run locally through `run-server.sh` / `run-client.sh` against a build of conformance `c321dd3` (its `dist/index.js` is byte-identical to the published alpha.11 tarball):

| Leg | Result |
|---|---|
| server `--suite active` | 73 passed / 0 failed (new `server-session-lifecycle` 3/3; 31 teardown DELETEs, all 200) |
| server `--suite draft` | 103 / 0 |
| server `--suite all --spec-version 2026-07-28` | 151 / 0 |
| server `--suite all` | 204 / 25 — the nine `tasks-*`, all expected, none stale |
| client `--suite all` | 458 / 9 — the nine per-check DPoP/WIF entries, all expected; no solo re-run needed |
| client `--suite all --spec-version 2026-07-28` | 381 / 0 |

Reviewers will see one extra `wire-schema-valid` row per instrumented scenario and ~31 `DELETE /mcp 200` lines per stateful server leg in the logs; both are expected.

For reference, main also scores 30/30 + 37/37 (server) and 18/18 + 32/32 (client) on the new `--requirements 2025-11-25` / `--requirements 2026-07-28` sets. Wiring those in as CI legs is a follow-up.

## Breaking Changes

None. CI-only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
