### PR TITLE
Stop framing breaking changes as a workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,13 @@
 
 - `main` is the current stable line (v2); releases are cut from it (see
   `RELEASE.md`).
-- Removing or replacing an API must be intentional, and what shipped in 2.x
-  is public surface. Adding a replacement API or `@deprecated` shim is
-  likewise a deliberate design choice, not bolted on for free.
-- Changes that break code written against v1 (including those softened by a
-  backwards-compatibility shim) must be documented in `docs/migration.md`.
+- v2 is released; its public API is a compatibility contract for the 2.x
+  line. Removals, renames, or any change to an existing API's signature or
+  observable behaviour (including ones softened by a `@deprecated` shim) is a
+  design decision a maintainer makes explicitly, and should generally be
+  avoided.
+- `docs/migration.md` is the v1 → v2 record and is closed to new entries.
+  Correcting errors or improving clarity in what's there is fine.
 - `v1.x` is the maintenance branch for the previous major. Backport PRs
   target it and use a `[v1.x]` title prefix; only critical bug fixes and
   security fixes land there.
@@ -127,18 +129,6 @@ What the existing pragmas mean:
   others.
 - `# pragma: no branch` — excludes branch arcs only. coverage.py misreports the
   `->exit` arc for nested `async with` on Python 3.11+ (worse on 3.14/Windows).
-
-## Breaking Changes
-
-When making breaking changes, document them in `docs/migration.md` — including
-changes softened by a backwards-compatibility shim. Include:
-
-- What changed
-- Why it changed
-- How to migrate existing code
-
-Search for related sections in the migration guide and group related changes together
-rather than adding new standalone sections.
 
 ## Documentation
 


### PR DESCRIPTION
Rewords the two places in `AGENTS.md` that still framed breaking changes as a documented workflow, now that 2.x is the released stable line.

## Motivation and Context

The Branching Model bullets ("removing or replacing an API must be intentional… changes that break code written against v1 must be documented in `docs/migration.md`") and the `## Breaking Changes` section were written while v2 was being assembled. Read today they nudge an agent toward "breaking public API is fine as long as it's written up in the migration guide", and treat `docs/migration.md` as a live document to append to.

This PR states the 2.x compatibility contract in one bullet (changes to existing public API are an explicit maintainer decision and generally avoided), marks `docs/migration.md` as the finished v1 → v2 record that's closed to new entries, and drops the `## Breaking Changes` section, which only existed to describe how to add to that file.

## How Has This Been Tested?

`pre-commit run --files AGENTS.md` (markdownlint) passes. No code changes.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

`CONTRIBUTING.md` still tells human contributors that `main` takes "New APIs, refactors" with no stability caveat; left for a follow-up so this stays scoped to agent guidance.
