### PR TITLE
fix(mcpserver): ignore the return annotation when finding the context parameter

### DIFF
--- a/src/mcp/server/mcpserver/utilities/context_injection.py
+++ b/src/mcp/server/mcpserver/utilities/context_injection.py
@@ -29,6 +29,10 @@ def find_context_parameter(fn: Callable[..., Any]) -> str | None:
         # If we can't resolve type hints, we can't find the context parameter
         return None
 
+    # `get_type_hints` reports the return annotation under the "return" key, which is
+    # not a parameter and must not be mistaken for one.
+    hints.pop("return", None)
+
     # Check each parameter's type hint
     for param_name, annotation in hints.items():
         # Handle direct Context type

--- a/tests/server/mcpserver/test_context_injection.py
+++ b/tests/server/mcpserver/test_context_injection.py
@@ -1,0 +1,90 @@
+"""Tests for context parameter discovery and injection."""
+
+from mcp_types import TextContent, TextResourceContents
+
+from mcp.client.client import Client
+from mcp.server.mcpserver import Context, MCPServer
+from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
+
+
+def test_context_parameter_is_found_by_its_annotation() -> None:
+    """SDK-defined: a parameter annotated with `Context` is the one context is injected into."""
+
+    def fn(value: int, ctx: Context) -> str:
+        raise NotImplementedError
+
+    assert find_context_parameter(fn) == "ctx"
+
+
+def test_context_return_annotation_is_not_reported_as_a_parameter() -> None:
+    """SDK-defined: a `Context` return annotation is not a parameter, so nothing is injected."""
+
+    def fn(value: int) -> Context:
+        raise NotImplementedError
+
+    assert find_context_parameter(fn) is None
+
+
+def test_context_in_a_union_return_annotation_is_not_reported_as_a_parameter() -> None:
+    """SDK-defined: a union return annotation mentioning `Context` is still not a parameter."""
+
+    def fn(value: int) -> Context | None:
+        raise NotImplementedError
+
+    assert find_context_parameter(fn) is None
+
+
+def test_context_parameter_wins_over_a_context_return_annotation() -> None:
+    """SDK-defined: the real parameter is found even when the return annotation is also `Context`."""
+
+    def fn(ctx: Context) -> Context:
+        raise NotImplementedError
+
+    assert find_context_parameter(fn) == "ctx"
+
+
+async def test_tool_returning_context_is_called_with_only_its_own_arguments() -> None:
+    """A tool whose return annotation mentions `Context` runs without a spurious `return` argument."""
+    server = MCPServer("test")
+
+    @server.tool()
+    def maybe_context(value: int) -> Context | str:
+        return f"got {value}"
+
+    async with Client(server) as client:
+        result = await client.call_tool("maybe_context", {"value": 7})
+
+    assert result.is_error is False
+    assert result.structured_content == {"result": "got 7"}
+
+
+async def test_prompt_returning_context_is_called_with_only_its_own_arguments() -> None:
+    """A prompt whose return annotation mentions `Context` runs without a spurious `return` argument."""
+    server = MCPServer("test")
+
+    @server.prompt()
+    def maybe_context(value: str) -> Context | str:
+        return f"got {value}"
+
+    async with Client(server) as client:
+        result = await client.get_prompt("maybe_context", {"value": "seven"})
+
+    content = result.messages[0].content
+    assert isinstance(content, TextContent)
+    assert content.text == "got seven"
+
+
+async def test_resource_template_returning_context_is_called_with_only_its_own_arguments() -> None:
+    """A resource template whose return annotation mentions `Context` runs without a spurious `return`."""
+    server = MCPServer("test")
+
+    @server.resource("res://{value}")
+    def maybe_context(value: str) -> Context | str:
+        return f"got {value}"
+
+    async with Client(server) as client:
+        result = await client.read_resource("res://seven")
+
+    contents = result.contents[0]
+    assert isinstance(contents, TextResourceContents)
+    assert contents.text == "got seven"


### PR DESCRIPTION
Fixes #3298

## What's wrong

`find_context_parameter()` loops over everything `typing.get_type_hints()` returns. That
mapping includes the function's return annotation under the special `"return"` key, which
isn't a parameter.

So a handler annotated `-> Context` (or a union containing it) gets recorded as having a
context parameter named `"return"`, and the context is injected under that name when the
handler is called. `return` is a keyword and can't be declared as a parameter, so the call
always fails — registration succeeds and the breakage only shows up at invocation time.

It isn't only tools: prompts and resource templates resolve their context through the same
function. Reverting just `context_injection.py` and exercising one of each:

```
TOOL     is_error: True | Error executing tool tool_fn: tool_fn() got an unexpected keyword
argument 'return'
PROMPT   RAISED: MCPError Internal server error
RESOURCE RAISED: MCPError Error creating resource from template res://x
```

## The fix

Drop the `"return"` key before scanning the hints, so only real parameters are considered.

## Why this should be safe

Every path that previously resolved to `"return"` failed at invocation, so nothing could
have been depending on it — this only turns a guaranteed failure into working behaviour.

Handlers that have both a real `Context` parameter and a `Context` return annotation were
already fine, because `get_type_hints()` yields parameters before `return` (you get
`['a', 'ctx', 'b', 'return']` for `def f(a, ctx, b) -> Context`). I've pinned that ordering
in a test so a later refactor can't quietly break it.

## Tests

New `tests/server/mcpserver/test_context_injection.py`:

- the positive path (a parameter annotated `Context` is found)
- `-> Context` isn't reported as a parameter
- `-> Context | None` isn't reported as a parameter
- a real `Context` parameter still wins when the return annotation is also `Context`
- end-to-end through `Client(server)` for a tool, a prompt and a resource template

Five of the seven fail without the `src/` change.

`./scripts/test` passes (100% branch coverage, `strict-no-cover` clean), ruff and pyright
are clean on the changed files, and the new tests pass on 3.10 and 3.14.

## Related PRs

No overlap with #3236 or #2623, which touch the same module for unrelated reasons. I
test-merged both against this branch and neither conflicts.

---

_Disclosure: I used AI assistance (Claude Code) for this change. I've reviewed it myself
and can explain it._