### PR TITLE
fix(server): deregister terminated streamable HTTP sessions

### DIFF
--- a/src/mcp/server/streamable_http_manager.py
+++ b/src/mcp/server/streamable_http_manager.py
@@ -281,6 +281,9 @@ class StreamableHTTPSessionManager:
             if transport.idle_scope is not None and self.session_idle_timeout is not None:
                 transport.idle_scope.deadline = anyio.current_time() + self.session_idle_timeout  # pragma: no cover
             await transport.handle_request(scope, receive, send)
+            if transport.is_terminated:
+                self._server_instances.pop(request_mcp_session_id, None)
+                self._session_owners.pop(request_mcp_session_id, None)
             return
 
         if request_mcp_session_id is None:

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -305,6 +305,36 @@ async def test_stateful_session_cleanup_on_graceful_exit(running_manager: tuple[
 
 
 @pytest.mark.anyio
+async def test_terminated_existing_session_is_removed_from_registry(
+    running_manager: tuple[StreamableHTTPSessionManager, Server],
+):
+    manager, _app = running_manager
+    session_id = "terminated-session"
+    transport = AsyncMock()
+    transport.is_terminated = True
+    transport.idle_scope = None
+    manager._server_instances[session_id] = transport
+
+    scope = {
+        "type": "http",
+        "method": "DELETE",
+        "path": "/mcp",
+        "headers": [(MCP_SESSION_ID_HEADER.encode(), session_id.encode())],
+    }
+
+    async def mock_receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def mock_send(_message: Message):
+        pass
+
+    await manager.handle_request(scope, mock_receive, mock_send)
+
+    assert session_id not in manager._server_instances
+    assert session_id not in manager._session_owners
+
+
+@pytest.mark.anyio
 async def test_stateful_session_cleanup_on_exception(running_manager: tuple[StreamableHTTPSessionManager, Server]):
     manager, _app = running_manager
 

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import anyio
@@ -288,10 +288,6 @@ async def test_stateful_session_cleanup_on_graceful_exit(running_manager: tuple[
                 break
 
     assert session_id is not None, "Session ID not found in response headers"
-
-    # Seed the owner registry so this assertion verifies that the cleanup path
-    # removes the session owner as well as the server instance.
-    manager._session_owners[session_id] = cast(Any, None)
 
     mock_serve.assert_called_once()
 

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import anyio
@@ -288,6 +288,10 @@ async def test_stateful_session_cleanup_on_graceful_exit(running_manager: tuple[
                 break
 
     assert session_id is not None, "Session ID not found in response headers"
+
+    # Seed the owner registry so this assertion verifies that the cleanup path
+    # removes the session owner as well as the server instance.
+    manager._session_owners[session_id] = cast(Any, None)
 
     mock_serve.assert_called_once()
 

--- a/tests/server/test_streamable_http_manager.py
+++ b/tests/server/test_streamable_http_manager.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import anyio
@@ -314,6 +314,7 @@ async def test_terminated_existing_session_is_removed_from_registry(
     transport.is_terminated = True
     transport.idle_scope = None
     manager._server_instances[session_id] = transport
+    manager._session_owners[session_id] = cast(Any, None)
 
     scope = {
         "type": "http",


### PR DESCRIPTION
## Summary

- remove terminated existing sessions from both session registries immediately after handling the request
- add a regression test for the clean DELETE/session termination path

Fixes #3300

## Scope

- The fix is for the handshake-era streamable HTTP path. Released `mcp` 1.29.0 has no modern request handler, so clients negotiating a newer protocol version still use the affected handshake path there.
- This is not mitigated through the public server APIs: `session_idle_timeout` is not accepted by `streamable_http_app()` or `MCPServer`, and FastMCP does not expose it either. Deployments using those APIs cannot configure the idle reaper without reaching into lower-level internals.

## Validation

- `uv run --frozen ruff format ...`
- `uv run --frozen ruff check src/mcp/server/streamable_http_manager.py tests/server/test_streamable_http_manager.py`
- `uv run --frozen pyright src/mcp/server/streamable_http_manager.py tests/server/test_streamable_http_manager.py`
- `uv run --frozen pytest tests/server/test_streamable_http_manager.py -q` (31 passed)
- `git diff --check`