### PR TITLE
Preserve exception chains with raise ... from

### DIFF
--- a/src/mcp/client/auth/utils.py
+++ b/src/mcp/client/auth/utils.py
@@ -424,4 +424,4 @@ async def handle_token_response_scopes(
         token_response = OAuthToken.model_validate_json(content)
         return token_response
     except ValidationError as e:  # pragma: no cover
-        raise OAuthTokenError(f"Invalid token response: {e}")
+        raise OAuthTokenError(f"Invalid token response: {e}") from e

--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -1131,7 +1131,7 @@ class ClientSession:
         try:
             validator_cls.check_schema(output_schema)
         except SchemaError as e:
-            raise RuntimeError(f"Invalid schema for tool {name}: {e}")
+            raise RuntimeError(f"Invalid schema for tool {name}: {e}") from e
         # jsonschema ships no `py.typed`, so pyright reads typeshed's stub, which declares
         # `registry` as required (concrete validators default it); cast to a schema-only ctor.
         validator = cast("Callable[[dict[str, Any]], Validator]", validator_cls)(output_schema)

--- a/src/mcp/server/auth/middleware/client_auth.py
+++ b/src/mcp/server/auth/middleware/client_auth.py
@@ -80,8 +80,8 @@ class ClientAuthenticator:
 
                 if basic_client_id != client_id:
                     raise AuthenticationError("Client ID mismatch in Basic auth")
-            except (ValueError, UnicodeDecodeError, binascii.Error):
-                raise AuthenticationError("Invalid Basic authentication header")
+            except (ValueError, UnicodeDecodeError, binascii.Error) as e:
+                raise AuthenticationError("Invalid Basic authentication header") from e
 
         elif client.token_endpoint_auth_method == "client_secret_post":
             raw_form_data = form_data.get("client_secret")

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -197,4 +197,4 @@ class Prompt(BaseModel):
         except MCPError:
             raise
         except Exception as e:
-            raise ValueError(f"Error rendering prompt {self.name}: {e}")
+            raise ValueError(f"Error rendering prompt {self.name}: {e}") from e

--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -106,7 +106,7 @@ class FunctionResource(Resource):
         except MCPError:
             raise
         except Exception as e:
-            raise ValueError(f"Error reading resource {self.uri}: {e}")
+            raise ValueError(f"Error reading resource {self.uri}: {e}") from e
 
     @classmethod
     def from_function(
@@ -188,7 +188,7 @@ class FileResource(Resource):
                 return await anyio.to_thread.run_sync(self.path.read_bytes)
             return await anyio.to_thread.run_sync(partial(self.path.read_text, encoding=self.encoding))
         except Exception as e:
-            raise ValueError(f"Error reading file {self.path}: {e}")
+            raise ValueError(f"Error reading file {self.path}: {e}") from e
 
 
 class HttpResource(Resource):
@@ -233,7 +233,7 @@ class DirectoryResource(Resource):
                 return list(self.path.glob(self.pattern)) if not self.recursive else list(self.path.rglob(self.pattern))
             return list(self.path.glob("*")) if not self.recursive else list(self.path.rglob("*"))
         except Exception as e:
-            raise ValueError(f"Error listing directory {self.path}: {e}")
+            raise ValueError(f"Error listing directory {self.path}: {e}") from e
 
     async def read(self) -> str:  # Always returns JSON string  # pragma: no cover
         """Read the directory listing."""
@@ -242,4 +242,4 @@ class DirectoryResource(Resource):
             file_list = [str(f.relative_to(self.path)) for f in files if f.is_file()]
             return json.dumps({"files": file_list}, indent=2)
         except Exception as e:
-            raise ValueError(f"Error reading directory {self.path}: {e}")
+            raise ValueError(f"Error reading directory {self.path}: {e}") from e

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -435,9 +435,9 @@ class MCPServer(Generic[LifespanResultT]):
         try:
             results = await self.read_resource(params.uri, context)
         except ResourceNotFoundError as err:
-            raise MCPError(code=INVALID_PARAMS, message=str(err), data={"uri": str(params.uri)})
+            raise MCPError(code=INVALID_PARAMS, message=str(err), data={"uri": str(params.uri)}) from err
         except ResourceError as err:
-            raise MCPError(code=INTERNAL_ERROR, message=str(err), data={"uri": str(params.uri)})
+            raise MCPError(code=INTERNAL_ERROR, message=str(err), data={"uri": str(params.uri)}) from err
         if isinstance(results, InputRequiredResult):
             return results
         contents: list[TextResourceContents | BlobResourceContents] = []


### PR DESCRIPTION
## Summary

- Adds `from` clause to 11 `raise` statements that catch one exception and raise another, preserving the original traceback and `__cause__`
- Without `from`, Python shows "During handling of the above exception, another exception occurred" instead of "The above exception was the direct cause of the following exception", and callers cannot inspect `__cause__` to determine the root cause programmatically
- Follows the pattern established in #2542 for the remaining sites

### Files changed

| File | Change |
|------|--------|
| `client/session.py` | `SchemaError` → `RuntimeError` |
| `client/auth/utils.py` | `ValidationError` → `OAuthTokenError` |
| `server/auth/middleware/client_auth.py` | `ValueError`/`UnicodeDecodeError`/`binascii.Error` → `AuthenticationError` |
| `server/mcpserver/resources/types.py` | `Exception` → `ValueError` (4 sites) |
| `server/mcpserver/server.py` | `ResourceNotFoundError` → `MCPError`, `ResourceError` → `MCPError` |
| `server/mcpserver/prompts/base.py` | `Exception` → `ValueError` |

## Related issue

Fixes #2564

## Verification

- Mechanical change only — appends `from e`/`from err`/`from exc` to existing `raise` statements
- No behavioral change; exception messages remain identical
- Some sites listed in #2564 were already fixed on current `main` (resource_manager.py, templates.py, resolve.py); this PR covers the remaining 11