### PR TITLE
docs: lead the README client example with a URL, not the server object

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-A URL means Streamable HTTP, the transport you deploy. `Client` can also launch a local server as a stdio subprocess or take any custom transport, and in tests you hand it the server object itself (`Client(mcp)`): no process, no port. [Clients](https://py.sdk.modelcontextprotocol.io/client/) has the rest.
+A URL means Streamable HTTP, the transport you deploy. `Client` can also launch a local server as a stdio subprocess or take any custom transport; [Clients](https://py.sdk.modelcontextprotocol.io/client/) has the rest.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -86,18 +86,22 @@ Notice what you did **not** write: no JSON Schema (`a: int, b: int` _is_ the sch
 
 ## A client in 10 lines
 
-The same package is a full MCP **client**. `Client` connects to a URL, a stdio subprocess, a custom transport, or (for tests) straight to a server object in memory with no transport at all:
+The same package is a full MCP **client**. Serve `server.py` over HTTP:
+
+```bash
+uv run mcp run server.py --transport streamable-http
+```
+
+then point a `Client` at it:
 
 ```python
 import asyncio
 
 from mcp import Client
 
-from server import mcp
-
 
 async def main() -> None:
-    async with Client(mcp) as client:
+    async with Client("http://localhost:8000/mcp") as client:
         result = await client.call_tool("add", {"a": 1, "b": 2})
         print(result.structured_content)  # {'result': 3}
 
@@ -105,7 +109,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-Swap `mcp` for a URL like `"http://localhost:8000/mcp"` and the exact same code talks to a server over HTTP.
+A URL means Streamable HTTP, the transport you deploy. `Client` can also launch a local server as a stdio subprocess or take any custom transport, and in tests you hand it the server object itself (`Client(mcp)`): no process, no port. [Clients](https://py.sdk.modelcontextprotocol.io/client/) has the rest.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-Swap `mcp` for `"http://localhost:8000/mcp"` and the exact same code talks to a remote server.
+Swap `mcp` for a URL like `"http://localhost:8000/mcp"` and the exact same code talks to a server over HTTP.
 
 ## Contributing
 

--- a/src/mcp/cli/cli.py
+++ b/src/mcp/cli/cli.py
@@ -311,7 +311,7 @@ def run(
         typer.Option(
             "--transport",
             "-t",
-            help="Transport protocol to use (stdio or sse)",
+            help="Transport protocol to use (stdio, sse, or streamable-http)",
         ),
     ] = None,
 ) -> None:  # pragma: no cover


### PR DESCRIPTION
Reworks the README's "A client in 10 lines" so the first client a reader sees connects the way a real program does: serve the `server.py` from the section above with `uv run mcp run server.py --transport streamable-http`, then `Client("http://localhost:8000/mcp")`. The closing sentence mentions stdio and custom transports and links to the Clients docs; in-memory is left to the Testing page.

Also fixes the `mcp run --transport` help text, which still said "stdio or sse" even though `streamable-http` is accepted (and is what the README now tells you to run).

## Motivation and Context

Started as #3313 (calling a localhost URL a "remote server" read oddly). Looking at it more closely, the bigger problem was that the example imported the server object and connected in-process, then offered the URL as the variation. In-process is a testing convenience, not how anyone connects to a real server, so the landing example shouldn't lead with it.

Closes #3313

## How Has This Been Tested?

Ran the README verbatim: extracted the server block, the `mcp run ... --transport streamable-http` line and the client block into a scratch directory, started the server with that exact command (listens on `127.0.0.1:8000/mcp`), ran the client, got `{'result': 3}`. Also checked `localhost` vs `127.0.0.1`, a second run against the same server, and that `mcp run --help` shows the new text. `pre-commit run --files README.md src/mcp/cli/cli.py` passes.

## Breaking Changes

None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The docs site has the same lean in more places (the Clients section leads with in-memory, several "what `Client` accepts" lists put the server object first). That's a broader docs pass and is deliberately not in this PR.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
