### PR TITLE
MCPServer: content-block returns are unstructured, prompt messages take Image/Audio

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -677,7 +677,7 @@ All submodules under `mcp.server.fastmcp.*` are now under `mcp.server.mcpserver.
 Beyond the changes covered in this section, the everyday `FastMCP` surface carries over to `MCPServer` as-is:
 
 - **Decorators.** `@mcp.tool()`, `@mcp.resource()`, `@mcp.prompt()`, and `@mcp.completion()` take the same arguments and handler signatures as v1. The lowlevel [`on_completion` reshape](#lowlevel-server-decorator-based-handlers-replaced-with-constructor-on_-params) applies only to the lowlevel `Server`; a high-level `@mcp.completion()` handler is still called as `(ref, argument, context)`.
-- **Tool return handling.** A returned `CallToolResult` (including an `Annotated[CallToolResult, YourModel]` output schema, and `_meta`) is passed through, `Image` and `Audio` convert to content blocks as before, ready-made content blocks are kept as-is, and dict, list, scalar, and model returns are wrapped into `content` and `structured_content` by the same rules.
+- **Tool return handling.** A returned `CallToolResult` (including an `Annotated[CallToolResult, YourModel]` output schema, and `_meta`) is passed through, `Image` and `Audio` convert to content blocks as before, ready-made content blocks are kept as-is (neither is [structured by default](#content-block-image-and-audio-return-annotations-are-unstructured) now, even inside a `list`), and dict, list, scalar, and model returns are wrapped into `content` and `structured_content` by the same rules.
 - **Listing and registration methods.** `list_tools()`, `list_resources()`, `list_resource_templates()`, and `list_prompts()` return the same lists and are still what the protocol handlers call, so subclass overrides still take effect. `add_tool()`, `add_resource()`, and `add_prompt()` are unchanged.
 - **Helpers.** `Image.to_image_content()`, `Audio.to_audio_content()`, and the prompt `Message`, `UserMessage`, and `AssistantMessage` classes.
 - **Lifespan.** The `lifespan=` constructor argument and `ctx.request_context.lifespan_context` work as before, and the class is still generic over the lifespan result: `FastMCP[MyState]` becomes `MCPServer[MyState]`. (`Context`'s own type parameters did change; see [`RequestContext` type parameters simplified](#requestcontext-type-parameters-simplified).)
@@ -923,6 +923,22 @@ running on the event-loop thread:
   worker-thread limit.
 
 Declare the handler `async def` to keep it on the event loop.
+
+### Content-block, `Image`, and `Audio` return annotations are unstructured
+
+A tool whose return annotation mentions a content block (`TextContent`,
+`ImageContent`, `AudioContent`, `ResourceLink`, `EmbeddedResource`), `Image`, or
+`Audio` anywhere (alone, or inside a `list`, `tuple`, or union) now registers
+with no `output_schema` and returns no `structured_content`; `content` is built
+exactly as before. v1 (and 2.0) published the block type's own Pydantic schema as
+the tool's `output_schema` and echoed the serialized blocks into
+`structured_content` a second time, while an annotation with `Image` or `Audio`
+inside a generic (`-> list[Image]`) raised at registration (a bare `-> Image` was
+already unstructured).
+
+If a client reads `structured_content` from such a tool, return a model,
+`TypedDict`, or `dict` instead, or pass `structured_output=True` to keep
+publishing a content block's schema.
 
 ### `MCPServer.call_tool()` returns `CallToolResult`
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -668,7 +668,7 @@ All submodules under `mcp.server.fastmcp.*` are now under `mcp.server.mcpserver.
 
 - `Image`, `Audio` — from `mcp.server.mcpserver` (or `.utilities.types`)
 - `Icon` — from `mcp.server.mcpserver` or `mcp.types` (not a top-level `mcp` export); its `mimeType` field is now `mime_type` per the [snake_case renames](#field-names-changed-from-camelcase-to-snake_case), though the `mimeType=` kwarg still constructs
-- `Message`, `UserMessage`, `AssistantMessage` — from `mcp.server.mcpserver.prompts.base`
+- `Message`, `UserMessage`, `AssistantMessage` — from `mcp.server.mcpserver` (or `.prompts.base`)
 - `ToolError`, `ResourceError` — from `mcp.server.mcpserver.exceptions`
 - `MCPServerError` (renamed from `FastMCPError`) — from `mcp.server.mcpserver.exceptions`
 
@@ -678,7 +678,7 @@ Beyond the changes covered in this section, the everyday `FastMCP` surface carri
 
 - **Decorators.** `@mcp.tool()`, `@mcp.resource()`, `@mcp.prompt()`, and `@mcp.completion()` take the same arguments and handler signatures as v1. The lowlevel [`on_completion` reshape](#lowlevel-server-decorator-based-handlers-replaced-with-constructor-on_-params) applies only to the lowlevel `Server`; a high-level `@mcp.completion()` handler is still called as `(ref, argument, context)`.
 - **Tool return handling.** A returned `CallToolResult` (including an `Annotated[CallToolResult, YourModel]` output schema, and `_meta`) is passed through, `Image` and `Audio` convert to content blocks as before, ready-made content blocks are kept as-is (neither is [structured by default](#content-block-image-and-audio-return-annotations-are-unstructured) now, even inside a `list`), and dict, list, scalar, and model returns are wrapped into `content` and `structured_content` by the same rules.
-- **Listing and registration methods.** `list_tools()`, `list_resources()`, `list_resource_templates()`, and `list_prompts()` return the same lists and are still what the protocol handlers call, so subclass overrides still take effect. `add_tool()`, `add_resource()`, and `add_prompt()` are unchanged.
+- **Listing and registration methods.** `list_tools()`, `list_resources()`, `list_resource_templates()`, and `list_prompts()` return the same lists and are still what the protocol handlers call, so subclass overrides still take effect. `add_tool()`, `add_resource()`, and `add_prompt()` are unchanged (`add_prompt()` additionally accepts the plain function, like `add_tool()`).
 - **Helpers.** `Image.to_image_content()`, `Audio.to_audio_content()`, and the prompt `Message`, `UserMessage`, and `AssistantMessage` classes.
 - **Lifespan.** The `lifespan=` constructor argument and `ctx.request_context.lifespan_context` work as before, and the class is still generic over the lifespan result: `FastMCP[MyState]` becomes `MCPServer[MyState]`. (`Context`'s own type parameters did change; see [`RequestContext` type parameters simplified](#requestcontext-type-parameters-simplified).)
 - **Tool internals.** `Tool`, `Tool.from_function()`, `FuncMetadata`, `ArgModelBase`, and `func_metadata()` keep their v1 shapes; the one change is the now-required `context` argument to `Tool.run()`, described [below](#mcpservercall_tool-read_resource-get_prompt-now-accept-a-context-parameter).

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -668,7 +668,7 @@ All submodules under `mcp.server.fastmcp.*` are now under `mcp.server.mcpserver.
 
 - `Image`, `Audio` — from `mcp.server.mcpserver` (or `.utilities.types`)
 - `Icon` — from `mcp.server.mcpserver` or `mcp.types` (not a top-level `mcp` export); its `mimeType` field is now `mime_type` per the [snake_case renames](#field-names-changed-from-camelcase-to-snake_case), though the `mimeType=` kwarg still constructs
-- `Message`, `UserMessage`, `AssistantMessage` — from `mcp.server.mcpserver` (or `.prompts.base`)
+- `Message`, `UserMessage`, `AssistantMessage` — from `mcp.server.mcpserver.prompts.base`
 - `ToolError`, `ResourceError` — from `mcp.server.mcpserver.exceptions`
 - `MCPServerError` (renamed from `FastMCPError`) — from `mcp.server.mcpserver.exceptions`
 
@@ -677,8 +677,8 @@ All submodules under `mcp.server.fastmcp.*` are now under `mcp.server.mcpserver.
 Beyond the changes covered in this section, the everyday `FastMCP` surface carries over to `MCPServer` as-is:
 
 - **Decorators.** `@mcp.tool()`, `@mcp.resource()`, `@mcp.prompt()`, and `@mcp.completion()` take the same arguments and handler signatures as v1. The lowlevel [`on_completion` reshape](#lowlevel-server-decorator-based-handlers-replaced-with-constructor-on_-params) applies only to the lowlevel `Server`; a high-level `@mcp.completion()` handler is still called as `(ref, argument, context)`.
-- **Tool return handling.** A returned `CallToolResult` (including an `Annotated[CallToolResult, YourModel]` output schema, and `_meta`) is passed through, `Image` and `Audio` convert to content blocks as before, ready-made content blocks are kept as-is (neither is [structured by default](#content-block-image-and-audio-return-annotations-are-unstructured) now, even inside a `list`), and dict, list, scalar, and model returns are wrapped into `content` and `structured_content` by the same rules.
-- **Listing and registration methods.** `list_tools()`, `list_resources()`, `list_resource_templates()`, and `list_prompts()` return the same lists and are still what the protocol handlers call, so subclass overrides still take effect. `add_tool()`, `add_resource()`, and `add_prompt()` are unchanged (`add_prompt()` additionally accepts the plain function, like `add_tool()`).
+- **Tool return handling.** A returned `CallToolResult` (including an `Annotated[CallToolResult, YourModel]` output schema, and `_meta`) is passed through, `Image` and `Audio` convert to content blocks as before, ready-made content blocks are kept as-is, and dict, list, scalar, and model returns are wrapped into `content` and `structured_content` by the same rules.
+- **Listing and registration methods.** `list_tools()`, `list_resources()`, `list_resource_templates()`, and `list_prompts()` return the same lists and are still what the protocol handlers call, so subclass overrides still take effect. `add_tool()`, `add_resource()`, and `add_prompt()` are unchanged.
 - **Helpers.** `Image.to_image_content()`, `Audio.to_audio_content()`, and the prompt `Message`, `UserMessage`, and `AssistantMessage` classes.
 - **Lifespan.** The `lifespan=` constructor argument and `ctx.request_context.lifespan_context` work as before, and the class is still generic over the lifespan result: `FastMCP[MyState]` becomes `MCPServer[MyState]`. (`Context`'s own type parameters did change; see [`RequestContext` type parameters simplified](#requestcontext-type-parameters-simplified).)
 - **Tool internals.** `Tool`, `Tool.from_function()`, `FuncMetadata`, `ArgModelBase`, and `func_metadata()` keep their v1 shapes; the one change is the now-required `context` argument to `Tool.run()`, described [below](#mcpservercall_tool-read_resource-get_prompt-now-accept-a-context-parameter).
@@ -923,22 +923,6 @@ running on the event-loop thread:
   worker-thread limit.
 
 Declare the handler `async def` to keep it on the event loop.
-
-### Content-block, `Image`, and `Audio` return annotations are unstructured
-
-A tool whose return annotation mentions a content block (`TextContent`,
-`ImageContent`, `AudioContent`, `ResourceLink`, `EmbeddedResource`), `Image`, or
-`Audio` anywhere (alone, or inside a `list`, `tuple`, or union) now registers
-with no `output_schema` and returns no `structured_content`; `content` is built
-exactly as before. v1 (and 2.0) published the block type's own Pydantic schema as
-the tool's `output_schema` and echoed the serialized blocks into
-`structured_content` a second time, while an annotation with `Image` or `Audio`
-inside a generic (`-> list[Image]`) raised at registration (a bare `-> Image` was
-already unstructured).
-
-If a client reads `structured_content` from such a tool, return a model,
-`TypedDict`, or `dict` instead, or pass `structured_output=True` to keep
-publishing a content block's schema.
 
 ### `MCPServer.call_tool()` returns `CallToolResult`
 

--- a/docs/servers/structured-output.md
+++ b/docs/servers/structured-output.md
@@ -210,7 +210,7 @@ The opposite, `structured_output=True`, turns the automatic detection into a req
 
 ## Content blocks and media
 
-Content blocks and media (`TextContent`, `EmbeddedResource`, `Image`, `Audio` and friends, on their own or as the items of a `list` or `tuple` or the arms of a union) are opted out for you: they are for the model to read, so auto-detection derives no schema from them (**[Images, audio & icons](media.md)** covers `Image` and `Audio`). `structured_output=True` still forces one for the content-block classes.
+Content blocks and media (`TextContent`, `EmbeddedResource`, `Image`, `Audio` and friends, on their own, as the items of a `list`, `tuple` or `Sequence`, or as the arms of a union) are opted out for you: they are for the model to read, so auto-detection derives no schema from them (**[Images, audio & icons](media.md)** covers `Image` and `Audio`). `structured_output=True` still forces one for the content-block classes.
 
 ## A class without type hints
 

--- a/docs/servers/structured-output.md
+++ b/docs/servers/structured-output.md
@@ -208,9 +208,13 @@ No `output_schema`, no wrapping, no validation. `structured_content` is `None` a
 
 The opposite, `structured_output=True`, turns the automatic detection into a requirement: a tool whose return type can't produce a schema raises at import time instead of falling back to text.
 
+## Content blocks and media
+
+Content blocks and media (`TextContent`, `EmbeddedResource`, `Image`, `Audio` and friends, on their own or as the items of a `list` or `tuple` or the arms of a union) are opted out for you: they are for the model to read, so auto-detection derives no schema from them (**[Images, audio & icons](media.md)** covers `Image` and `Audio`). `structured_output=True` still forces one for the content-block classes.
+
 ## A class without type hints
 
-Content blocks and media (`TextContent`, `EmbeddedResource`, `Image`, `Audio` and friends, alone or inside a `list` or union) are not structured automatically: they are for the model to read (**[Images, audio & icons](media.md)** covers `Image` and `Audio`). Beyond those, there is one way to end up unstructured without asking for it: return a class that has **no annotations on its body**.
+There is one way to end up unstructured without asking for it: return a class that has **no annotations on its body**.
 
 ```python title="server.py" hl_lines="6-9"
 --8<-- "docs_src/structured_output/tutorial009.py"

--- a/docs/servers/structured-output.md
+++ b/docs/servers/structured-output.md
@@ -210,7 +210,7 @@ The opposite, `structured_output=True`, turns the automatic detection into a req
 
 ## A class without type hints
 
-There is one way to end up unstructured without asking for it: return a class that has **no annotations on its body**.
+Content blocks and media (`TextContent`, `EmbeddedResource`, `Image`, `Audio` and friends, alone or inside a `list` or union) are not structured automatically: they are for the model to read (**[Images, audio & icons](media.md)** covers `Image` and `Audio`). Beyond those, there is one way to end up unstructured without asking for it: return a class that has **no annotations on its body**.
 
 ```python title="server.py" hl_lines="6-9"
 --8<-- "docs_src/structured_output/tutorial009.py"
@@ -240,6 +240,6 @@ There is one way to end up unstructured without asking for it: return a class th
 * Scalars, lists, tuples and unions are wrapped in `{"result": ...}`. Models, `TypedDict`s, dataclasses, annotated classes and `dict[str, ...]` are objects already and stay as they are.
 * Every result carries `content` (text, for the model) **and** `structured_content` (data, for the application).
 * What you return is validated against the schema. A mismatch is a tool error, not a corrupt result.
-* `structured_output=False` opts a tool out. A class without type hints opts out silently; watch for it.
+* `structured_output=False` opts a tool out. Content blocks, `Image` and `Audio` opt out by default; a class without type hints opts out silently, so watch for it.
 
 You now own everything a tool can say back. Next, the second primitive: **[Resources](resources.md)**.

--- a/src/mcp/client/client.py
+++ b/src/mcp/client/client.py
@@ -946,5 +946,4 @@ class Client:
     @deprecated("The roots capability is deprecated as of 2026-07-28 (SEP-2577).", category=MCPDeprecationWarning)
     async def send_roots_list_changed(self) -> None:
         """Send a notification that the roots list has changed."""
-        # TODO(Marcelo): Currently, there is no way for the server to handle this. We should add support.
         await self.session.send_roots_list_changed()  # pyright: ignore[reportDeprecated]

--- a/src/mcp/server/mcpserver/__init__.py
+++ b/src/mcp/server/mcpserver/__init__.py
@@ -13,6 +13,7 @@ from mcp.server.request_state import (
 )
 
 from .context import Context
+from .prompts.base import AssistantMessage, Message, UserMessage
 from .resolve import (
     AcceptedElicitation,
     CancelledElicitation,
@@ -32,6 +33,9 @@ __all__ = [
     "Context",
     "Image",
     "Audio",
+    "Message",
+    "UserMessage",
+    "AssistantMessage",
     "Icon",
     "Resolve",
     "Elicit",

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -114,10 +114,9 @@ class Prompt(BaseModel):
         if context_kwarg is None:  # pragma: no branch
             context_kwarg = find_context_parameter(fn)
 
-        # Get schema from func_metadata, excluding context parameter
+        # Only the argument model is needed; a prompt has no output schema to derive
         func_arg_metadata = func_metadata(
-            fn,
-            skip_names=[context_kwarg] if context_kwarg is not None else [],
+            fn, skip_names=[context_kwarg] if context_kwarg is not None else [], structured_output=False
         )
         parameters = func_arg_metadata.arg_model.model_json_schema()
 

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Awaitable, Callable, Sequence
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import anyio.to_thread
 import pydantic_core
@@ -60,7 +60,11 @@ class AssistantMessage(Message):
         super().__init__(content=content, **kwargs)
 
 
-message_validator = TypeAdapter[UserMessage | AssistantMessage](UserMessage | AssistantMessage)
+# Both classes accept either role, so the first arm always matches: validate left to right rather than
+# trying both (which converted - and for path-backed Image/Audio, read - the content twice).
+message_validator: TypeAdapter[UserMessage | AssistantMessage] = TypeAdapter(
+    Annotated[UserMessage | AssistantMessage, Field(union_mode="left_to_right")]
+)
 
 _PromptResultItem = str | ContentBlock | Image | Audio | Message | dict[str, Any]
 SyncPromptResult = _PromptResultItem | InputRequiredResult | Sequence[_PromptResultItem]
@@ -188,18 +192,15 @@ class Prompt(BaseModel):
             # Convert result to messages
             messages: list[Message] = []
             for msg in result:  # type: ignore[reportUnknownVariableType]
-                try:
-                    if isinstance(msg, Message):
-                        messages.append(msg)
-                    elif isinstance(msg, dict):
-                        messages.append(message_validator.validate_python(msg))
-                    elif isinstance(msg, str | ContentBlock | Image | Audio):  # bare content is one user message
-                        messages.append(UserMessage(msg))
-                    else:  # pragma: no cover
-                        content = pydantic_core.to_json(msg, fallback=str, indent=2).decode()
-                        messages.append(Message(role="user", content=content))
-                except Exception:  # pragma: no cover
-                    raise ValueError(f"Could not convert prompt result to message: {msg}")
+                if isinstance(msg, Message):
+                    messages.append(msg)
+                elif isinstance(msg, dict):
+                    messages.append(message_validator.validate_python(msg))
+                elif isinstance(msg, str | ContentBlock | Image | Audio):  # bare content is one user message
+                    messages.append(UserMessage(msg))
+                else:  # pragma: no cover
+                    content = pydantic_core.to_json(msg, fallback=str, indent=2).decode()
+                    messages.append(Message(role="user", content=content))
 
             return messages
         except MCPError:

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -62,7 +62,8 @@ class AssistantMessage(Message):
 
 message_validator = TypeAdapter[UserMessage | AssistantMessage](UserMessage | AssistantMessage)
 
-SyncPromptResult = str | Message | dict[str, Any] | InputRequiredResult | Sequence[str | Message | dict[str, Any]]
+_PromptResultItem = str | ContentBlock | Image | Audio | Message | dict[str, Any]
+SyncPromptResult = _PromptResultItem | InputRequiredResult | Sequence[_PromptResultItem]
 PromptResult = SyncPromptResult | Awaitable[SyncPromptResult]
 
 
@@ -98,7 +99,7 @@ class Prompt(BaseModel):
         """Create a Prompt from a function.
 
         The function can return:
-        - A string (converted to a message)
+        - A string, content block, `Image` or `Audio` (each becomes a user message)
         - A Message object
         - A dict (converted to a message)
         - A sequence of any of the above
@@ -192,9 +193,8 @@ class Prompt(BaseModel):
                         messages.append(msg)
                     elif isinstance(msg, dict):
                         messages.append(message_validator.validate_python(msg))
-                    elif isinstance(msg, str):
-                        content = TextContent(type="text", text=msg)
-                        messages.append(UserMessage(content=content))
+                    elif isinstance(msg, str | ContentBlock | Image | Audio):  # bare content is one user message
+                        messages.append(UserMessage(msg))
                     else:  # pragma: no cover
                         content = pydantic_core.to_json(msg, fallback=str, indent=2).decode()
                         messages.append(Message(role="user", content=content))

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field, TypeAdapter, validate_call
 
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter, inject_context
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+from mcp.server.mcpserver.utilities.types import Audio, Image
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.shared.exceptions import MCPError
 
@@ -22,14 +23,22 @@ if TYPE_CHECKING:
 
 
 class Message(BaseModel):
-    """Base class for all prompt messages."""
+    """Base class for all prompt messages.
+
+    `content` may be a plain string (wrapped in `TextContent`), an `Image` or `Audio`
+    helper (converted to `ImageContent` / `AudioContent`), or any ready-made content block.
+    """
 
     role: Literal["user", "assistant"]
     content: ContentBlock
 
-    def __init__(self, content: str | ContentBlock, **kwargs: Any):
+    def __init__(self, content: str | ContentBlock | Image | Audio, **kwargs: Any):
         if isinstance(content, str):
             content = TextContent(type="text", text=content)
+        elif isinstance(content, Image):
+            content = content.to_image_content()
+        elif isinstance(content, Audio):
+            content = content.to_audio_content()
         super().__init__(content=content, **kwargs)
 
 
@@ -38,7 +47,7 @@ class UserMessage(Message):
 
     role: Literal["user", "assistant"] = "user"
 
-    def __init__(self, content: str | ContentBlock, **kwargs: Any):
+    def __init__(self, content: str | ContentBlock | Image | Audio, **kwargs: Any):
         super().__init__(content=content, **kwargs)
 
 
@@ -47,7 +56,7 @@ class AssistantMessage(Message):
 
     role: Literal["user", "assistant"] = "assistant"
 
-    def __init__(self, content: str | ContentBlock, **kwargs: Any):
+    def __init__(self, content: str | ContentBlock | Image | Audio, **kwargs: Any):
         super().__init__(content=content, **kwargs)
 
 

--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -26,7 +26,11 @@ class Message(BaseModel):
     """Base class for all prompt messages.
 
     `content` may be a plain string (wrapped in `TextContent`), an `Image` or `Audio`
-    helper (converted to `ImageContent` / `AudioContent`), or any ready-made content block.
+    helper (converted to `ImageContent` / `AudioContent`, reading the file for path-backed
+    helpers), or any ready-made content block.
+
+    Raises:
+        OSError: If a path-backed `Image` or `Audio` cannot be read.
     """
 
     role: Literal["user", "assistant"]

--- a/src/mcp/server/mcpserver/resources/templates.py
+++ b/src/mcp/server/mcpserver/resources/templates.py
@@ -152,10 +152,9 @@ class ResourceTemplate(BaseModel):
         if context_kwarg is None:  # pragma: no branch
             context_kwarg = find_context_parameter(fn)
 
-        # Get schema from func_metadata, excluding context parameter
+        # Only the argument model is needed; a resource has no output schema to derive
         func_arg_metadata = func_metadata(
-            fn,
-            skip_names=[context_kwarg] if context_kwarg is not None else [],
+            fn, skip_names=[context_kwarg] if context_kwarg is not None else [], structured_output=False
         )
         parameters = func_arg_metadata.arg_model.model_json_schema()
 

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -918,8 +918,8 @@ class MCPServer(Generic[LifespanResultT]):
     ) -> Callable[[_CallableT], _CallableT]:
         """Decorator to register a prompt.
 
-        The function returns the prompt messages (a string, `Message`, dict,
-        or a sequence of these), or an `InputRequiredResult` to request
+        The function returns the prompt messages (a string, content block, `Image`/`Audio`,
+        `Message`, dict, or a sequence of these), or an `InputRequiredResult` to request
         client input first (the 2026-07-28 multi-round-trip flow — read
         `ctx.input_responses` on the retry).
 

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -890,12 +890,47 @@ class MCPServer(Generic[LifespanResultT]):
 
         return decorator
 
-    def add_prompt(self, prompt: Prompt) -> None:
+    @overload
+    def add_prompt(self, prompt: Prompt) -> None: ...
+
+    @overload
+    def add_prompt(
+        self,
+        fn: Callable[..., Any],
+        /,
+        *,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        icons: list[Icon] | None = None,
+    ) -> None: ...
+
+    def add_prompt(
+        self,
+        prompt: Prompt | Callable[..., Any],
+        *,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        icons: list[Icon] | None = None,
+    ) -> None:
         """Add a prompt to the server.
 
+        Pass the function that renders the prompt: its name, docstring and parameters become
+        the prompt's name, description and arguments, exactly as with `@prompt()`. A ready-made
+        `Prompt` instance is registered as-is.
+
         Args:
-            prompt: A Prompt instance to add
+            prompt: The function to register as a prompt, or a `Prompt` instance
+            name: Optional name for the prompt (defaults to the function name)
+            title: Optional human-readable title for the prompt
+            description: Optional description (defaults to the function's docstring)
+            icons: Optional list of icons for the prompt
         """
+        if not isinstance(prompt, Prompt):
+            prompt = Prompt.from_function(prompt, name=name, title=title, description=description, icons=icons)
+        elif any(arg is not None for arg in (name, title, description, icons)):
+            raise TypeError("name, title, description and icons can only be set when registering a function")
         self._prompt_manager.add_prompt(prompt)
 
     def remove_prompt(self, name: str) -> None:

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -890,47 +890,12 @@ class MCPServer(Generic[LifespanResultT]):
 
         return decorator
 
-    @overload
-    def add_prompt(self, prompt: Prompt) -> None: ...
-
-    @overload
-    def add_prompt(
-        self,
-        fn: Callable[..., Any],
-        /,
-        *,
-        name: str | None = None,
-        title: str | None = None,
-        description: str | None = None,
-        icons: list[Icon] | None = None,
-    ) -> None: ...
-
-    def add_prompt(
-        self,
-        prompt: Prompt | Callable[..., Any],
-        *,
-        name: str | None = None,
-        title: str | None = None,
-        description: str | None = None,
-        icons: list[Icon] | None = None,
-    ) -> None:
+    def add_prompt(self, prompt: Prompt) -> None:
         """Add a prompt to the server.
 
-        Pass the function that renders the prompt: its name, docstring and parameters become
-        the prompt's name, description and arguments, exactly as with `@prompt()`. A ready-made
-        `Prompt` instance is registered as-is.
-
         Args:
-            prompt: The function to register as a prompt, or a `Prompt` instance
-            name: Optional name for the prompt (defaults to the function name)
-            title: Optional human-readable title for the prompt
-            description: Optional description (defaults to the function's docstring)
-            icons: Optional list of icons for the prompt
+            prompt: A Prompt instance to add
         """
-        if not isinstance(prompt, Prompt):
-            prompt = Prompt.from_function(prompt, name=name, title=title, description=description, icons=icons)
-        elif any(arg is not None for arg in (name, title, description, icons)):
-            raise TypeError("name, title, description and icons can only be set when registering a function")
         self._prompt_manager.add_prompt(prompt)
 
     def remove_prompt(self, name: str) -> None:

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -33,6 +33,16 @@ def _is_input_required_type(obj: Any) -> bool:
     return isinstance(obj, type) and issubclass(obj, InputRequiredResult)
 
 
+_CONTENT_TYPES = (*get_args(ContentBlock), Image, Audio)
+
+
+def _contains_content_type(tp: Any) -> bool:
+    """Whether `tp` is, or is parameterized by, a content block class or the `Image`/`Audio` helpers."""
+    if get_origin(tp) is not None:
+        return any(_contains_content_type(arg) for arg in get_args(tp))
+    return isinstance(tp, type) and issubclass(tp, _CONTENT_TYPES)
+
+
 class StrictJsonSchema(GenerateJsonSchema):
     """A JSON schema generator that raises exceptions instead of emitting warnings.
 
@@ -222,6 +232,9 @@ def func_metadata(
             - TypedDict - converted to a Pydantic model with same fields
             - Dataclasses and other annotated classes - converted to Pydantic models
             - Generic types (list, dict, Union, etc.) - wrapped in a model with a 'result' field
+            - Content blocks (TextContent, EmbeddedResource, ...), Image and Audio, anywhere in the
+                annotation - unstructured when auto-detecting; structured_output=True bypasses this rule
+                (a content block then publishes its own schema; Image/Audio have none and raise)
 
     Returns:
         A FuncMetadata object containing:
@@ -344,6 +357,12 @@ def func_metadata(
             return FuncMetadata(arg_model=arguments_model)
     else:
         original_annotation = effective_annotation
+
+    if structured_output is None and _contains_content_type(return_type_expr):
+        # Content blocks and the Image/Audio helpers are what the model reads, not data for the
+        # application: deriving a schema would publish the block's own model as output_schema and
+        # echo every block into structured_content. structured_output=True still forces one.
+        return FuncMetadata(arg_model=arguments_model)
 
     output_model, output_schema, wrap_output = _try_create_model_and_schema(
         original_annotation, return_type_expr, func.__name__

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import json
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from itertools import chain
 from types import GenericAlias
 from typing import Annotated, Any, Union, cast, get_args, get_origin, get_type_hints
@@ -34,13 +34,19 @@ def _is_input_required_type(obj: Any) -> bool:
 
 
 _CONTENT_TYPES = (*get_args(ContentBlock), Image, Audio)
+_CONTENT_SEQUENCE_ORIGINS = (list, tuple, Sequence, Iterable)
 
 
-def _contains_content_type(tp: Any) -> bool:
-    """Whether `tp` is, or is parameterized by, a content block class or the `Image`/`Audio` helpers."""
-    if get_origin(tp) is not None:
-        return any(_contains_content_type(arg) for arg in get_args(tp))
-    return isinstance(tp, type) and issubclass(tp, _CONTENT_TYPES)
+def _returns_content(annotation: Any) -> bool:
+    """Whether a return annotation declares content blocks or the `Image`/`Audio` helpers, bare or as
+    the items of a list/tuple or the arms of a union: the values `_convert_to_content` renders as blocks
+    rather than dumping as data. Keep the two in sync."""
+    origin = get_origin(annotation)
+    if origin is None:
+        return isinstance(annotation, type) and issubclass(annotation, _CONTENT_TYPES)
+    if origin is Annotated or is_union_origin(origin) or origin in _CONTENT_SEQUENCE_ORIGINS:
+        return any(_returns_content(arg) for arg in get_args(annotation))
+    return False
 
 
 class StrictJsonSchema(GenerateJsonSchema):
@@ -232,9 +238,9 @@ def func_metadata(
             - TypedDict - converted to a Pydantic model with same fields
             - Dataclasses and other annotated classes - converted to Pydantic models
             - Generic types (list, dict, Union, etc.) - wrapped in a model with a 'result' field
-            - Content blocks (TextContent, EmbeddedResource, ...), Image and Audio, anywhere in the
-                annotation - unstructured when auto-detecting; structured_output=True bypasses this rule
-                (a content block then publishes its own schema; Image/Audio have none and raise)
+            - Content blocks (TextContent, EmbeddedResource, ...), Image and Audio, bare or inside a
+                list, tuple or union - unstructured when auto-detecting; structured_output=True bypasses
+                this rule (a content block then publishes its own schema; Image/Audio have none and raise)
 
     Returns:
         A FuncMetadata object containing:
@@ -358,10 +364,11 @@ def func_metadata(
     else:
         original_annotation = effective_annotation
 
-    if structured_output is None and _contains_content_type(return_type_expr):
+    if structured_output is None and _returns_content(return_type_expr):
         # Content blocks and the Image/Audio helpers are what the model reads, not data for the
-        # application: deriving a schema would publish the block's own model as output_schema and
-        # echo every block into structured_content. structured_output=True still forces one.
+        # application: a derived schema would advertise the block's own model as output_schema (and,
+        # unless the tool builds its own CallToolResult, echo every block into structured_content).
+        # structured_output=True still forces one.
         return FuncMetadata(arg_model=arguments_model)
 
     output_model, output_schema, wrap_output = _try_create_model_and_schema(
@@ -565,7 +572,7 @@ def _convert_to_content(result: Any) -> list[ContentBlock]:
     Note: This conversion logic comes from previous versions of MCPServer and is being
     retained for purposes of backwards compatibility. It produces different unstructured
     output than the lowlevel server tool call handler, which just serializes structured
-    content verbatim.
+    content verbatim. `_returns_content` is the annotation-level mirror of these branches.
     """
     if result is None:  # pragma: no cover
         return []

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import json
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from itertools import chain
 from types import GenericAlias
 from typing import Annotated, Any, Union, cast, get_args, get_origin, get_type_hints
@@ -34,7 +34,8 @@ def _is_input_required_type(obj: Any) -> bool:
 
 
 _CONTENT_TYPES = (*get_args(ContentBlock), Image, Audio)
-_CONTENT_SEQUENCE_ORIGINS = (list, tuple, Sequence, Iterable)
+# `_convert_to_content` unrolls list/tuple values; a `Sequence[...]` annotation is one of those at runtime.
+_CONTENT_SEQUENCE_ORIGINS = (list, tuple, Sequence)
 
 
 def _returns_content(annotation: Any) -> bool:
@@ -44,7 +45,9 @@ def _returns_content(annotation: Any) -> bool:
     origin = get_origin(annotation)
     if origin is None:
         return isinstance(annotation, type) and issubclass(annotation, _CONTENT_TYPES)
-    if origin is Annotated or is_union_origin(origin) or origin in _CONTENT_SEQUENCE_ORIGINS:
+    if origin is Annotated:
+        return _returns_content(get_args(annotation)[0])
+    if is_union_origin(origin) or origin in _CONTENT_SEQUENCE_ORIGINS:
         return any(_returns_content(arg) for arg in get_args(annotation))
     return False
 

--- a/tests/docs_src/test_structured_output.py
+++ b/tests/docs_src/test_structured_output.py
@@ -2,7 +2,7 @@
 
 import pytest
 from inline_snapshot import snapshot
-from mcp_types import TextContent
+from mcp_types import EmbeddedResource, ImageContent, TextContent, TextResourceContents
 
 from docs_src.structured_output import (
     tutorial001,
@@ -17,6 +17,7 @@ from docs_src.structured_output import (
 )
 from mcp import Client
 from mcp.server import MCPServer
+from mcp.server.mcpserver import Image
 from mcp.server.mcpserver.exceptions import InvalidSignature
 
 # See test_index.py for why this is a per-module mark and not a conftest hook.
@@ -170,6 +171,36 @@ async def test_structured_output_false_opts_out() -> None:
         assert result.structured_content is None
         assert result.content == [
             TextContent(type="text", text="London: 17 degrees, overcast, light rain easing by evening.")
+        ]
+
+
+async def test_content_blocks_and_media_are_opted_out_of_structured_output() -> None:
+    """The "Content blocks and media" section: a content-block or `Image`/`Audio` return annotation, bare or
+    as list items, derives no output schema and no structured content; the blocks are the result."""
+    mcp = MCPServer("Reports")
+    document = EmbeddedResource(
+        type="resource", resource=TextResourceContents(uri="report://q3", mime_type="text/markdown", text="# Q3")
+    )
+
+    @mcp.tool()
+    def report() -> EmbeddedResource:
+        return document
+
+    @mcp.tool()
+    def chart() -> list[str | Image]:
+        return ["Sales by region:", Image(data=b"png", format="png")]
+
+    async with Client(mcp) as client:
+        tools = {tool.name: tool for tool in (await client.list_tools()).tools}
+        assert tools["report"].output_schema is None
+        assert tools["chart"].output_schema is None
+        report_result = await client.call_tool("report", {})
+        assert (report_result.content, report_result.structured_content) == ([document], None)
+        chart_result = await client.call_tool("chart", {})
+        assert chart_result.structured_content is None
+        assert chart_result.content == [
+            TextContent(type="text", text="Sales by region:"),
+            ImageContent(type="image", data="cG5n", mime_type="image/png"),
         ]
 
 

--- a/tests/server/mcpserver/prompts/test_base.py
+++ b/tests/server/mcpserver/prompts/test_base.py
@@ -3,15 +3,17 @@ from typing import Any
 
 import pytest
 from mcp_types import (
+    AudioContent,
     ElicitRequest,
     ElicitRequestFormParams,
     EmbeddedResource,
+    ImageContent,
     InputRequiredResult,
     TextContent,
     TextResourceContents,
 )
 
-from mcp.server.mcpserver import Context
+from mcp.server.mcpserver import Audio, Context, Image
 from mcp.server.mcpserver.prompts.base import AssistantMessage, Message, Prompt, UserMessage
 
 
@@ -243,3 +245,18 @@ async def test_render_passes_input_required_result_through_unchanged():
     prompt = Prompt.from_function(asking_prompt)
     result = await prompt.render(None, Context())
     assert result is sentinel
+
+
+@pytest.mark.parametrize(
+    ("helper", "expected"),
+    [
+        (Image(data=b"img", format="png"), ImageContent(type="image", data="aW1n", mime_type="image/png")),
+        (Audio(data=b"snd", format="wav"), AudioContent(type="audio", data="c25k", mime_type="audio/wav")),
+    ],
+)
+def test_message_converts_image_and_audio_helpers_to_content_blocks(
+    helper: Image | Audio, expected: ImageContent | AudioContent
+) -> None:
+    """SDK-defined: prompt messages accept the same `Image`/`Audio` helpers tools return."""
+    assert UserMessage(helper).content == expected
+    assert AssistantMessage(content=helper).content == expected

--- a/tests/server/mcpserver/prompts/test_base.py
+++ b/tests/server/mcpserver/prompts/test_base.py
@@ -13,8 +13,8 @@ from mcp_types import (
     TextResourceContents,
 )
 
-from mcp.server.mcpserver import Audio, Context, Image
-from mcp.server.mcpserver.prompts.base import AssistantMessage, Message, Prompt, UserMessage
+from mcp.server.mcpserver import AssistantMessage, Audio, Context, Image, MCPServer, Message, UserMessage
+from mcp.server.mcpserver.prompts.base import Prompt
 
 
 class TestRenderPrompt:
@@ -260,3 +260,33 @@ def test_message_converts_image_and_audio_helpers_to_content_blocks(
     """SDK-defined: prompt messages accept the same `Image`/`Audio` helpers tools return."""
     assert UserMessage(helper).content == expected
     assert AssistantMessage(content=helper).content == expected
+
+
+@pytest.mark.anyio
+async def test_prompt_dict_result_accepts_image_helper_as_content() -> None:
+    """SDK-defined: the dict form is validated through `Message.__init__`, so helpers convert there too."""
+
+    def fn() -> dict[str, Any]:
+        return {"role": "user", "content": Image(data=b"img", format="png")}
+
+    assert await Prompt.from_function(fn).render(None, Context()) == [
+        UserMessage(ImageContent(type="image", data="aW1n", mime_type="image/png"))
+    ]
+
+
+class _Slide:
+    """A plain class pydantic cannot build a schema for."""
+
+
+@pytest.mark.anyio
+async def test_prompt_return_annotation_is_not_run_through_tool_output_schema_derivation() -> None:
+    """SDK-defined: a prompt only needs its argument model, so an unschematizable return annotation
+    registers (it used to raise from the tool structured-output machinery)."""
+    mcp = MCPServer()
+
+    @mcp.prompt()
+    def deck(topic: str) -> list[_Slide]:
+        raise NotImplementedError
+
+    [listed] = await mcp.list_prompts()
+    assert [arg.name for arg in listed.arguments or []] == ["topic"]

--- a/tests/server/mcpserver/prompts/test_base.py
+++ b/tests/server/mcpserver/prompts/test_base.py
@@ -1,4 +1,5 @@
 import threading
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -316,3 +317,15 @@ async def test_bare_content_returned_from_a_prompt_becomes_user_messages(returne
         return returned
 
     assert await Prompt.from_function(fn).render(None, Context()) == expected
+
+
+@pytest.mark.anyio
+async def test_prompt_returning_media_with_an_unreadable_file_fails_to_render(tmp_path: Path) -> None:
+    """SDK-defined: a bare `Image` whose file cannot be read fails the render (an error for the client)
+    instead of degrading to a text message."""
+
+    def fn() -> Image:
+        return Image(path=tmp_path / "missing.png")
+
+    with pytest.raises(ValueError):
+        await Prompt.from_function(fn).render(None, Context())

--- a/tests/server/mcpserver/prompts/test_base.py
+++ b/tests/server/mcpserver/prompts/test_base.py
@@ -290,3 +290,29 @@ async def test_prompt_return_annotation_is_not_run_through_tool_output_schema_de
 
     [listed] = await mcp.list_prompts()
     assert [arg.name for arg in listed.arguments or []] == ["topic"]
+
+
+_PNG = Image(data=b"img", format="png")
+_PNG_BLOCK = ImageContent(type="image", data="aW1n", mime_type="image/png")
+_DOC = EmbeddedResource(
+    type="resource", resource=TextResourceContents(uri="file://notes.md", text="notes", mime_type="text/markdown")
+)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("returned", "expected"),
+    [
+        (_PNG, [UserMessage(_PNG_BLOCK)]),
+        (_DOC, [UserMessage(_DOC)]),
+        (["Look at this:", _PNG], [UserMessage("Look at this:"), UserMessage(_PNG_BLOCK)]),
+    ],
+)
+async def test_bare_content_returned_from_a_prompt_becomes_user_messages(returned: Any, expected: list[Message]):
+    """SDK-defined: what a tool may return bare (a content block, `Image`, `Audio`), a prompt may too;
+    each item becomes one user message instead of being JSON-dumped into text."""
+
+    def fn() -> Any:
+        return returned
+
+    assert await Prompt.from_function(fn).render(None, Context()) == expected

--- a/tests/server/mcpserver/resources/test_resource_template.py
+++ b/tests/server/mcpserver/resources/test_resource_template.py
@@ -505,3 +505,18 @@ async def test_create_resource_passes_input_required_result_through_unchanged():
     template = ResourceTemplate.from_function(fn=ask, uri_template="ask://{topic}")
     result = await template.create_resource("ask://databases", {"topic": "databases"}, Context())
     assert result is sentinel
+
+
+class _Chart:
+    """A plain class pydantic cannot build a schema for."""
+
+
+def test_template_return_annotation_is_not_run_through_tool_output_schema_derivation() -> None:
+    """SDK-defined: a resource template only needs its argument model, so an unschematizable return
+    annotation registers (it used to raise from the tool structured-output machinery)."""
+
+    def charts(year: str) -> list[_Chart]:
+        raise NotImplementedError
+
+    template = ResourceTemplate.from_function(charts, uri_template="charts://{year}")
+    assert template.uri_template == "charts://{year}"

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -10,9 +10,10 @@ from typing import Annotated, Any, Final, NamedTuple, TypedDict
 import annotated_types
 import pytest
 from dirty_equals import IsPartialDict
-from mcp_types import CallToolResult, InputRequiredResult
+from mcp_types import CallToolResult, ContentBlock, EmbeddedResource, InputRequiredResult, TextContent
 from pydantic import BaseModel, Field
 
+from mcp.server.mcpserver import Audio, Image
 from mcp.server.mcpserver.exceptions import InvalidSignature
 from mcp.server.mcpserver.utilities.func_metadata import func_metadata
 
@@ -852,6 +853,61 @@ def test_unstructured_output_unannotated_class():
 
     meta = func_metadata(func_returning_unannotated)
     assert meta.output_schema is None
+
+
+def _returns_block() -> EmbeddedResource:
+    raise NotImplementedError
+
+
+def _returns_blocks() -> list[ContentBlock]:
+    raise NotImplementedError
+
+
+def _returns_strings_and_images() -> list[str | Image]:
+    raise NotImplementedError
+
+
+def _returns_audio_clips() -> tuple[Audio, ...]:
+    raise NotImplementedError
+
+
+def _returns_call_tool_result_annotated_with_blocks() -> Annotated[CallToolResult, list[TextContent]]:
+    raise NotImplementedError
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        _returns_block,
+        _returns_blocks,
+        _returns_strings_and_images,
+        _returns_audio_clips,
+        _returns_call_tool_result_annotated_with_blocks,
+    ],
+)
+def test_content_block_return_annotation_yields_no_output_schema(tool: Callable[..., Any]):
+    """SDK-defined: content blocks and the Image/Audio helpers anywhere in the return annotation are
+    presentation, not data, so auto-detection derives no output schema (and `list[str | Image]` /
+    `tuple[Audio, ...]`, which pydantic cannot build a schema for, register instead of raising)."""
+    assert func_metadata(tool).output_schema is None
+
+
+def test_structured_output_true_overrides_the_content_block_rule():
+    """SDK-defined: the explicit flag still publishes the block's own schema for callers who want it."""
+    assert func_metadata(_returns_block, structured_output=True).output_model is EmbeddedResource
+
+
+def test_model_with_a_content_block_field_stays_structured():
+    """SDK-defined: only the return annotation is inspected for content types, never a model's fields."""
+
+    class Report(BaseModel):
+        summary: str
+        attachment: EmbeddedResource
+
+    def tool() -> Report:
+        raise NotImplementedError
+
+    assert func_metadata(tool).output_model is Report
 
 
 def test_tool_call_result_is_unstructured_and_not_converted():

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -871,6 +871,10 @@ def _returns_audio_clips() -> tuple[Audio, ...]:
     raise NotImplementedError
 
 
+def _returns_described_blocks() -> list[Annotated[TextContent, Field(description="one line each")]]:
+    raise NotImplementedError
+
+
 def _returns_call_tool_result_annotated_with_blocks() -> Annotated[CallToolResult, list[TextContent]]:
     raise NotImplementedError
 
@@ -882,6 +886,7 @@ def _returns_call_tool_result_annotated_with_blocks() -> Annotated[CallToolResul
         _returns_blocks,
         _returns_strings_and_images,
         _returns_audio_clips,
+        _returns_described_blocks,
         _returns_call_tool_result_annotated_with_blocks,
     ],
 )

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -897,17 +897,24 @@ def test_structured_output_true_overrides_the_content_block_rule():
     assert func_metadata(_returns_block, structured_output=True).output_model is EmbeddedResource
 
 
-def test_model_with_a_content_block_field_stays_structured():
-    """SDK-defined: only the return annotation is inspected for content types, never a model's fields."""
+class _Report(BaseModel):
+    summary: str
+    attachment: EmbeddedResource
 
-    class Report(BaseModel):
-        summary: str
-        attachment: EmbeddedResource
 
-    def tool() -> Report:
-        raise NotImplementedError
+def _returns_report() -> _Report:
+    raise NotImplementedError
 
-    assert func_metadata(tool).output_model is Report
+
+def _returns_blocks_by_key() -> dict[str, TextContent]:
+    raise NotImplementedError
+
+
+@pytest.mark.parametrize("tool", [_returns_report, _returns_blocks_by_key])
+def test_content_blocks_as_model_fields_or_mapping_values_stay_structured(tool: Callable[..., Any]):
+    """SDK-defined: the rule mirrors `_convert_to_content`, which renders blocks only when they are the
+    value itself or list/tuple items; a model field or a mapping value is data and keeps its schema."""
+    assert func_metadata(tool).output_schema is not None
 
 
 def test_tool_call_result_is_unstructured_and_not_converted():

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -437,20 +437,8 @@ class TestServerTools:
             assert isinstance(content3, AudioContent)
             assert content3.mime_type == "audio/wav"
             assert content3.data == "def"
-            assert result.structured_content is not None
-            assert "result" in result.structured_content
-            structured_result = result.structured_content["result"]
-            assert len(structured_result) == 3
-
-            expected_content = [
-                {"type": "text", "text": "Hello"},
-                {"type": "image", "data": "abc", "mimeType": "image/png"},
-                {"type": "audio", "data": "def", "mimeType": "audio/wav"},
-            ]
-
-            for i, expected in enumerate(expected_content):
-                for key, value in expected.items():
-                    assert structured_result[i][key] == value
+            # Content blocks are for the model, not data: no output schema, nothing echoed as structured
+            assert result.structured_content is None
 
     async def test_tool_mixed_list_with_audio_and_image(self, tmp_path: Path):
         """Test that lists containing Image objects and other types are handled
@@ -463,10 +451,8 @@ class TestServerTools:
         audio_path = tmp_path / "test.wav"
         audio_path.write_bytes(b"test audio data")
 
-        # TODO(Marcelo): It seems if we add the proper type hint, it generates an invalid JSON schema.
-        # We need to fix this.
-        def mixed_list_fn() -> list:  # type: ignore
-            return [  # type: ignore
+        def mixed_list_fn() -> list[str | Image | Audio | dict[str, str] | TextContent]:
+            return [
                 "text message",
                 Image(image_path),
                 Audio(audio_path),
@@ -475,7 +461,7 @@ class TestServerTools:
             ]
 
         mcp = MCPServer()
-        mcp.add_tool(mixed_list_fn)  # type: ignore
+        mcp.add_tool(mixed_list_fn)
         async with Client(mcp) as client:
             result = await client.call_tool("mixed_list_fn", {})
             assert len(result.content) == 5
@@ -501,7 +487,7 @@ class TestServerTools:
             content5 = result.content[4]
             assert isinstance(content5, TextContent)
             assert content5.text == "direct content"
-            # Check structured content - untyped list with Image objects should NOT have structured output
+            # Image/Audio/TextContent in the annotation: no output schema, so nothing echoed as structured
             assert result.structured_content is None
 
     async def test_tool_structured_output_basemodel(self):

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -50,6 +50,7 @@ from mcp.server.context import ServerRequestContext
 from mcp.server.mcpserver import Context, MCPServer, ResourceSecurity
 from mcp.server.mcpserver.exceptions import ResourceNotFoundError, ToolError
 from mcp.server.mcpserver.prompts.base import Message, UserMessage
+from mcp.server.mcpserver.prompts.base import Prompt as PromptTemplate  # `Prompt` here is the mcp_types wire model
 from mcp.server.mcpserver.resources import FileResource, FunctionResource
 from mcp.server.mcpserver.utilities.types import Audio, Image
 from mcp.server.subscriptions import (
@@ -2318,6 +2319,46 @@ async def test_context_notify_outside_a_request_raises() -> None:
 def test_context_exposes_its_mcp_server() -> None:
     mcp = MCPServer()
     assert Context(mcp_server=mcp).mcp_server is mcp
+
+
+def _greet(who: str) -> str:
+    """Say hi."""
+    return f"hi {who}"
+
+
+async def test_add_prompt_registers_a_function_like_the_decorator() -> None:
+    """SDK-defined: `add_prompt(fn, ...)` derives name, description and arguments as `@prompt()` does."""
+    mcp = MCPServer()
+    mcp.add_prompt(_greet, title="Greeter")
+
+    async with Client(mcp) as client:
+        [listed] = (await client.list_prompts()).prompts
+        result = await client.get_prompt("_greet", {"who": "max"})
+
+    assert (listed.name, listed.title, listed.description) == ("_greet", "Greeter", "Say hi.")
+    assert [arg.name for arg in listed.arguments or []] == ["who"]
+    assert result.messages[0].content == TextContent(type="text", text="hi max")
+
+
+async def test_add_prompt_registers_a_prompt_instance_as_is() -> None:
+    """SDK-defined: a ready-made prompt handed to `add_prompt` (the 2.0 form) is registered exactly as built."""
+    mcp = MCPServer()
+    mcp.add_prompt(prompt=PromptTemplate.from_function(_greet, name="custom"))
+    [listed] = await mcp.list_prompts()
+    assert listed.name == "custom"
+
+
+async def test_add_prompt_rejects_overrides_alongside_a_prompt_instance() -> None:
+    """SDK-defined: the keyword overrides only apply to the function form; passing them alongside a
+    ready-made prompt is rejected rather than silently ignored."""
+    mcp = MCPServer()
+    prompt: Any = PromptTemplate.from_function(_greet)  # Any: the overloads already reject this call statically
+    with pytest.raises(TypeError) as exc_info:
+        mcp.add_prompt(prompt, name="renamed")
+    assert str(exc_info.value) == snapshot(
+        "name, title, description and icons can only be set when registering a function"
+    )
+    assert await mcp.list_prompts() == []
 
 
 def test_remove_prompt_removes_and_unknown_name_raises() -> None:

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -50,7 +50,6 @@ from mcp.server.context import ServerRequestContext
 from mcp.server.mcpserver import Context, MCPServer, ResourceSecurity
 from mcp.server.mcpserver.exceptions import ResourceNotFoundError, ToolError
 from mcp.server.mcpserver.prompts.base import Message, UserMessage
-from mcp.server.mcpserver.prompts.base import Prompt as PromptTemplate  # `Prompt` here is the mcp_types wire model
 from mcp.server.mcpserver.resources import FileResource, FunctionResource
 from mcp.server.mcpserver.utilities.types import Audio, Image
 from mcp.server.subscriptions import (
@@ -2319,46 +2318,6 @@ async def test_context_notify_outside_a_request_raises() -> None:
 def test_context_exposes_its_mcp_server() -> None:
     mcp = MCPServer()
     assert Context(mcp_server=mcp).mcp_server is mcp
-
-
-def _greet(who: str) -> str:
-    """Say hi."""
-    return f"hi {who}"
-
-
-async def test_add_prompt_registers_a_function_like_the_decorator() -> None:
-    """SDK-defined: `add_prompt(fn, ...)` derives name, description and arguments as `@prompt()` does."""
-    mcp = MCPServer()
-    mcp.add_prompt(_greet, title="Greeter")
-
-    async with Client(mcp) as client:
-        [listed] = (await client.list_prompts()).prompts
-        result = await client.get_prompt("_greet", {"who": "max"})
-
-    assert (listed.name, listed.title, listed.description) == ("_greet", "Greeter", "Say hi.")
-    assert [arg.name for arg in listed.arguments or []] == ["who"]
-    assert result.messages[0].content == TextContent(type="text", text="hi max")
-
-
-async def test_add_prompt_registers_a_prompt_instance_as_is() -> None:
-    """SDK-defined: a ready-made prompt handed to `add_prompt` (the 2.0 form) is registered exactly as built."""
-    mcp = MCPServer()
-    mcp.add_prompt(prompt=PromptTemplate.from_function(_greet, name="custom"))
-    [listed] = await mcp.list_prompts()
-    assert listed.name == "custom"
-
-
-async def test_add_prompt_rejects_overrides_alongside_a_prompt_instance() -> None:
-    """SDK-defined: the keyword overrides only apply to the function form; passing them alongside a
-    ready-made prompt is rejected rather than silently ignored."""
-    mcp = MCPServer()
-    prompt: Any = PromptTemplate.from_function(_greet)  # Any: the overloads already reject this call statically
-    with pytest.raises(TypeError) as exc_info:
-        mcp.add_prompt(prompt, name="renamed")
-    assert str(exc_info.value) == snapshot(
-        "name, title, description and icons can only be set when registering a function"
-    )
-    assert await mcp.list_prompts() == []
 
 
 def test_remove_prompt_removes_and_unknown_name_raises() -> None:


### PR DESCRIPTION
Four small `MCPServer`/client fixes that remove traps the server docs would otherwise have to explain around. One commit per item so they can be reviewed (or dropped) independently.

**Behaviour change to call out in the release notes (item 1):** a tool whose return annotation is a content-block type (`-> EmbeddedResource`, `-> list[TextContent]`, `-> tuple[TextContent, ...]`, `-> str | TextContent`, ...) or has `Image`/`Audio` as its list/tuple items no longer advertises `outputSchema` and no longer returns `structuredContent`; its `content` is unchanged. Pass `structured_output=True` to keep the old shape.

## Motivation and Context

**1. Content-block, `Image` and `Audio` return annotations are unstructured** (`func_metadata`)

`@mcp.tool() def f() -> EmbeddedResource` published the pydantic schema of the `EmbeddedResource` class itself (~2 KB) as the tool's `outputSchema` and echoed the block into `structuredContent` a second time. Same for `-> ResourceLink`, `-> TextContent`, `-> list[ContentBlock]`, `tuple[...]`, unions. `-> Image` escaped only because `Image` is a plain class, and `-> list[Image]` / `-> list[str | Image]` / `-> Image | Audio` didn't register at all (`PydanticSchemaGenerationError` from `create_model`, outside the existing `try`).

In auto-detect mode (`structured_output=None`), a return annotation that declares content blocks or the `Image`/`Audio` helpers — bare, as the items of a `list`/`tuple`/`Sequence`, or as the arms of a union (through `Annotated`/`Optional`) — now derives no output schema. That is the annotation-level mirror of what `_convert_to_content` already does with those values at runtime; mapping values and model fields are data and keep their schema exactly as before. `structured_output=True` still forces a schema. The check sits right before schema derivation, so there is one rule and one override; `Annotated[CallToolResult, list[TextContent]]` is covered by the same rule (on `main` that spelling failed every call unless `structured_content` was hand-built).

`Prompt.from_function` and `ResourceTemplate.from_function` only ever needed the argument model but ran the same auto-detection, so an unschematizable return annotation on a *prompt* or *resource template* (`-> list[SomePlainClass]`) failed registration with a tool structured-output error; they now pass `structured_output=False`, which also keeps this rule from reaching beyond tools.

**2. Prompt messages accept `Image` / `Audio`** (`prompts/base.py`)

Tools convert the helpers; `UserMessage(Image(...))` was a pydantic validation error (client saw `-32603`), so you had to write `Image(...).to_image_content()`. `Message.__init__` now does the same conversion `str` already gets. The dict form (`{"role": "user", "content": Image(...)}`) works too since validation goes through `__init__`.

A prompt function may also *return* bare content the way a tool does — `Image(...)`, a ready-made content block, or a list mixing captions and images — and each item becomes one user message; previously anything that wasn't a `str`/`Message`/dict was JSON-dumped (an `Image` arrived as its `repr`). That last part is its own commit (`Prompt functions may return bare content blocks, Image or Audio`) and can be dropped independently; the JSON-dump fallback for other values is untouched, and conversion errors (e.g. an unreadable media file) now reach the existing `Error rendering prompt ...` handler instead of being re-wrapped as `Could not convert prompt result to message: <repr>`.

**3. Prompt message classes exported from `mcp.server.mcpserver`** (`__init__.py`)

`Message`, `UserMessage`, `AssistantMessage` are re-exported next to `Image`/`Audio`, so the prompt examples import everything from one place. (An earlier revision also let `add_prompt()` take a function like `add_tool()`; that was dropped — `add_resource()`/`add_prompt()` take built objects today, and changing the imperative registration API deserves its own pass across all three primitives. `mcp.add_prompt(Prompt.from_function(fn, ...))` remains the runtime-registration spelling.)

**4. Stale TODO in `Client.send_roots_list_changed`**

The comment claimed the server can't handle the notification; the lowlevel `Server` has `on_roots_list_changed` and `tests/interaction/lowlevel/test_roots.py` drives it. (The runtime deprecation warning currently fires once per decorated layer for the `Client` -> `ClientSession` delegations and for `ctx.info()` -> `ctx.log()` -> `send_log_message`; that is the same across ~10 call sites and is left for a follow-up rather than special-casing roots here.)

## How Has This Been Tested?

- New/updated unit tests: parametrized `func_metadata` cases (bare block, `list[ContentBlock]`, `list[str | Image]`, `tuple[Audio, ...]`, `Annotated[CallToolResult, list[TextContent]]`), the `structured_output=True` override, a model *with* a content-block field staying structured; `Image`/`Audio` in `UserMessage`/`AssistantMessage`.
- Review-round pins: `dict[str, TextContent]` and a model with a block field stay structured; a prompt and a resource template with an unschematizable return annotation register; dict-form prompt message with an `Image`; bare `Image`/`EmbeddedResource`/`[str, Image]` prompt returns; `tests/docs_src/test_structured_output.py` proves the new page section.
- The existing `test_tool_mixed_content` flips to `structured_content is None`; `test_tool_mixed_list_with_audio_and_image` gets its real annotation back and loses a TODO plus three `type: ignore`s.
- Exercised a user-style server over a real stdio subprocess before/after: on `main` the module fails to import (`-> list[str | Image]`), `report`/`blocks` advertise `outputSchema`, and the image prompt is an internal error; on this branch `tools/list` shows no `outputSchema` for the content tools (and still one for `structured_output=True` and a `dict[str, float]` control) and the prompt renders text/image/audio.

## Breaking Changes

None. No signature, export, or documented behaviour changes; per VERSIONING.md these are bug fixes plus additive API for a minor release, so the migration guide is untouched.

The one observable difference is item 1: tools whose return annotation is a content-block type stop advertising `outputSchema` and stop returning `structuredContent` (their `content` is unchanged). No docs page presented that shape as the intended contract (the media page says such results carry no output schema; the structured-output page enumerates models, TypedDicts, dataclasses, scalars and generics), and `-> list[Image]` not registering was a plain bug. It does show up in the everything-server's `test_image_content` / `test_audio_content` / `test_embedded_resource` / `test_multiple_content_types`; the conformance scenarios only assert on `content`, so they are unaffected. Anyone who wants the old shape passes `structured_output=True`. `docs/servers/structured-output.md` gets two sentences so the published page stays accurate.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Not done here, noted as follow-ups:

- Deprecated public methods delegating to other deprecated public methods emit `MCPDeprecationWarning` once per layer (`Client.set_logging_level`/`subscribe_resource`/`unsubscribe_resource`/`send_progress_notification`/`send_roots_list_changed`, and `Context.debug/info/warning/error` -> `log` -> `ServerSession.send_log_message`). The clean fix is undecorated private bodies that both public layers call, plus a "one warning per call, attributed to the caller" regression test. (The roots deprecation text cites SEP-2577; the notification's removal at 2026-07-28 is SEP-2575 — same pass.)
- Typing indirections: `type X = ...` (PEP 695) and `NewType` return annotations are not unwrapped by the content rule, by the existing `InputRequiredResult` stripping, or by `Annotated[CallToolResult, ...]` detection (baseline behaviour, not a regression). One alias-resolution step on the inspected return type feeding all three is the right place.
- `_try_create_model_and_schema` builds its wrapper models outside the `try`, so `-> list[SomePlainClass]` on a tool (and `structured_output=True` with `-> list[Image]`, or `dict[str, Image]`) still raises a raw `PydanticSchemaGenerationError` instead of falling back / raising `InvalidSignature`.
- Path-backed `Image`/`Audio` are read and base64-encoded on the event loop wherever they are converted: `Tool.run` -> `convert_result` -> `_convert_to_content` (since v1), `Message.__init__` inside an async prompt function, and now render's bare-content arm. Fix once, in the helpers or inside the existing worker-thread hop, for tools and prompts together.
- Prompt message roles: `UserMessage` and `AssistantMessage` both declare `role: Literal["user", "assistant"]` (as in v1), so a dict-form `{"role": "assistant", ...}` materialises as `UserMessage(role="assistant")` — wire output is right, `isinstance(msg, AssistantMessage)` is not. The validator is now left-to-right so content is converted once. Narrowing each subclass to its own literal and discriminating on `role` works at runtime but trips pyright strict (`reportIncompatibleVariableOverride`), so the real fix is a small hierarchy reshape plus a decision on whether `UserMessage(x, role="assistant")` should keep constructing.

The docs pages that motivated this (media, prompts) are being rewritten separately; the doc edits here are only the ones needed to keep currently published statements true.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
