### PR TITLE
OAuth client: refresh before re-authorizing, and discover before refreshing

### DIFF
--- a/docs/client/oauth-clients.md
+++ b/docs/client/oauth-clients.md
@@ -81,7 +81,7 @@ The first time `Client` sends a request, the server answers `401`. The provider 
 3. **Authorization.** It generates the PKCE pair and a `state`, builds the authorization URL, awaits your `redirect_handler`, then awaits your `callback_handler` for the code.
 4. **Exchange.** It trades the code for an `OAuthToken`, stores it, and replays your original request with `Authorization: Bearer ...`.
 
-After that it is quiet. Tokens come out of storage, an expired access token is refreshed with the refresh token, and only when none of that works does it run the flow again.
+After that it is quiet. Tokens come out of storage, an expired access token is refreshed with the refresh token, and only when none of that works does it run the flow again. That holds across restarts: a new process that finds a refresh token in storage answers the first `401` by rediscovering the authorization server and refreshing, not by sending anyone back to the browser.
 
 You wrote none of it. Two keyword arguments remain (`client_metadata_url` and `validate_resource_url`), and this file needs neither. `client_metadata_url` is the one worth knowing about; it gets its own section below.
 

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -656,10 +656,11 @@ class OAuthClientProvider(httpx2.Auth):
                         self.context.client_info is not None
                         and self.context.client_info.client_id == self.context.client_metadata_url
                         and self.context.auth_server_url is not None
-                        and self.context.client_info.issuer not in (None, self.context.auth_server_url)
+                        and self.context.client_info.issuer != self.context.auth_server_url
                     ):
                         # A CIMD client_id is portable across authorization servers; the tokens issued
-                        # under it and the cached metadata are not. Keep the record, re-stamped.
+                        # under it and the cached metadata are not. Keep the record, re-stamped. An
+                        # unstamped record's tokens have unknown provenance and are dropped the same way.
                         self.context.clear_tokens()
                         self.context.oauth_metadata = None
                         self.context.client_info.issuer = self.context.auth_server_url

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -586,8 +586,13 @@ class OAuthClientProvider(httpx2.Auth):
             # Capture protocol version from request headers
             self.context.protocol_version = request.headers.get(MCP_PROTOCOL_VERSION_HEADER)
 
-            if not self.context.is_token_valid() and self.context.can_refresh_token():
-                # Try to refresh token
+            # Refresh ahead of the request only when the token endpoint is already known; on a cold
+            # start the request goes out and the 401 branch discovers, then refreshes.
+            if (
+                not self.context.is_token_valid()
+                and self.context.can_refresh_token()
+                and self.context.oauth_metadata is not None
+            ):
                 refresh_request = await self._refresh_token()
                 refresh_response = yield refresh_request
 
@@ -741,10 +746,18 @@ class OAuthClientProvider(httpx2.Auth):
                                 client_information.issuer = discovered_issuer
                             self.context.client_info = client_information
                             await self.context.storage.set_client_info(client_information)
+                            # Held tokens belong to a previous client and cannot be refreshed by this one.
+                            self.context.clear_tokens()
 
-                    # Step 5: Perform authorization and complete token exchange
-                    token_response = yield await self._perform_authorization()
-                    await self._handle_token_response(token_response)
+                    # Step 5: Refresh with the stored refresh token first (RFC 6749 §6); run the full
+                    # authorization only when there is none or the server rejects it.
+                    refreshed = False
+                    if self.context.can_refresh_token():
+                        refresh_response = yield await self._refresh_token()
+                        refreshed = await self._handle_refresh_response(refresh_response)
+                    if not refreshed:
+                        token_response = yield await self._perform_authorization()
+                        await self._handle_token_response(token_response)
                 except Exception:
                     logger.exception("OAuth flow error")
                     raise

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -652,6 +652,18 @@ class OAuthClientProvider(httpx2.Auth):
                         # Any cached AS metadata is for the old server; drop it so a failed
                         # rediscovery cannot leak the old registration/token endpoints into Step 4.
                         self.context.oauth_metadata = None
+                    elif (
+                        self.context.client_info is not None
+                        and self.context.client_info.client_id == self.context.client_metadata_url
+                        and self.context.auth_server_url is not None
+                        and self.context.client_info.issuer not in (None, self.context.auth_server_url)
+                    ):
+                        # A CIMD client_id is portable across authorization servers; the tokens issued
+                        # under it and the cached metadata are not. Keep the record, re-stamped.
+                        self.context.clear_tokens()
+                        self.context.oauth_metadata = None
+                        self.context.client_info.issuer = self.context.auth_server_url
+                        await self.context.storage.set_client_info(self.context.client_info)
 
                     asm_discovery_urls = build_oauth_authorization_server_metadata_discovery_urls(
                         self.context.auth_server_url, self.context.server_url
@@ -747,21 +759,6 @@ class OAuthClientProvider(httpx2.Auth):
                             await self.context.storage.set_client_info(client_information)
                             # Held tokens belong to a previous client and cannot be refreshed by this one.
                             self.context.clear_tokens()
-
-                    # A CIMD client_id is portable across authorization servers (SEP-2352) but tokens
-                    # issued under it are not: on an issuer change keep the record, drop the tokens.
-                    client_info = self.context.client_info
-                    current_issuer = self.context.auth_server_url or (
-                        str(self.context.oauth_metadata.issuer) if self.context.oauth_metadata else None
-                    )
-                    if (
-                        client_info.client_id == self.context.client_metadata_url
-                        and current_issuer is not None
-                        and client_info.issuer not in (None, current_issuer)
-                    ):
-                        self.context.clear_tokens()
-                        client_info.issuer = current_issuer
-                        await self.context.storage.set_client_info(client_info)
 
                     # Step 5: Refresh with the stored refresh token first (RFC 6749 §6); run the full
                     # authorization only when there is none or the server rejects it.

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -550,6 +550,29 @@ class OAuthClientProvider(httpx2.Auth):
             self._initialized = False
             return False
 
+    async def _apply_issuer_binding(self, issuer: str) -> bool:
+        """Apply SEP-2352 to the held registration now that the authorization server's issuer is known.
+
+        Credentials bound to another issuer are discarded with their tokens so the flow re-registers.
+        A CIMD record is portable, so it is kept and re-stamped, but tokens it carried over from
+        another issuer (or of unknown origin, when the record is unstamped) are dropped. Returns
+        True when the held state was for a different issuer.
+        """
+        client_info = self.context.client_info
+        if client_info is None:
+            return False
+        if not credentials_match_issuer(client_info, issuer, self.context.client_metadata_url):
+            logger.debug("Authorization server changed; discarding bound credentials and re-registering")
+            self.context.client_info = None
+            self.context.clear_tokens()
+            return True
+        if client_info.client_id == self.context.client_metadata_url and client_info.issuer != issuer:
+            self.context.clear_tokens()
+            client_info.issuer = issuer
+            await self.context.storage.set_client_info(client_info)
+            return True
+        return False
+
     async def _initialize(self) -> None:
         """Load stored tokens and client info."""
         self.context.current_tokens = await self.context.storage.get_tokens()
@@ -636,35 +659,13 @@ class OAuthClientProvider(httpx2.Auth):
                         else:
                             logger.debug(f"Protected resource metadata discovery failed: {url}")
 
-                    # SEP-2352: stored credentials are bound to the issuer that registered them.
-                    # If the authorization server changed, drop them (and the old tokens) so the
-                    # flow re-registers instead of presenting another server's credentials.
-                    if (
-                        self.context.client_info is not None
-                        and self.context.auth_server_url is not None
-                        and not credentials_match_issuer(
-                            self.context.client_info, self.context.auth_server_url, self.context.client_metadata_url
-                        )
+                    # SEP-2352: stored credentials and tokens belong to the issuer they came from.
+                    if self.context.auth_server_url is not None and await self._apply_issuer_binding(
+                        self.context.auth_server_url
                     ):
-                        logger.debug("Authorization server changed; discarding bound credentials and re-registering")
-                        self.context.client_info = None
-                        self.context.clear_tokens()
                         # Any cached AS metadata is for the old server; drop it so a failed
-                        # rediscovery cannot leak the old registration/token endpoints into Step 4.
+                        # rediscovery cannot leak the old endpoints into Steps 4-5.
                         self.context.oauth_metadata = None
-                    elif (
-                        self.context.client_info is not None
-                        and self.context.client_info.client_id == self.context.client_metadata_url
-                        and self.context.auth_server_url is not None
-                        and self.context.client_info.issuer != self.context.auth_server_url
-                    ):
-                        # A CIMD client_id is portable across authorization servers; the tokens issued
-                        # under it and the cached metadata are not. Keep the record, re-stamped. An
-                        # unstamped record's tokens have unknown provenance and are dropped the same way.
-                        self.context.clear_tokens()
-                        self.context.oauth_metadata = None
-                        self.context.client_info.issuer = self.context.auth_server_url
-                        await self.context.storage.set_client_info(self.context.client_info)
 
                     asm_discovery_urls = build_oauth_authorization_server_metadata_discovery_urls(
                         self.context.auth_server_url, self.context.server_url
@@ -688,21 +689,9 @@ class OAuthClientProvider(httpx2.Auth):
                             logger.debug(f"OAuth metadata discovery failed: {url}")
 
                     # SEP-2352: on the legacy no-PRM path the issuer is only known after ASM
-                    # discovery, so re-evaluate the binding here using the discovered metadata
-                    # issuer (mirroring the bound_issuer fallback in Step 4).
-                    if (
-                        self.context.client_info is not None
-                        and self.context.auth_server_url is None
-                        and self.context.oauth_metadata is not None
-                        and not credentials_match_issuer(
-                            self.context.client_info,
-                            str(self.context.oauth_metadata.issuer),
-                            self.context.client_metadata_url,
-                        )
-                    ):
-                        logger.debug("Authorization server changed; discarding bound credentials and re-registering")
-                        self.context.client_info = None
-                        self.context.clear_tokens()
+                    # discovery (mirroring the bound_issuer fallback in Step 4).
+                    if self.context.auth_server_url is None and self.context.oauth_metadata is not None:
+                        await self._apply_issuer_binding(str(self.context.oauth_metadata.issuer))
 
                     # Step 3: Apply scope selection strategy
                     self.context.client_metadata.scope = get_client_metadata_scopes(

--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -374,7 +374,7 @@ class OAuthClientProvider(httpx2.Auth):
         if self.context.client_metadata.redirect_uris is None:
             raise OAuthFlowError("No redirect URIs provided for authorization code grant")  # pragma: no cover
         if not self.context.redirect_handler:
-            raise OAuthFlowError("No redirect handler provided for authorization code grant")  # pragma: no cover
+            raise OAuthFlowError("No redirect handler provided for authorization code grant")
         if not self.context.callback_handler:
             raise OAuthFlowError("No callback handler provided for authorization code grant")  # pragma: no cover
 
@@ -521,6 +521,8 @@ class OAuthClientProvider(httpx2.Auth):
         if response.status_code != 200:
             logger.warning(f"Token refresh failed: {response.status_code}")
             self.context.clear_tokens()
+            # Re-read storage on the next request: the failure may have been transient.
+            self._initialized = False
             return False
 
         try:
@@ -545,6 +547,7 @@ class OAuthClientProvider(httpx2.Auth):
         except ValidationError:  # pragma: no cover
             logger.exception("Invalid refresh response")
             self.context.clear_tokens()
+            self._initialized = False
             return False
 
     async def _initialize(self) -> None:
@@ -593,12 +596,8 @@ class OAuthClientProvider(httpx2.Auth):
                 and self.context.can_refresh_token()
                 and self.context.oauth_metadata is not None
             ):
-                refresh_request = await self._refresh_token()
-                refresh_response = yield refresh_request
-
-                if not await self._handle_refresh_response(refresh_response):
-                    # Refresh failed, need full re-authentication
-                    self._initialized = False
+                refresh_response = yield await self._refresh_token()
+                await self._handle_refresh_response(refresh_response)
 
             if self.context.is_token_valid():
                 self._add_auth_header(request)
@@ -748,6 +747,21 @@ class OAuthClientProvider(httpx2.Auth):
                             await self.context.storage.set_client_info(client_information)
                             # Held tokens belong to a previous client and cannot be refreshed by this one.
                             self.context.clear_tokens()
+
+                    # A CIMD client_id is portable across authorization servers (SEP-2352) but tokens
+                    # issued under it are not: on an issuer change keep the record, drop the tokens.
+                    client_info = self.context.client_info
+                    current_issuer = self.context.auth_server_url or (
+                        str(self.context.oauth_metadata.issuer) if self.context.oauth_metadata else None
+                    )
+                    if (
+                        client_info.client_id == self.context.client_metadata_url
+                        and current_issuer is not None
+                        and client_info.issuer not in (None, current_issuer)
+                    ):
+                        self.context.clear_tokens()
+                        client_info.issuer = current_issuer
+                        await self.context.storage.set_client_info(client_info)
 
                     # Step 5: Refresh with the stored refresh token first (RFC 6749 §6); run the full
                     # authorization only when there is none or the server rejects it.

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -3282,15 +3282,20 @@ async def test_expired_token_is_not_refreshed_ahead_of_the_request_before_metada
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("stamped_issuer", ["https://old-as.example.com", None], ids=["stamped-elsewhere", "unstamped"])
 async def test_cimd_record_is_restamped_and_its_tokens_and_cached_metadata_dropped_when_prm_names_a_new_issuer(
-    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
+    client_metadata: OAuthClientMetadata,
+    mock_storage: MockTokenStorage,
+    valid_tokens: OAuthToken,
+    stamped_issuer: str | None,
 ) -> None:
     """SEP-2352 for CIMD: the URL client_id survives an authorization-server change, nothing else does.
 
-    A long-lived provider holds a CIMD record stamped with the old issuer, tokens minted there, and
-    the old server's cached metadata. As soon as PRM names a different issuer, the tokens and the
-    cached metadata are dropped and the record is re-stamped and persisted, so a failed
-    rediscovery cannot leave the old endpoints in play and no refresh reaches the new server.
+    A long-lived provider holds a CIMD record stamped with another issuer (or, from an older store,
+    not stamped at all), tokens of matching provenance, and cached metadata. As soon as PRM names
+    the issuer in use, the tokens and the cached metadata are dropped and the record is re-stamped
+    and persisted, so a failed rediscovery cannot leave old endpoints in play and no refresh token
+    of unconfirmed origin reaches the named server.
     """
     cimd_url = "https://client.example.com/.well-known/mcp-client"
     provider = OAuthClientProvider(
@@ -3300,7 +3305,7 @@ async def test_cimd_record_is_restamped_and_its_tokens_and_cached_metadata_dropp
         client_metadata_url=cimd_url,
     )
     provider.context.client_info = OAuthClientInformationFull(
-        client_id=cimd_url, token_endpoint_auth_method="none", issuer="https://old-as.example.com"
+        client_id=cimd_url, token_endpoint_auth_method="none", issuer=stamped_issuer
     )
     provider.context.current_tokens = valid_tokens
     provider.context.token_expiry_time = time.time() + 1800

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -3279,3 +3279,55 @@ async def test_expired_token_is_not_refreshed_ahead_of_the_request_before_metada
 
     with pytest.raises(StopAsyncIteration):
         await auth_flow.asend(httpx2.Response(200, request=request))
+
+
+@pytest.mark.anyio
+async def test_cimd_record_is_restamped_and_its_tokens_and_cached_metadata_dropped_when_prm_names_a_new_issuer(
+    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
+) -> None:
+    """SEP-2352 for CIMD: the URL client_id survives an authorization-server change, nothing else does.
+
+    A long-lived provider holds a CIMD record stamped with the old issuer, tokens minted there, and
+    the old server's cached metadata. As soon as PRM names a different issuer, the tokens and the
+    cached metadata are dropped and the record is re-stamped and persisted, so a failed
+    rediscovery cannot leave the old endpoints in play and no refresh reaches the new server.
+    """
+    cimd_url = "https://client.example.com/.well-known/mcp-client"
+    provider = OAuthClientProvider(
+        server_url="https://api.example.com/v1/mcp",
+        client_metadata=client_metadata,
+        storage=mock_storage,
+        client_metadata_url=cimd_url,
+    )
+    provider.context.client_info = OAuthClientInformationFull(
+        client_id=cimd_url, token_endpoint_auth_method="none", issuer="https://old-as.example.com"
+    )
+    provider.context.current_tokens = valid_tokens
+    provider.context.token_expiry_time = time.time() + 1800
+    provider.context.oauth_metadata = OAuthMetadata(
+        issuer=AnyHttpUrl("https://old-as.example.com"),
+        authorization_endpoint=AnyHttpUrl("https://old-as.example.com/authorize"),
+        token_endpoint=AnyHttpUrl("https://old-as.example.com/token"),
+    )
+    provider._initialized = True
+
+    auth_flow = provider.async_auth_flow(httpx2.Request("GET", "https://api.example.com/v1/mcp"))
+    request = await auth_flow.__anext__()
+    prm_req = await auth_flow.asend(httpx2.Response(401, request=request))
+    prm_response = httpx2.Response(
+        200,
+        content=b'{"resource": "https://api.example.com/v1/mcp", "authorization_servers": ["https://new-as.example.com"]}',
+        request=prm_req,
+    )
+    asm_req = await auth_flow.asend(prm_response)
+
+    assert str(asm_req.url) == "https://new-as.example.com/.well-known/oauth-authorization-server"
+    assert provider.context.current_tokens is None
+    assert provider.context.oauth_metadata is None
+    assert provider.context.client_info is not None
+    assert (provider.context.client_info.client_id, provider.context.client_info.issuer) == (
+        cimd_url,
+        "https://new-as.example.com",
+    )
+    assert mock_storage._client_info is provider.context.client_info
+    await auth_flow.aclose()

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -4,7 +4,7 @@ import base64
 import json
 import time
 from unittest import mock
-from urllib.parse import parse_qs, quote, unquote, urlparse
+from urllib.parse import parse_qs, parse_qsl, quote, unquote, urlparse
 
 import httpx2
 import pytest
@@ -3333,6 +3333,59 @@ async def test_cimd_record_is_restamped_and_its_tokens_and_cached_metadata_dropp
     assert (provider.context.client_info.client_id, provider.context.client_info.issuer) == (
         cimd_url,
         "https://new-as.example.com",
+    )
+    assert mock_storage._client_info is provider.context.client_info
+    await auth_flow.aclose()
+
+
+@pytest.mark.anyio
+async def test_cimd_record_is_restamped_and_its_tokens_dropped_when_only_asm_reveals_a_new_issuer(
+    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage, valid_tokens: OAuthToken
+) -> None:
+    """The CIMD rebinding also applies on the legacy no-PRM path, where the issuer is learned from AS metadata.
+
+    PRM discovery 404s, so the issuer only becomes known from the root well-known metadata; it
+    differs from the record's stamp, so the tokens are dropped and the record re-stamped before
+    any refresh could be attempted, and the flow proceeds to authorize rather than refresh.
+    """
+    cimd_url = "https://client.example.com/.well-known/mcp-client"
+    provider = OAuthClientProvider(
+        server_url="https://api.example.com/v1/mcp",
+        client_metadata=client_metadata,
+        storage=mock_storage,
+        client_metadata_url=cimd_url,
+    )
+    provider.context.client_info = OAuthClientInformationFull(
+        client_id=cimd_url, token_endpoint_auth_method="none", issuer="https://old-as.example.com"
+    )
+    provider.context.current_tokens = valid_tokens
+    provider.context.token_expiry_time = time.time() + 1800
+    provider._initialized = True
+    provider._perform_authorization_code_grant = mock.AsyncMock(return_value=("auth-code", "verifier"))
+
+    auth_flow = provider.async_auth_flow(httpx2.Request("GET", "https://api.example.com/v1/mcp"))
+    request = await auth_flow.__anext__()
+    prm_req = await auth_flow.asend(httpx2.Response(401, request=request))
+    prm_req = await auth_flow.asend(httpx2.Response(404, request=prm_req))
+    asm_req = await auth_flow.asend(httpx2.Response(404, request=prm_req))
+    assert str(asm_req.url) == "https://api.example.com/.well-known/oauth-authorization-server"
+    asm_response = httpx2.Response(
+        200,
+        content=(
+            b'{"issuer": "https://api.example.com", '
+            b'"authorization_endpoint": "https://api.example.com/authorize", '
+            b'"token_endpoint": "https://api.example.com/token", '
+            b'"client_id_metadata_document_supported": true}'
+        ),
+        request=asm_req,
+    )
+    next_req = await auth_flow.asend(asm_response)
+
+    assert dict(parse_qsl(next_req.content.decode()))["grant_type"] == "authorization_code"
+    assert provider.context.client_info is not None
+    assert (provider.context.client_info.client_id, provider.context.client_info.issuer) == (
+        cimd_url,
+        "https://api.example.com",
     )
     assert mock_storage._client_info is provider.context.client_info
     await auth_flow.aclose()

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -3253,3 +3253,29 @@ async def test_issuer_is_stamped_when_same_origin_fallback_register_is_on_the_di
         await auth_flow.asend(httpx2.Response(200, request=final_req))
     except StopAsyncIteration:
         pass
+
+
+@pytest.mark.anyio
+async def test_expired_token_is_not_refreshed_ahead_of_the_request_before_metadata_is_discovered(
+    oauth_provider: OAuthClientProvider, valid_tokens: OAuthToken
+) -> None:
+    """With no authorization-server metadata yet, an expired token is not refreshed at a guessed endpoint.
+
+    The request goes out unauthenticated instead, so the 401 branch discovers the real token
+    endpoint before the refresh token is presented anywhere (#3240).
+    """
+    oauth_provider.context.current_tokens = valid_tokens
+    oauth_provider.context.token_expiry_time = time.time() - 60
+    oauth_provider.context.client_info = OAuthClientInformationFull(client_id="c", redirect_uris=None)
+    oauth_provider.context.oauth_metadata = None
+    oauth_provider._initialized = True
+
+    request = httpx2.Request("POST", "https://api.example.com/v1/mcp")
+    auth_flow = oauth_provider.async_auth_flow(request)
+    first = await auth_flow.__anext__()
+
+    assert first is request
+    assert "Authorization" not in first.headers
+
+    with pytest.raises(StopAsyncIteration):
+        await auth_flow.asend(httpx2.Response(200, request=request))

--- a/tests/interaction/_requirements.py
+++ b/tests/interaction/_requirements.py
@@ -3883,6 +3883,26 @@ REQUIREMENTS: dict[str, Requirement] = {
         transports=("streamable-http",),
         note="OAuth is HTTP-only.",
     ),
+    "client-auth:refresh:on-401": Requirement(
+        source="issue:#3250",
+        behavior=(
+            "A 401 received while a refresh token is held is answered, after rediscovery, with a "
+            "refresh_token grant before any interactive authorization, so a client constructed over "
+            "persisted tokens and client registration recovers from an expired access token headlessly."
+        ),
+        transports=("streamable-http",),
+        note="OAuth is HTTP-only. RFC 6749 §1.5 (E)-(H); matches the TypeScript, C# and Rust SDKs.",
+    ),
+    "client-auth:refresh:discovered-endpoint": Requirement(
+        source="issue:#3240",
+        behavior=(
+            "A refresh in a process that has not yet discovered the authorization server happens only after "
+            "protected-resource and authorization-server metadata discovery and posts to the advertised "
+            "token endpoint, never to a path guessed from the server origin."
+        ),
+        transports=("streamable-http",),
+        note="OAuth is HTTP-only.",
+    ),
     "client-auth:resource-parameter": Requirement(
         source=f"{SPEC_BASE_URL}/basic/authorization#resource-parameter-implementation",
         behavior=(

--- a/tests/interaction/_requirements.py
+++ b/tests/interaction/_requirements.py
@@ -3897,11 +3897,14 @@ REQUIREMENTS: dict[str, Requirement] = {
         source="issue:#3240",
         behavior=(
             "A refresh in a process that has not yet discovered the authorization server happens only after "
-            "protected-resource and authorization-server metadata discovery and posts to the advertised "
-            "token endpoint, never to a path guessed from the server origin."
+            "protected-resource and authorization-server metadata discovery and posts to the token endpoint "
+            "that metadata advertises."
         ),
         transports=("streamable-http",),
-        note="OAuth is HTTP-only.",
+        note=(
+            "OAuth is HTTP-only. When discovery yields no AS metadata at all, the 2025-03-26 origin-derived "
+            "fallback endpoint is still used, as it is for the authorization itself."
+        ),
     ),
     "client-auth:resource-parameter": Requirement(
         source=f"{SPEC_BASE_URL}/basic/authorization#resource-parameter-implementation",

--- a/tests/interaction/auth/_harness.py
+++ b/tests/interaction/auth/_harness.py
@@ -26,7 +26,14 @@ from mcp.client.streamable_http import streamable_http_client
 from mcp.server import Server
 from mcp.server.auth.provider import AccessToken, ProviderTokenVerifier
 from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions, RevocationOptions
-from mcp.shared.auth import AuthorizationCodeResult, OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+from mcp.shared.auth import (
+    AuthorizationCodeResult,
+    OAuthClientInformationFull,
+    OAuthClientMetadata,
+    OAuthMetadata,
+    OAuthToken,
+    ProtectedResourceMetadata,
+)
 from tests.interaction._connect import BASE_URL, NO_DNS_REBINDING_PROTECTION
 from tests.interaction.auth._provider import InMemoryAuthorizationServerProvider
 from tests.interaction.transports._bridge import StreamingASGITransport
@@ -271,6 +278,53 @@ def shim(
 ) -> AppShim:
     """Build an `app_shim` for `connect_with_oauth` that applies `shimmed_app` with these overrides."""
     return lambda app: shimmed_app(app, not_found=not_found, serve=serve)
+
+
+def path_prefixed_as_shim(prefix: str) -> AppShim:
+    """Build an `app_shim` that presents the co-hosted authorization server as living under `prefix`.
+
+    The SDK server mounts `/authorize`, `/token` and `/register` at the origin root whatever the
+    issuer, so an AS whose endpoints sit under a path cannot be configured natively. This serves
+    PRM naming `{BASE_URL}{prefix}` as the AS, serves that issuer's metadata at the RFC 8414
+    path-inserted well-known URL with every endpoint under the prefix, forwards `{prefix}/x` to the
+    real `/x`, and 404s the bare root endpoints and root metadata so a client guessing origin-root
+    paths fails as it would against such a server. Pair with
+    `InMemoryAuthorizationServerProvider(issuer=f"{BASE_URL}{prefix}")` so the redirect `iss` matches.
+    """
+    issuer = f"{BASE_URL}{prefix}"
+    prm = ProtectedResourceMetadata(resource=AnyHttpUrl(f"{BASE_URL}/mcp"), authorization_servers=[AnyHttpUrl(issuer)])
+    asm = OAuthMetadata(
+        issuer=AnyHttpUrl(issuer),
+        authorization_endpoint=AnyHttpUrl(f"{issuer}/authorize"),
+        token_endpoint=AnyHttpUrl(f"{issuer}/token"),
+        registration_endpoint=AnyHttpUrl(f"{issuer}/register"),
+        scopes_supported=["mcp"],
+        response_types_supported=["code"],
+        grant_types_supported=["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported=["client_secret_post", "client_secret_basic", "none"],
+        code_challenge_methods_supported=["S256"],
+    )
+
+    def factory(app: ASGIApp) -> ASGIApp:
+        inner = shimmed_app(
+            app,
+            not_found=frozenset({"/token", "/authorize", "/register", "/.well-known/oauth-authorization-server"}),
+            serve={
+                "/.well-known/oauth-protected-resource/mcp": metadata_body(prm),
+                f"/.well-known/oauth-authorization-server{prefix}": metadata_body(asm),
+            },
+        )
+
+        async def wrapped(scope: Scope, receive: Receive, send: Send) -> None:
+            if scope["type"] == "http" and scope["path"].startswith(f"{prefix}/"):
+                path = scope["path"][len(prefix) :]
+                await app({**scope, "path": path, "raw_path": path.encode()}, receive, send)
+                return
+            await inner(scope, receive, send)
+
+        return wrapped
+
+    return factory
 
 
 @dataclass

--- a/tests/interaction/auth/_provider.py
+++ b/tests/interaction/auth/_provider.py
@@ -103,6 +103,10 @@ class InMemoryAuthorizationServerProvider(
         )
         return access
 
+    def expire_access_token(self, token: str) -> None:
+        """Move an issued access token's server-side expiry into the past so the bearer middleware 401s it."""
+        self.access_tokens[token] = self.access_tokens[token].model_copy(update={"expires_at": int(time.time()) - 1})
+
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
         return self.clients.get(client_id)
 

--- a/tests/interaction/auth/test_lifecycle.py
+++ b/tests/interaction/auth/test_lifecycle.py
@@ -18,6 +18,7 @@ from mcp_types import INTERNAL_ERROR, ListToolsResult, Tool
 from pydantic import AnyHttpUrl, AnyUrl
 
 from mcp import MCPError
+from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider, PrivateKeyJWTOAuthProvider
 from mcp.server import Server, ServerRequestContext
 from mcp.shared.auth import OAuthClientInformationFull, OAuthMetadata
@@ -25,12 +26,15 @@ from tests.interaction._connect import BASE_URL
 from tests.interaction._requirements import requirement
 from tests.interaction.auth._harness import (
     REDIRECT_URI,
+    AppShim,
     InMemoryTokenStorage,
     RecordedRequest,
     auth_settings,
     connect_with_oauth,
     m2m_token_shim,
     metadata_body,
+    oauth_client_metadata,
+    path_prefixed_as_shim,
     record_requests,
     shim,
     step_up_shim,
@@ -96,6 +100,29 @@ def seeded_client(provider: InMemoryAuthorizationServerProvider, **kwargs: objec
     assert info.client_id is not None
     provider.clients[info.client_id] = info
     return info
+
+
+async def first_process_login(
+    provider: InMemoryAuthorizationServerProvider, storage: InMemoryTokenStorage, *, app_shim: AppShim | None = None
+) -> str:
+    """Run one interactive connect so `storage` holds what a first process leaves behind; return its access token.
+
+    The restart tests then build a fresh `OAuthClientProvider` over the same storage, as a second
+    process would, so the registration and tokens carry exactly what the SDK persists.
+    """
+    server = Server("guarded", on_list_tools=list_tools)
+    async with connect_with_oauth(server, provider=provider, storage=storage, app_shim=app_shim) as (client, _):
+        await client.list_tools()
+    assert storage.tokens is not None and storage.tokens.refresh_token is not None
+    return storage.tokens.access_token
+
+
+def restarted_headless_provider(storage: InMemoryTokenStorage) -> OAuthClientProvider:
+    """A provider as a second, headless process constructs it: same storage, fresh state, no handlers.
+
+    Reaching the interactive step raises rather than opening a browser the scenario says is absent.
+    """
+    return OAuthClientProvider(server_url=f"{BASE_URL}/mcp", client_metadata=oauth_client_metadata(), storage=storage)
 
 
 @requirement("client-auth:refresh:transparent")
@@ -352,6 +379,91 @@ async def test_a_failed_refresh_clears_stored_tokens_and_restarts_the_full_flow(
     assert storage.client_info is not None
     assert storage.tokens is not None
     assert storage.tokens.access_token in provider.access_tokens
+
+
+@requirement("client-auth:refresh:on-401")
+async def test_a_restarted_client_answers_a_401_with_its_stored_refresh_token() -> None:
+    """A second process holding only persisted tokens and registration refreshes on 401 instead of re-authorizing.
+
+    Steps: (1) a first process logs in and its storage keeps the registration and a refresh token;
+    (2) the server-side access token lapses; (3) a fresh provider over the same storage, with no
+    browser, connects. The recording proves the stale bearer drew a 401, discovery ran, one
+    `refresh_token` grant followed, and neither `/authorize` nor `/register` was touched.
+    SDK behaviour per RFC 6749 §1.5; regression bar for #3250 / #1318.
+    """
+    provider = InMemoryAuthorizationServerProvider()
+    storage = InMemoryTokenStorage()
+    with anyio.fail_after(5):
+        stale_access_token = await first_process_login(provider, storage)
+    provider.expire_access_token(stale_access_token)
+
+    recorded, on_request = record_requests()
+    server = Server("guarded", on_list_tools=list_tools)
+    with anyio.fail_after(5):
+        async with connect_with_oauth(
+            server, provider=provider, auth=restarted_headless_provider(storage), on_request=on_request
+        ) as (client, _):
+            result = await client.list_tools()
+
+    assert result.tools[0].name == "echo"
+    assert [(r.method, r.path) for r in recorded[:5]] == snapshot(
+        [
+            ("POST", "/mcp"),
+            ("GET", "/.well-known/oauth-protected-resource/mcp"),
+            ("GET", "/.well-known/oauth-authorization-server"),
+            ("POST", "/token"),
+            ("POST", "/mcp"),
+        ]
+    )
+    assert recorded[0].headers["authorization"] == f"Bearer {stale_access_token}"
+    assert [form_body(r)["grant_type"] for r in find(recorded, "POST", "/token")] == ["refresh_token"]
+    assert find(recorded, "GET", "/authorize") == [] and find(recorded, "POST", "/register") == []
+    assert storage.tokens is not None and storage.tokens.access_token != stale_access_token
+    assert storage.tokens.access_token in provider.access_tokens
+
+
+@requirement("client-auth:refresh:discovered-endpoint")
+async def test_a_restarted_client_refreshes_at_the_token_endpoint_advertised_under_a_path() -> None:
+    """Against an authorization server under `/oauth2/v1`, a second process refreshes at `/oauth2/v1/token`.
+
+    The bare `/token` 404s here. Nothing is discovered yet in the second process, so no refresh is
+    attempted before the request; the 401 drives discovery and the single refresh POST goes to the
+    advertised endpoint. Regression bar for #3240, where the guessed `{origin}/token` 404ed and the
+    refresh token was discarded.
+    """
+    prefix = "/oauth2/v1"
+    provider = InMemoryAuthorizationServerProvider(issuer=f"{BASE_URL}{prefix}")
+    storage = InMemoryTokenStorage()
+    app_shim = path_prefixed_as_shim(prefix)
+    with anyio.fail_after(5):
+        stale_access_token = await first_process_login(provider, storage, app_shim=app_shim)
+    provider.expire_access_token(stale_access_token)
+
+    recorded, on_request = record_requests()
+    server = Server("guarded", on_list_tools=list_tools)
+    with anyio.fail_after(5):
+        async with connect_with_oauth(
+            server,
+            provider=provider,
+            auth=restarted_headless_provider(storage),
+            app_shim=app_shim,
+            on_request=on_request,
+        ) as (client, _):
+            result = await client.list_tools()
+
+    assert result.tools[0].name == "echo"
+    assert [(r.method, r.path) for r in recorded[:5]] == snapshot(
+        [
+            ("POST", "/mcp"),
+            ("GET", "/.well-known/oauth-protected-resource/mcp"),
+            ("GET", "/.well-known/oauth-authorization-server/oauth2/v1"),
+            ("POST", "/oauth2/v1/token"),
+            ("POST", "/mcp"),
+        ]
+    )
+    token_posts = [r for r in recorded if r.method == "POST" and r.path.endswith("/token")]
+    assert [(r.path, form_body(r)["grant_type"]) for r in token_posts] == [("/oauth2/v1/token", "refresh_token")]
+    assert not any(r.path.endswith("/authorize") for r in recorded)
 
 
 @requirement("client-auth:client-credentials")

--- a/tests/interaction/auth/test_lifecycle.py
+++ b/tests/interaction/auth/test_lifecycle.py
@@ -18,15 +18,16 @@ from mcp_types import INTERNAL_ERROR, ListToolsResult, Tool
 from pydantic import AnyHttpUrl, AnyUrl
 
 from mcp import MCPError
-from mcp.client.auth import OAuthClientProvider
+from mcp.client.auth import OAuthClientProvider, OAuthFlowError
 from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider, PrivateKeyJWTOAuthProvider
 from mcp.server import Server, ServerRequestContext
-from mcp.shared.auth import OAuthClientInformationFull, OAuthMetadata
+from mcp.shared.auth import OAuthClientInformationFull, OAuthMetadata, OAuthToken
 from tests.interaction._connect import BASE_URL
 from tests.interaction._requirements import requirement
 from tests.interaction.auth._harness import (
     REDIRECT_URI,
     AppShim,
+    HeadlessOAuth,
     InMemoryTokenStorage,
     RecordedRequest,
     auth_settings,
@@ -123,6 +124,17 @@ def restarted_headless_provider(storage: InMemoryTokenStorage) -> OAuthClientPro
     Reaching the interactive step raises rather than opening a browser the scenario says is absent.
     """
     return OAuthClientProvider(server_url=f"{BASE_URL}/mcp", client_metadata=oauth_client_metadata(), storage=storage)
+
+
+def restarted_interactive_provider(storage: InMemoryTokenStorage, headless: HeadlessOAuth) -> OAuthClientProvider:
+    """A provider as a second process with a browser available constructs it: same storage, fresh state."""
+    return OAuthClientProvider(
+        server_url=f"{BASE_URL}/mcp",
+        client_metadata=oauth_client_metadata(),
+        storage=storage,
+        redirect_handler=headless.redirect_handler,
+        callback_handler=headless.callback_handler,
+    )
 
 
 @requirement("client-auth:refresh:transparent")
@@ -464,6 +476,154 @@ async def test_a_restarted_client_refreshes_at_the_token_endpoint_advertised_und
     token_posts = [r for r in recorded if r.method == "POST" and r.path.endswith("/token")]
     assert [(r.path, form_body(r)["grant_type"]) for r in token_posts] == [("/oauth2/v1/token", "refresh_token")]
     assert not any(r.path.endswith("/authorize") for r in recorded)
+
+
+@requirement("client-auth:invalid-grant-clears-tokens")
+async def test_a_refresh_the_server_rejects_on_the_401_path_falls_back_to_authorization() -> None:
+    """When the 401 path's refresh is rejected, the flow runs the full authorization instead of giving up.
+
+    Second process with a browser; the harness denies the one refresh with `invalid_grant`. The
+    recording proves the refresh was tried first, then exactly one authorize and code exchange,
+    with no re-registration.
+    """
+    provider = InMemoryAuthorizationServerProvider(fail_next_refresh=True)
+    storage = InMemoryTokenStorage()
+    with anyio.fail_after(5):
+        provider.expire_access_token(await first_process_login(provider, storage))
+
+    recorded, on_request = record_requests()
+    headless = HeadlessOAuth()
+    server = Server("guarded", on_list_tools=list_tools)
+    with anyio.fail_after(5):
+        async with connect_with_oauth(
+            server,
+            provider=provider,
+            auth=restarted_interactive_provider(storage, headless),
+            headless=headless,
+            on_request=on_request,
+        ) as (client, _):
+            result = await client.list_tools()
+
+    assert result.tools[0].name == "echo"
+    assert [form_body(r)["grant_type"] for r in find(recorded, "POST", "/token")] == snapshot(
+        ["refresh_token", "authorization_code"]
+    )
+    counts = path_counts(recorded)
+    assert counts[("GET", "/authorize")] == 1
+    assert counts[("POST", "/register")] == 0
+
+
+@requirement("client-auth:refresh:on-401")
+async def test_a_headless_client_whose_refresh_failed_retries_it_from_storage_on_the_next_connection() -> None:
+    """A failed refresh does not wedge a long-lived headless provider: the next connection reloads and refreshes.
+
+    The harness denies the first refresh with `invalid_grant` but leaves the refresh token valid,
+    standing in for a transient token-endpoint failure. The first connect raises (no browser to
+    fall back to); the second, through the same provider instance, refreshes and succeeds.
+    """
+    provider = InMemoryAuthorizationServerProvider(fail_next_refresh=True)
+    storage = InMemoryTokenStorage()
+    with anyio.fail_after(5):
+        provider.expire_access_token(await first_process_login(provider, storage))
+    daemon = restarted_headless_provider(storage)
+
+    with anyio.fail_after(5):
+        with pytest.RaisesGroup(pytest.RaisesExc(OAuthFlowError), flatten_subgroups=True):
+            await connect_with_oauth(
+                Server("guarded", on_list_tools=list_tools), provider=provider, auth=daemon
+            ).__aenter__()
+
+    recorded, on_request = record_requests()
+    with anyio.fail_after(5):
+        async with connect_with_oauth(
+            Server("guarded", on_list_tools=list_tools), provider=provider, auth=daemon, on_request=on_request
+        ) as (client, _):
+            result = await client.list_tools()
+
+    assert result.tools[0].name == "echo"
+    assert [form_body(r)["grant_type"] for r in find(recorded, "POST", "/token")] == ["refresh_token"]
+    assert find(recorded, "GET", "/authorize") == []
+
+
+@requirement("client-auth:refresh:on-401")
+async def test_a_fresh_registration_does_not_present_tokens_left_from_a_previous_client() -> None:
+    """Tokens found in storage without their registration are not refreshed under a newly registered client.
+
+    The second process finds tokens but no `client_info` (lost, or never persisted), so the 401
+    path registers a new client; the refresh token belonged to the old one and is dropped rather
+    than presented, and the flow authorizes once. RFC 6749 §6 binds refresh tokens to their client.
+    """
+    provider = InMemoryAuthorizationServerProvider()
+    storage = InMemoryTokenStorage()
+    with anyio.fail_after(5):
+        provider.expire_access_token(await first_process_login(provider, storage))
+    storage.client_info = None
+
+    recorded, on_request = record_requests()
+    headless = HeadlessOAuth()
+    server = Server("guarded", on_list_tools=list_tools)
+    with anyio.fail_after(5):
+        async with connect_with_oauth(
+            server,
+            provider=provider,
+            auth=restarted_interactive_provider(storage, headless),
+            headless=headless,
+            on_request=on_request,
+        ) as (client, _):
+            result = await client.list_tools()
+
+    assert result.tools[0].name == "echo"
+    assert [(r.method, r.path) for r in recorded[:6]] == snapshot(
+        [
+            ("POST", "/mcp"),
+            ("GET", "/.well-known/oauth-protected-resource/mcp"),
+            ("GET", "/.well-known/oauth-authorization-server"),
+            ("POST", "/register"),
+            ("GET", "/authorize"),
+            ("POST", "/token"),
+        ]
+    )
+    assert [form_body(r)["grant_type"] for r in find(recorded, "POST", "/token")] == ["authorization_code"]
+
+
+@requirement("client-auth:as-binding")
+async def test_a_cimd_client_keeps_its_id_but_drops_its_tokens_when_the_authorization_server_changes() -> None:
+    """A CIMD registration is portable across authorization servers; the tokens issued under it are not.
+
+    Storage holds a CIMD record stamped with a previous issuer and a refresh token minted there.
+    On the 401 the discovered issuer differs, so the flow keeps the URL client_id, re-stamps it,
+    and authorizes afresh instead of presenting the old refresh token to the new server (SEP-2352;
+    the TypeScript SDK discards tokens on the same mismatch).
+    """
+    recorded, on_request = record_requests()
+    provider = InMemoryAuthorizationServerProvider()
+    seeded_client(provider, client_id=CIMD_URL)
+    stale = OAuthClientInformationFull(
+        client_id=CIMD_URL,
+        token_endpoint_auth_method="none",
+        redirect_uris=[AnyUrl(REDIRECT_URI)],
+        issuer="https://old-as.example.com",
+    )
+    storage = InMemoryTokenStorage(client_info=stale)
+    storage.tokens = OAuthToken(access_token="issued-by-old-as", refresh_token="refresh-from-old-as", expires_in=3600)
+    server = Server("guarded", on_list_tools=list_tools)
+
+    with anyio.fail_after(5):
+        async with connect_with_oauth(
+            server,
+            provider=provider,
+            storage=storage,
+            client_metadata_url=CIMD_URL,
+            app_shim=shim(serve={ASM_PATH: cimd_supported_metadata()}),
+            on_request=on_request,
+        ) as (client, _):
+            await client.list_tools()
+
+    assert [form_body(r)["grant_type"] for r in find(recorded, "POST", "/token")] == ["authorization_code"]
+    assert all(b"refresh-from-old-as" not in r.content for r in recorded)
+    assert path_counts(recorded)[("POST", "/register")] == 0
+    assert storage.client_info is not None
+    assert (storage.client_info.client_id, storage.client_info.issuer) == (CIMD_URL, f"{BASE_URL}/")
 
 
 @requirement("client-auth:client-credentials")


### PR DESCRIPTION
On a 401, `OAuthClientProvider` now tries the stored refresh token (after rediscovery) before falling back to interactive authorization, and the pre-request refresh only runs once authorization-server metadata is known, so it never guesses `{origin}/token`. A restarted or headless client with a persisted refresh token recovers from an expired access token without a browser.

Closes #3240, closes #3250, closes #1318.

## Motivation and Context

The provider had two ways to obtain a token that each lacked half of what they needed: the pre-request branch could refresh but never ran discovery, and the 401 branch ran discovery but never tried the refresh token. After a restart nothing restores an expiry, so the pre-request branch is skipped, the stale bearer draws a 401, and the flow goes to the browser with a usable refresh token in hand — headless clients just fail. If an application forced the pre-request path by reporting the loaded token as expired, the refresh went to a path derived from the server origin, which 404s for any authorization server under a path, and the refresh token was then discarded. #1318 reported this a year ago; #3240 and #3250 are the same defect from two angles. The 401 branch did refresh in 1.10/1.11; #1071 moved that block ahead of the request instead of duplicating it and nothing tested the restart path.

## What changed

- 401 branch, Step 5: `if can_refresh_token(): refresh` → on success retry the request; otherwise (no refresh token, or the server rejected it) run the full grant as before.
- Pre-request refresh: additionally gated on `oauth_metadata is not None`. In-process behaviour is unchanged (metadata is cached after the first flow); on a cold start the request goes out and the 401 branch discovers, then refreshes.
- A failed refresh (either site) resets `_initialized` inside `_handle_refresh_response`, so the next request re-reads storage; a long-lived headless provider whose one refresh hit a transient error retries it rather than staying tokenless for the life of the process. Classifying failures (keep the refresh token on 5xx, clear only on `invalid_grant`) is left for the follow-up below.
- A fresh dynamic registration clears any held tokens (they were issued to a previous client and can't be refreshed by the new one).
- A CIMD `client_id` is portable across authorization servers, but tokens issued under it are not: when the issuer that becomes known (from PRM, or from AS metadata on the legacy no-PRM path) differs from the record's SEP-2352 stamp — or the record carries no stamp, so its tokens have no confirmed origin — the record is kept and re-stamped and its tokens (and any cached metadata from the previous server) are dropped before anything is refreshed (the TypeScript SDK's `discardIfIssuerMismatch`). The existing bound-credential discard and this rule now live in one `_apply_issuer_binding` method called at both points the issuer becomes known, replacing the two inline copies.

`src/` is +55/−41. No public API change, `TokenStorage` untouched. This is the TypeScript SDK's ordering (`auth()` refreshes before `startAuthorization`) and matches C#/Rust.

## How Has This Been Tested?

Interaction tests against the SDK's own AS+RS in process, each logging in as a "first process" and then connecting a fresh provider over the same storage: refresh on 401 after restart (no handlers wired); the same against an AS mounted under `/oauth2/v1` (bare `/token` 404s) proving the refresh goes to the advertised endpoint; a rejected 401-path refresh falling back to authorization; a headless provider retrying the refresh on its next connection after a failed one; a fresh registration not presenting tokens left from a previous client; and a CIMD client keeping its id but dropping its tokens on an issuer change. Each was mutation-checked against the line it pins. Unit tests pin that an expired token is not refreshed ahead of the request while metadata is unknown, and the CIMD rebinding on both discovery paths (stamped elsewhere, and unstamped). Manifest gains `client-auth:refresh:on-401` and `client-auth:refresh:discovered-endpoint`; the harness gains a path-prefixed-AS shim and `expire_access_token`.

Also driven over real sockets (uvicorn serving the SDK AS with 3 s access tokens, then under a prefix; a separate application process with file-backed storage run repeatedly): headless runs after expiry show `401 → PRM → ASM → POST …/token grant_type=refresh_token → 200`; with `tokens.json` rewritten to `expires_in=-1` and an app that derives expiry on load (the #3240 setup) there is no guessed `/token` request and the refresh lands on `/oauth2/v1/token`.

## Breaking Changes

None. Behavioural notes: a 401 with a refresh token in storage now produces one token-endpoint request before any redirect (a `scope=` challenge wider than the grant is then met by the 403 step-up on the retry, as in the TypeScript SDK). A cold start with an access token the server no longer accepts costs one 401 round trip before the refresh, unless the application restores both the expiry and the AS metadata itself. Against 2025-03-26-era servers that publish no metadata at all, in-process expiry now also goes through that 401 (and the failing well-known probes) instead of a single pre-request refresh; everywhere else in-process behaviour is unchanged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

An earlier revision of this branch also folded in the #3256 recovery (expired DCR secret / `invalid_client` → re-register once) and a cold-start pre-request discovery mode. Review surfaced enough edge cases in both (403 step-up path, pre-registered credentials, tokens outliving their registration, a coarse-clock test knob) that they're better handled separately, so this PR is cut back to the refresh fix and the rest follows:

- #3256 (lapsed `client_secret_expires_at`, `invalid_client` handling incl. the 403 step-up exchange) — separate PR.
- Stored-token contract: an SDK-stamped `issuer` (and client binding) plus `issued_at` on the persisted token, following the `OAuthClientInformationFull.issuer` precedent, and a way for `TokenStorage` to forget tokens. Known exposures until then, stated rather than fixed here: (a) for pre-registered / unstamped `client_info` the 401-path refresh presents the stored refresh token (and client secret, as the code exchange already did) to whichever issuer the resource server's PRM now names — needs a token issuer stamp to detect; (b) `clear_tokens()` is memory-only, so a process that re-registers but cannot complete authorization leaves the previous client's `tokens.json` beside the new `client_info`, and the next process presents that refresh token under the new client once (rejected as `invalid_grant`) before authorizing; (c) verbatim storages get no real expiry across restarts. Refresh-failure classification and the `{server-origin}` fallback base used when PRM named an AS whose metadata could not be fetched belong in the same pass.
- No conformance scenario issues a refresh token today (modelcontextprotocol/conformance#139 is the nearest), so this isn't observable there yet.
- Supersedes #2492, #2875, #3263. (#1784 and #3248 restore expiry in `_initialize`, which this PR deliberately doesn't; the stored-token follow-up covers that.)

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
