### PR TITLE
Hand TypedDict tool results to pydantic natively

### DIFF
--- a/docs/servers/structured-output.md
+++ b/docs/servers/structured-output.md
@@ -100,7 +100,7 @@ Not every shape deserves a class. A `TypedDict` produces the same schema:
 --8<-- "docs_src/structured_output/tutorial003.py"
 ```
 
-A `TypedDict` is a plain `dict` at runtime, so that is what you build and return. The schema, the validation, and `structured_content` are identical to the `BaseModel` version (minus the descriptions, which `TypedDict` has no place for).
+A `TypedDict` is a plain `dict` at runtime, so that is what you build and return. The schema, the validation, and `structured_content` are identical to the `BaseModel` version: the class docstring and `Annotated[..., Field(description=...)]` carry the descriptions, and a `NotRequired` key you leave out of the dict stays out of `structured_content`.
 
 ## A dataclass
 

--- a/docs/servers/structured-output.md
+++ b/docs/servers/structured-output.md
@@ -100,7 +100,7 @@ Not every shape deserves a class. A `TypedDict` produces the same schema:
 --8<-- "docs_src/structured_output/tutorial003.py"
 ```
 
-A `TypedDict` is a plain `dict` at runtime, so that is what you build and return. The schema, the validation, and `structured_content` are identical to the `BaseModel` version: the class docstring and `Annotated[..., Field(description=...)]` carry the descriptions, and a `NotRequired` key you leave out of the dict stays out of `structured_content`.
+A `TypedDict` is a plain `dict` at runtime, so that is what you build and return. The schema, the validation, and `structured_content` follow the same rules as the `BaseModel` version: add a class docstring or `Annotated[..., Field(description=...)]` and they become the descriptions, and a `NotRequired` key you leave out of the dict stays out of `structured_content`.
 
 ## A dataclass
 

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -1,19 +1,20 @@
 import functools
 import inspect
 import json
+import sys
 from collections.abc import Awaitable, Callable, Sequence
 from itertools import chain
 from types import GenericAlias
-from typing import Annotated, Any, Union, cast, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, Union, cast, get_args, get_origin
 
 import anyio
 import anyio.to_thread
 import pydantic_core
 from mcp_types import CallToolResult, ContentBlock, InputRequiredResult, TextContent
-from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, WithJsonSchema, create_model
+from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, TypeAdapter, WithJsonSchema, create_model
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaWarningKind
-from typing_extensions import is_typeddict
+from typing_extensions import NotRequired, TypedDict, get_type_hints, is_typeddict
 from typing_inspection.introspection import (
     UNKNOWN,
     AnnotationSource,
@@ -85,8 +86,14 @@ class ArgModelBase(BaseModel):
 class FuncMetadata(BaseModel):
     arg_model: Annotated[type[ArgModelBase], WithJsonSchema(None)]
     output_schema: dict[str, Any] | None = None
-    output_model: Annotated[type[BaseModel], WithJsonSchema(None)] | None = None
+    output_model: Annotated[type[Any], WithJsonSchema(None)] | None = None
     wrap_output: bool = False
+
+    @functools.cached_property
+    def output_adapter(self) -> TypeAdapter[Any]:
+        """Validates and serializes structured output against `output_model`."""
+        assert self.output_model is not None, "Output model must be set if output schema is defined"
+        return TypeAdapter(self.output_model)
 
     def validate_arguments(self, arguments_to_validate: dict[str, Any]) -> dict[str, Any]:
         """Validate raw arguments into a one-level kwargs dict (no function call).
@@ -144,8 +151,7 @@ class FuncMetadata(BaseModel):
             return result
         if isinstance(result, CallToolResult):
             if self.output_schema is not None:
-                assert self.output_model is not None, "Output model must be set if output schema is defined"
-                self.output_model.model_validate(result.structured_content)
+                self.output_adapter.validate_python(result.structured_content)
             return result
 
         unstructured_content = _convert_to_content(result)
@@ -156,9 +162,12 @@ class FuncMetadata(BaseModel):
         if self.wrap_output:
             result = {"result": result}
 
-        assert self.output_model is not None, "Output model must be set if output schema is defined"
-        validated = self.output_model.model_validate(result)
-        structured_content = validated.model_dump(mode="json", by_alias=True)
+        validated = self.output_adapter.validate_python(result)
+        if isinstance(validated, BaseModel):
+            # Dump via the instance so a returned subclass keeps its own fields.
+            structured_content = validated.model_dump(mode="json", by_alias=True)
+        else:
+            structured_content = self.output_adapter.dump_python(validated, mode="json", by_alias=True)
 
         return CallToolResult(content=unstructured_content, structured_content=structured_content)
 
@@ -238,7 +247,7 @@ def func_metadata(
             - BaseModel subclasses (used directly)
             - Primitive types (str, int, float, bool, bytes, None) - wrapped in a
                 model with a 'result' field
-            - TypedDict - converted to a Pydantic model with same fields
+            - TypedDict - used directly
             - Dataclasses and other annotated classes - converted to Pydantic models
             - Generic types (list, dict, Union, etc.) - wrapped in a model with a 'result' field
             - Content blocks (TextContent, EmbeddedResource, ...), Image and Audio, bare or inside a
@@ -374,30 +383,41 @@ def func_metadata(
         # structured_output=True still forces one.
         return FuncMetadata(arg_model=arguments_model)
 
-    output_model, output_schema, wrap_output = _try_create_model_and_schema(
-        original_annotation, return_type_expr, func.__name__
-    )
+    output_model, wrap_output = _create_output_model(original_annotation, return_type_expr, func.__name__)
 
-    if output_model is None and structured_output is True:
+    if output_model is not None:
+        meta = FuncMetadata(arg_model=arguments_model, output_model=output_model, wrap_output=wrap_output)
+        try:
+            # Building the validator here surfaces unsupported types at registration rather than on the
+            # first call. StrictJsonSchema raises instead of emitting warnings.
+            meta.output_schema = meta.output_adapter.json_schema(schema_generator=StrictJsonSchema)
+            return meta
+        except (
+            PydanticUserError,
+            TypeError,
+            ValueError,
+            pydantic_core.SchemaError,
+            pydantic_core.ValidationError,
+        ) as e:
+            # These are expected errors when a type can't be converted to a Pydantic schema
+            # PydanticUserError: When Pydantic can't handle the type (e.g. PydanticInvalidForJsonSchema);
+            #   subclasses TypeError on pydantic <2.13 and RuntimeError on pydantic >=2.13
+            # ValueError: When there are issues with the type definition (including our custom warnings)
+            # SchemaError: When Pydantic can't build a schema
+            # ValidationError: When validation fails
+            logger.info(f"Cannot create schema for type {return_type_expr} in {func.__name__}: {type(e).__name__}: {e}")
+
+    if structured_output is True:
         # Model creation failed or produced warnings - no structured output
         raise InvalidSignature(
             f"Function {func.__name__}: return type {return_type_expr} is not serializable for structured output"
         )
 
-    return FuncMetadata(
-        arg_model=arguments_model,
-        output_schema=output_schema,
-        output_model=output_model,
-        wrap_output=wrap_output,
-    )
+    return FuncMetadata(arg_model=arguments_model)
 
 
-def _try_create_model_and_schema(
-    original_annotation: Any,
-    type_expr: Any,
-    func_name: str,
-) -> tuple[type[BaseModel] | None, dict[str, Any] | None, bool]:
-    """Try to create a model and schema for the given annotation without warnings.
+def _create_output_model(original_annotation: Any, type_expr: Any, func_name: str) -> tuple[type[Any] | None, bool]:
+    """Pick the type structured output is validated against for the given return annotation.
 
     Args:
         original_annotation: The original return annotation (may be wrapped in `Annotated`).
@@ -406,11 +426,11 @@ def _try_create_model_and_schema(
         func_name: The name of the function.
 
     Returns:
-        tuple of (model or None, schema or None, wrap_output)
-        Model and schema are None if warnings occur or creation fails.
+        tuple of (model or None, wrap_output)
+        Model is None if the type cannot carry structured output.
         wrap_output is True if the result needs to be wrapped in {"result": ...}
     """
-    model = None
+    model: type[Any] | None = None
     wrap_output = False
 
     # First handle special case: None
@@ -446,9 +466,9 @@ def _try_create_model_and_schema(
         if issubclass(type_annotation, BaseModel):
             model = type_annotation
 
-        # Case 2: TypedDicts:
+        # Case 2: TypedDicts (pydantic reads qualifiers, totality, docstring and `Annotated` metadata natively)
         elif is_typeddict(type_annotation):
-            model = _create_model_from_typeddict(type_annotation)
+            model = _pydantic_readable_typeddict(type_annotation)
 
         # Case 3: Primitive types that need wrapping
         elif type_annotation in (str, int, float, bool, bytes, type(None)):
@@ -470,30 +490,7 @@ def _try_create_model_and_schema(
         model = _create_wrapped_model(func_name, original_annotation)
         wrap_output = True
 
-    if model:
-        # If we successfully created a model, try to get its schema
-        # Use StrictJsonSchema to raise exceptions instead of warnings
-        try:
-            schema = model.model_json_schema(schema_generator=StrictJsonSchema)
-        except (
-            PydanticUserError,
-            TypeError,
-            ValueError,
-            pydantic_core.SchemaError,
-            pydantic_core.ValidationError,
-        ) as e:
-            # These are expected errors when a type can't be converted to a Pydantic schema
-            # PydanticUserError: When Pydantic can't handle the type (e.g. PydanticInvalidForJsonSchema);
-            #   subclasses TypeError on pydantic <2.13 and RuntimeError on pydantic >=2.13
-            # ValueError: When there are issues with the type definition (including our custom warnings)
-            # SchemaError: When Pydantic can't build a schema
-            # ValidationError: When validation fails
-            logger.info(f"Cannot create schema for type {type_expr} in {func_name}: {type(e).__name__}: {e}")
-            return None, None, False
-
-        return model, schema, wrap_output
-
-    return None, None, False
+    return model, wrap_output
 
 
 _no_default = object()
@@ -523,25 +520,29 @@ def _create_model_from_class(cls: type[Any], type_hints: dict[str, Any]) -> type
     return create_model(cls.__name__, __config__=ConfigDict(from_attributes=True), **model_fields)
 
 
-def _create_model_from_typeddict(td_type: type[Any]) -> type[BaseModel]:
-    """Create a Pydantic model from a TypedDict.
+def _pydantic_readable_typeddict(td_type: type[Any]) -> type[Any]:
+    """pydantic refuses `typing.TypedDict` below Python 3.12 (it needs `__orig_bases__`); rebuild those as an
+    equivalent `typing_extensions.TypedDict` so tool authors don't have to know. Delete once 3.11 support goes."""
+    if sys.version_info >= (3, 12) or type(td_type).__module__ != "typing":
+        return td_type
+    return _as_typing_extensions_typeddict(td_type)  # pragma: lax no cover
 
-    The created model will have the same name and fields as the TypedDict.
-    """
-    type_hints = get_type_hints(td_type)
-    required_keys = getattr(td_type, "__required_keys__", set(type_hints.keys()))
 
-    model_fields: dict[str, Any] = {}
-    for field_name, field_type in type_hints.items():
-        if field_name not in required_keys:
-            # For optional TypedDict fields, set default=None
-            # This makes them not required in the Pydantic model
-            # The model should use exclude_unset=True when dumping to get TypedDict semantics
-            model_fields[field_name] = (field_type, None)
-        else:
-            model_fields[field_name] = field_type
-
-    return create_model(td_type.__name__, **model_fields)
+def _as_typing_extensions_typeddict(td_type: type[Any]) -> type[Any]:  # pragma: lax no cover
+    items: dict[str, Any] = {}
+    for name, hint in get_type_hints(td_type, include_extras=True).items():
+        key = inspect_annotation(hint, annotation_source=AnnotationSource.TYPED_DICT)
+        item: Any = Annotated[(key.type, *key.metadata)] if key.metadata else key.type
+        # pydantic's rule: an explicit qualifier wins over class totality. Needed because a stdlib TypedDict
+        # this old computes `__required_keys__` without seeing `typing_extensions` qualifiers.
+        required = (name in td_type.__required_keys__ or "required" in key.qualifiers) and (
+            "not_required" not in key.qualifiers
+        )
+        items[name] = item if required else NotRequired[item]
+    # The functional form, spelled so type checkers don't try to evaluate it statically.
+    rebuilt = cast("Callable[[str, dict[str, Any]], type[Any]]", TypedDict)(td_type.__name__, items)
+    rebuilt.__doc__ = td_type.__doc__
+    return rebuilt
 
 
 def _create_wrapped_model(func_name: str, annotation: Any) -> type[BaseModel]:

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -11,10 +11,19 @@ import anyio
 import anyio.to_thread
 import pydantic_core
 from mcp_types import CallToolResult, ContentBlock, InputRequiredResult, TextContent
-from pydantic import BaseModel, ConfigDict, Field, PydanticUserError, TypeAdapter, WithJsonSchema, create_model
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    PydanticUserError,
+    TypeAdapter,
+    WithJsonSchema,
+    create_model,
+)
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaWarningKind
-from typing_extensions import NotRequired, TypedDict, get_type_hints, is_typeddict
+from typing_extensions import NotRequired, ReadOnly, TypedDict, get_type_hints, is_typeddict
 from typing_inspection.introspection import (
     UNKNOWN,
     AnnotationSource,
@@ -84,16 +93,27 @@ class ArgModelBase(BaseModel):
 
 
 class FuncMetadata(BaseModel):
+    """A tool function's argument model plus, for structured output, the published `output_schema` and the
+    `output_model` results are validated against. Constructing one with an `output_model` and no schema derives
+    the schema (and raises if pydantic can't); the fields are read live, so clearing or reassigning them later
+    takes effect on the next call."""
+
     arg_model: Annotated[type[ArgModelBase], WithJsonSchema(None)]
     output_schema: dict[str, Any] | None = None
     output_model: Annotated[type[Any], WithJsonSchema(None)] | None = None
     wrap_output: bool = False
+    _adapter: tuple[type[Any], TypeAdapter[Any]] | None = PrivateAttr(default=None)
 
-    @functools.cached_property
-    def output_adapter(self) -> TypeAdapter[Any]:
-        """Validates and serializes structured output against `output_model`."""
-        assert self.output_model is not None, "Output model must be set if output schema is defined"
-        return TypeAdapter(self.output_model)
+    def model_post_init(self, context: Any, /) -> None:
+        if self.output_model is not None and self.output_schema is None:
+            # StrictJsonSchema raises instead of warning, so an unserializable return type fails construction.
+            self.output_schema = self._output_adapter(self.output_model).json_schema(schema_generator=StrictJsonSchema)
+
+    def _output_adapter(self, output_model: type[Any]) -> TypeAdapter[Any]:
+        """The validator/serializer for `output_model`, built once and rebuilt only if the field is reassigned."""
+        if self._adapter is None or self._adapter[0] is not output_model:
+            self._adapter = (output_model, TypeAdapter(_pydantic_readable_typeddict(output_model)))
+        return self._adapter[1]
 
     def validate_arguments(self, arguments_to_validate: dict[str, Any]) -> dict[str, Any]:
         """Validate raw arguments into a one-level kwargs dict (no function call).
@@ -149,25 +169,29 @@ class FuncMetadata(BaseModel):
         """
         if isinstance(result, InputRequiredResult):
             return result
+        # A schema published without a model (hand-built metadata) is advertised but not validated here.
+        output_model = self.output_model if self.output_schema is not None else None
         if isinstance(result, CallToolResult):
-            if self.output_schema is not None:
-                self.output_adapter.validate_python(result.structured_content)
+            if output_model is not None:
+                self._output_adapter(output_model).validate_python(result.structured_content)
             return result
 
         unstructured_content = _convert_to_content(result)
 
-        if self.output_schema is None:
+        if output_model is None:
             return CallToolResult(content=unstructured_content)
 
         if self.wrap_output:
             result = {"result": result}
 
-        validated = self.output_adapter.validate_python(result)
+        # The tool hands back Python-side names; the wire (and outputSchema) use aliases.
+        adapter = self._output_adapter(output_model)
+        validated = adapter.validate_python(result, by_alias=True, by_name=True)
         if isinstance(validated, BaseModel):
             # Dump via the instance so a returned subclass keeps its own fields.
             structured_content = validated.model_dump(mode="json", by_alias=True)
         else:
-            structured_content = self.output_adapter.dump_python(validated, mode="json", by_alias=True)
+            structured_content = adapter.dump_python(validated, mode="json", by_alias=True)
 
         return CallToolResult(content=unstructured_content, structured_content=structured_content)
 
@@ -257,7 +281,9 @@ def func_metadata(
     Returns:
         A FuncMetadata object containing:
         - arg_model: A Pydantic model representing the function's arguments
-        - output_model: A Pydantic model for the return type if the output is structured
+        - output_schema: The published JSON schema for structured output, or None if the output is unstructured
+        - output_model: The type structured output is validated against: the declared BaseModel or TypedDict,
+            or a synthesized model for wrapped, `dict[str, T]` and annotated-class returns
         - wrap_output: Whether the function result needs to be wrapped in `{"result": ...}` for structured output.
     """
     try:
@@ -386,14 +412,14 @@ def func_metadata(
     output_model, wrap_output = _create_output_model(original_annotation, return_type_expr, func.__name__)
 
     if output_model is not None:
-        meta = FuncMetadata(arg_model=arguments_model, output_model=output_model, wrap_output=wrap_output)
         try:
-            # Building the validator here surfaces unsupported types at registration rather than on the
-            # first call. StrictJsonSchema raises instead of emitting warnings.
-            meta.output_schema = meta.output_adapter.json_schema(schema_generator=StrictJsonSchema)
-            return meta
+            # FuncMetadata builds the validator and schema on construction, so an unsupported return type
+            # surfaces here, at registration, rather than on the first call.
+            return FuncMetadata(arg_model=arguments_model, output_model=output_model, wrap_output=wrap_output)
         except (
             PydanticUserError,
+            ForbiddenQualifier,
+            NameError,
             TypeError,
             ValueError,
             pydantic_core.SchemaError,
@@ -402,7 +428,10 @@ def func_metadata(
             # These are expected errors when a type can't be converted to a Pydantic schema
             # PydanticUserError: When Pydantic can't handle the type (e.g. PydanticInvalidForJsonSchema);
             #   subclasses TypeError on pydantic <2.13 and RuntimeError on pydantic >=2.13
-            # ValueError: When there are issues with the type definition (including our custom warnings)
+            # ForbiddenQualifier, NameError: an invalid qualifier or unresolvable annotation on a TypedDict key,
+            #   met while rebuilding a stdlib TypedDict below 3.12 (pydantic reports both as PydanticUserError)
+            # ValueError: When there are issues with the type definition (including our custom warnings);
+            #   arrives wrapped in a ValidationError when raised during FuncMetadata construction
             # SchemaError: When Pydantic can't build a schema
             # ValidationError: When validation fails
             logger.info(f"Cannot create schema for type {return_type_expr} in {func.__name__}: {type(e).__name__}: {e}")
@@ -468,7 +497,7 @@ def _create_output_model(original_annotation: Any, type_expr: Any, func_name: st
 
         # Case 2: TypedDicts (pydantic reads qualifiers, totality, docstring and `Annotated` metadata natively)
         elif is_typeddict(type_annotation):
-            model = _pydantic_readable_typeddict(type_annotation)
+            model = type_annotation
 
         # Case 3: Primitive types that need wrapping
         elif type_annotation in (str, int, float, bool, bytes, type(None)):
@@ -520,12 +549,14 @@ def _create_model_from_class(cls: type[Any], type_hints: dict[str, Any]) -> type
     return create_model(cls.__name__, __config__=ConfigDict(from_attributes=True), **model_fields)
 
 
-def _pydantic_readable_typeddict(td_type: type[Any]) -> type[Any]:
-    """pydantic refuses `typing.TypedDict` below Python 3.12 (it needs `__orig_bases__`); rebuild those as an
-    equivalent `typing_extensions.TypedDict` so tool authors don't have to know. Delete once 3.11 support goes."""
-    if sys.version_info >= (3, 12) or type(td_type).__module__ != "typing":
-        return td_type
-    return _as_typing_extensions_typeddict(td_type)  # pragma: lax no cover
+def _pydantic_readable_typeddict(output_model: type[Any]) -> type[Any]:
+    """pydantic refuses `typing.TypedDict` below Python 3.12 (it needs `__orig_bases__`); rebuild such a return
+    type as an equivalent `typing_extensions.TypedDict` so tool authors don't have to know. Only the class itself
+    (its keys, docstring and own config) is rebuilt: stdlib TypedDicts nested inside it, or config inherited from
+    one, still need `typing_extensions` there. Delete with 3.11 support."""
+    if sys.version_info >= (3, 12) or not is_typeddict(output_model) or type(output_model).__module__ != "typing":
+        return output_model
+    return _as_typing_extensions_typeddict(output_model)  # pragma: lax no cover
 
 
 def _as_typing_extensions_typeddict(td_type: type[Any]) -> type[Any]:  # pragma: lax no cover
@@ -533,6 +564,8 @@ def _as_typing_extensions_typeddict(td_type: type[Any]) -> type[Any]:  # pragma:
     for name, hint in get_type_hints(td_type, include_extras=True).items():
         key = inspect_annotation(hint, annotation_source=AnnotationSource.TYPED_DICT)
         item: Any = Annotated[(key.type, *key.metadata)] if key.metadata else key.type
+        if "read_only" in key.qualifiers:
+            item = ReadOnly[item]
         # pydantic's rule: an explicit qualifier wins over class totality. Needed because a stdlib TypedDict
         # this old computes `__required_keys__` without seeing `typing_extensions` qualifiers.
         required = (name in td_type.__required_keys__ or "required" in key.qualifiers) and (
@@ -541,7 +574,9 @@ def _as_typing_extensions_typeddict(td_type: type[Any]) -> type[Any]:  # pragma:
         items[name] = item if required else NotRequired[item]
     # The functional form, spelled so type checkers don't try to evaluate it statically.
     rebuilt = cast("Callable[[str, dict[str, Any]], type[Any]]", TypedDict)(td_type.__name__, items)
-    rebuilt.__doc__ = td_type.__doc__
+    for attr in ("__doc__", "__module__", "__qualname__", "__pydantic_config__"):
+        if hasattr(td_type, attr):
+            setattr(rebuilt, attr, getattr(td_type, attr))
     return rebuilt
 
 

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -9,9 +9,11 @@ from typing import Annotated, Any, Final, NamedTuple, TypedDict
 
 import annotated_types
 import pytest
+import typing_extensions
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, ContentBlock, EmbeddedResource, InputRequiredResult, TextContent
 from pydantic import BaseModel, Field
+from typing_extensions import NotRequired, ReadOnly, Required
 
 from mcp.server.mcpserver import Audio, Image
 from mcp.server.mcpserver.exceptions import InvalidSignature
@@ -773,22 +775,28 @@ def test_structured_output_dataclass():
 def test_structured_output_typeddict():
     """Test structured output with TypedDict return types"""
 
+    # stdlib TypedDict with a qualifier: exercises the typing_extensions rebuild below Python 3.12
     class PersonTypedDictOptional(TypedDict, total=False):
-        name: str
+        name: Required[str]
         age: int
 
-    def func_returning_typeddict_optional() -> PersonTypedDictOptional:  # pragma: no cover
+    def func_returning_typeddict_optional() -> PersonTypedDictOptional:
         return {"name": "Dave"}  # Only returning one field to test partial dict
 
     meta = func_metadata(func_returning_typeddict_optional)
     assert meta.output_schema == {
         "type": "object",
         "properties": {
-            "name": {"title": "Name", "type": "string", "default": None},
-            "age": {"title": "Age", "type": "integer", "default": None},
+            "name": {"title": "Name", "type": "string"},
+            "age": {"title": "Age", "type": "integer"},
         },
+        "required": ["name"],
         "title": "PersonTypedDictOptional",
     }
+    # An optional key the tool leaves out is absent, not null, so it validates against the schema above
+    result = meta.convert_result(func_returning_typeddict_optional())
+    assert isinstance(result, CallToolResult)
+    assert result.structured_content == {"name": "Dave"}
 
     # Test with total=True (all required)
     class PersonTypedDictRequired(TypedDict):
@@ -809,6 +817,40 @@ def test_structured_output_typeddict():
         },
         "required": ["name", "age", "email"],
         "title": "PersonTypedDictRequired",
+    }
+
+
+def test_structured_output_typeddict_qualifiers_and_metadata():
+    """PEP 655/705 qualifiers register on every supported Python and decide `required`; the docstring
+    and `Annotated` field metadata reach the schema like they do for a BaseModel."""
+
+    class Forecast(typing_extensions.TypedDict, total=False):
+        """Tomorrow's weather."""
+
+        city: Required[Annotated[str, Field(description="City name")]]
+        high: ReadOnly[Required[float]]
+        low: float
+        summary: NotRequired[Annotated[str, Field(max_length=80)]]
+
+    def forecast() -> Forecast:
+        return {"city": "Berlin", "high": 21.5}
+
+    with pytest.warns(UserWarning, match="ReadOnly"):  # pydantic notes it won't enforce ReadOnly
+        meta = func_metadata(forecast)
+    result = meta.convert_result(forecast())
+    assert isinstance(result, CallToolResult)
+    assert result.structured_content == {"city": "Berlin", "high": 21.5}
+    assert meta.output_schema == {
+        "type": "object",
+        "title": "Forecast",
+        "description": "Tomorrow's weather.",
+        "properties": {
+            "city": {"title": "City", "type": "string", "description": "City name"},
+            "high": {"title": "High", "type": "number"},
+            "low": {"title": "Low", "type": "number"},
+            "summary": {"title": "Summary", "type": "string", "maxLength": 80},
+        },
+        "required": ["city", "high"],
     }
 
 

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -5,19 +5,21 @@
 # pyright: reportUnknownLambdaType=false
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Annotated, Any, Final, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Annotated, Any, Final, NamedTuple, TypedDict
 
 import annotated_types
 import pytest
-import typing_extensions
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, ContentBlock, EmbeddedResource, InputRequiredResult, TextContent
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 from typing_extensions import NotRequired, ReadOnly, Required
 
 from mcp.server.mcpserver import Audio, Image
 from mcp.server.mcpserver.exceptions import InvalidSignature
-from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+from mcp.server.mcpserver.utilities.func_metadata import ArgModelBase, FuncMetadata, func_metadata
+
+if TYPE_CHECKING:
+    from decimal import Decimal
 
 
 class SomeInputModelA(BaseModel):
@@ -821,13 +823,14 @@ def test_structured_output_typeddict():
 
 
 def test_structured_output_typeddict_qualifiers_and_metadata():
-    """PEP 655/705 qualifiers register on every supported Python and decide `required`; the docstring
-    and `Annotated` field metadata reach the schema like they do for a BaseModel."""
+    """PEP 655/705 qualifiers register on every supported Python and decide `required`; the docstring and
+    `Annotated` field metadata reach the schema like they do for a BaseModel, and an alias names the wire key.
+    A stdlib TypedDict, so below 3.12 all of this goes through the typing_extensions rebuild."""
 
-    class Forecast(typing_extensions.TypedDict, total=False):
+    class Forecast(TypedDict, total=False):
         """Tomorrow's weather."""
 
-        city: Required[Annotated[str, Field(description="City name")]]
+        city: Required[Annotated[str, Field(alias="cityName", description="City name")]]
         high: ReadOnly[Required[float]]
         low: float
         summary: NotRequired[Annotated[str, Field(max_length=80)]]
@@ -839,19 +842,56 @@ def test_structured_output_typeddict_qualifiers_and_metadata():
         meta = func_metadata(forecast)
     result = meta.convert_result(forecast())
     assert isinstance(result, CallToolResult)
-    assert result.structured_content == {"city": "Berlin", "high": 21.5}
+    assert result.structured_content == {"cityName": "Berlin", "high": 21.5}
     assert meta.output_schema == {
         "type": "object",
         "title": "Forecast",
         "description": "Tomorrow's weather.",
         "properties": {
-            "city": {"title": "City", "type": "string", "description": "City name"},
+            "cityName": {"title": "Cityname", "type": "string", "description": "City name"},
             "high": {"title": "High", "type": "number"},
             "low": {"title": "Low", "type": "number"},
             "summary": {"title": "Summary", "type": "string", "maxLength": 80},
         },
-        "required": ["city", "high"],
+        "required": ["cityName", "high"],
     }
+
+
+def test_func_metadata_built_by_hand_keeps_a_given_output_schema():
+    """A hand-built FuncMetadata publishes the schema it was given but still validates results against output_model."""
+    meta = FuncMetadata(arg_model=ArgModelBase, output_model=SomeInputModelB.InnerModel, output_schema={"x": 1})
+    assert meta.output_schema == {"x": 1}
+    with pytest.raises(ValidationError):
+        meta.convert_result({"x": "not an int"})
+
+
+def test_func_metadata_output_fields_are_read_live():
+    """Code in the wild switches structured output off or on by assigning the fields after registration."""
+
+    def total() -> int:
+        return 3
+
+    meta = func_metadata(total)
+    meta.output_schema = None
+    off = meta.convert_result(total())
+    meta.output_schema, meta.output_model, meta.wrap_output = {"type": "object"}, SomeInputModelB.InnerModel, False
+    on = meta.convert_result({"x": 3})
+    assert isinstance(off, CallToolResult) and isinstance(on, CallToolResult)
+    assert (off.structured_content, on.structured_content) == (None, {"x": 3})
+
+
+def test_structured_output_typeddict_with_unresolvable_annotation_is_unstructured():
+    """An annotation only importable under TYPE_CHECKING degrades the same way on every supported Python."""
+
+    class Report(TypedDict):
+        total: "Decimal"
+
+    def report() -> Report:  # pragma: no cover
+        raise NotImplementedError
+
+    assert func_metadata(report).output_schema is None
+    with pytest.raises(InvalidSignature):
+        func_metadata(report, structured_output=True)
 
 
 def test_structured_output_ordinary_class():

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1,7 +1,7 @@
 import base64
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, TypedDict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
@@ -44,7 +44,7 @@ from mcp_types import (
 from pydantic import BaseModel
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, TypedDict
 
 from mcp.client import Client
 from mcp.server.context import ServerRequestContext
@@ -716,7 +716,6 @@ class TestServerTools:
             assert "Unknown tool" in content.text
 
 
-@pytest.mark.anyio
 async def test_typeddict_tool_omitting_optional_keys_passes_client_validation():
     """The client validates structured content against the tool's output schema, so a `NotRequired`
     key the tool leaves out must be absent from `structured_content` rather than null."""

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1,7 +1,7 @@
 import base64
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, TypedDict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
@@ -44,6 +44,7 @@ from mcp_types import (
 from pydantic import BaseModel
 from starlette.applications import Starlette
 from starlette.routing import Mount, Route
+from typing_extensions import NotRequired
 
 from mcp.client import Client
 from mcp.server.context import ServerRequestContext
@@ -713,6 +714,33 @@ class TestServerTools:
             content = result.content[0]
             assert isinstance(content, TextContent)
             assert "Unknown tool" in content.text
+
+
+@pytest.mark.anyio
+async def test_typeddict_tool_omitting_optional_keys_passes_client_validation():
+    """The client validates structured content against the tool's output schema, so a `NotRequired`
+    key the tool leaves out must be absent from `structured_content` rather than null."""
+
+    class Person(TypedDict):
+        name: str
+        age: NotRequired[int]
+
+    mcp = MCPServer()
+
+    @mcp.tool()
+    def get_person() -> Person:
+        return {"name": "Dave"}
+
+    async with Client(mcp) as client:
+        (tool,) = (await client.list_tools()).tools
+        assert tool.output_schema == {
+            "type": "object",
+            "title": "Person",
+            "properties": {"name": {"title": "Name", "type": "string"}, "age": {"title": "Age", "type": "integer"}},
+            "required": ["name"],
+        }
+        result = await client.call_tool("get_person", {})
+        assert result.structured_content == {"name": "Dave"}
 
 
 class TestServerResources:


### PR DESCRIPTION
MCPServer now validates and serializes `TypedDict` tool results through pydantic's own TypedDict support instead of mirroring the TypedDict into a hand-built `BaseModel`.

Fixes #3224
Fixes #3227

## Motivation and Context

The hand-built mirror in `_create_model_from_typeddict` was the common root of a few problems with `TypedDict` return types:

- Optional keys (`NotRequired`, `total=False`) got a `None` default and were dumped as `null`, so a tool that left one out produced `structuredContent` that violated its own `outputSchema` (`{"type": "integer", "default": null}`) and the client rejected the call (#3224). This affected every Python version.
- The field types came from `typing.get_type_hints`, which leaves `NotRequired`/`Required` in place on 3.10 and `ReadOnly` in place on 3.10–3.12; `create_model` rejects bare qualifiers, so registration raised `PydanticForbiddenQualifier` (#3227, plus the unreported `ReadOnly` variant).
- The TypedDict's docstring and any `Annotated[..., Field(...)]` metadata never reached the schema, and constraints weren't enforced.

Nested and wrapped TypedDicts (`-> list[Person]`, a TypedDict inside a model) already went through pydantic natively and had none of these issues, so this makes the top-level case consistent with them.

What changes:

- `TypedDict` returns are handled by a `TypeAdapter` over the TypedDict itself; `_create_model_from_typeddict` is gone.
- pydantic refuses `typing.TypedDict` below Python 3.12, so on 3.10/3.11 a stdlib TypedDict return type is rebuilt as an equivalent `typing_extensions.TypedDict` when the validator is built (per-key required/optional derived the way pydantic does it; docstring, `__module__`/`__qualname__`, `__pydantic_config__` and `ReadOnly` carried over). `output_model` stays the class the user declared. Only the top-level class is rebuilt: a stdlib TypedDict nested inside one (or config inherited from a stdlib base) still needs `typing_extensions` below 3.12 and otherwise falls back to unstructured output with an INFO log; wrapped forms (`list[StdTD]`, `StdTD | None`, ...) raise pydantic's "use typing_extensions.TypedDict" at registration exactly as they do on `main`. Delete when 3.11 support is dropped.
- `FuncMetadata` derives a private validator (and `output_schema`, unless one is given) from `output_model` when it is constructed; `func_metadata()` constructs it inside the existing "not serializable for structured output" fallback, so unsupported return types still degrade (or raise `InvalidSignature` with `structured_output=True`). The fields are read live: code that clears or assigns `output_schema`/`output_model` on a registered tool's `fn_metadata` keeps working, and the validator is rebuilt if `output_model` is reassigned. `FuncMetadata.output_model` is the TypedDict class for TypedDict tools (still the model class for everything else); its annotation widens to `type[Any] | None`.
- Results are validated with `by_name=True` as well as by alias, so a return type declaring `Field(alias=...)` accepts the Python-side keys a tool naturally returns while `structuredContent` carries the aliases the schema advertises.

This supersedes #3225 — thanks @sainikhiljuluri for the thorough reports and the initial fix, and @gingeekrishna for the `typing_extensions.get_type_hints` pointer. I went with the native route rather than `exclude_unset` because `exclude_unset` recurses into nested models (a `BaseModel` with defaults inside a TypedDict would lose its defaulted fields) and the mirror would still publish `default: null` and drop metadata.

## How Has This Been Tested?

- New/updated unit tests for qualifiers, `Annotated` metadata, aliases and omitted keys (using stdlib `TypedDict` so the 3.10/3.11 legs go through the rebuild), hand-built and post-registration-mutated `FuncMetadata`, an unresolvable key annotation, plus an in-memory `Client(server)` round trip; the changed tests fail on `main`.
- Drove a stdio server with TypedDict tools (both `typing` and `typing_extensions` spellings, `NotRequired`/`Required`/`ReadOnly`, nested model with defaults, passthrough `CallToolResult`) through `mcp.Client` on 3.14 and on 3.10, and compared against `main`.

## Breaking Changes

No code changes needed. Observable differences, mostly for TypedDict tools:

- `outputSchema` no longer carries `"default": null` on optional keys; the class docstring becomes `description`; `Annotated[..., Field(...)]` descriptions/constraints/aliases and `__pydantic_config__`/`@with_config` (e.g. `extra='forbid'`, `alias_generator`) now appear and are enforced.
- Omitted optional keys are absent from `structuredContent` instead of `null`.
- A TypedDict pydantic can't build a schema for (un-schema-able value type, unresolvable key annotation) now falls back to unstructured output (or `InvalidSignature` with `structured_output=True`) like other unsupported return types, instead of raising from the decorator. One 3.10-only wrinkle: a quoted forward reference inside a builtin generic on a TypedDict key (`children: list["Node"]`) is something pydantic can't resolve on 3.10, so it takes that fallback too; `from __future__ import annotations`, `List["Node"]` or quoting the whole annotation work.
- For any structured return type, a dict keyed by field names now validates where the type declares aliases (previously only alias keys did).
- A `ReadOnly` key triggers pydantic's own `UserWarning` ("Pydantic will not protect items from any mutation") once at registration. I left that visible rather than filtering pydantic's message in library code; happy to revisit.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Not included, possible follow-ups: dataclass/plain-class returns still go through the hand-built model (`InitVar` fields, `slots=True`, `default_factory` have similar rough edges); the synthesized models (wrapped `{"result": ...}`, `dict[str, T]`, dataclass/plain class) are still constructed outside the fallback `try`, so an un-schema-able member type there still raises at registration; recursive return types publish a root `$ref` schema that 2025-11-25 sessions reject (#3337, pre-existing for `BaseModel`, now also TypedDict); schema is generated in validation mode while content is serialized (#3100).

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
