### PR TITLE
fix: include PROGRAMDATA in inherited Windows environment

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -45,6 +45,7 @@ DEFAULT_INHERITED_ENV_VARS = (
         "LOCALAPPDATA",
         "PATH",
         "PATHEXT",
+        "PROGRAMDATA",
         "PROCESSOR_ARCHITECTURE",
         "SYSTEMDRIVE",
         "SYSTEMROOT",


### PR DESCRIPTION
## Description

Fixes a Windows-specific MCP SSH transport issue where the subprocess can terminate shortly after the `initialize` message.

On Windows, the stdio client builds a restricted inherited environment for spawned MCP server processes. `PROGRAMDATA` was missing from the inherited environment variables.

This can cause Windows executables such as `ssh.exe` and related process behavior to differ from a normal environment.

### Change

Added `PROGRAMDATA` to `DEFAULT_INHERITED_ENV_VARS` in `src/mcp/client/stdio.py`.

### Testing

* Reproduced the original Windows MCP + SSH failure.
* Reproduced the behavior outside Claude Desktop.
* Tested the restricted environment with `Popen`.
* Verified that `PROGRAMDATA` is now included.
* Ran the stdio client test suite successfully: **25 passed, 8 skipped**.
* `git diff --check` passes.

### Related Issue

Fixes/addresses MCP SSH transport closing immediately on Windows after the `initialize` message.

Issue: #1822
