### PR TITLE
fix(mcpserver): serialize empty list and tuple returns into TextContent

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -590,6 +590,9 @@ def _convert_to_content(result: Any) -> list[ContentBlock]:
         return [result.to_audio_content()]
 
     if isinstance(result, list | tuple):
+        if not result:
+            return [TextContent(type="text", text="[]" if isinstance(result, list) else "()")]
+
         return list(
             chain.from_iterable(
                 _convert_to_content(item)

--- a/tests/interaction/mcpserver/test_tools.py
+++ b/tests/interaction/mcpserver/test_tools.py
@@ -441,3 +441,24 @@ async def test_adding_and_removing_tools_does_not_notify_connected_clients(conne
     assert received == snapshot(
         [LoggingMessageNotification(params=LoggingMessageNotificationParams(level="info", data="tool set changed"))]
     )
+
+
+async def test_tool_returning_empty_list_and_tuple_produces_text_content(connect: Connect, unstamped: Unstamp) -> None:
+    """A tool returning an empty list or tuple produces a TextContent block rather than zero content blocks."""
+    mcp = MCPServer("empty-tools")
+
+    @mcp.tool()
+    def get_empty_list() -> list[str]:
+        return []
+
+    @mcp.tool()
+    def get_empty_tuple() -> tuple[str, ...]:
+        return ()
+
+    async with connect(mcp) as client:
+        list_result = await client.call_tool("get_empty_list", {})
+        tuple_result = await client.call_tool("get_empty_tuple", {})
+
+    assert list_result.content == [TextContent(text="[]")]
+    assert tuple_result.content == [TextContent(text="()")]
+

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1376,3 +1376,23 @@ def test_union_of_only_input_required_subclasses_yields_no_output_schema():
 
     meta = func_metadata(fn)
     assert meta.output_schema is None
+
+
+def test_convert_to_content_empty_list_and_tuple():
+    from mcp.server.mcpserver.utilities.func_metadata import _convert_to_content
+
+    empty_list_res = _convert_to_content([])
+    assert len(empty_list_res) == 1
+    assert isinstance(empty_list_res[0], TextContent)
+    assert empty_list_res[0].text == "[]"
+
+    empty_tuple_res = _convert_to_content(())
+    assert len(empty_tuple_res) == 1
+    assert isinstance(empty_tuple_res[0], TextContent)
+    assert empty_tuple_res[0].text == "()"
+
+    non_empty_res = _convert_to_content(["hello", "world"])
+    assert len(non_empty_res) == 2
+    assert non_empty_res[0].text == "hello"
+    assert non_empty_res[1].text == "world"
+


### PR DESCRIPTION
## Description
Fixes #3307

When a `@mcp.tool()` function returns an empty list `[]` or tuple `()`, `_convert_to_content` previously collapsed the return value into an empty list of content blocks (`content: []`). This caused downstream clients (such as Claude Desktop, LangGraph, and IDE integrations) to treat valid empty results as errored executions due to zero content blocks.

## Changes Made
- Updated `_convert_to_content` in `src/mcp/server/mcpserver/utilities/func_metadata.py` to return `[TextContent(type="text", text="[]")]` for empty lists (and `"()"` for empty tuples).
- Added unit test in `tests/server/mcpserver/test_func_metadata.py`.
- Added end-to-end client/server interaction test in `tests/interaction/mcpserver/test_tools.py`.

## Checklist
- [x] Linked existing issue #3307.
- [x] Unit and interaction tests added.