### PR TITLE
fix(client): validate JSON-null structuredContent against outputSchema

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -1141,7 +1141,9 @@ class ClientSession:
         if output_schema is not None:
             from jsonschema import exceptions as jsonschema_exceptions
 
-            if result.structured_content is None:
+            # SEP-2106 allows JSON null. Pydantic maps both omitted and explicit
+            # null to None; model_fields_set is the presence check (not falsy).
+            if result.structured_content is None and "structured_content" not in result.model_fields_set:
                 raise RuntimeError(f"Tool {name} has an output schema but did not return structured content")
             validator = self._output_schema_validator(name, output_schema)
             # `best_match` picks the same error the previous `jsonschema.validate()` call raised,

--- a/tests/client/test_session_promotions.py
+++ b/tests/client/test_session_promotions.py
@@ -67,6 +67,49 @@ async def test_validate_tool_result_raises_on_schema_mismatch() -> None:
 
 
 @pytest.mark.anyio
+async def test_validate_tool_result_accepts_explicit_json_null_when_the_schema_allows_it() -> None:
+    """SEP-2106: JSON null is a legal structuredContent value. A parsed result that
+    includes `"structuredContent": null` must be validated against the schema, not
+    rejected as a missing field. Pydantic stores both omitted and JSON null as None;
+    `model_fields_set` is how the client tells them apart.
+    """
+    server = _make_server({"type": "null"})
+    parsed = CallToolResult.model_validate({"content": [], "structuredContent": None})
+    async with Client(server) as client:
+        await client.session.validate_tool_result("t", parsed)
+
+
+@pytest.mark.anyio
+async def test_validate_tool_result_rejects_explicit_json_null_when_the_schema_does_not_allow_it() -> None:
+    """An explicit JSON null that fails the advertised object schema is a schema mismatch,
+    not a missing structuredContent field.
+    """
+    server = _make_server({"type": "object", "properties": {"x": {"type": "integer"}}, "required": ["x"]})
+    parsed = CallToolResult.model_validate({"content": [], "structuredContent": None})
+    async with Client(server) as client:
+        with pytest.raises(RuntimeError, match="Invalid structured content returned by tool t"):
+            await client.session.validate_tool_result("t", parsed)
+
+
+@pytest.mark.anyio
+async def test_validate_tool_result_still_rejects_omitted_structured_content() -> None:
+    server = _make_server({"type": "null"})
+    async with Client(server) as client:
+        with pytest.raises(RuntimeError, match="Tool t has an output schema but did not return structured content"):
+            await client.session.validate_tool_result("t", CallToolResult(content=[]))
+
+
+@pytest.mark.anyio
+async def test_validate_tool_result_validates_falsy_non_null_structured_content() -> None:
+    """0 / false / "" are present JSON values and must be schema-checked, not treated as missing."""
+    server = _make_server({"type": "number"})
+    async with Client(server) as client:
+        await client.session.validate_tool_result("t", CallToolResult(content=[], structured_content=0))
+        with pytest.raises(RuntimeError, match="Invalid structured content returned by tool t"):
+            await client.session.validate_tool_result("t", CallToolResult(content=[], structured_content=False))
+
+
+@pytest.mark.anyio
 async def test_validate_tool_result_raises_on_an_unusable_output_schema() -> None:
     """A schema that isn't valid JSON Schema is reported as such, on every call."""
     server = _make_server({"type": "not-a-json-schema-type"})


### PR DESCRIPTION
Fixes #3345

SEP-2106 allows `structuredContent` to be JSON null. `validate_tool_result` treated `structured_content is None` as a missing field, so a tool that advertised a null-capable `outputSchema` and returned `"structuredContent": null` never reached jsonschema validation.

Pydantic stores both omitted and explicit JSON null as `None`. This uses `model_fields_set` as the presence check, matching the TypeScript SDK's `=== undefined` (not null / not falsy) check.

## Motivation and Context

Declared `outputSchema` was not validated against a legal JSON-null `structuredContent` value. Clients rejected a conforming result as missing instead of schema-checking it. Omitted `structuredContent` still fails closed.

## How Has This Been Tested?

`uv run --frozen pytest tests/client/test_session_promotions.py tests/interaction/lowlevel/test_tools.py::test_declared_output_schema_with_no_structured_content_is_rejected_by_the_client tests/interaction/lowlevel/test_tools.py::test_call_tool_structured_content_violating_output_schema_is_rejected_by_the_client -q`

24 passed, including new cases for:

- explicit JSON null against `{"type": "null"}` (accept)
- explicit JSON null against an object schema (schema mismatch, not missing)
- omitted field (existing missing-field error)
- falsy non-null values `0` / `false`

## Breaking Changes

None. Omitted `structuredContent` still raises the same RuntimeError. Only an explicit JSON null is now schema-validated.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Not assigned on #3345. Opening as a draft per the small-fix-with-tests shape; CONTRIBUTING may auto-close until a maintainer assigns the issue. Reporter of #3345.

AI assistance: researched and implemented with Grok 4.6; I reviewed the spec text, the TypeScript v2 presence check, Pydantic `model_fields_set` on parsed `CallToolResult`, and the new tests.

No protocol change. No new schema surface. Does not duplicate the existing jsonschema check; it only stops the presence check from swallowing JSON null before that check runs.