### PR TITLE
[v1.x] Complete the FastMCP Settings model at import time

### DIFF
--- a/src/mcp/server/fastmcp/server.py
+++ b/src/mcp/server/fastmcp/server.py
@@ -1087,6 +1087,11 @@ class FastMCP(Generic[LifespanResultT]):
             raise ValueError(str(e))
 
 
+# `Settings.lifespan` refers to FastMCP, which is only defined above; complete the model now so
+# settings sources never see an unresolved annotation when a FastMCP instance is created.
+Settings.model_rebuild()
+
+
 class StreamableHTTPASGIApp:
     """
     ASGI application for Streamable HTTP server transport.

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -10,6 +10,7 @@ from starlette.routing import Mount, Route
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.prompts.base import Message, UserMessage
 from mcp.server.fastmcp.resources import FileResource, FunctionResource
+from mcp.server.fastmcp.server import Settings
 from mcp.server.fastmcp.utilities.types import Audio, Image
 from mcp.server.session import ServerSession
 from mcp.server.transport_security import TransportSecuritySettings
@@ -29,6 +30,11 @@ from mcp.types import (
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import Context
+
+
+def test_settings_model_is_complete_at_import():
+    """The Settings model resolves its FastMCP annotation at import, so building one needs no deferred rebuild."""
+    assert Settings.__pydantic_complete__
 
 
 class TestServer:


### PR DESCRIPTION
`Settings.lifespan` is annotated with `FastMCP`, which is defined further down `mcp/server/fastmcp/server.py`, so pydantic leaves the `Settings` model incomplete at import and only rebuilds it lazily on the first `FastMCP()` call. pydantic-settings 2.15 added `IncompleteFieldDefinitionWarning` for exactly this situation, emitted whenever a settings source inspects such a field — i.e. on every `FastMCP(...)` construction. With `filterwarnings = ["error"]` that fails the whole test suite on the `highest` dependency resolution, which is why every open v1.x PR is currently red there.

## Motivation and Context

Call `Settings.model_rebuild()` once `FastMCP` exists so the model is complete before anything instantiates it. No behaviour change beyond the warning going away; the settings values resolve exactly as before.

`main` doesn't use pydantic-settings, so this is v1.x only.

## How Has This Been Tested?

`tests/server/fastmcp/test_server.py::test_settings_model_is_complete_at_import` asserts the model is complete after import (fails on `v1.x` today). Full suite, pyright and ruff pass locally on the locked resolution; the `highest` CI jobs on this PR are the check against pydantic-settings 2.15.

## Breaking Changes

None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

None.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
