### PR TITLE
Accept boolean sub-schemas in 2025-11-25 tool schema properties

### DIFF
--- a/scripts/gen_surface_types.py
+++ b/scripts/gen_surface_types.py
@@ -55,6 +55,18 @@ SCHEMA_PATCHES: dict[str, list[tuple[str, Any, Any]]] = {
             {"$ref": "#/$defs/PrimitiveSchemaDefinition"},
             {},
         ),
+        # JSON Schema 2020-12 allows a boolean wherever a sub-schema is expected, and
+        # 2026-07-28 already leaves these free-form; accept `true`/`false` property schemas.
+        (
+            "$defs/Tool/properties/inputSchema/properties/properties/additionalProperties",
+            {"additionalProperties": True, "properties": {}, "type": "object"},
+            {"anyOf": [{"additionalProperties": True, "properties": {}, "type": "object"}, {"type": "boolean"}]},
+        ),
+        (
+            "$defs/Tool/properties/outputSchema/properties/properties/additionalProperties",
+            {"additionalProperties": True, "properties": {}, "type": "object"},
+            {"anyOf": [{"additionalProperties": True, "properties": {}, "type": "object"}, {"type": "boolean"}]},
+        ),
     ],
     "2026-07-28": [
         ("$defs/NumberSchema/properties/default/type", "number", ["integer", "number"]),

--- a/src/mcp-types/mcp_types/_v2025_11_25/__init__.py
+++ b/src/mcp-types/mcp_types/_v2025_11_25/__init__.py
@@ -1358,7 +1358,7 @@ class InputSchema(WireModel):
         extra="allow",
     )
     schema_: Annotated[str | None, Field(alias="$schema")] = None
-    properties: dict[str, dict[str, Any]] | None = None
+    properties: dict[str, dict[str, Any] | bool] | None = None
     required: list[str] | None = None
     type: Literal["object"]
 
@@ -1376,7 +1376,7 @@ class OutputSchema(WireModel):
         extra="allow",
     )
     schema_: Annotated[str | None, Field(alias="$schema")] = None
-    properties: dict[str, dict[str, Any]] | None = None
+    properties: dict[str, dict[str, Any] | bool] | None = None
     required: list[str] | None = None
     type: Literal["object"]
 

--- a/tests/types/test_methods.py
+++ b/tests/types/test_methods.py
@@ -474,6 +474,22 @@ def test_elicit_request_surface_accepts_loose_property_schemas():
     assert isinstance(parsed, types.ElicitRequest)
 
 
+def test_2025_11_25_tool_schema_surfaces_accept_boolean_sub_schemas():
+    """JSON Schema 2020-12 allows `true`/`false` wherever a sub-schema is expected; real servers emit them."""
+    tool = {
+        "name": "echo",
+        "inputSchema": {"type": "object", "properties": {"arg": True}},
+        "outputSchema": {
+            "type": "object",
+            "properties": {"result": True, "hidden": False, "rows": {"type": "array", "items": True}},
+            "required": ["result"],
+        },
+    }
+    sieved = methods.serialize_server_result("tools/list", "2025-11-25", {"tools": [tool]})
+    assert sieved["tools"][0]["inputSchema"] == tool["inputSchema"]
+    assert sieved["tools"][0]["outputSchema"] == tool["outputSchema"]
+
+
 def test_response_map_keys_mirror_the_request_map_keys():
     assert set(methods.SERVER_RESULTS) == set(methods.CLIENT_REQUESTS)
     assert set(methods.CLIENT_RESULTS) == set(methods.SERVER_REQUESTS)


### PR DESCRIPTION
Fixes #3353

The generated 2025-11-25 wire models for `Tool.inputSchema` / `Tool.outputSchema` typed every value under `properties` as an object, so a tool advertising `"properties": {"result": true}` (a valid JSON Schema 2020-12 boolean sub-schema) failed `ListToolsResult` validation and the whole listing was discarded on any pre-2026 session. This widens those values to `object | boolean`.

## Motivation and Context

JSON Schema 2020-12 allows `true`/`false` anywhere a sub-schema is expected. The 2026-07-28 surface already accepts this (SEP-2106 made `inputSchema`/`outputSchema` free-form), so the 2025-11-25 strictness is an artefact of the `schema.ts` → JSON rendering rather than spec text, and it breaks real public servers (see the issue). It bites both directions: an SDK client listing a foreign server's tools, and an SDK server forwarding a third-party schema to a legacy-negotiated client.

The fix is two entries in the generator's existing `SCHEMA_PATCHES["2025-11-25"]` list plus regeneration. The generated diff is two lines; the 2026-07-28 module is byte-for-byte unchanged.

## How Has This Been Tested?

- New `test_2025_11_25_tool_schema_surfaces_accept_boolean_sub_schemas` in `tests/types/test_methods.py` (fails before, passes after).
- Drove a real `mcp.Client` against an in-process low-level `Server` advertising `{"properties": {"result": true}}`: `mode="legacy"` (negotiated 2025-11-25) fails on `main` with `tools.0.outputSchema.properties.result dict_type` and succeeds with this change, returning the schema intact; `mode="auto"` (2026-07-28) passes on both. `false`, nested `items: true`, and `inputSchema` variants also pass; `null`/string property values are still rejected.
- `scripts/gen_surface_types.py --check`, `ruff`, `pyright` clean; full suite has no new failures.

## Breaking Changes

None — strictly more lenient inbound validation.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Only the direct values of `properties` were affected: every other JSON Schema keyword at the schema root is an untyped extra (`extra="allow"`), and anything nested inside a property object is `Any`. The same `ListToolsResult` class serves 2024-11-05, 2025-03-26, and 2025-06-18 sessions, so those are fixed too. Related: #3337 (same failure shape, different trigger).

## AI Disclosure

I have used Claude Code for authoring this PR.
