### PR TITLE
Extract docstring param descriptions into JSON Schema

### DIFF
--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Hashable
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
@@ -15,6 +16,7 @@ from mcp.server.mcpserver.resolve import (
     returns_input_required,
 )
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
+from mcp.server.mcpserver.utilities.docstring_parsing import parse_docstring
 from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.shared.exceptions import MCPError
@@ -75,7 +77,14 @@ class Tool(BaseModel):
         if func_name == "<lambda>":
             raise ValueError("You must provide a name for lambda functions")
 
-        func_doc = description or fn.__doc__ or ""
+        if description is not None:
+            func_doc = description
+            docstring_params: dict[str, str] = {}
+        else:
+            raw_doc = inspect.getdoc(fn) or ""
+            summary, docstring_params = parse_docstring(raw_doc)
+            func_doc = summary
+
         is_async = is_async_callable(fn)
 
         if context_kwarg is None:  # pragma: no branch
@@ -96,6 +105,7 @@ class Tool(BaseModel):
             fn,
             skip_names=skip_names,
             structured_output=structured_output,
+            docstring_param_descriptions=docstring_params,
         )
         parameters = func_arg_metadata.arg_model.model_json_schema(by_alias=True)
 

--- a/src/mcp/server/mcpserver/utilities/docstring_parsing.py
+++ b/src/mcp/server/mcpserver/utilities/docstring_parsing.py
@@ -1,0 +1,289 @@
+"""Utilities for parsing function docstrings to extract summaries and parameter descriptions.
+
+Supports Google, NumPy, and Sphinx (reST) docstring formats.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def parse_docstring(docstring: str | None) -> tuple[str, dict[str, str]]:
+    """Parse a docstring and return (summary, param_descriptions).
+
+    The summary is the text before the first recognized section header
+    (Args, Parameters, :param, Returns, etc.). Parameter descriptions are
+    extracted from whichever docstring style is detected.
+
+    Supports Google, NumPy, and Sphinx (reST) docstring formats.
+
+    Args:
+        docstring: The raw docstring text, or None.
+
+    Returns:
+        A tuple of (summary_text, {param_name: description}).
+        summary_text has leading/trailing whitespace stripped.
+        param_name keys are the bare parameter names (no type info).
+    """
+    if not docstring:
+        return ("", {})
+
+    lines = docstring.expandtabs().splitlines()
+
+    # Find where the summary ends by detecting the first section header.
+    section_start = _find_section_start(lines)
+
+    # Build the summary from lines before the section.
+    summary = "\n".join(lines[:section_start]).strip()
+
+    # Parse parameter descriptions from the section onward.
+    param_descriptions: dict[str, str] = {}
+    if section_start < len(lines):
+        remaining = lines[section_start:]
+        param_descriptions = (
+            _try_parse_google_params(remaining)
+            or _try_parse_sphinx_params(remaining)
+            or _try_parse_numpy_params(remaining)
+        )
+
+    return (summary, param_descriptions)
+
+
+# ---------------------------------------------------------------------------
+# Section-start detection
+# ---------------------------------------------------------------------------
+
+# Google-style: "Args:", "Arguments:", "Parameters:", "Params:"
+_GOOGLE_SECTION_RE = re.compile(
+    r"^\s*(Args|Arguments|Parameters|Params|Returns?|Raises?|Yields?|Examples?|Notes?|References?|Attributes?|Todo)\s*:\s*$",
+    re.IGNORECASE,
+)
+
+# NumPy-style: a word on its own line followed by a line of dashes
+_NUMPY_SECTION_WORD_RE = re.compile(
+    r"^\s*(Parameters|Returns?|Raises?|Yields?|Examples?|Notes?|References?|See Also|Attributes?|Methods)\s*$",
+    re.IGNORECASE,
+)
+_NUMPY_DASHES_RE = re.compile(r"^\s*-{3,}\s*$")
+
+# Sphinx-style: ":param ...", ":type ...", ":returns:", ":rtype:", ":raises:"
+_SPHINX_DIRECTIVE_RE = re.compile(r"^\s*:(param|type|returns?|rtype|raises?)\s")
+
+
+def _find_section_start(lines: list[str]) -> int:
+    """Return the index of the first recognised section header, or len(lines)."""
+    for i, line in enumerate(lines):
+        if _GOOGLE_SECTION_RE.match(line):
+            return i
+        if _SPHINX_DIRECTIVE_RE.match(line):
+            return i
+        if _NUMPY_SECTION_WORD_RE.match(line) and i + 1 < len(lines) and _NUMPY_DASHES_RE.match(lines[i + 1]):
+            return i
+    return len(lines)
+
+
+# ---------------------------------------------------------------------------
+# Google-style parameter parsing
+# ---------------------------------------------------------------------------
+
+_GOOGLE_PARAM_SECTION_RE = re.compile(r"^\s*(Args|Arguments|Parameters|Params)\s*:\s*$", re.IGNORECASE)
+_GOOGLE_OTHER_SECTION_RE = re.compile(
+    r"^\s*(Returns?|Raises?|Yields?|Examples?|Notes?|References?|Attributes?|Todo)\s*:\s*$",
+    re.IGNORECASE,
+)
+_GOOGLE_PARAM_LINE_RE = re.compile(r"^(\s+)(\w+)\s*(?:\([^)]*\))?\s*:\s*(.*)")
+
+
+def _try_parse_google_params(lines: list[str]) -> dict[str, str]:
+    """Parse Google-style parameter descriptions from *lines* (starting at a section header).
+
+    Returns an empty dict if no Google-style parameters are found.
+    """
+    params: dict[str, str] = {}
+
+    # Find the "Args:" (or similar) section.
+    section_body_start: int | None = None
+    for i, line in enumerate(lines):
+        if _GOOGLE_PARAM_SECTION_RE.match(line):
+            section_body_start = i + 1
+            break
+
+    if section_body_start is None:
+        return params
+
+    i = section_body_start
+    base_indent: int | None = None
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Skip blank lines.
+        if not line.strip():
+            i += 1
+            continue
+
+        # Stop at another section header.
+        if _GOOGLE_OTHER_SECTION_RE.match(line) or _GOOGLE_PARAM_SECTION_RE.match(line):
+            break
+        # Also stop at NumPy-style sections that happen to follow.
+        if _NUMPY_SECTION_WORD_RE.match(line) and i + 1 < len(lines) and _NUMPY_DASHES_RE.match(lines[i + 1]):
+            break
+
+        m = _GOOGLE_PARAM_LINE_RE.match(line)
+        if m:
+            indent = len(m.group(1))
+            if base_indent is None:
+                base_indent = indent
+
+            if indent == base_indent:
+                param_name = m.group(2)
+                desc_parts = [m.group(3).strip()] if m.group(3).strip() else []
+
+                # Collect continuation lines (indented deeper than the param line).
+                j = i + 1
+                while j < len(lines):
+                    cont = lines[j]
+                    if not cont.strip():
+                        j += 1
+                        continue
+                    cont_indent = len(cont) - len(cont.lstrip())
+                    if cont_indent > base_indent:
+                        desc_parts.append(cont.strip())
+                        j += 1
+                    else:
+                        break
+                params[param_name] = " ".join(desc_parts)
+                i = j
+                continue
+
+        i += 1
+
+    return params
+
+
+# ---------------------------------------------------------------------------
+# Sphinx (reST) parameter parsing
+# ---------------------------------------------------------------------------
+
+_SPHINX_PARAM_RE = re.compile(r"^\s*:param\s+(?:\w+\s+)?(\w+)\s*:\s*(.*)")
+
+
+def _try_parse_sphinx_params(lines: list[str]) -> dict[str, str]:
+    """Parse Sphinx-style parameter descriptions.
+
+    Handles both ``:param name: desc`` and ``:param type name: desc`` forms.
+    """
+    params: dict[str, str] = {}
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = _SPHINX_PARAM_RE.match(line)
+        if m:
+            param_name = m.group(1)
+            desc_parts = [m.group(2).strip()] if m.group(2).strip() else []
+            param_indent = len(line) - len(line.lstrip())
+
+            # Collect continuation lines.
+            j = i + 1
+            while j < len(lines):
+                cont = lines[j]
+                if not cont.strip():
+                    j += 1
+                    continue
+                cont_indent = len(cont) - len(cont.lstrip())
+                if cont.lstrip().startswith(":"):
+                    break
+                if cont_indent > param_indent:
+                    desc_parts.append(cont.strip())
+                    j += 1
+                else:
+                    break
+            params[param_name] = " ".join(desc_parts)
+            i = j
+            continue
+        i += 1
+
+    return params
+
+
+# ---------------------------------------------------------------------------
+# NumPy-style parameter parsing
+# ---------------------------------------------------------------------------
+
+_NUMPY_PARAM_LINE_RE = re.compile(r"^(\s*)(\w+)\s*(?::\s*.*)?$")
+
+
+def _try_parse_numpy_params(lines: list[str]) -> dict[str, str]:
+    """Parse NumPy-style parameter descriptions.
+
+    Format::
+
+        Parameters
+        ----------
+        param_name : type
+            Description of param.
+    """
+    params: dict[str, str] = {}
+
+    # Find the "Parameters" section.
+    section_body_start: int | None = None
+    for i, line in enumerate(lines):
+        if _NUMPY_SECTION_WORD_RE.match(line) and re.match(r"^\s*(Parameters)\s*$", line, re.IGNORECASE):
+            if i + 1 < len(lines) and _NUMPY_DASHES_RE.match(lines[i + 1]):
+                section_body_start = i + 2
+                break
+
+    if section_body_start is None:
+        return params
+
+    i = section_body_start
+    while i < len(lines):
+        line = lines[i]
+
+        # Skip blank lines.
+        if not line.strip():
+            i += 1
+            continue
+
+        # Stop at another section (word followed by dashes).
+        if _NUMPY_SECTION_WORD_RE.match(line) and i + 1 < len(lines) and _NUMPY_DASHES_RE.match(lines[i + 1]):
+            break
+
+        m = _NUMPY_PARAM_LINE_RE.match(line)
+        if m:
+            param_indent = len(m.group(1))
+            param_name = m.group(2)
+
+            # Description is on subsequent indented lines.
+            desc_parts: list[str] = []
+            j = i + 1
+            while j < len(lines):
+                desc_line = lines[j]
+                if not desc_line.strip():
+                    # Blank line might separate paragraphs within description.
+                    # Look ahead to see if next non-blank is still indented.
+                    k = j + 1
+                    while k < len(lines) and not lines[k].strip():
+                        k += 1
+                    if k < len(lines):
+                        next_indent = len(lines[k]) - len(lines[k].lstrip())
+                        if next_indent > param_indent:
+                            j += 1
+                            continue
+                    break
+
+                desc_indent = len(desc_line) - len(desc_line.lstrip())
+                if desc_indent > param_indent:
+                    desc_parts.append(desc_line.strip())
+                    j += 1
+                else:
+                    break
+
+            if desc_parts:
+                params[param_name] = " ".join(desc_parts)
+            i = j
+            continue
+
+        i += 1
+
+    return params

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -240,10 +240,24 @@ class FuncMetadata(BaseModel):
     )
 
 
+def _has_explicit_field_description(annotation: Any, default: Any) -> bool:
+    """Check whether a parameter already carries an explicit ``Field(description=...)``."""
+    # Check Annotated metadata for a FieldInfo with a description.
+    if get_origin(annotation) is Annotated:
+        for meta in get_args(annotation)[1:]:
+            if isinstance(meta, FieldInfo) and meta.description is not None:
+                return True
+    # Check default value (e.g. ``x: int = Field(1, description="...")``).
+    if isinstance(default, FieldInfo) and default.description is not None:
+        return True
+    return False
+
+
 def func_metadata(
     func: Callable[..., Any],
     skip_names: Sequence[str] = (),
     structured_output: bool | None = None,
+    docstring_param_descriptions: dict[str, str] | None = None,
 ) -> FuncMetadata:
     """Given a function, return metadata including a Pydantic model representing its signature.
 
@@ -261,6 +275,10 @@ def func_metadata(
         func: The function to convert to a Pydantic model
         skip_names: A list of parameter names to skip. These will not be included in
             the model.
+        docstring_param_descriptions: An optional mapping of parameter names to
+            descriptions extracted from the function's docstring. When provided,
+            descriptions are injected as Pydantic field descriptions for parameters
+            that do not already have an explicit ``Field(description=...)``.
         structured_output: Controls whether the tool's output is structured or unstructured
             - If None, auto-detects based on the function's return type annotation
             - If True, creates a structured tool (return type annotation permitting)
@@ -314,6 +332,14 @@ def func_metadata(
             field_kwargs["alias"] = field_name
             # Use a prefixed field name
             field_name = f"field_{field_name}"
+
+        # Inject docstring-derived description when no explicit Field(description=...) exists.
+        if (
+            docstring_param_descriptions
+            and param.name in docstring_param_descriptions
+            and not _has_explicit_field_description(annotation, param.default)
+        ):
+            field_kwargs["description"] = docstring_param_descriptions[param.name]
 
         if param.default is not inspect.Parameter.empty:
             dynamic_pydantic_model_params[field_name] = (

--- a/tests/server/mcpserver/test_docstring_parsing.py
+++ b/tests/server/mcpserver/test_docstring_parsing.py
@@ -1,0 +1,386 @@
+# pyright: reportUnknownParameterType=false
+# pyright: reportMissingParameterType=false
+# pyright: reportUnknownArgumentType=false
+"""Tests for docstring parsing and integration with func_metadata / Tool.from_function."""
+
+from typing import Annotated
+
+from pydantic import Field
+
+from mcp.server.mcpserver.tools.base import Tool
+from mcp.server.mcpserver.utilities.docstring_parsing import parse_docstring
+from mcp.server.mcpserver.utilities.func_metadata import func_metadata
+
+# ---------------------------------------------------------------------------
+# Unit tests for parse_docstring
+# ---------------------------------------------------------------------------
+
+
+class TestParseDocstringGoogle:
+    """Google-style docstring parsing."""
+
+    def test_summary_and_params(self):
+        docstring = """Do something useful.
+
+        This is extra description.
+
+        Args:
+            x: The x value.
+            y (int): The y value.
+        """
+        summary, params = parse_docstring(docstring)
+        assert summary == "Do something useful.\n\nThis is extra description."
+        assert params == {"x": "The x value.", "y": "The y value."}
+
+    def test_multiline_param_description(self):
+        docstring = """Summary.
+
+        Args:
+            x: A long description
+                that spans multiple lines.
+            y: Short.
+        """
+        summary, params = parse_docstring(docstring)
+        assert summary == "Summary."
+        assert params["x"] == "A long description that spans multiple lines."
+        assert params["y"] == "Short."
+
+    def test_params_stops_at_returns(self):
+        docstring = """Summary.
+
+        Args:
+            x: The x value.
+
+        Returns:
+            Something.
+        """
+        summary, params = parse_docstring(docstring)
+        assert summary == "Summary."
+        assert params == {"x": "The x value."}
+
+    def test_arguments_keyword(self):
+        docstring = """Summary.
+
+        Arguments:
+            name: The name.
+        """
+        _, params = parse_docstring(docstring)
+        assert params == {"name": "The name."}
+
+    def test_parameters_keyword(self):
+        docstring = """Summary.
+
+        Parameters:
+            name: The name.
+        """
+        _, params = parse_docstring(docstring)
+        assert params == {"name": "The name."}
+
+
+class TestParseDocstringNumPy:
+    """NumPy-style docstring parsing."""
+
+    def test_summary_and_params(self):
+        docstring = """Do something useful.
+
+        Parameters
+        ----------
+        x : int
+            The x value.
+        y : str
+            The y value.
+        """
+        summary, params = parse_docstring(docstring)
+        assert summary == "Do something useful."
+        assert params == {"x": "The x value.", "y": "The y value."}
+
+    def test_multiline_param_description(self):
+        docstring = """Summary.
+
+        Parameters
+        ----------
+        x : int
+            A long description
+            that spans multiple lines.
+        y : str
+            Short.
+        """
+        summary, params = parse_docstring(docstring)
+        assert params["x"] == "A long description that spans multiple lines."
+        assert params["y"] == "Short."
+
+    def test_stops_at_returns_section(self):
+        docstring = """Summary.
+
+        Parameters
+        ----------
+        x : int
+            The x value.
+
+        Returns
+        -------
+        str
+            Something.
+        """
+        summary, params = parse_docstring(docstring)
+        assert summary == "Summary."
+        assert params == {"x": "The x value."}
+
+
+class TestParseDocstringSphinx:
+    """Sphinx (reST) docstring parsing."""
+
+    def test_summary_and_params(self):
+        docstring = """Do something useful.
+
+        :param x: The x value.
+        :param y: The y value.
+        """
+        summary, params = parse_docstring(docstring)
+        assert summary == "Do something useful."
+        assert params == {"x": "The x value.", "y": "The y value."}
+
+    def test_typed_param(self):
+        docstring = """Summary.
+
+        :param int x: The x value.
+        :param str y: The y value.
+        """
+        _, params = parse_docstring(docstring)
+        assert params == {"x": "The x value.", "y": "The y value."}
+
+    def test_multiline_param_description(self):
+        docstring = """Summary.
+
+        :param x: A long description
+            that spans multiple lines.
+        :param y: Short.
+        """
+        _, params = parse_docstring(docstring)
+        assert params["x"] == "A long description that spans multiple lines."
+        assert params["y"] == "Short."
+
+    def test_skips_type_directives(self):
+        docstring = """Summary.
+
+        :param x: The x value.
+        :type x: int
+        :param y: The y value.
+        """
+        _, params = parse_docstring(docstring)
+        assert params == {"x": "The x value.", "y": "The y value."}
+
+
+class TestParseDocstringEdgeCases:
+    """Edge cases for parse_docstring."""
+
+    def test_none_docstring(self):
+        summary, params = parse_docstring(None)
+        assert summary == ""
+        assert params == {}
+
+    def test_empty_docstring(self):
+        summary, params = parse_docstring("")
+        assert summary == ""
+        assert params == {}
+
+    def test_summary_only(self):
+        summary, params = parse_docstring("Just a summary.")
+        assert summary == "Just a summary."
+        assert params == {}
+
+    def test_multiline_summary_only(self):
+        summary, params = parse_docstring("First line.\n\nSecond paragraph.")
+        assert summary == "First line.\n\nSecond paragraph."
+        assert params == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration: func_metadata with docstring_param_descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestFuncMetadataDocstringDescriptions:
+    """Test that docstring param descriptions are injected into the Pydantic model."""
+
+    def test_descriptions_injected(self):
+        def my_func(x: int, y: str) -> str:
+            return f"{x}{y}"
+
+        meta = func_metadata(
+            my_func,
+            docstring_param_descriptions={"x": "The x value.", "y": "The y value."},
+        )
+        schema = meta.arg_model.model_json_schema()
+        assert schema["properties"]["x"]["description"] == "The x value."
+        assert schema["properties"]["y"]["description"] == "The y value."
+
+    def test_explicit_field_description_takes_precedence(self):
+        def my_func(x: Annotated[int, Field(description="Explicit desc")], y: str) -> str:
+            return f"{x}{y}"
+
+        meta = func_metadata(
+            my_func,
+            docstring_param_descriptions={"x": "Docstring desc.", "y": "The y value."},
+        )
+        schema = meta.arg_model.model_json_schema()
+        assert schema["properties"]["x"]["description"] == "Explicit desc"
+        assert schema["properties"]["y"]["description"] == "The y value."
+
+    def test_explicit_default_field_description_takes_precedence(self):
+        def my_func(x: int = Field(1, description="Default field desc"), y: str = "hi") -> str:  # type: ignore[assignment]
+            return f"{x}{y}"
+
+        meta = func_metadata(
+            my_func,
+            docstring_param_descriptions={"x": "Docstring desc.", "y": "The y value."},
+        )
+        schema = meta.arg_model.model_json_schema()
+        assert schema["properties"]["x"]["description"] == "Default field desc"
+        assert schema["properties"]["y"]["description"] == "The y value."
+
+    def test_no_docstring_descriptions(self):
+        def my_func(x: int) -> str:
+            return str(x)
+
+        meta = func_metadata(my_func, docstring_param_descriptions=None)
+        schema = meta.arg_model.model_json_schema()
+        assert "description" not in schema["properties"]["x"]
+
+    def test_partial_docstring_descriptions(self):
+        def my_func(x: int, y: str) -> str:
+            return f"{x}{y}"
+
+        meta = func_metadata(
+            my_func,
+            docstring_param_descriptions={"x": "Only x described."},
+        )
+        schema = meta.arg_model.model_json_schema()
+        assert schema["properties"]["x"]["description"] == "Only x described."
+        assert "description" not in schema["properties"]["y"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: Tool.from_function end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestToolFromFunctionDocstring:
+    """Test that Tool.from_function uses the docstring summary and injects param descriptions."""
+
+    def test_google_style(self):
+        def my_tool(x: int, y: str) -> str:
+            """Do something useful.
+
+            Args:
+                x: The x value.
+                y: The y value.
+
+            Returns:
+                A result string.
+            """
+            return f"{x}{y}"
+
+        tool = Tool.from_function(my_tool)
+        assert tool.description == "Do something useful."
+        assert tool.parameters["properties"]["x"]["description"] == "The x value."
+        assert tool.parameters["properties"]["y"]["description"] == "The y value."
+
+    def test_numpy_style(self):
+        def my_tool(x: int, y: str) -> str:
+            """Do something useful.
+
+            Parameters
+            ----------
+            x : int
+                The x value.
+            y : str
+                The y value.
+
+            Returns
+            -------
+            str
+                A result string.
+            """
+            return f"{x}{y}"
+
+        tool = Tool.from_function(my_tool)
+        assert tool.description == "Do something useful."
+        assert tool.parameters["properties"]["x"]["description"] == "The x value."
+        assert tool.parameters["properties"]["y"]["description"] == "The y value."
+
+    def test_sphinx_style(self):
+        def my_tool(x: int, y: str) -> str:
+            """Do something useful.
+
+            :param x: The x value.
+            :param y: The y value.
+            :returns: A result string.
+            """
+            return f"{x}{y}"
+
+        tool = Tool.from_function(my_tool)
+        assert tool.description == "Do something useful."
+        assert tool.parameters["properties"]["x"]["description"] == "The x value."
+        assert tool.parameters["properties"]["y"]["description"] == "The y value."
+
+    def test_no_docstring(self):
+        def my_tool(x: int) -> str:
+            return str(x)
+
+        tool = Tool.from_function(my_tool)
+        assert tool.description == ""
+        assert "description" not in tool.parameters["properties"]["x"]
+
+    def test_summary_only_docstring(self):
+        def my_tool(x: int) -> str:
+            """Just a summary."""
+            return str(x)
+
+        tool = Tool.from_function(my_tool)
+        assert tool.description == "Just a summary."
+        assert "description" not in tool.parameters["properties"]["x"]
+
+    def test_explicit_description_overrides_docstring(self):
+        def my_tool(x: int) -> str:
+            """Docstring summary.
+
+            Args:
+                x: From docstring.
+            """
+            return str(x)
+
+        tool = Tool.from_function(my_tool, description="Explicit description")
+        assert tool.description == "Explicit description"
+        # When an explicit description is provided, docstring param parsing is skipped.
+        assert "description" not in tool.parameters["properties"]["x"]
+
+    def test_explicit_field_description_wins_over_docstring(self):
+        def my_tool(x: Annotated[int, Field(description="From Field")], y: str) -> str:
+            """Summary.
+
+            Args:
+                x: From docstring.
+                y: Y from docstring.
+            """
+            return f"{x}{y}"
+
+        tool = Tool.from_function(my_tool)
+        assert tool.description == "Summary."
+        assert tool.parameters["properties"]["x"]["description"] == "From Field"
+        assert tool.parameters["properties"]["y"]["description"] == "Y from docstring."
+
+    def test_multiline_summary_before_args(self):
+        def my_tool(x: int) -> str:
+            """First line of summary.
+
+            More details about the tool.
+
+            Args:
+                x: The x value.
+            """
+            return str(x)
+
+        tool = Tool.from_function(my_tool)
+        assert tool.description == "First line of summary.\n\nMore details about the tool."
+        assert tool.parameters["properties"]["x"]["description"] == "The x value."


### PR DESCRIPTION
## Summary

Fixes #226

- Adds a docstring parser (`docstring_parsing.py`) supporting Google, NumPy, and Sphinx formats to extract parameter descriptions
- `Tool.from_function()` now uses `inspect.getdoc()` (which resolves inherited docstrings) and passes parsed param descriptions to `func_metadata()`
- `func_metadata()` injects descriptions into Pydantic model fields only when no explicit `Field(description=...)` is already set — explicit annotations always win
- 22 tests covering all formats, edge cases, integration with `func_metadata`, and end-to-end `Tool.from_function` behavior

## Test plan

- [x] All 22 new tests pass (`pytest tests/server/mcpserver/test_docstring_parsing.py`)
- [x] Explicit `Field(description=...)` is never overridden by docstring
- [x] `inspect.getdoc()` resolves inherited docstrings correctly
- [x] Functions with no docstring, empty docstring, or summary-only docstring handled gracefully