### PR TITLE
Fix Context injection crash with return type annotations

### DIFF
--- a/src/mcp/server/mcpserver/utilities/context_injection.py
+++ b/src/mcp/server/mcpserver/utilities/context_injection.py
@@ -29,8 +29,16 @@ def find_context_parameter(fn: Callable[..., Any]) -> str | None:
         # If we can't resolve type hints, we can't find the context parameter
         return None
 
+    # Only examine actual function parameters, not the return annotation.
+    # ``typing.get_type_hints`` includes a ``"return"`` key for the return
+    # annotation which is not a parameter.
+    sig_params = set(inspect.signature(fn).parameters)
+
     # Check each parameter's type hint
     for param_name, annotation in hints.items():
+        if param_name not in sig_params:
+            continue
+
         # Handle direct Context type
         if inspect.isclass(annotation) and issubclass(annotation, Context):
             return param_name


### PR DESCRIPTION
## Summary

Fixes #3298

- `typing.get_type_hints()` includes a `"return"` key when the function has a return annotation, but `inspect.signature().parameters` does not — iterating over the hints dict caused a `KeyError` when looking up `"return"` in the parameter list
- Added a check to skip keys from `get_type_hints()` that aren't in `signature.parameters`, fixing the crash without altering Context injection behavior

## Test plan

- [x] Functions with `-> ReturnType` annotations no longer crash during context injection
- [x] Context parameters are still correctly identified and injected
- [x] Functions without return annotations unaffected