### PR TITLE
Suppress traceback for prompt argument validation errors

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -1298,6 +1298,12 @@ class MCPServer(Generic[LifespanResultT]):
             )
         except MCPError:
             raise
+        except ValueError as e:
+            # Expected validation errors (e.g. missing required arguments)
+            # don't need a full traceback — a warning with the message is
+            # enough for server operators to diagnose the problem.
+            logger.warning(f"Error getting prompt {name}: {e}")
+            raise
         except Exception as e:
             logger.exception(f"Error getting prompt {name}")
             raise ValueError(str(e)) from e


### PR DESCRIPTION
## Summary

Fixes #3342

- Adds `except ValueError` block before the generic `except Exception` in `get_prompt` handler
- Uses `logger.warning()` (no traceback) instead of `logger.exception()` for validation errors, since these are expected user input errors, not server bugs
- Generic exceptions still log full tracebacks via `logger.exception()`

## Test plan

- [x] Invalid prompt arguments produce a clean warning log (no traceback)
- [x] Unexpected exceptions still produce full tracebacks
- [x] Error response content unchanged for callers