### PR TITLE
Log exceptions when tool execution fails

### DIFF
--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -422,6 +422,7 @@ class MCPServer(Generic[LifespanResultT]):
         except MCPError:
             raise
         except Exception as e:
+            logger.exception(f"Error calling tool {params.name}")
             return CallToolResult(content=[TextContent(type="text", text=str(e))], is_error=True)
 
     async def _handle_list_resources(


### PR DESCRIPTION
## Summary

Fixes #3266

- Added `logger.exception()` in the `except Exception` block of `_handle_call_tool` so tool failures are logged server-side with full tracebacks
- Previously exceptions were silently caught and returned as error text with no logging

## Test plan

- [x] Tool exceptions appear in server logs with full traceback
- [x] Error response to client unchanged