### PR TITLE
Fix ClientSession swallowing exceptions in default message_handler

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -250,6 +250,9 @@ class MessageHandlerFnT(Protocol):
 
 
 async def _default_message_handler(message: IncomingMessage) -> None:
+    if isinstance(message, Exception):
+        logger.error("ClientSession Error: %s", message)
+        raise message
     await anyio.lowlevel.checkpoint()
 
 


### PR DESCRIPTION
Fixes #1401 by raising \Exception\ messages passed into the default \message_handler\ instead of swallowing them. This ensures stream errors propagate out of the \ClientSession\ by default.