### PR TITLE
Retire caller-supplied numeric request ids against future mints

### DIFF
--- a/src/mcp/shared/direct_dispatcher.py
+++ b/src/mcp/shared/direct_dispatcher.py
@@ -117,6 +117,7 @@ class DirectDispatcher:
         self._on_notify_intercept: OnNotifyIntercept | None = None
         self._next_id = 0
         self._in_flight_ids: set[RequestId] = set()
+        self._retired_ids: set[int] = set()
         self._ready = anyio.Event()
         self._close_event = anyio.Event()
         self._running = False
@@ -250,16 +251,21 @@ class DirectDispatcher:
                     in_flight_key = coerce_request_id(request_id)
                     if in_flight_key in self._in_flight_ids:
                         raise ValueError(f"request id {request_id!r} is already in flight")
+                    # Same no-reuse rule as JSONRPCDispatcher: retire the coerced
+                    # key so a later minted request can't land on it.
+                    if isinstance(in_flight_key, int):
+                        self._retired_ids.add(in_flight_key)
                 else:
                     # Synthesize an id (the DispatchContext contract reserves None
                     # for notifications), minting past any key a supplied id
                     # occupies: the collision error is reserved for the caller
                     # who actually chose the id.
                     self._next_id += 1
-                    while self._next_id in self._in_flight_ids:
+                    while self._next_id in self._in_flight_ids or self._next_id in self._retired_ids:
                         self._next_id += 1
                     request_id = self._next_id
                     in_flight_key = request_id
+                    self._retired_ids = {key for key in self._retired_ids if key > request_id}
                 self._in_flight_ids.add(in_flight_key)
                 dctx = self._make_context(on_progress=opts.get("on_progress"), request_id=request_id)
                 try:

--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -307,6 +307,7 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
         self._next_id = 0
         self._pending: dict[RequestId, _Pending] = {}
         self._in_flight: dict[RequestId, _InFlight[TransportT]] = {}
+        self._retired_ids: set[int] = set()
         self._on_notify_intercept: OnNotifyIntercept | None = None
         self._tg: anyio.abc.TaskGroup | None = None
         self._running = False
@@ -346,12 +347,18 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
             pending_key = coerce_request_id(request_id)
             if pending_key in self._pending:
                 raise ValueError(f"request id {request_id!r} is already in flight")
+            # Spec: an id is never reused in a session, even after completion —
+            # retire the coerced key so a later minted request can't land on it.
+            if isinstance(pending_key, int):
+                self._retired_ids.add(pending_key)
         else:
             # Mint past any key a supplied id occupies: the collision error is
             # reserved for the caller who actually chose the id.
             request_id = self._allocate_id()
-            while request_id in self._pending:
+            while request_id in self._pending or request_id in self._retired_ids:
                 request_id = self._allocate_id()
+            # The counter never goes back, so retired keys below it are spent.
+            self._retired_ids = {key for key in self._retired_ids if key > request_id}
             pending_key = request_id
         out_params = dict(params) if params is not None else {}
         out_meta = dict(out_params.get("_meta") or {})

--- a/tests/shared/test_dispatcher.py
+++ b/tests/shared/test_dispatcher.py
@@ -482,6 +482,37 @@ async def test_minted_ids_skip_a_caller_supplied_id_still_in_flight(pair_factory
 
 
 @pytest.mark.anyio
+async def test_minted_ids_advance_past_a_completed_caller_supplied_numeric_id(pair_factory: PairFactory):
+    """Spec: an id MUST NOT be reused by the requestor within a session — not even
+    after its request completed and left the in-flight set. Accepting a numeric
+    supplied id advances the mint counter past it, so minted ids never revisit it."""
+    async with running_pair(pair_factory) as (client, _server, _crec, srec):
+        with anyio.fail_after(5):
+            await client.send_raw_request("first", None, {"request_id": 1})
+            for _ in range(3):
+                await client.send_raw_request("plain", None)
+    supplied, *minted = (ctx.request_id for ctx in srec.contexts)
+    assert supplied == 1
+    assert minted == [2, 3, 4]
+
+
+@pytest.mark.anyio
+async def test_minted_ids_advance_past_a_completed_supplied_numeric_string_id(pair_factory: PairFactory):
+    """The collision domain folds "7" and 7 into one key, so accepting the string form
+    retires 7 against future mints even though it left the in-flight set."""
+    async with running_pair(pair_factory) as (client, _server, _crec, srec):
+        with anyio.fail_after(5):
+            await client.send_raw_request("first", None, {"request_id": "7"})
+            # Mints walk 1..9 but must skip the retired 7.
+            for _ in range(9):
+                await client.send_raw_request("plain", None)
+    supplied, *minted = (ctx.request_id for ctx in srec.contexts)
+    assert supplied == "7"
+    assert type(supplied) is str
+    assert minted == [1, 2, 3, 4, 5, 6, 8, 9, 10]
+
+
+@pytest.mark.anyio
 async def test_supplied_numeric_string_id_collides_with_its_int_twin(pair_factory: PairFactory):
     """ "7" and 7 are one id in the collision domain on BOTH dispatchers, so the
     in-memory pair raises exactly where the wire dispatcher (whose pending keys


### PR DESCRIPTION
# Retire caller-supplied numeric request ids against future mints

Fixes #3126

## What

A caller-supplied `CallOptions["request_id"]` left the dispatcher's in-flight tracking once its request completed, so the minted-id sequence eventually landed on that same id again — two different requests with one id on the wire, which the spec forbids:

> The request ID MUST NOT have been previously used by the requestor within the same session.

Reproduced on `main`: supply id `1`, let it complete, mint three requests → wire ids `[1, 1, 2, 3]`.

## How

Accepted numeric supplied ids are added to a small retired set on **both** dispatchers; minting skips `in-flight ∪ retired` and prunes retired entries as the monotonic counter passes them (so the set stays bounded by ids the counter hasn't reached yet).

## Deliberate deviation from the fix sketched on the issue

The issue proposed advancing the counter at accept time (`max(self._next_id, pending_key)`). That variant also burns every id *below* a supplied one whenever it is accepted while still in flight, flipping the documented contract in `test_minted_ids_skip_a_caller_supplied_id_still_in_flight` from mints `[1, 2, 4]` to `[4, 5, 6]`. The retire-set fixes reuse with zero change to existing behavior:

| Scenario | Before | After |
|---|---|---|
| Supplied `1` completes → mints | `[1, 1, 2]` ❌ | `[2, 3, 4]` |
| Supplied `"7"` completes → mints walk 9 | `[1..9]` reuses 7 ❌ | `[1..6, 8, 9, 10]` |
| Supplied `"3"` in flight → mints | `[1, 2, 4]` | unchanged |

If maintainers prefer the simpler accept-time advancement and adjusting the in-flight expectation instead, that tradeoff is yours to call — happy to rework.

## Tests

Both regression tests run through the shared `pair_factory`, so each covers `JSONRPCDispatcher` and `DirectDispatcher`:

- completed numeric supplied id is never revisited (`[2, 3, 4]`)
- completed numeric-string supplied id retires its coerced twin (`[1..6, 8, 9, 10]`)

Full gate green locally: `./scripts/test`, ruff format/check, pyright.

(AI-assisted implementation, prepared with a coding agent and reviewed by me.)
