### PR TITLE
Give recursive tool output schemas an object root

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -73,6 +73,30 @@ class StrictJsonSchema(GenerateJsonSchema):
         raise ValueError(f"JSON schema warning: {kind} - {detail}")
 
 
+_DEFS_REF_PREFIX = "#/$defs/"
+
+
+def _with_object_root(schema: dict[str, Any]) -> dict[str, Any]:
+    """Give a generated schema whose root is a bare `$ref` an object root.
+
+    Pydantic emits `{"$defs": ..., "$ref": "#/$defs/Model"}` for self-referential
+    return types, but the published tool schema requires `type: "object"` at the
+    root. Wrapping the reference (instead of inlining it) terminates on recursive
+    models; refs to non-object defs are left alone.
+    """
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or "type" in schema or not ref.startswith(_DEFS_REF_PREFIX):
+        return schema
+    defs: dict[str, Any] = schema["$defs"] if "$defs" in schema else {}
+    try:
+        is_object_root = defs[ref[len(_DEFS_REF_PREFIX) :]]["type"] == "object"
+    except (KeyError, TypeError):
+        return schema
+    if not is_object_root:
+        return schema
+    return {"type": "object", "allOf": [{"$ref": ref}], **{k: v for k, v in schema.items() if k != "$ref"}}
+
+
 class ArgModelBase(BaseModel):
     """A model representing the arguments to a function."""
 
@@ -107,7 +131,9 @@ class FuncMetadata(BaseModel):
     def model_post_init(self, context: Any, /) -> None:
         if self.output_model is not None and self.output_schema is None:
             # StrictJsonSchema raises instead of warning, so an unserializable return type fails construction.
-            self.output_schema = self._output_adapter(self.output_model).json_schema(schema_generator=StrictJsonSchema)
+            self.output_schema = _with_object_root(
+                self._output_adapter(self.output_model).json_schema(schema_generator=StrictJsonSchema)
+            )
 
     def _output_adapter(self, output_model: type[Any]) -> TypeAdapter[Any]:
         """The validator/serializer for `output_model`, built once and rebuilt only if the field is reassigned."""

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -628,6 +628,41 @@ def test_structured_output_basemodel():
     }
 
 
+def test_structured_output_recursive_model():
+    """A self-referential return type publishes its schema with `type: "object"` at
+    the root — pydantic emits a bare `$ref` root, which the published tool schema
+    contract rejects. The reference is wrapped (not inlined), which terminates on
+    recursive models."""
+
+    class Node(BaseModel):
+        name: str
+        children: list["Node"] = []
+
+    def func_returning_tree() -> Node:  # pragma: no cover
+        raise NotImplementedError
+
+    meta = func_metadata(func_returning_tree)
+    node_def: dict[str, Any] = {
+        "properties": {
+            "name": {"title": "Name", "type": "string"},
+            "children": {
+                "default": [],
+                "items": {"$ref": "#/$defs/Node"},
+                "title": "Children",
+                "type": "array",
+            },
+        },
+        "required": ["name"],
+        "title": "Node",
+        "type": "object",
+    }
+    assert meta.output_schema == {
+        "type": "object",
+        "allOf": [{"$ref": "#/$defs/Node"}],
+        "$defs": {"Node": node_def},
+    }
+
+
 def test_structured_output_primitives():
     """Test structured output with primitive return types"""
 

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -2423,3 +2423,30 @@ async def test_middleware_can_refuse_subscriptions_listen_before_the_ack() -> No
                 pass  # pragma: no cover - the refusal precedes the stream
     assert exc_info.value.error.code == INVALID_REQUEST
     assert exc_info.value.error.message == "not permitted to watch the requested resources"
+
+
+@pytest.mark.anyio
+async def test_recursive_tool_output_schema_serves_on_legacy_sessions() -> None:
+    """A self-referential tool return type publishes `type: "object"` at the schema
+    root, so `tools/list` succeeds on 2025-11-25 sessions whose OutputSchema model
+    rejects a bare `$ref` root instead of failing the entire listing (#3337)."""
+
+    class Node(BaseModel):
+        name: str
+        children: list["Node"] = []
+
+    mcp = MCPServer("rec")
+
+    @mcp.tool()
+    def tree() -> Node:
+        return Node(name="root")
+
+    async with Client(mcp) as client:
+        tools = (await client.list_tools()).tools
+        assert tools[0].output_schema is not None
+        assert tools[0].output_schema["type"] == "object"
+
+    async with Client(mcp, mode="legacy") as client:
+        tools = (await client.list_tools()).tools
+        assert tools[0].output_schema is not None
+        assert tools[0].output_schema["type"] == "object"


### PR DESCRIPTION
# Give recursive tool output schemas an object root

Fixes #3337

## What

A tool whose return type is self-referential publishes `{"$defs": {...}, "$ref": "#/$defs/Node"}` with no root `"type"`. The 2025-11-25 `OutputSchema` model requires `type: Literal["object"]` at the root, so serving `tools/list` to a legacy-negotiated session failed validation for the **entire listing** — legacy clients lost every tool, not just the recursive one.

Reproduced on `main`: a `MCPServer` with one recursive-BaselineModel tool serves modern sessions fine, but `Client(mcp, mode="legacy")` gets `MCPError: Handler returned an invalid result`.

## How

Normalization happens where derivation already lives — `FuncMetadata.model_post_init`, next to the existing `StrictJsonSchema` call. When pydantic emits a root that is a bare `$ref` to an *object* def, the schema is published as:

```json
{"type": "object", "allOf": [{"$ref": "#/$defs/Node"}], "$defs": {"Node": {...}}}
```

Wrapping rather than inlining is what terminates on recursive models. Sibling `$ref` + `type` would also satisfy the model; wrapping keeps it draft-agnostic.

Scope guards:

- Refs to non-object defs are left alone (only object-typed defs get wrapped).
- Hand-built `output_schema`s are untouched — "a schema published without a model is advertised but not validated", and that stays true.
- Modern sessions see no change for any non-recursive tool (pydantic only produces bare-`$ref` roots for self-referential types).

The reporter's separate question — whether one unrepresentable tool should degrade instead of failing the listing — is a design decision deliberately left out of this PR.

## Tests

- Unit (`test_func_metadata.py`): exact-schema assertion for a recursive BaseModel return — root `type`, `allOf`-wrapped ref, `$defs` preserved.
- End-to-end (`test_server.py`): `tools/list` succeeds on both `Client(mcp)` and `Client(mcp, mode="legacy")` with a recursive tool registered.

Both fail on `main` exactly as #3337 describes. Full gate green locally: `./scripts/test`, ruff format/check, pyright.

(AI-assisted implementation, prepared with a coding agent and reviewed by me.)
