### PR TITLE
Give recursive tool return types an object-rooted output schema

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -74,6 +74,25 @@ class StrictJsonSchema(GenerateJsonSchema):
         raise ValueError(f"JSON schema warning: {kind} - {detail}")
 
 
+_LOCAL_DEFS_PREFIX = "#/$defs/"
+
+
+def _inline_root_ref(schema: dict[str, Any]) -> dict[str, Any]:
+    """Give a schema whose root is a bare `$ref` into `$defs` an inline root.
+
+    pydantic emits a self-referential model as `{"$defs": {...}, "$ref": "#/$defs/Model"}`, with no
+    `type` at the root; `Tool.outputSchema` needs an object root (required on the wire through
+    2025-11-25). The referenced definition is copied onto the root and `$defs` is kept, since nested
+    references still point into it. Root siblings of the `$ref` win over the definition's keys.
+    """
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith(_LOCAL_DEFS_PREFIX):
+        return schema
+    definition = cast(dict[str, Any], schema["$defs"][ref.removeprefix(_LOCAL_DEFS_PREFIX)])
+    siblings = {key: value for key, value in schema.items() if key != "$ref"}
+    return {**definition, **siblings}
+
+
 class ArgModelBase(BaseModel):
     """A model representing the arguments to a function."""
 
@@ -108,7 +127,8 @@ class FuncMetadata(BaseModel):
     def model_post_init(self, context: Any, /) -> None:
         if self.output_model is not None and self.output_schema is None:
             # StrictJsonSchema raises instead of warning, so an unserializable return type fails construction.
-            self.output_schema = self._output_adapter(self.output_model).json_schema(schema_generator=StrictJsonSchema)
+            schema = self._output_adapter(self.output_model).json_schema(schema_generator=StrictJsonSchema)
+            self.output_schema = _inline_root_ref(schema)
 
     def _output_adapter(self, output_model: type[Any]) -> TypeAdapter[Any]:
         """The validator/serializer for `output_model`, built once and rebuilt only if the field is reassigned."""

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1202,6 +1202,34 @@ def test_structured_output_nested_models():
     }
 
 
+def test_structured_output_self_referential_model_gets_an_object_root():
+    """pydantic publishes a recursive model as a bare root `$ref`; the definition is inlined onto the
+    root and `$defs` is kept for the nested reference."""
+
+    class Node(BaseModel):
+        name: str
+        children: list["Node"] = []
+
+    def tree() -> Node:
+        return Node(name="root", children=[Node(name="leaf")])
+
+    node_definition: dict[str, Any] = {
+        "properties": {
+            "name": {"title": "Name", "type": "string"},
+            "children": {"default": [], "items": {"$ref": "#/$defs/Node"}, "title": "Children", "type": "array"},
+        },
+        "required": ["name"],
+        "title": "Node",
+        "type": "object",
+    }
+    meta = func_metadata(tree)
+    assert meta.output_schema == {**node_definition, "$defs": {"Node": node_definition}}
+
+    result = meta.convert_result(tree())
+    assert isinstance(result, CallToolResult)
+    assert result.structured_content == {"name": "root", "children": [{"name": "leaf", "children": []}]}
+
+
 def test_structured_output_unserializable_type_error():
     """Test error when structured_output=True is used with unserializable types"""
 

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -2167,6 +2167,29 @@ async def test_prompt_input_required_result_on_legacy_session_is_a_serialization
     assert exc.value.error.message == "Handler returned an invalid result"
 
 
+async def test_recursive_tool_return_type_lists_and_calls_on_legacy_session():
+    """A 2025-11-25 session requires `type: object` at the outputSchema root; a self-referential
+    return type must not fail the whole listing, and its result validates client-side via `$defs`."""
+
+    class Node(BaseModel):
+        name: str
+        children: list["Node"] = []
+
+    mcp = MCPServer()
+
+    @mcp.tool()
+    def tree() -> Node:
+        return Node(name="root", children=[Node(name="leaf")])
+
+    async with Client(mcp, mode="legacy") as client:
+        [tool] = (await client.list_tools()).tools
+        assert tool.output_schema is not None
+        assert tool.output_schema["type"] == "object"
+        assert tool.output_schema["properties"]["children"]["items"] == {"$ref": "#/$defs/Node"}
+        result = await client.call_tool("tree", {})
+    assert result.structured_content == {"name": "root", "children": [{"name": "leaf", "children": []}]}
+
+
 async def test_resource_template_input_required_result_on_legacy_session_is_a_serialization_error():
     """Pins the shared era gate for resources/read: a pre-2026 session has no
     input_required vocabulary, so the runner rejects the frame with -32603."""


### PR DESCRIPTION
Fixes #3337

When a tool's return type is self-referential, pydantic emits the output schema as `{"$defs": {...}, "$ref": "#/$defs/Node"}` with no `type` at the root. `Tool.outputSchema` requires `type: "object"` at the root on 2025-11-25 and earlier, so one such tool failed the *entire* `tools/list` result for every legacy-negotiated client (`Handler returned an invalid result`). This inlines the referenced definition onto the root and keeps `$defs` for the nested references.

## Motivation and Context

The trigger is narrow (recursive `BaseModel`, recursive `TypedDict` since #3331, mutually recursive models, `RootModel[Model]`), but the blast radius when hit is the whole tool listing, and it isn't only this SDK's serializer that objects: TypeScript SDK 1.x, TypeScript SDK 2.x on pre-2026 sessions, and C# SDK 1.x clients all reject a listing containing a `$ref`-rooted `outputSchema`. FastMCP hit the same thing (PrefectHQ/fastmcp#2455) and it's cited in SEP-2106's rationale.

The fix is unconditional rather than per-protocol-version: the schema *is* an object, pydantic just spells a recursive root as `$ref` (it only unpacks a root `$ref` when the definition is referenced exactly once). The resulting shape is what pydantic already produces for the non-recursive version of the same model, and `docs/servers/structured-output.md` already promises that model return types publish an object root. Other SDKs that can emit recursive roots (zod 4, schemars, System.Text.Json) all inline the root too.

## How Has This Been Tested?

- `test_structured_output_self_referential_model_gets_an_object_root` pins the generated shape and round-trips a nested result through `convert_result`.
- `test_recursive_tool_return_type_lists_and_calls_on_legacy_session` drives `Client(mcp, mode="legacy")` through `tools/list` and `tools/call`; both tests fail on `main`.
- Drove it by hand on both `mode="legacy"` and 2026-07-28 with self-referential, mutually recursive, and `TypedDict` return types, and validated the resulting wire `ListToolsResult` against the spec's `schema/2025-11-25/schema.json` (valid; the old shape fails with `'type' is a required property`).

## Breaking Changes

None. The only observable change is the JSON content of `output_schema` for recursive return types: the root gains the definition's keys, `$defs` is unchanged, `structuredContent` is unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Deliberately out of scope: a `RootModel` whose root is not an object (`RootModel[list[int]]`, `RootModel[int]`) still publishes a non-object root and non-dict `structuredContent`, which fails both `tools/list` and that tool's `tools/call` on legacy sessions. That one genuinely isn't an object, so it needs either reclassification as a wrapped output or per-version projection of schema and value; I'll open a separate issue.

A v1.x backport follows — v1 ships the same shape silently and strict clients reject it there too.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
