### PR TITLE
[v1.x] Give recursive tool return types an object-rooted output schema

### DIFF
--- a/src/mcp/server/fastmcp/utilities/func_metadata.py
+++ b/src/mcp/server/fastmcp/utilities/func_metadata.py
@@ -45,6 +45,25 @@ class StrictJsonSchema(GenerateJsonSchema):
         raise ValueError(f"JSON schema warning: {kind} - {detail}")
 
 
+_LOCAL_DEFS_PREFIX = "#/$defs/"
+
+
+def _inline_root_ref(schema: dict[str, Any]) -> dict[str, Any]:
+    """Give a schema whose root is a bare `$ref` into `$defs` an inline root.
+
+    pydantic emits a self-referential model as `{"$defs": {...}, "$ref": "#/$defs/Model"}`, with no
+    `type` at the root; `Tool.outputSchema` requires `type: object` at the root. The referenced
+    definition is copied onto the root and `$defs` is kept, since nested references still point into
+    it. Root siblings of the `$ref` win over the definition's keys.
+    """
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith(_LOCAL_DEFS_PREFIX):
+        return schema
+    definition = cast(dict[str, Any], schema["$defs"][ref.removeprefix(_LOCAL_DEFS_PREFIX)])
+    siblings = {key: value for key, value in schema.items() if key != "$ref"}
+    return {**definition, **siblings}
+
+
 class ArgModelBase(BaseModel):
     """A model representing the arguments to a function."""
 
@@ -428,7 +447,7 @@ def _try_create_model_and_schema(
             logger.info(f"Cannot create schema for type {type_expr} in {func_name}: {type(e).__name__}: {e}")
             return None, None, False
 
-        return model, schema, wrap_output
+        return model, _inline_root_ref(schema), wrap_output
 
     return None, None, False
 

--- a/tests/server/fastmcp/test_func_metadata.py
+++ b/tests/server/fastmcp/test_func_metadata.py
@@ -983,6 +983,33 @@ def test_structured_output_nested_models():
     }
 
 
+def test_structured_output_self_referential_model_gets_an_object_root():
+    """pydantic publishes a recursive model as a bare root `$ref`; the definition is inlined onto the
+    root and `$defs` is kept for the nested reference."""
+
+    class Node(BaseModel):
+        name: str
+        children: list["Node"] = []
+
+    def tree() -> Node:
+        return Node(name="root", children=[Node(name="leaf")])
+
+    node_definition: dict[str, Any] = {
+        "properties": {
+            "name": {"title": "Name", "type": "string"},
+            "children": {"default": [], "items": {"$ref": "#/$defs/Node"}, "title": "Children", "type": "array"},
+        },
+        "required": ["name"],
+        "title": "Node",
+        "type": "object",
+    }
+    meta = func_metadata(tree)
+    assert meta.output_schema == {**node_definition, "$defs": {"Node": node_definition}}
+
+    _, structured_content = meta.convert_result(tree())
+    assert structured_content == {"name": "root", "children": [{"name": "leaf", "children": []}]}
+
+
 def test_structured_output_unserializable_type_error():
     """Test error when structured_output=True is used with unserializable types"""
     from typing import NamedTuple

--- a/tests/server/fastmcp/test_server.py
+++ b/tests/server/fastmcp/test_server.py
@@ -525,6 +525,30 @@ class TestServerTools:
             assert '"name": "John Doe"' in result.content[0].text
 
     @pytest.mark.anyio
+    async def test_tool_structured_output_self_referential_model(self):
+        """A self-referential return type publishes an object-rooted outputSchema (required by the
+        2025-11-25 Tool shape) and its result validates client-side through the kept `$defs`."""
+
+        class Node(BaseModel):
+            name: str
+            children: list["Node"] = []
+
+        def tree() -> Node:
+            return Node(name="root", children=[Node(name="leaf")])
+
+        mcp = FastMCP()
+        mcp.add_tool(tree)
+
+        async with client_session(mcp._mcp_server) as client:
+            [tool] = (await client.list_tools()).tools
+            assert tool.outputSchema is not None
+            assert tool.outputSchema["type"] == "object"
+            assert tool.outputSchema["properties"]["children"]["items"] == {"$ref": "#/$defs/Node"}
+            result = await client.call_tool("tree", {})
+            assert result.isError is False
+            assert result.structuredContent == {"name": "root", "children": [{"name": "leaf", "children": []}]}
+
+    @pytest.mark.anyio
     async def test_tool_structured_output_primitive(self):
         """Test tool with structured output returning primitive type"""
 


### PR DESCRIPTION
Backport of #3376 to the v1.x line. Refs #3337.

When a FastMCP tool's return type is self-referential, pydantic emits the output schema as `{"$defs": {...}, "$ref": "#/$defs/Node"}` with no `type` at the root. `Tool.outputSchema` requires `type: "object"` at the root on every protocol version v1.x speaks, and strict clients — TypeScript SDK 1.x, C# SDK 1.x, and python-sdk 2.x on a 2025-11-25 session — reject the *entire* `tools/list` result when one tool publishes that shape. This inlines the referenced definition onto the root and keeps `$defs` for the nested references.

## Motivation and Context

On v1.x nothing errors on the Python side (`Tool.outputSchema` is `dict[str, Any]` and isn't shape-checked), so the failure shows up in the peer: a host embedding the TypeScript SDK 1.x sees the server as having no tools at all. That's the same report as PrefectHQ/fastmcp#2455. Given the blast radius against the most common client family and the size of the change, this seemed worth carrying on the maintenance line.

## How Has This Been Tested?

- `test_structured_output_self_referential_model_gets_an_object_root` pins the generated shape and round-trips a nested result.
- `test_tool_structured_output_self_referential_model` drives an in-memory client session through `tools/list` and `tools/call`; both fail before the change.
- Fed the resulting wire `ListToolsResult` to the TypeScript SDK 1.x `ListToolsResultSchema`: accepted after the change, `tools.0.outputSchema.type Invalid input: expected "object"` before. Also valid against the spec's `schema/2025-11-25/schema.json`.

## Breaking Changes

None. The only observable change is the JSON content of `outputSchema` for recursive return types: the root gains the definition's keys, `$defs` is unchanged, `structuredContent` is unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Same out-of-scope note as #3376: a `RootModel` whose root isn't an object still publishes a non-object root.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
