### PR TITLE
Build releases with the pinned hatchling and a publish action that accepts Metadata 2.5

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-          version: 0.9.5
+          version: 0.12.5
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -57,7 +57,7 @@ jobs:
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           # Lets a re-run after a partially failed upload publish the remaining
           # files instead of erroring on the ones already on PyPI.


### PR DESCRIPTION
The v2.1.0 Publishing run built fine but the upload step rejected the distributions before anything reached PyPI:

```
Checking dist/mcp-2.1.0-py3-none-any.whl: ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Motivation and Context

Two things combined:

- The build job runs uv 0.9.5, which does not apply `[tool.uv].build-constraint-dependencies` to `uv build`. The `hatchling==1.29.0` pin in `pyproject.toml` therefore never applied to release builds (the 2.0.0 wheel on PyPI says `Generator: hatchling 1.31.0`), and since hatchling 1.32.0 (2026-08-11) the floating build writes `Metadata-Version: 2.5`.
- The publish step is pinned to `gh-action-pypi-publish` v1.14.0, whose bundled metadata check predates 2.5. The v1.x workflow floats on `release/v1` (currently v1.14.2) and published a Metadata 2.5 wheel for v1.29.1 without complaint a few minutes earlier.

This bumps uv to 0.12.5 in the build job only, so the existing constraint takes effect (verified locally: uv 0.9.5 builds with hatchling 1.32.0 / Metadata 2.5; uv 0.11.15 and 0.12.5 build with hatchling 1.29.0 / Metadata 2.4, version-from-tag and the `mcp-types==` pin unchanged), and moves the publish action pin to v1.14.2 so a future metadata bump is not fatal either. The uv pin used by CI (`shared.yml`, `conformance.yml`) is left alone here.

## How Has This Been Tested?

Rebuilt both packages from this branch with uv 0.9.5, 0.11.15 and 0.12.5 and compared `METADATA`/`WHEEL`; `twine check --strict` passes on all of them. The workflow itself only runs on `release: published`, so the real test is re-cutting v2.1.0 from the merge commit.

## Breaking Changes

None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
