### PR TITLE
Point imports of mcp.server.fastmcp at the migration guide

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -17,7 +17,7 @@ Every section heading below names the API it affects, so searching this page for
 
 | Change | First symptom | Section |
 |---|---|---|
-| `FastMCP` renamed to `MCPServer` | `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` | [`FastMCP` renamed](#fastmcp-renamed-to-mcpserver) |
+| `FastMCP` renamed to `MCPServer` | `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` (newer 2.x releases follow it with a pointer to this guide) | [`FastMCP` renamed](#fastmcp-renamed-to-mcpserver) |
 | Fields renamed from camelCase to snake_case | `AttributeError: 'Tool' object has no attribute 'inputSchema'` | [snake_case fields](#field-names-changed-from-camelcase-to-snake_case) |
 | `mcp.types` names removed | `ImportError: cannot import name 'Content' from 'mcp.types'` | [Removed types](#removed-type-aliases-and-classes) |
 | `McpError` renamed to `MCPError` | `ImportError: cannot import name 'McpError' from 'mcp'` | [`McpError` renamed](#mcperror-renamed-to-mcperror) |
@@ -671,6 +671,8 @@ All submodules under `mcp.server.fastmcp.*` are now under `mcp.server.mcpserver.
 - `Message`, `UserMessage`, `AssistantMessage` — from `mcp.server.mcpserver.prompts.base`
 - `ToolError`, `ResourceError` — from `mcp.server.mcpserver.exceptions`
 - `MCPServerError` (renamed from `FastMCPError`) — from `mcp.server.mcpserver.exceptions`
+
+Importing `mcp.server.fastmcp`, or anything below it, raises `ModuleNotFoundError` (newer 2.x releases include a link to this section in its message), so existing `except ImportError` or `except ModuleNotFoundError` fallbacks around the v1 import keep working.
 
 ### What is unchanged on `MCPServer`
 

--- a/scripts/docs/gen_ref_pages.py
+++ b/scripts/docs/gen_ref_pages.py
@@ -31,11 +31,12 @@ API_DIR = ROOT / "docs" / "api"
 # it from `src/` would emit the unimportable `mcp-types.mcp_types.*`.
 PACKAGES = (ROOT / "src" / "mcp", ROOT / "src" / "mcp-types" / "mcp_types")
 
-# Alias packages that mirror another package's namespaces (`mcp.types` mirrors
-# `mcp_types`, `mcp.types.version` mirrors `mcp_types.version`): the mirrored
-# package's pages are the canonical rendering, so an alias, and every module
-# under it, earns no page of its own.
-EXCLUDED = frozenset({"mcp.types"})
+# Module paths that get no page, and neither does anything under them: alias
+# packages that mirror another package's namespaces (`mcp.types` mirrors
+# `mcp_types`), whose canonical rendering is the mirrored package's pages; and
+# removed v1 import paths (`mcp.server.fastmcp`) that only raise a pointer to
+# the migration guide and carry no API.
+EXCLUDED = frozenset({"mcp.types", "mcp.server.fastmcp"})
 
 _KIND_SECTIONS = {
     griffe.Kind.MODULE: "Modules",

--- a/src/mcp/server/fastmcp.py
+++ b/src/mcp/server/fastmcp.py
@@ -1,0 +1,16 @@
+"""Removed in mcp 2: `FastMCP` is now `mcp.server.mcpserver.MCPServer`.
+
+This module has no API. Importing it, or anything below it, raises
+`ModuleNotFoundError` with a message that points at the migration guide. It
+exists only because the bare "No module named 'mcp.server.fastmcp'" gave v1
+code no hint that the installed SDK is a different major version.
+"""
+
+_MESSAGE = (
+    "No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed to MCPServer "
+    "(from mcp.server.mcpserver import MCPServer) and other APIs changed; see the migration guide at "
+    "https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver "
+    "or pin 'mcp<2' to keep running v1 code."
+)
+
+raise ModuleNotFoundError(_MESSAGE, name=__name__)

--- a/tests/server/test_fastmcp.py
+++ b/tests/server/test_fastmcp.py
@@ -1,0 +1,55 @@
+"""The removed v1 import path `mcp.server.fastmcp` fails with a pointer to the migration guide."""
+
+import importlib
+import sys
+
+import pytest
+from inline_snapshot import snapshot
+
+import mcp.server
+from mcp.server.mcpserver import MCPServer
+
+
+def test_importing_fastmcp_raises_module_not_found_that_points_at_the_migration_guide() -> None:
+    """SDK-defined: the v1 path fails with the same exception type and `.name` as a module
+    that genuinely does not exist, but the message names the replacement and the guide."""
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        importlib.import_module("mcp.server.fastmcp")
+
+    assert exc_info.value.name == "mcp.server.fastmcp"
+    assert str(exc_info.value) == snapshot(
+        "No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed to MCPServer "
+        "(from mcp.server.mcpserver import MCPServer) and other APIs changed; see the migration guide at "
+        "https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver "
+        "or pin 'mcp<2' to keep running v1 code."
+    )
+    # A module that raises while executing is never cached, so nothing is left behind.
+    assert "mcp.server.fastmcp" not in sys.modules
+    assert not hasattr(mcp.server, "fastmcp")
+
+
+def test_importing_a_fastmcp_submodule_raises_the_parent_pointer() -> None:
+    """SDK-defined: a deep v1 path executes `mcp.server.fastmcp` first, so it fails with that
+    module's message and `.name` rather than a bare error for the leaf."""
+    with pytest.raises(ModuleNotFoundError) as parent:
+        importlib.import_module("mcp.server.fastmcp")
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        importlib.import_module("mcp.server.fastmcp.utilities.types")
+
+    assert exc_info.value.name == "mcp.server.fastmcp"
+    assert str(exc_info.value) == str(parent.value)
+
+
+def test_v1_first_import_shim_falls_back_to_mcpserver() -> None:
+    """SDK-defined: projects that support both majors try the v1 import and fall back on
+    `ModuleNotFoundError` (the narrowest guard seen in the wild), which is why the pointer is
+    raised as exactly that type and not as a bare `ImportError` or after a warning."""
+    fell_back = False
+    try:
+        server_class: type = importlib.import_module("mcp.server.fastmcp").FastMCP
+    except ModuleNotFoundError:
+        fell_back = True
+        server_class = MCPServer
+
+    assert fell_back
+    assert server_class is MCPServer


### PR DESCRIPTION
v1 code running against mcp 2 fails with a bare `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`, which reads like a broken install. This adds a 16-line `src/mcp/server/fastmcp.py` whose only statement raises the same exception with a message that says what happened:

```text
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed to MCPServer (from mcp.server.mcpserver import MCPServer) and other APIs changed; see the migration guide at https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver or pin 'mcp<2' to keep running v1 code.
```

Not #3189: nothing is aliased or re-exported and no warning is emitted. The old path still fails to import; it just says why.

## Motivation and Context

Since 2.0 shipped the bare string has been quoted in roughly a thousand downstream GitHub issues and PRs (one here, #3309), and new v1-shaped code keeps being written. It raises `ModuleNotFoundError` with `name=` set, rather than `ImportError`, because dual-version shims in the wild catch that class specifically or check `exc.name`; those keep working unchanged. It's a module file rather than a package so one file covers every `mcp.server.fastmcp.*` path, and it's excluded from the API reference so it stays undocumented and deletable in any release.

## How Has This Been Tested?

New `tests/server/test_fastmcp.py` (message snapshot, `.name`, nothing left in `sys.modules`, deep submodule path, v1-first fallback idiom); `./scripts/test`, pyright, docs build; and by hand via `python -c`, `mcp run`, and a built wheel.

## Breaking Changes

None. Exception type and `.name` are unchanged; only the message text differs, and `importlib.util.find_spec("mcp.server.fastmcp")` now returns a spec instead of `None`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Deliberately out of scope: the other removed v1 module paths (near-zero reports), `from mcp.server import FastMCP` and `McpError` (would need per-symbol `__getattr__`, cf. c27f95c8).

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>