### PR TITLE
fix(server): expose request cancellation on MCPServer context

### DIFF
--- a/src/mcp/server/context.py
+++ b/src/mcp/server/context.py
@@ -1,8 +1,9 @@
 import logging
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Generic, Protocol
 
+import anyio
 from mcp_types import LoggingLevel, RequestId, RequestParamsMeta
 from pydantic import BaseModel
 from typing_extensions import TypeVar, deprecated
@@ -41,6 +42,7 @@ class ServerRequestContext(Generic[LifespanContextT, RequestT]):
     lifespan_context: LifespanContextT
     protocol_version: str
     method: str
+    cancel_requested: anyio.Event = field(default_factory=anyio.Event)
     params: Mapping[str, Any] | None = None
     request_id: RequestId | None = None
     meta: RequestParamsMeta | None = None

--- a/src/mcp/server/mcpserver/context.py
+++ b/src/mcp/server/mcpserver/context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any, Generic, cast
 
+import anyio
 from mcp_types import ClientCapabilities, InputRequiredResult, InputResponseRequestParams, InputResponses, LoggingLevel
 from pydantic import AnyUrl, BaseModel
 from typing_extensions import deprecated
@@ -97,6 +98,11 @@ class Context(BaseModel, Generic[LifespanContextT, RequestT]):
         if self._request_context is None:
             raise ValueError("Context is not available outside of a request")
         return self._request_context
+
+    @property
+    def cancel_requested(self) -> anyio.Event:
+        """Set when the client requests cancellation of the current request."""
+        return self.request_context.cancel_requested
 
     def _nested_invocation(self) -> Context[LifespanContextT, RequestT]:
         """A Context for invoking another handler's function from inside this request.

--- a/src/mcp/server/runner.py
+++ b/src/mcp/server/runner.py
@@ -329,6 +329,7 @@ class ServerRunner(Generic[LifespanT]):
             session=session,
             lifespan_context=self.lifespan_state,
             method=method,
+            cancel_requested=dctx.cancel_requested,
             params=params,
             request_id=dctx.request_id,
             meta=meta,

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1970,6 +1970,33 @@ def _request_context(request: object | None) -> ServerRequestContext[None, objec
     )
 
 
+def test_context_cancel_requested_exposes_request_cancellation_event():
+    cancellation_event = anyio.Event()
+
+    request_context = ServerRequestContext(
+        session=AsyncMock(),
+        method="tools/call",
+        lifespan_context=None,
+        protocol_version="2025-11-25",
+        cancel_requested=cancellation_event,
+    )
+
+    ctx = Context(request_context=request_context, mcp_server=MagicMock())
+
+    assert ctx.cancel_requested is cancellation_event
+
+    cancellation_event.set()
+
+    assert ctx.cancel_requested.is_set()
+
+
+def test_context_cancel_requested_raises_outside_request():
+    ctx = Context(mcp_server=MagicMock())
+
+    with pytest.raises(ValueError, match="Context is not available outside of a request"):
+        _ = ctx.cancel_requested
+
+
 def test_context_headers_returns_request_headers():
     request = SimpleNamespace(headers={"x-github-user": "octocat"})
     ctx = Context(request_context=_request_context(request), mcp_server=MagicMock())


### PR DESCRIPTION
Fixes #3389.

## Problem

The high-level MCPServer Context does not expose the cancellation event available in the underlying dispatch context. Tool handlers therefore cannot observe cancellation or perform cooperative cleanup through the public API.

## Changes

- Add `cancel_requested` to `ServerRequestContext`.
- Forward the dispatcher's existing cancellation event when constructing the request context.
- Expose `cancel_requested` on the high-level `Context`.
- Preserve the existing error when context is accessed outside a request.
- Add regression tests for cancellation access and access outside a request.

## Testing

- All 168 tests passed:
  `python -m pytest tests/server/mcpserver/test_server.py -v --inline-snapshot=disable`
- Ruff linting passed.
- Ruff formatting checks passed.

AI assistance disclosure: I used AI to help investigate and implement this change. I reviewed the implementation and verified all tests myself.