### PR TITLE
Drop pydantic's auto-derived field titles from tool input schemas

### DIFF
--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -21,7 +21,7 @@ from mcp.server.mcpserver.resolve import (
     returns_input_required,
 )
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
-from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
+from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, NoAutoTitleJsonSchema, func_metadata
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.shared.exceptions import MCPError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
@@ -103,7 +103,9 @@ class Tool(BaseModel):
             skip_names=skip_names,
             structured_output=structured_output,
         )
-        parameters = func_arg_metadata.arg_model.model_json_schema(by_alias=True)
+        parameters = func_arg_metadata.arg_model.model_json_schema(
+            by_alias=True, schema_generator=NoAutoTitleJsonSchema
+        )
 
         # Match `model_dump_one_level`'s kwarg keys (alias when present, else field name)
         # so a by-name resolver param resolves to a key that exists at call time.

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -74,6 +74,22 @@ class StrictJsonSchema(GenerateJsonSchema):
         raise ValueError(f"JSON schema warning: {kind} - {detail}")
 
 
+class NoAutoTitleJsonSchema(GenerateJsonSchema):
+    """A JSON schema generator that omits pydantic's auto-derived field titles.
+
+    Pydantic titles every field by title-casing its name, so ``exercise_id``
+    gains ``"title": "Exercise Id"`` - a restatement of the key it sits under.
+    Tool schemas are sent to a model on every request, where that repetition is
+    paid for in context and carries nothing the field name does not.
+
+    Titles set explicitly via ``Field(title=...)`` are untouched: this only
+    suppresses the automatic ones.
+    """
+
+    def field_title_should_be_set(self, schema: Any) -> bool:
+        return False
+
+
 _LOCAL_DEFS_PREFIX = "#/$defs/"
 
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -159,7 +159,7 @@ async def test_client_list_tools(app: MCPServer):
                         name="greet",
                         description="Greet someone by name.",
                         input_schema={
-                            "properties": {"name": {"title": "Name", "type": "string"}},
+                            "properties": {"name": {"type": "string"}},
                             "required": ["name"],
                             "title": "greetArguments",
                             "type": "object",

--- a/tests/docs_src/test_client.py
+++ b/tests/docs_src/test_client.py
@@ -56,8 +56,8 @@ async def test_list_tools_returns_the_full_definition() -> None:
             {
                 "type": "object",
                 "properties": {
-                    "query": {"title": "Query", "type": "string"},
-                    "limit": {"default": 10, "title": "Limit", "type": "integer"},
+                    "query": {"type": "string"},
+                    "limit": {"default": 10, "type": "integer"},
                 },
                 "required": ["query"],
                 "title": "search_booksArguments",

--- a/tests/docs_src/test_context.py
+++ b/tests/docs_src/test_context.py
@@ -20,7 +20,7 @@ async def test_the_context_parameter_is_not_in_the_input_schema() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
-                "properties": {"query": {"title": "Query", "type": "string"}},
+                "properties": {"query": {"type": "string"}},
                 "required": ["query"],
                 "title": "search_booksArguments",
             }

--- a/tests/docs_src/test_dependencies.py
+++ b/tests/docs_src/test_dependencies.py
@@ -31,7 +31,7 @@ async def test_the_resolved_parameter_is_invisible_to_the_model() -> None:
     assert tool.input_schema == snapshot(
         {
             "type": "object",
-            "properties": {"title": {"title": "Title", "type": "string"}},
+            "properties": {"title": {"type": "string"}},
             "required": ["title"],
             "title": "reserve_bookArguments",
         }

--- a/tests/docs_src/test_first_steps.py
+++ b/tests/docs_src/test_first_steps.py
@@ -27,8 +27,8 @@ async def test_each_decorator_registers_one_primitive() -> None:
             {
                 "type": "object",
                 "properties": {
-                    "a": {"title": "A", "type": "integer"},
-                    "b": {"title": "B", "type": "integer"},
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
                 },
                 "required": ["a", "b"],
                 "title": "addArguments",

--- a/tests/docs_src/test_lifespan.py
+++ b/tests/docs_src/test_lifespan.py
@@ -29,7 +29,7 @@ async def test_context_parameter_never_reaches_the_input_schema() -> None:
         assert tool.input_schema == snapshot(
             {
                 "type": "object",
-                "properties": {"genre": {"title": "Genre", "type": "string"}},
+                "properties": {"genre": {"type": "string"}},
                 "required": ["genre"],
                 "title": "count_booksArguments",
             }

--- a/tests/docs_src/test_progress.py
+++ b/tests/docs_src/test_progress.py
@@ -19,9 +19,7 @@ async def test_context_parameter_is_invisible_to_the_model() -> None:
     """tutorial001: `ctx` comes from the type hint and never reaches the input schema."""
     async with Client(tutorial001.mcp) as client:
         (tool,) = (await client.list_tools()).tools
-        assert tool.input_schema["properties"] == {
-            "urls": {"items": {"type": "string"}, "title": "Urls", "type": "array"}
-        }
+        assert tool.input_schema["properties"] == {"urls": {"items": {"type": "string"}, "type": "array"}}
         assert tool.input_schema["required"] == ["urls"]
 
 

--- a/tests/docs_src/test_real_host.py
+++ b/tests/docs_src/test_real_host.py
@@ -20,7 +20,7 @@ async def test_the_host_sees_exactly_what_the_decorators_registered() -> None:
         assert search.input_schema == snapshot(
             {
                 "type": "object",
-                "properties": {"query": {"title": "Query", "type": "string"}},
+                "properties": {"query": {"type": "string"}},
                 "required": ["query"],
                 "title": "search_booksArguments",
             }

--- a/tests/docs_src/test_tools.py
+++ b/tests/docs_src/test_tools.py
@@ -21,8 +21,8 @@ async def test_signature_becomes_the_schema() -> None:
             {
                 "type": "object",
                 "properties": {
-                    "query": {"title": "Query", "type": "string"},
-                    "limit": {"title": "Limit", "type": "integer"},
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"},
                 },
                 "required": ["query", "limit"],
                 "title": "search_booksArguments",
@@ -50,8 +50,8 @@ async def test_default_value_makes_the_argument_optional() -> None:
             {
                 "type": "object",
                 "properties": {
-                    "query": {"title": "Query", "type": "string"},
-                    "limit": {"default": 10, "title": "Limit", "type": "integer"},
+                    "query": {"type": "string"},
+                    "limit": {"default": 10, "type": "integer"},
                 },
                 "required": ["query"],
                 "title": "search_booksArguments",
@@ -73,7 +73,6 @@ async def test_field_constraints_land_in_the_schema() -> None:
                 "description": "Maximum number of results.",
                 "maximum": 50,
                 "minimum": 1,
-                "title": "Limit",
                 "type": "integer",
             }
         )

--- a/tests/server/mcpserver/test_resolve.py
+++ b/tests/server/mcpserver/test_resolve.py
@@ -2766,7 +2766,7 @@ async def test_resolved_parameters_are_absent_from_the_advertised_tool_schema():
     assert advertised.input_schema == snapshot(
         {
             "type": "object",
-            "properties": {"title": {"title": "Title", "type": "string"}},
+            "properties": {"title": {"type": "string"}},
             "required": ["title"],
             "title": "quoteArguments",
         }

--- a/tests/server/mcpserver/test_tool_manager.py
+++ b/tests/server/mcpserver/test_tool_manager.py
@@ -1,11 +1,11 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, TypedDict
+from typing import Annotated, Any, TypedDict
 
 import pytest
 from mcp_types import CallToolResult, TextContent, ToolAnnotations
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from mcp.server.context import LifespanContextT, RequestT
 from mcp.server.mcpserver import Context, MCPServer
@@ -904,3 +904,33 @@ class TestRemoveTools:
         # Remove with correct case
         manager.remove_tool("test_func")
         assert manager.get_tool("test_func") is None
+
+
+def test_tool_input_schema_omits_auto_derived_titles():
+    """Auto-derived field titles are dropped; explicit ones survive.
+
+    Pydantic titles every field by title-casing its name, which restates the key
+    it sits under. Tool schemas are sent to the model on every request, so that
+    repetition costs context for nothing.
+    """
+
+    def log_set(
+        exercise_id: str,
+        reps: Annotated[int, Field(title="Repetitions performed")],
+        weight: Annotated[float, Field(description="in kilograms")] = 0.0,
+    ) -> str:
+        """Log a set."""
+        return "ok"
+
+    manager = ToolManager()
+    tool = manager.add_tool(log_set)
+    properties = tool.parameters["properties"]
+
+    assert "title" not in properties["exercise_id"]
+    assert "title" not in properties["weight"]
+    # An explicitly-set title is the author's choice, not pydantic's default.
+    assert properties["reps"]["title"] == "Repetitions performed"
+    # Nothing else about the schema changes.
+    assert properties["exercise_id"]["type"] == "string"
+    assert properties["weight"]["description"] == "in kilograms"
+    assert properties["weight"]["default"] == 0.0


### PR DESCRIPTION
<!--
Pull requests from outside the maintainer team need to link an open issue that
a maintainer has assigned to you (or one labeled `help wanted`); others are
closed automatically until that's in place. See CONTRIBUTING.md for details.
-->

Fixes #3391

Drops pydantic's auto-derived `title` from every property of a tool's `inputSchema`. A parameter named `exercise_id` no longer carries `"title": "Exercise Id"`.

Draft on purpose: #3391 asks two open questions — default vs opt-in, and whether to cover output schemas, prompts and resource templates in the same change. This branch is the smallest version that answers "yes to the default, tools only", so there is something concrete to react to. Say the word and I will reshape it.

## Motivation and Context

Tool schemas are re-sent to the model on every request, so anything in them is paid for in context on every turn. Pydantic titles each field by title-casing its name, which restates the key it already sits under and gives a model nothing to act on.

Measured against a live server — the [wger MCP server](https://github.com/wger-project/mcp-server), whose `tools/list` is 43,710 bytes across 49 tools:

| | bytes | share |
|---|---|---|
| tool descriptions (prose) | 10,904 | 25% |
| **auto-derived `title` keys (297)** | **8,333** | **19%** |
| `anyOf` null-wrapping | 1,869 | 4% |

The agent that prompted this is granted 43 of those tools and runs on a 32k-context local model: ~11,100 tokens of schema, 42% of the window gone before the first message. This returns about 2,000 of those tokens per request.

`GenerateJsonSchema.field_title_should_be_set` is the supported hook, and `func_metadata.py` already defines a custom generator (`StrictJsonSchema`) for the output path, so the pattern is established.

**An explicit `Field(title=...)` is preserved.** That is the line this draws: an explicit title is the author's choice; an auto-derived one is a default nobody asked for. Descriptions and constraints are untouched.

## How Has This Been Tested?

- Full suite green: `5805 passed, 8 skipped, 1 xfailed`.
- `uv run pyright` — 0 errors. `uv run ruff check .` — clean. `ruff format` applied.
- New regression test `test_tool_input_schema_omits_auto_derived_titles` asserts all three cases in one place: an auto title is gone, an explicit `Field(title=...)` survives, and `description` / `default` / `type` are unchanged.
- 12 existing expectations needed updating — mostly `snapshot(...)` in `tests/docs_src/`, refreshed with `--inline-snapshot=fix`, plus two hand-written dicts in `tests/client/test_client.py` and `tests/docs_src/test_progress.py`. That churn is the honest cost of changing the default and is the main thing to weigh.

## Breaking Changes

The wire format changes: `inputSchema` properties no longer carry auto-derived titles. No user code needs updating, and nothing in the MCP spec requires `title`. A client that *displays* `title` as a form label would fall back to the property name — that is the risk worth a maintainer's judgement, and the reason for the default-vs-opt-in question in #3391.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Not assigned to #3391 yet — I understand this stays closed until a maintainer picks it up, and I will push updates as new commits rather than force-pushing so it can reopen.

**Deliberately left out**, all measurable and all better as separate decisions:

- Output schemas (another 61 titles in the payload above), prompts, and resource templates, which generate titles the same way.
- The `anyOf: [{"type": "X"}, {"type": "null"}]` spelling of optionals — a further 4%, but that is pydantic's output rather than a hook this SDK controls.
- Tool descriptions are 25% of the payload and are *not* a target. In the server I measured they explain things a model genuinely cannot infer — one warns that a plank logged without `reps_unit` is stored as 60 repetitions rather than 60 seconds, unrecoverably. That is the schema earning its tokens.

*Disclosure: I used an AI agent to take the measurements and draft this change. The problem is one I hit in my own deployment, and I have read and can explain the result.*
