### PR TITLE
[v2.0.x] Point imports of mcp.server.fastmcp at the migration guide

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -21,7 +21,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-          version: 0.9.5
+          version: 0.12.5
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -57,7 +57,7 @@ jobs:
           path: dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           # Lets a re-run after a partially failed upload publish the remaining
           # files instead of erroring on the ones already on PyPI.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -12,7 +12,7 @@ Every section heading below names the API it affects, so searching this page for
 
 | Change | First symptom | Section |
 |---|---|---|
-| `FastMCP` renamed to `MCPServer` | `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` | [`FastMCP` renamed](#fastmcp-renamed-to-mcpserver) |
+| `FastMCP` renamed to `MCPServer` | `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` (newer 2.x releases follow it with a pointer to this guide) | [`FastMCP` renamed](#fastmcp-renamed-to-mcpserver) |
 | Fields renamed from camelCase to snake_case | `AttributeError: 'Tool' object has no attribute 'inputSchema'` | [snake_case fields](#field-names-changed-from-camelcase-to-snake_case) |
 | `mcp.types` names removed | `ImportError: cannot import name 'Content' from 'mcp.types'` | [Removed types](#removed-type-aliases-and-classes) |
 | `McpError` renamed to `MCPError` | `ImportError: cannot import name 'McpError' from 'mcp'` | [`McpError` renamed](#mcperror-renamed-to-mcperror) |
@@ -666,6 +666,8 @@ All submodules under `mcp.server.fastmcp.*` are now under `mcp.server.mcpserver.
 - `Message`, `UserMessage`, `AssistantMessage` — from `mcp.server.mcpserver.prompts.base`
 - `ToolError`, `ResourceError` — from `mcp.server.mcpserver.exceptions`
 - `MCPServerError` (renamed from `FastMCPError`) — from `mcp.server.mcpserver.exceptions`
+
+Importing `mcp.server.fastmcp`, or anything below it, raises `ModuleNotFoundError` (newer 2.x releases include a link to this section in its message), so existing `except ImportError` or `except ModuleNotFoundError` fallbacks around the v1 import keep working.
 
 ### What is unchanged on `MCPServer`
 

--- a/scripts/docs/gen_ref_pages.py
+++ b/scripts/docs/gen_ref_pages.py
@@ -30,11 +30,12 @@ API_DIR = ROOT / "docs" / "api"
 # it from `src/` would emit the unimportable `mcp-types.mcp_types.*`.
 PACKAGES = (ROOT / "src" / "mcp", ROOT / "src" / "mcp-types" / "mcp_types")
 
-# Alias packages that mirror another package's namespaces (`mcp.types` mirrors
-# `mcp_types`, `mcp.types.version` mirrors `mcp_types.version`): the mirrored
-# package's pages are the canonical rendering, so an alias, and every module
-# under it, earns no page of its own.
-EXCLUDED = frozenset({"mcp.types"})
+# Module paths that get no page, and neither does anything under them: alias
+# packages that mirror another package's namespaces (`mcp.types` mirrors
+# `mcp_types`), whose canonical rendering is the mirrored package's pages; and
+# removed v1 import paths (`mcp.server.fastmcp`) that only raise a pointer to
+# the migration guide and carry no API.
+EXCLUDED = frozenset({"mcp.types", "mcp.server.fastmcp"})
 
 _KIND_SECTIONS = {
     griffe.Kind.MODULE: "Modules",

--- a/src/mcp/server/fastmcp.py
+++ b/src/mcp/server/fastmcp.py
@@ -1,0 +1,16 @@
+"""Removed in mcp 2: `FastMCP` is now `mcp.server.mcpserver.MCPServer`.
+
+This module has no API. Importing it, or anything below it, raises
+`ModuleNotFoundError` with a message that points at the migration guide. It
+exists only because the bare "No module named 'mcp.server.fastmcp'" gave v1
+code no hint that the installed SDK is a different major version.
+"""
+
+_MESSAGE = (
+    "No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed to MCPServer "
+    "(from mcp.server.mcpserver import MCPServer) and other APIs changed; see the migration guide at "
+    "https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver "
+    "or pin 'mcp<2' to keep running v1 code."
+)
+
+raise ModuleNotFoundError(_MESSAGE, name=__name__)

--- a/tests/server/test_fastmcp.py
+++ b/tests/server/test_fastmcp.py
@@ -1,0 +1,55 @@
+"""The removed v1 import path `mcp.server.fastmcp` fails with a pointer to the migration guide."""
+
+import importlib
+import sys
+
+import pytest
+from inline_snapshot import snapshot
+
+import mcp.server
+from mcp.server.mcpserver import MCPServer
+
+
+def test_importing_fastmcp_raises_module_not_found_that_points_at_the_migration_guide() -> None:
+    """SDK-defined: the v1 path fails with the same exception type and `.name` as a module
+    that genuinely does not exist, but the message names the replacement and the guide."""
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        importlib.import_module("mcp.server.fastmcp")
+
+    assert exc_info.value.name == "mcp.server.fastmcp"
+    assert str(exc_info.value) == snapshot(
+        "No module named 'mcp.server.fastmcp'. This is mcp 2.x, where FastMCP was renamed to MCPServer "
+        "(from mcp.server.mcpserver import MCPServer) and other APIs changed; see the migration guide at "
+        "https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver "
+        "or pin 'mcp<2' to keep running v1 code."
+    )
+    # A module that raises while executing is never cached, so nothing is left behind.
+    assert "mcp.server.fastmcp" not in sys.modules
+    assert not hasattr(mcp.server, "fastmcp")
+
+
+def test_importing_a_fastmcp_submodule_raises_the_parent_pointer() -> None:
+    """SDK-defined: a deep v1 path executes `mcp.server.fastmcp` first, so it fails with that
+    module's message and `.name` rather than a bare error for the leaf."""
+    with pytest.raises(ModuleNotFoundError) as parent:
+        importlib.import_module("mcp.server.fastmcp")
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        importlib.import_module("mcp.server.fastmcp.utilities.types")
+
+    assert exc_info.value.name == "mcp.server.fastmcp"
+    assert str(exc_info.value) == str(parent.value)
+
+
+def test_v1_first_import_shim_falls_back_to_mcpserver() -> None:
+    """SDK-defined: projects that support both majors try the v1 import and fall back on
+    `ModuleNotFoundError` (the narrowest guard seen in the wild), which is why the pointer is
+    raised as exactly that type and not as a bare `ImportError` or after a warning."""
+    fell_back = False
+    try:
+        server_class: type = importlib.import_module("mcp.server.fastmcp").FastMCP
+    except ModuleNotFoundError:
+        fell_back = True
+        server_class = MCPServer
+
+    assert fell_back
+    assert server_class is MCPServer


### PR DESCRIPTION
Backport of #3388 onto `v2.0.0` so it can ship as 2.0.1. `v2.0.x` was cut at the `v2.0.0` tag; this PR is the only thing on top of it.

Three cherry-picks (`-x`, all applied cleanly):

- #3380 — needed here because `publish-pypi.yml` runs from the tagged commit, and the 2.0.0-era workflow would rebuild with floating hatchling and hit the same Metadata 2.5 upload rejection v2.1.0 did.
- The two commits from #3388: `src/mcp/server/fastmcp.py` raising `ModuleNotFoundError` with the pointer, the API-reference exclusion, tests, and the two `docs/migration.md` clarity edits.

## Motivation and Context

See #3388. A 2.0.1 reaches installs pinned to `mcp==2.0.*` / `<2.1`; everyone unpinned gets it from the next release off `main`.

## How Has This Been Tested?

On this branch: `./scripts/test` (5585 passed, 100% coverage, `strict-no-cover` clean), pyright, ruff, `scripts/docs/build_config.py` (no `fastmcp` page), and the import by hand. `uv-dynamic-versioning` resolves the branch as `2.0.1.devN`, so a `v2.0.1` tag here yields 2.0.1.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Release: `gh release create v2.0.1 --target <merge sha on v2.0.x> --latest=false` so 2.1.0 stays "Latest". `deploy-docs.yml` only fires from `main`, so the docs site is unaffected by this branch. If you'd rather keep #3380 as its own commit on `v2.0.x`, rebase-merge instead of squash.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>