### PR TITLE
[v1.x] Resolve tool output-schema references within the schema document only

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -428,17 +428,24 @@ class ClientSession(
 
         if output_schema is not None:
             from jsonschema import SchemaError, ValidationError, validate
+            from referencing import Registry
+            from referencing.exceptions import Unresolvable
 
             if result.structuredContent is None:
                 raise RuntimeError(
                     f"Tool {name} has an output schema but did not return structured content"
                 )  # pragma: no cover
+            # An explicit empty registry: `$ref`s resolve within the schema document and the bundled metaschemas.
+            registry: Registry[Any] = Registry()
             try:
-                validate(result.structuredContent, output_schema)
+                validate(result.structuredContent, output_schema, registry=registry)
             except ValidationError as e:
                 raise RuntimeError(f"Invalid structured content returned by tool {name}: {e}")  # pragma: no cover
             except SchemaError as e:  # pragma: no cover
                 raise RuntimeError(f"Invalid schema for tool {name}: {e}")  # pragma: no cover
+            except Unresolvable as e:
+                # A `$ref` did not resolve within the schema document.
+                raise RuntimeError(f"Invalid schema for tool {name}: {e}") from e
 
     @overload
     @deprecated("Use list_prompts(params=PaginatedRequestParams(...)) instead")

--- a/tests/client/test_output_schema_validation.py
+++ b/tests/client/test_output_schema_validation.py
@@ -1,9 +1,11 @@
 import logging
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
 import pytest
+from referencing.exceptions import Unresolvable
 
 from mcp.server.lowlevel import Server
 from mcp.shared.memory import (
@@ -215,3 +217,34 @@ class TestClientOutputSchemaValidation:
 
                 # Check that warning was logged
                 assert "Tool mystery_tool not listed" in caplog.text
+
+
+# jsonschema's fallback retriever emits this DeprecationWarning; keep it a plain warning so the
+# assertions below decide the outcome rather than the suite's warnings-as-errors filter.
+@pytest.mark.filterwarnings("default:Automatically retrieving remote references:DeprecationWarning")
+@pytest.mark.anyio
+async def test_output_schema_ref_outside_the_document_is_rejected(tmp_path: Path):
+    """A `$ref` to a URI outside the output schema is not resolved, and a result whose validation
+    reaches one fails as an invalid schema (spec `$ref` resolution; applying it to `file:` URIs too
+    is SDK-defined)."""
+    target = tmp_path / "schema.json"
+    target.write_text("{}", encoding="utf-8")
+    server = Server("test-server")
+
+    @server.list_tools()
+    async def list_tools():
+        return [
+            Tool(name="probe", description="", inputSchema={"type": "object"}, outputSchema={"$ref": target.as_uri()})
+        ]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict[str, Any]):
+        return {"v": 1}
+
+    with bypass_server_output_validation():
+        async with client_session(server) as client:
+            with pytest.raises(RuntimeError) as exc_info:
+                await client.call_tool("probe", {})
+            # SDK-authored prefix only; the tail is `referencing`'s text.
+            assert str(exc_info.value).startswith("Invalid schema for tool probe: ")
+            assert isinstance(exc_info.value.__cause__, Unresolvable)


### PR DESCRIPTION
Backport of #3394 to `v1.x`.

Passes an explicit empty `referencing.Registry` to the client's output-schema validation (`ClientSession._validate_tool_result`), so `$ref`s in a tool's `outputSchema` resolve within that schema and the bundled metaschemas, per the spec's [`$ref` resolution](https://modelcontextprotocol.io/specification/2026-07-28/basic#ref-resolution) section. A reference that doesn't resolve there surfaces from `call_tool` as `RuntimeError("Invalid schema for tool …")`, the same shape the method already uses for an invalid schema.

## Motivation and Context

Same change as on `main`; see #3394. jsonschema merges its bundled metaschemas into any registry it is given, so `#/$defs/…`, `#/definitions/…`, `$anchor`, embedded `$id` resources and `$ref`s to the standard metaschema URIs resolve as before.

## How Has This Been Tested?

New test in `tests/client/test_output_schema_validation.py` through the in-memory client session; the existing recursive-`$defs` server test covers in-document references. Full suite, coverage, pyright and ruff clean locally.

## Breaking Changes

No API changes. A result whose validation reaches a `$ref` outside the schema document now fails with `RuntimeError: Invalid schema for tool <name>: …`, and a dangling in-document `$ref` surfaces as that same `RuntimeError` rather than a `referencing` exception.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

`referencing` is jsonschema's own dependency and the type of its `registry=` parameter; it is imported directly, as on `main`. The new test uses the file's existing `bypass_server_output_validation()` helper like its neighbours, and is a plain top-level function per the current test guidelines.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
