### PR TITLE
fix: make URL elicitation errors pickle-safe

### DIFF
--- a/src/mcp/shared/exceptions.py
+++ b/src/mcp/shared/exceptions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any, cast
 
 from mcp_types import INVALID_REQUEST, URL_ELICITATION_REQUIRED, ElicitRequestURLParams, ErrorData, JSONRPCError
@@ -117,3 +118,7 @@ class UrlElicitationRequiredError(MCPError):
         raw_elicitations = cast(list[dict[str, Any]], data.get("elicitations", []))
         elicitations = [ElicitRequestURLParams.model_validate(e) for e in raw_elicitations]
         return cls(elicitations, error.message)
+
+    def __reduce__(self) -> tuple[Callable[[ErrorData], UrlElicitationRequiredError], tuple[ErrorData]]:
+        """Reconstruct the exception from its wire-compatible error payload."""
+        return (self.from_error, (self.error,))

--- a/tests/shared/test_exceptions.py
+++ b/tests/shared/test_exceptions.py
@@ -1,5 +1,7 @@
 """Tests for MCP exception classes."""
 
+import pickle
+
 import pytest
 from mcp_types import URL_ELICITATION_REQUIRED, ElicitRequestURLParams, ErrorData, JSONRPCError
 
@@ -115,6 +117,27 @@ def test_url_elicitation_required_error_serialization_roundtrip() -> None:
     assert reconstructed.elicitations[0].elicitation_id == original.elicitations[0].elicitation_id
     assert reconstructed.elicitations[0].url == original.elicitations[0].url
     assert reconstructed.elicitations[0].message == original.elicitations[0].message
+
+
+def test_url_elicitation_required_error_pickle_roundtrip() -> None:
+    """Pickle reconstruction preserves the specialized exception payload."""
+    original = UrlElicitationRequiredError(
+        [
+            ElicitRequestURLParams(
+                mode="url",
+                message="Auth required",
+                url="https://example.com/auth",
+                elicitation_id="test-123",
+            )
+        ],
+        message="Please authenticate",
+    )
+
+    restored = pickle.loads(pickle.dumps(original))
+
+    assert isinstance(restored, UrlElicitationRequiredError)
+    assert restored.error == original.error
+    assert restored.elicitations == original.elicitations
 
 
 def test_url_elicitation_required_error_data_contains_elicitations() -> None:


### PR DESCRIPTION
## Summary

`UrlElicitationRequiredError` could not be unpickled because the inherited exception state stores `(code, message, data)`, while its constructor expects an elicitation list and optional message.

This change adds a `__reduce__` implementation that reconstructs the exception through the existing `from_error` method, preserving the wire error payload and elicitation details.

## Validation

- `uv run --frozen pytest tests/shared/test_exceptions.py` (11 passed)
- `uv run --frozen ruff check src/mcp/shared/exceptions.py tests/shared/test_exceptions.py`
- `uv run --frozen pyright src/mcp/shared/exceptions.py tests/shared/test_exceptions.py`
- `git diff --check`

The full test suite was also run; it has one unrelated Windows environment failure in `tests/client/test_transport_stream_cleanup.py::test_sse_client_closes_all_streams_on_connection_error`, where the local proxy returned HTTP 502 instead of the expected connection error.

Fixes #2431.
