### PR TITLE
fix(server): omit derived tool schema titles

### DIFF
--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -21,7 +21,7 @@ from mcp.server.mcpserver.resolve import (
     returns_input_required,
 )
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
-from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
+from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, NoTitleJsonSchema, func_metadata
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.shared.exceptions import MCPError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
@@ -103,7 +103,7 @@ class Tool(BaseModel):
             skip_names=skip_names,
             structured_output=structured_output,
         )
-        parameters = func_arg_metadata.arg_model.model_json_schema(by_alias=True)
+        parameters = func_arg_metadata.arg_model.model_json_schema(by_alias=True, schema_generator=NoTitleJsonSchema)
 
         # Match `model_dump_one_level`'s kwarg keys (alias when present, else field name)
         # so a by-name resolver param resolves to a key that exists at call time.

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -74,6 +74,14 @@ class StrictJsonSchema(GenerateJsonSchema):
         raise ValueError(f"JSON schema warning: {kind} - {detail}")
 
 
+class NoTitleJsonSchema(StrictJsonSchema):
+    """A strict JSON schema generator that omits titles derived from field names."""
+
+    def field_title_should_be_set(self, schema: Any) -> bool:
+        """Return false so Pydantic does not add a title derived from the field name."""
+        return False
+
+
 _LOCAL_DEFS_PREFIX = "#/$defs/"
 
 

--- a/tests/server/mcpserver/test_title.py
+++ b/tests/server/mcpserver/test_title.py
@@ -1,7 +1,10 @@
 """Integration tests for title field functionality."""
 
+from typing import Annotated
+
 import pytest
 from mcp_types import Prompt, Resource, ResourceTemplate, Tool, ToolAnnotations
+from pydantic import Field
 
 from mcp import Client
 from mcp.server.mcpserver import MCPServer
@@ -85,6 +88,23 @@ async def test_tool_title_precedence():
         assert "tool_with_both" in tools
         both = tools["tool_with_both"]
         assert both.title == "Primary Title"
+
+
+@pytest.mark.anyio
+async def test_tool_input_schema_omits_derived_titles_but_preserves_explicit_titles():
+    """Tool schemas omit Pydantic's field-name titles while preserving explicit titles."""
+    mcp = MCPServer(name="SchemaTitleServer")
+
+    @mcp.tool()
+    def typed_tool(required: str, explicit: Annotated[int, Field(title="Explicit Count")]) -> str:  # pragma: no cover
+        return f"{required}: {explicit}"
+
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+
+    properties = tools.tools[0].input_schema["properties"]
+    assert properties["required"] == {"type": "string"}
+    assert properties["explicit"] == {"title": "Explicit Count", "type": "integer"}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Problem

Pydantic derives a title from every tool argument name in the published JSON Schema. For example, `exercise_id` becomes `"title": "Exercise Id"`; the title repeats the property key and increases the tool schema sent to models on every request.

## Root Cause

`Tool.from_function` calls Pydantic's default `model_json_schema`, whose generator adds field-name titles whenever a field does not provide an explicit title.

## Solution

Use a strict schema generator for tool input models that disables only Pydantic's automatic field-name title generation. Explicit `Field(title=...)` metadata remains unchanged.

## Changes

- Add `NoTitleJsonSchema`, based on the existing strict generator, with `field_title_should_be_set` disabled.
- Use it when `Tool.from_function` builds the input schema.
- Add an integration regression test covering both derived and explicit field titles.

## Testing

- `py -3.10 -m pytest -q --noconftest tests/server/mcpserver/test_title.py tests/server/mcpserver/test_func_metadata.py` (passed: 64)
- `py -3.10 -m ruff check src/mcp/server/mcpserver/utilities/func_metadata.py src/mcp/server/mcpserver/tools/base.py tests/server/mcpserver/test_title.py` (passed)
- `py -3.10 -m ruff format --check src/mcp/server/mcpserver/utilities/func_metadata.py src/mcp/server/mcpserver/tools/base.py tests/server/mcpserver/test_title.py` (passed)
- `py -3.10 -m compileall -q src/mcp/server/mcpserver/utilities/func_metadata.py src/mcp/server/mcpserver/tools/base.py tests/server/mcpserver/test_title.py` (passed)
- `git diff --check` (passed)
- Full typecheck was not verified locally because the partial Git checkout did not contain the configured `mcp-types` environment; the targeted runtime and static checks above passed.

## Compatibility/Risk

This changes only generated tool input schemas. It removes redundant auto-derived property titles while preserving explicit titles and all other validation metadata. Consumers that depended on Pydantic's derived titles may observe a smaller schema, but property names and types are unchanged.

## Notes for Reviewer

Please confirm that removing default property titles is the desired default for MCP tool schemas, and whether output schemas, prompts, or resource templates should follow in a separate change.

## Linked Issue

Closes #3391
