### PR TITLE
fix: record JSON-RPC errors on client OpenTelemetry spans

### DIFF
--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -32,7 +32,7 @@ from mcp_types import (
     ProgressToken,
     RequestId,
 )
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, StatusCode
 from pydantic import ValidationError
 from typing_extensions import TypeVar
 
@@ -385,7 +385,7 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                 span_name,
                 kind=SpanKind.CLIENT,
                 attributes={"mcp.method.name": method, "jsonrpc.request.id": str(request_id)},
-            ):
+            ) as span:
                 # SEP-414: inject W3C trace context; `_meta` stays on the wire even with a no-op tracer.
                 inject_trace_context(out_meta)
                 msg = JSONRPCRequest(jsonrpc="2.0", id=request_id, method=method, params=out_params)
@@ -401,6 +401,10 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                 with anyio.fail_after(opts.get("timeout")):
                     timeout_armed = True
                     outcome = await receive.receive()
+                if isinstance(outcome, ErrorData):
+                    span.set_status(StatusCode.ERROR)
+                    span.set_attribute("error.type", "mcp_error")
+                    span.set_attribute("rpc.response.status_code", outcome.code)
         except TimeoutError:
             if not timeout_armed:
                 # `fail_after` arms only after the write, so this TimeoutError is the

--- a/tests/server/test_otel.py
+++ b/tests/server/test_otel.py
@@ -14,8 +14,10 @@ import pytest
 from mcp_types import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
+    METHOD_NOT_FOUND,
     CallToolRequestParams,
     CallToolResult,
+    ErrorData,
     GetPromptRequestParams,
     GetPromptResult,
     ListToolsResult,
@@ -68,6 +70,25 @@ async def test_emits_server_span_with_method_and_target(server: SrvT, spans: Spa
     assert span.attributes["gen_ai.tool.name"] == "mytool"
     assert isinstance(span.attributes["jsonrpc.request.id"], str)
     assert span.status.status_code == StatusCode.UNSET
+
+
+@pytest.mark.anyio
+async def test_client_span_records_jsonrpc_error_response(server: SrvT, spans: SpanCapture):
+    async def missing_method(ctx: Ctx, params: PaginatedRequestParams | None) -> ErrorData:
+        return ErrorData(code=METHOD_NOT_FOUND, message="missing")
+
+    server.add_request_handler("missing", PaginatedRequestParams, missing_method)
+    async with connected_runner(server) as (client, _):
+        spans.clear()
+        with pytest.raises(MCPError) as exc:
+            await client.send_raw_request("missing", {})
+
+    assert exc.value.error.code == METHOD_NOT_FOUND
+    [span] = [s for s in spans.finished() if s.kind == SpanKind.CLIENT]
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes is not None
+    assert span.attributes["error.type"] == "mcp_error"
+    assert span.attributes["rpc.response.status_code"] == METHOD_NOT_FOUND
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Client OpenTelemetry spans did not record JSON-RPC error responses because `ErrorData` was converted to `MCPError` after the span context exited. This made failed client requests indistinguishable from successful requests in telemetry.

This change records `StatusCode.ERROR`, `error.type`, and `rpc.response.status_code` while the client span is still active. The existing `MCPError` behavior is unchanged.

## Tests

- `uv run --frozen pytest tests/server/test_otel.py -q` (17 passed)
- `uv run --frozen ruff check src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py`
- `uv run --frozen ruff format --check src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py`
- `uv run --frozen pyright src/mcp/shared/jsonrpc_dispatcher.py tests/server/test_otel.py`
- Full suite with `PYTHONUTF8=1`: 5574 passed, 16 skipped, 1 xfailed; one unrelated local HTTP 502 failure in `tests/client/test_transport_stream_cleanup.py::test_sse_client_closes_all_streams_on_connection_error`.

AI assistance was used during development, and the change was reviewed and verified locally.

Fixes #3174