### PR TITLE
[v1.x] fix: make MCP errors pickle-safe

### DIFF
--- a/src/mcp/shared/exceptions.py
+++ b/src/mcp/shared/exceptions.py
@@ -17,6 +17,10 @@ class McpError(Exception):
         super().__init__(error.message)
         self.error = error
 
+    def __reduce__(self) -> tuple[type[McpError], tuple[ErrorData]]:
+        """Reconstruct the exception from its complete wire error payload."""
+        return type(self), (self.error,)
+
 
 class UrlElicitationRequiredError(McpError):
     """
@@ -69,3 +73,7 @@ class UrlElicitationRequiredError(McpError):
         raw_elicitations = cast(list[dict[str, Any]], data.get("elicitations", []))
         elicitations = [ElicitRequestURLParams.model_validate(e) for e in raw_elicitations]
         return cls(elicitations, error.message)
+
+    def __reduce__(self) -> tuple[Any, tuple[ErrorData]]:
+        """Reconstruct the specialized exception from its wire error payload."""
+        return self.from_error, (self.error,)

--- a/tests/shared/test_exceptions.py
+++ b/tests/shared/test_exceptions.py
@@ -1,9 +1,22 @@
 """Tests for MCP exception classes."""
 
+import pickle
+
 import pytest
 
 from mcp.shared.exceptions import McpError, UrlElicitationRequiredError
 from mcp.types import URL_ELICITATION_REQUIRED, ElicitRequestURLParams, ErrorData
+
+
+def test_mcp_error_pickle_roundtrip() -> None:
+    """Test that McpError preserves its wire payload through pickle."""
+    original = McpError(ErrorData(code=-32600, message="Authentication Required", data={"retry": True}))
+
+    reconstructed = pickle.loads(pickle.dumps(original))
+
+    assert isinstance(reconstructed, McpError)
+    assert reconstructed.error == original.error
+    assert str(reconstructed) == str(original)
 
 
 class TestUrlElicitationRequiredError:
@@ -157,3 +170,24 @@ class TestUrlElicitationRequiredError:
 
         # The exception's string representation should match the message
         assert str(error) == "URL elicitation required"
+
+    def test_pickle_roundtrip(self) -> None:
+        """Test that URL elicitation errors preserve their payload through pickle."""
+        original = UrlElicitationRequiredError(
+            [
+                ElicitRequestURLParams(
+                    mode="url",
+                    message="Auth required",
+                    url="https://example.com/auth",
+                    elicitationId="test-123",
+                )
+            ],
+            message="Custom message",
+        )
+
+        reconstructed = pickle.loads(pickle.dumps(original))
+
+        assert isinstance(reconstructed, UrlElicitationRequiredError)
+        assert reconstructed.error == original.error
+        assert reconstructed.elicitations == original.elicitations
+        assert str(reconstructed) == "Custom message"


### PR DESCRIPTION
## Summary

- Add explicit pickle reconstruction for `McpError` using its complete `ErrorData` payload.
- Add specialized reconstruction for `UrlElicitationRequiredError` through its existing `from_error` parser.
- Add regression tests covering payload, message, and URL elicitation preservation across standard-library pickle round-trips.

Fixes #2431

## Verification

- `uv run --frozen pytest tests/shared/test_exceptions.py tests/shared/test_session.py tests/client/test_stdio.py -q`
- `NO_PROXY="*" no_proxy="*" ALL_PROXY="" all_proxy="" HTTP_PROXY="" http_proxy="" HTTPS_PROXY="" https_proxy="" ./scripts/test` (`1184 passed`, `95 skipped`, `1 xfailed`, `100.00%` coverage)
- `uv run --frozen pyright`
- `uv run --frozen ruff check src/mcp/shared/exceptions.py tests/shared/test_exceptions.py`

AI assistance was used during investigation and drafting; I reviewed the implementation, regression coverage, and verification results personally.