### PR TITLE
Handle client disconnects while reading POST body

### DIFF
--- a/src/mcp/server/streamable_http.py
+++ b/src/mcp/server/streamable_http.py
@@ -37,7 +37,7 @@ from mcp_types import (
 from mcp_types.version import is_version_at_least
 from pydantic import ValidationError
 from sse_starlette import EventSourceResponse
-from starlette.requests import Request
+from starlette.requests import ClientDisconnect, Request
 from starlette.responses import Response
 from starlette.types import Receive, Scope, Send
 
@@ -714,6 +714,9 @@ class StreamableHTTPServerTransport:
                 finally:
                     await sse_stream_reader.aclose()
 
+        except ClientDisconnect:
+            logger.debug("Client disconnected while reading POST request body")
+            return
         except Exception as err:
             logger.exception("Error handling POST request")
             response = self._create_error_response(

--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -657,6 +657,46 @@ async def _post_to_transport(transport: StreamableHTTPServerTransport, body: dic
 
 
 @pytest.mark.anyio
+async def test_streamable_http_post_client_disconnect_is_not_reported_as_500(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR, logger="mcp.server.streamable_http")
+    transport = StreamableHTTPServerTransport(mcp_session_id="valid-id")
+    assert transport.mcp_session_id is not None
+    scope: Scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "query_string": b"",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"accept", b"application/json, text/event-stream"),
+            (MCP_SESSION_ID_HEADER.encode(), transport.mcp_session_id.encode()),
+        ],
+    }
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    async with transport.connect():
+        with anyio.move_on_after(1) as cancel_scope:
+            await transport.handle_request(scope, receive, send)
+
+        assert not cancel_scope.cancel_called
+        assert not sent
+        assert [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "mcp.server.streamable_http" and record.levelno >= logging.ERROR
+        ] == []
+        await transport.terminate()
+
+
+@pytest.mark.anyio
 async def test_transport_whose_idle_period_ran_out_answers_as_terminated() -> None:
     """Once the idle scope has fired, a request that still reaches the transport is answered 404 and the
     transport is terminated, instead of being dispatched into the message loop the host is leaving."""


### PR DESCRIPTION
Fixes #1648.

## Motivation and Context

This PR handles client disconnects while reading Streamable HTTP POST request bodies without reporting them as server errors.

When Starlette raises `ClientDisconnect` while reading the POST body, the current handler falls through to the generic exception path. That logs an error and attempts to return a 500 response, even though the client has already disconnected.

## How Has This Been Tested?

```bash
env -u PYTHONHOME -u PYTHONPATH uv run pytest tests/shared/test_streamable_http.py -k 'post_client_disconnect_is_not_reported_as_500 or transport_reports_stream_closure'
env -u PYTHONHOME -u PYTHONPATH uv run pyright src/mcp/server/streamable_http.py tests/shared/test_streamable_http.py
env -u PYTHONHOME -u PYTHONPATH uv run ruff format src/mcp/server/streamable_http.py tests/shared/test_streamable_http.py --check
env -u PYTHONHOME -u PYTHONPATH uv run ruff check src/mcp/server/streamable_http.py tests/shared/test_streamable_http.py
```

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have disclosed AI assistance and can explain the change in my own words
- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
