### PR TITLE
Fix JSON string parsing for UUID tool arguments

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -49,6 +49,18 @@ _CONTENT_TYPES = (*get_args(ContentBlock), Image, Audio)
 _CONTENT_SEQUENCE_ORIGINS = (list, tuple, Sequence)
 
 
+def _annotation_accepts_str(annotation: Any) -> bool:
+    """Whether an annotation can accept a plain string value."""
+    if annotation is Any or annotation is str:
+        return True
+    origin = get_origin(annotation)
+    if origin is Annotated:
+        return _annotation_accepts_str(get_args(annotation)[0])
+    if is_union_origin(origin):
+        return any(_annotation_accepts_str(arg) for arg in get_args(annotation))
+    return False
+
+
 def _returns_content(annotation: Any) -> bool:
     """Whether a return annotation declares content blocks or the `Image`/`Audio` helpers, bare or as
     the items of a list/tuple or the arms of a union: the values `_convert_to_content` renders as blocks
@@ -258,10 +270,17 @@ class FuncMetadata(BaseModel):
                     # Not JSON, or JSON the parser refuses (over-long integers, deep
                     # nesting): leave the string for validation to accept or reject.
                     continue
-                if isinstance(pre_parsed, str | int | float):
+                if isinstance(pre_parsed, str):
+                    if not _annotation_accepts_str(field_info.annotation):
+                        new_data[data_key] = pre_parsed
                     # This is likely that the raw value is e.g. `"hello"` which we
                     # Should really be parsed as '"hello"' in Python - but if we parse
-                    # it as JSON it'll turn into just 'hello'. So we skip it.
+                    # it as JSON it'll turn into just 'hello'. So we skip it for
+                    # annotations that can already accept a string.
+                    continue
+                if isinstance(pre_parsed, int | float):
+                    # Pydantic can coerce numeric strings for numeric annotations; leaving
+                    # the original string also avoids changing string-like union behavior.
                     continue
                 new_data[data_key] = pre_parsed
         assert new_data.keys() == data.keys()

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -3,9 +3,11 @@
 # pyright: reportMissingParameterType=false
 # pyright: reportUnknownArgumentType=false
 # pyright: reportUnknownLambdaType=false
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any, Final, NamedTuple, TypedDict
+from uuid import UUID, uuid4
 
 import annotated_types
 import pytest
@@ -224,6 +226,26 @@ def test_str_vs_list_str():
     # Test list input for union type
     result = meta.pre_parse_json({"str_or_list": '["hello", "world"]'})
     assert result["str_or_list"] == ["hello", "world"]
+
+
+@pytest.mark.anyio
+async def test_json_string_is_parsed_for_uuid():
+    """Test that JSON strings are parsed for non-string annotations like UUID."""
+
+    def func_with_uuid(value: UUID):  # pragma: no cover
+        return value
+
+    meta = func_metadata(func_with_uuid)
+    value = uuid4()
+
+    result = await meta.call_fn(
+        func_with_uuid,
+        fn_is_async=False,
+        arguments=meta.validate_arguments({"value": json.dumps(str(value))}),
+        arguments_to_pass_directly=None,
+    )
+
+    assert result == value
 
 
 def test_pre_parse_json_leaves_strings_the_json_parser_refuses_untouched():


### PR DESCRIPTION
Fixes #1873.

## Motivation and Context

This fixes JSON string pre-parsing for non-string tool argument annotations such as `UUID`.

Previously, `pre_parse_json()` skipped all JSON values parsed into primitive types, including strings. This preserved string-like annotations correctly, but caused non-string annotations such as `UUID` to receive the original JSON-encoded string with surrounding quotes.

## How Has This Been Tested?

```bash
env -u PYTHONHOME -u PYTHONPATH uv run pytest tests/server/mcpserver/test_func_metadata.py
env -u PYTHONHOME -u PYTHONPATH uv run ruff check src/mcp/server/mcpserver/utilities/func_metadata.py tests/server/mcpserver/test_func_metadata.py
env -u PYTHONHOME -u PYTHONPATH uv run pyright src/mcp/server/mcpserver/utilities/func_metadata.py tests/server/mcpserver/test_func_metadata.py
```

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have disclosed AI assistance and can explain the change in my own words
- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
