### PR TITLE
Fix KeyError and exit stack leak on empty servers in ClientSessionGroup (#3384)

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -414,11 +414,6 @@ class ClientSessionGroup:
         except MCPError as err:  # pragma: no cover
             logging.warning(f"Could not fetch tools: {err}")
 
-        # Clean up exit stack for session if we couldn't retrieve anything
-        # from the server.
-        if not any((prompts_temp, resources_temp, tools_temp)):
-            del self._session_exit_stacks[session]  # pragma: no cover
-
         # Check for duplicates.
         matching_prompts = prompts_temp.keys() & self._prompts.keys()
         if matching_prompts:

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -402,3 +402,53 @@ async def test_client_session_group_establish_session_parameterized(
             # 3. Assert returned values
             assert returned_server_info is mock_initialize_result.server_info
             assert returned_session is mock_entered_session
+
+
+@pytest.mark.anyio
+async def test_client_session_group_connect_empty_server_with_session():
+    mock_session = mock.AsyncMock()
+    mock_session.list_prompts.return_value = types.ListPromptsResult(prompts=[])
+    mock_session.list_resources.return_value = types.ListResourcesResult(resources=[])
+    mock_session.list_tools.return_value = types.ListToolsResult(tools=[])
+
+    group = ClientSessionGroup()
+    server_info = types.Implementation(name="empty-server", version="1.0")
+
+    # Connecting an empty server via connect_with_session should succeed without KeyError
+    await group.connect_with_session(server_info, mock_session)
+    assert mock_session in group._sessions
+    assert group.tools == {}
+    assert group.resources == {}
+    assert group.prompts == {}
+
+    # Disconnecting should also work cleanly
+    await group.disconnect_from_server(mock_session)
+    assert mock_session not in group._sessions
+
+
+@pytest.mark.anyio
+async def test_client_session_group_connect_empty_server_via_connect_to_server():
+    mock_server_params = mock.Mock(spec=StdioServerParameters)
+    mock_session = mock.AsyncMock()
+    mock_session.list_prompts.return_value = types.ListPromptsResult(prompts=[])
+    mock_session.list_resources.return_value = types.ListResourcesResult(resources=[])
+    mock_session.list_tools.return_value = types.ListToolsResult(tools=[])
+
+    mock_stack = mock.AsyncMock(spec=contextlib.AsyncExitStack)
+    server_info = types.Implementation(name="empty-server", version="1.0")
+
+    group = ClientSessionGroup()
+    with mock.patch.object(group, "_establish_session", return_value=(server_info, mock_session)):
+        # Simulate exit stack registered during establish_session
+        group._session_exit_stacks[mock_session] = mock_stack
+        session = await group.connect_to_server(mock_server_params)
+
+        assert session is mock_session
+        assert mock_session in group._sessions
+        assert mock_session in group._session_exit_stacks
+
+        # When disconnecting, the exit stack must be cleanly closed
+        await group.disconnect_from_server(mock_session)
+        assert mock_session not in group._sessions
+        assert mock_session not in group._session_exit_stacks
+        mock_stack.aclose.assert_awaited_once()


### PR DESCRIPTION
## Description

Fixes #3384.

Connecting a `ClientSessionGroup` to a server that exposes no tools, resources, or prompts previously caused two distinct issues due to `del self._session_exit_stacks[session]` in `_aggregate_components`:
1. When connecting via `connect_with_session()`, the caller manages the session lifecycle, so `session` is not present in `_session_exit_stacks`. The unconditional deletion raised a raw `KeyError`.
2. When connecting via `connect_to_server()`, the deletion dropped the tracking entry without closing the underlying `session_stack`. The session was still registered in `self._sessions`, but calling `disconnect_from_server(session)` subsequently failed to close the session's exit stack because `session in self._session_exit_stacks` was `False`.

### Changes
- Remove the premature deletion of `_session_exit_stacks[session]` in `_aggregate_components`.
- Allow servers that expose no components to be registered and managed cleanly in `ClientSessionGroup`.
- Add unit tests verifying both `connect_with_session` and `connect_to_server` lifecycles on empty servers.

## Testing
- Added regression tests in `tests/client/test_session_group.py`:
  - `test_client_session_group_connect_empty_server_with_session`
  - `test_client_session_group_connect_empty_server_via_connect_to_server`
- Passed all tests: `uv run pytest tests/client/test_session_group.py`
- Passed linters: `uv run ruff check` and `uv run ruff format --check`