### PR TITLE
fix(client): stop retrying GET stream when server answers 405

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -227,6 +227,17 @@ class StreamableHTTPTransport:
                     # Stream ended normally (server closed) - reset attempt counter
                     attempt = 0
 
+            except httpx2.HTTPStatusError as exc:
+                if exc.response.status_code == 405:
+                    # Per the Streamable HTTP spec, a 405 response to GET means
+                    # the server does not offer a server-initiated SSE stream.
+                    # Retrying can never succeed, so disable the GET stream for
+                    # this session instead of pointlessly retrying (and logging
+                    # a reconnect every time a session is created).
+                    logger.info("GET stream disabled: server does not support server-initiated SSE (405)")
+                    return
+                logger.debug("GET stream error", exc_info=True)
+                attempt += 1
             except Exception:
                 logger.debug("GET stream error", exc_info=True)
                 attempt += 1

--- a/tests/client/test_streamable_http_405.py
+++ b/tests/client/test_streamable_http_405.py
@@ -1,0 +1,84 @@
+"""Tests for GET stream handling when the server rejects GET with 405.
+
+Some production MCP servers (e.g. GitHub Copilot's MCP endpoint) do not offer
+a server-initiated SSE stream and answer every GET with ``405 Method Not
+Allowed``. Per the Streamable HTTP spec, 405 is the server's definitive way of
+saying "no GET stream", so the client must not keep retrying: it burns the
+reconnection budget on every session and spams logs with reconnect noise.
+"""
+
+import time
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import httpx2
+import pytest
+
+from mcp.client.streamable_http import StreamableHTTPTransport
+
+
+class _FailingEventSource:
+    """Async context manager that raises immediately on ``__aenter__``."""
+
+    def __init__(self, error: Exception, counter: list[int]) -> None:
+        self._error = error
+        self._counter = counter
+
+    async def __aenter__(self) -> None:
+        self._counter[0] += 1
+        raise self._error
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
+class _FailingClient:
+    def __init__(self, error: Exception, counter: list[int]) -> None:
+        self._error = error
+        self._counter = counter
+
+    def sse(self, url: str, headers: dict[str, str] | None = None) -> _FailingEventSource:
+        return _FailingEventSource(self._error, self._counter)
+
+
+def _status_error(status_code: int) -> httpx2.HTTPStatusError:
+    request = httpx2.Request("GET", "http://localhost:8000/mcp")
+    response = httpx2.Response(status_code, request=request)
+    return httpx2.HTTPStatusError(
+        f"Server returned status {status_code}", request=request, response=response
+    )
+
+
+@pytest.mark.anyio
+async def test_get_stream_405_disables_retry() -> None:
+    """405 on GET is definitive: stop retrying instead of exhausting attempts."""
+    transport = StreamableHTTPTransport("http://localhost:8000/mcp")
+    transport.session_id = "session-1"
+
+    attempts = [0]
+    client = _FailingClient(_status_error(405), attempts)
+
+    start = time.monotonic()
+    await transport.handle_get_stream(client, cast(Any, MagicMock()))
+    elapsed = time.monotonic() - start
+
+    assert attempts == [1]  # no retry after a definitive 405
+    assert elapsed < 1.0  # no reconnect backoff sleep
+
+
+@pytest.mark.anyio
+async def test_get_stream_other_http_errors_still_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-405 errors keep the existing bounded-retry behavior."""
+    from mcp.client import streamable_http as sh
+
+    monkeypatch.setattr(sh, "DEFAULT_RECONNECTION_DELAY_MS", 0)
+
+    transport = StreamableHTTPTransport("http://localhost:8000/mcp")
+    transport.session_id = "session-1"
+
+    attempts = [0]
+    client = _FailingClient(_status_error(500), attempts)
+
+    await transport.handle_get_stream(client, cast(Any, MagicMock()))
+
+    assert attempts == [sh.MAX_RECONNECTION_ATTEMPTS]


### PR DESCRIPTION
## Summary

`handle_get_stream` treats an HTTP **405** response to the GET stream like any other transport error and retries. Per the [Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-06-18/basic#transports), a `405 Method Not Allowed` on GET is the server's **definitive** signal that it does not offer a server-initiated SSE stream — the client should accept that and proceed without the GET stream, not retry.

## Real-world impact

Observed against a production MCP endpoint that does not implement GET SSE (GitHub Copilot's `https://api.githubcopilot.com/mcp/`, which is used by several MCP clients, including self-hosted agent platforms such as [TencentCloud/Octop](https://github.com/TencentCloud/Octop)). Every new streamable-HTTP session there produces:

```
INFO mcp.client.streamable_http — Received session ID: d1d45fa5-...
INFO mcp.client.streamable_http — GET stream disconnected, reconnecting in 1000ms...
INFO mcp.client.streamable_http — GET stream disconnected, reconnecting in 1000ms...
```

That is 2 pointless GET requests + 2 retry backoff sleeps per session, plus misleading "disconnected" log noise suggesting a network problem when the server is behaving exactly per spec. In SDK versions with an unbounded reconnect loop this manifests as an endless ~1s reconnect cycle per session.

## Fix

In `handle_get_stream`, catch `httpx2.HTTPStatusError` first: if the status is 405, log once ("GET stream disabled: server does not support server-initiated SSE (405)") and return — the session keeps working normally over POST, which is the entire point of the Streamable HTTP transport's optional GET stream. All other errors keep the existing bounded-retry behavior unchanged.

## Testing

- Added `tests/client/test_streamable_http_405.py`:
  - `test_get_stream_405_disables_retry` — a 405 produces exactly **one** GET attempt and no backoff sleep.
  - `test_get_stream_other_http_errors_still_retry` — a 500 still consumes the bounded retry budget (`MAX_RECONNECTION_ATTEMPTS`), proving no behavior change for non-405 errors.