### PR TITLE
test: skip symlink escape test without symlink privileges

### DIFF
--- a/tests/shared/test_path_security.py
+++ b/tests/shared/test_path_security.py
@@ -142,7 +142,10 @@ def test_safe_join_rejects_symlink_escape(tmp_path: Path):
     outside.mkdir()
     sandbox = tmp_path / "sandbox"
     sandbox.mkdir()
-    (sandbox / "escape").symlink_to(outside)
+    try:
+        (sandbox / "escape").symlink_to(outside)
+    except OSError as exc:  # pragma: lax no cover - depends on filesystem privileges
+        pytest.skip(f"symlink creation is not permitted here: {exc}")
 
     with pytest.raises(PathEscapeError, match="escapes base"):
         safe_join(sandbox, "escape", "secret.txt")


### PR DESCRIPTION
Fixes #3408.

On Windows without symlink privileges, such as a normal checkout without elevation or Developer Mode, Path.symlink_to() raises WinError 1314 before safe_join() is exercised. The test therefore fails during setup instead of checking the path-escape behavior.

This change catches OSError only around symlink creation and skips the test when the filesystem does not allow it. The existing PathEscapeError assertion is unchanged and still runs whenever the link setup succeeds. The exception arm uses the repository's lax no-cover marker because whether it runs depends on filesystem privileges, while the repository includes tests in its coverage target.

I reproduced the original failure on the locked revision, then verified the focused test now skips cleanly on this Windows environment. The rest of tests/shared/test_path_security.py passes with 54 passed and 1 skipped. I also exercised the original escape assertion through a temporary directory-junction-backed harness, which completed successfully. Ruff check, Ruff format check, and Pyright all pass for the changed test file.

The full project suite was not run locally. The checkout path required an ASCII mapped drive for uv because the local Windows Python installation cannot decode the Unicode editable-install paths during site initialization.

This contribution was prepared with AI assistance and reviewed locally before opening the pull request.
