### PR TITLE
fix(client): re-raise transport exceptions in default message handler

### DIFF
--- a/src/mcp/client/session.py
+++ b/src/mcp/client/session.py
@@ -250,6 +250,14 @@ class MessageHandlerFnT(Protocol):
 
 
 async def _default_message_handler(message: IncomingMessage) -> None:
+    """Acknowledge server notifications; re-raise transport-level exceptions.
+
+    Transport Exception items (e.g. httpx.ReadTimeout from streamablehttp_client
+    when sse_read_timeout fires) must propagate instead of leaving send_request
+    awaiters hung. See https://github.com/modelcontextprotocol/python-sdk/issues/1401.
+    """
+    if isinstance(message, Exception):
+        raise message
     await anyio.lowlevel.checkpoint()
 
 

--- a/tests/client/test_session.py
+++ b/tests/client/test_session.py
@@ -2061,3 +2061,36 @@ def test_intercept_consumes_acks_for_live_routes_and_leaves_malformed_ones():
     # Events deliver but are never consumed - they still tee to message_handler.
     assert intercept("notifications/tools/list_changed", meta) is False
     assert list(route._pending) == [ToolsListChanged()]  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.anyio
+async def test_default_message_handler_raises_on_transport_exception():
+    """Default handler re-raises transport Exception items instead of swallowing them (#1401)."""
+    from mcp.client.session import _default_message_handler
+
+    boom = RuntimeError("transport went away")
+    with pytest.raises(RuntimeError, match="transport went away"):
+        await _default_message_handler(boom)
+
+    await _default_message_handler(types.ToolListChangedNotification())
+
+
+@pytest.mark.anyio
+async def test_transport_exception_in_stream_logs_at_error_level(caplog):
+    """A transport Exception on the read stream is logged at ERROR via message_handler (#1401)."""
+    import logging
+
+    s2c_send, s2c_recv = anyio.create_memory_object_stream[SessionMessage | Exception](1)
+    c2s_send, c2s_recv = anyio.create_memory_object_stream[SessionMessage](1)
+
+    try:
+        with caplog.at_level(logging.ERROR, logger="client"):
+            async with ClientSession(s2c_recv, c2s_send):
+                await s2c_send.send(RuntimeError("sse_read_timeout fired"))
+                await anyio.sleep(0.05)
+                await anyio.sleep(0)
+        assert any("message_handler raised on transport exception" in rec.message for rec in caplog.records)
+        assert "sse_read_timeout fired" in caplog.text
+    finally:
+        s2c_send.close()
+        c2s_recv.close()


### PR DESCRIPTION
## Summary

Fixes the silent-hang in `ClientSession._default_message_handler` where transport-level exceptions (e.g. `httpx.ReadTimeout` from `streamablehttp_client` when `sse_read_timeout` fires) were checkpointed and dropped.

Fixes #1401

## Problem

`IncomingMessage` is `ServerNotification | Exception`, but the default handler was:

```python
async def _default_message_handler(message: IncomingMessage) -> None:
    await anyio.lowlevel.checkpoint()
```

The `Exception` branch never ran, so `send_request` awaiters hung.

## Fix

Re-raise transport `Exception` items. `_deliver_stream_exception` already runs the handler in a spawned task and logs `message_handler raised on transport exception` — that path was a no-op because the default never raised. User-supplied handlers are untouched.

Failing in-flight `send_request` waiters with the transport exception is intentionally left as a follow-up so this stays a one-handler change.

## Test plan

- `test_default_message_handler_raises_on_transport_exception` — handler re-raises `RuntimeError`; notifications still return cleanly
- `test_transport_exception_in_stream_logs_at_error_level` — injecting an exception onto a live `ClientSession` read stream logs at ERROR on the `client` logger
