### PR TITLE
fix(client): handle empty servers in ClientSessionGroup without KeyError or leaked stacks

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -414,11 +414,6 @@ class ClientSessionGroup:
         except MCPError as err:  # pragma: no cover
             logging.warning(f"Could not fetch tools: {err}")
 
-        # Clean up exit stack for session if we couldn't retrieve anything
-        # from the server.
-        if not any((prompts_temp, resources_temp, tools_temp)):
-            del self._session_exit_stacks[session]  # pragma: no cover
-
         # Check for duplicates.
         matching_prompts = prompts_temp.keys() & self._prompts.keys()
         if matching_prompts:

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -402,3 +402,23 @@ async def test_client_session_group_establish_session_parameterized(
             # 3. Assert returned values
             assert returned_server_info is mock_initialize_result.server_info
             assert returned_session is mock_entered_session
+
+
+@pytest.mark.anyio
+async def test_client_session_group_connect_empty_server():
+    """Test connecting to a server that registers no tools, resources, or prompts."""
+    mock_session = mock.AsyncMock(spec=mcp.ClientSession)
+    mock_session.list_prompts.return_value = types.ListPromptsResult(prompts=[])
+    mock_session.list_resources.return_value = types.ListResourcesResult(resources=[])
+    mock_session.list_tools.return_value = types.ListToolsResult(tools=[])
+
+    server_info = types.Implementation(name="empty_server", version="1.0")
+    group = ClientSessionGroup()
+
+    # Should not raise KeyError when aggregating empty server
+    session = await group.connect_with_session(server_info, mock_session)
+    assert session is mock_session
+    assert mock_session in group._sessions
+    assert not group.tools
+    assert not group.resources
+    assert not group.prompts


### PR DESCRIPTION
Fixes #3384

### Problem
When connecting a `ClientSessionGroup` to a server that exposes no tools, resources, or prompts:
1. When called via `connect_with_session()`, `self._session_exit_stacks` does not contain `session`, causing `del self._session_exit_stacks[session]` to raise a `KeyError`.
2. When called via `connect_to_server()`, `del self._session_exit_stacks[session]` silently forgot the session's exit stack without closing it, causing subsequent `disconnect_from_server()` calls to leak the underlying transport/session context.

### Fix
- Removed the spurious `del self._session_exit_stacks[session]` in `_aggregate_components`. Empty servers are valid connected sessions with empty component sets.
- Added unit test in `tests/client/test_session_group.py` verifying connecting to an empty server via `connect_with_session`.