### PR TITLE
fix(server): serialize non-finite floats as null in text content blocks

### DIFF
--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -203,7 +203,9 @@ class Prompt(BaseModel):
                 elif isinstance(msg, str | ContentBlock | Image | Audio):  # bare content is one user message
                     messages.append(UserMessage(msg))
                 else:  # pragma: no cover
-                    content = pydantic_core.to_json(msg, fallback=str, indent=2).decode()
+                    content = pydantic_core.to_json(
+                        msg, fallback=str, indent=2, inf_nan_mode="null"
+                    ).decode()
                     messages.append(Message(role="user", content=content))
 
             return messages

--- a/src/mcp/server/mcpserver/resources/types.py
+++ b/src/mcp/server/mcpserver/resources/types.py
@@ -100,7 +100,9 @@ class FunctionResource(Resource):
         elif isinstance(result, str):
             return result
         else:
-            return pydantic_core.to_json(result, fallback=str, indent=2).decode()
+            return pydantic_core.to_json(
+                result, fallback=str, indent=2, inf_nan_mode="null"
+            ).decode()
 
     @classmethod
     def from_function(

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -666,6 +666,8 @@ def _convert_to_content(result: Any) -> list[ContentBlock]:
         )
 
     if not isinstance(result, str):
-        result = pydantic_core.to_json(result, fallback=str, indent=2).decode()
+        result = pydantic_core.to_json(
+            result, fallback=str, indent=2, inf_nan_mode="null"
+        ).decode()
 
     return [TextContent(type="text", text=result)]

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -1520,3 +1520,19 @@ def test_union_of_only_input_required_subclasses_yields_no_output_schema():
 
     meta = func_metadata(fn)
     assert meta.output_schema is None
+
+
+def test_convert_to_content_non_finite_floats():
+    import json
+    import math
+    from mcp.server.mcpserver.utilities.func_metadata import _convert_to_content
+
+    result = {"mean": 1.5, "stddev": math.nan, "max": math.inf, "min": -math.inf}
+    content = _convert_to_content(result)
+    assert len(content) == 1
+    assert content[0].type == "text"
+    text = content[0].text
+    # Must be valid RFC 8259 JSON parseable by standard JSON parsers
+    parsed = json.loads(text)
+    assert parsed == {"mean": 1.5, "stddev": None, "max": None, "min": None}
+


### PR DESCRIPTION
Fixes #3385

### Problem
When serializing unstructured tool returns, resources, or prompts into text content blocks, `pydantic_core.to_json(..., fallback=str, indent=2)` was used with default `inf_nan_mode='constants'`.
This caused non-finite floats (`math.nan`, `math.inf`, `-math.inf`) to be emitted as bare JavaScript tokens `NaN` and `Infinity`, which violate RFC 8259 JSON specifications and cause non-Python clients (e.g. Node/TypeScript `JSON.parse`) to fail with SyntaxErrors.

### Fix
- Updated `to_json` calls in `src/mcp/server/mcpserver/utilities/func_metadata.py`, `src/mcp/server/mcpserver/resources/types.py`, and `src/mcp/server/mcpserver/prompts/base.py` to specify `inf_nan_mode="null"`.
- This ensures output in text blocks is strictly compliant RFC 8259 JSON and aligns with the structured output path behavior.
- Added unit test in `tests/server/mcpserver/test_func_metadata.py`.