### PR TITLE
fix(dispatcher): advance mint counter past caller-supplied request ids

### DIFF
--- a/src/mcp/shared/direct_dispatcher.py
+++ b/src/mcp/shared/direct_dispatcher.py
@@ -250,6 +250,11 @@ class DirectDispatcher:
                     in_flight_key = coerce_request_id(request_id)
                     if in_flight_key in self._in_flight_ids:
                         raise ValueError(f"request id {request_id!r} is already in flight")
+                    # Same mint-past rule as JSONRPCDispatcher: the counter must
+                    # clear a completed supplied id so minted ids never revisit
+                    # it (#3126). Minted ids are ints, so only numeric keys collide.
+                    if isinstance(in_flight_key, int):
+                        self._next_id = max(self._next_id, in_flight_key)
                 else:
                     # Synthesize an id (the DispatchContext contract reserves None
                     # for notifications), minting past any key a supplied id

--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -346,6 +346,12 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
             pending_key = coerce_request_id(request_id)
             if pending_key in self._pending:
                 raise ValueError(f"request id {request_id!r} is already in flight")
+            # The mint counter must also clear this id once it completes, not
+            # only while it is pending: the spec forbids reusing a request id
+            # within a session (#3126). Minted ids are ints, so only numeric
+            # keys ("7" and 7 share the coerced key) can collide.
+            if isinstance(pending_key, int):
+                self._next_id = max(self._next_id, pending_key)
         else:
             # Mint past any key a supplied id occupies: the collision error is
             # reserved for the caller who actually chose the id.

--- a/tests/shared/test_dispatcher.py
+++ b/tests/shared/test_dispatcher.py
@@ -25,7 +25,15 @@ from mcp_types import (
 
 from mcp.shared._compat import resync_tracer
 from mcp.shared.direct_dispatcher import DirectDispatcher, create_direct_dispatcher_pair
-from mcp.shared.dispatcher import DispatchContext, Dispatcher, OnNotify, OnNotifyIntercept, OnRequest, Outbound
+from mcp.shared.dispatcher import (
+    DispatchContext,
+    Dispatcher,
+    OnNotify,
+    OnNotifyIntercept,
+    OnRequest,
+    Outbound,
+    coerce_request_id,
+)
 from mcp.shared.exceptions import MCPError
 from mcp.shared.transport_context import TransportContext
 
@@ -451,7 +459,9 @@ async def test_send_raw_request_with_in_flight_request_id_raises_and_frees_id_on
 @pytest.mark.anyio
 async def test_minted_ids_skip_a_caller_supplied_id_still_in_flight(pair_factory: PairFactory):
     """The dispatcher mints PAST a key a supplied id occupies — the collision error
-    is reserved for the caller who chose the id, never an innocent minted request."""
+    is reserved for the caller who chose the id, never an innocent minted request.
+    Since the counter is advanced past the supplied key on acceptance (#3126),
+    minted ids continue from beyond it rather than skipping it only on collision."""
     entered = anyio.Event()
     release = anyio.Event()
     seen_ids: list[RequestId | None] = []
@@ -478,7 +488,10 @@ async def test_minted_ids_skip_a_caller_supplied_id_still_in_flight(pair_factory
                 for _ in range(3):
                     await client.send_raw_request("plain", None)
                 release.set()
-            assert [request_id for request_id in seen_ids if request_id != "3"] == [1, 2, 4]
+            # The counter was advanced past 3 when the supplied id was accepted
+            # (#3126), so minting continues from 4 instead of skipping only on
+            # collision — the "never collide with a supplied id" contract holds.
+            assert [request_id for request_id in seen_ids if request_id != "3"] == [4, 5, 6]
 
 
 @pytest.mark.anyio
@@ -576,3 +589,59 @@ async def test_a_raising_notify_intercept_is_contained_and_passes_the_frame_thro
 if TYPE_CHECKING:
     _d: Dispatcher[TransportContext] = DirectDispatcher(TransportContext(kind="direct", can_send_request=True))
     _o: Outbound = _d
+
+
+@pytest.mark.anyio
+async def test_minted_ids_never_reuse_a_completed_caller_supplied_id(pair_factory: PairFactory):
+    """The mint counter must skip past a COMPLETED caller-supplied numeric id, not
+    just in-flight ones. Reusing a completed id on the wire violates the spec's
+    "request id MUST NOT have been previously used by the requestor within the
+    same session" and can cross-wire responses on stateful peers (#3126)."""
+    async with running_pair(pair_factory) as (client, _server, _crec, srec):
+        with anyio.fail_after(5):
+            # A caller-supplied numeric id that will COMPLETE before any minting.
+            await client.send_raw_request("supplied", None, {"request_id": 2})
+            # Three dispatcher-minted requests after the supplied one is done.
+            await client.send_raw_request("minted-1", None)
+            await client.send_raw_request("minted-2", None)
+            await client.send_raw_request("minted-3", None)
+    wire_ids = [ctx.request_id for ctx in srec.contexts]
+    assert wire_ids[0] == 2
+    minted = wire_ids[1:]
+    assert len(minted) == 3
+    # None of the minted ids may revisit the completed supplied id 2 (nor
+    # collide with each other).
+    assert len(set(map(coerce_request_id, minted))) == 3
+    assert all(coerce_request_id(i) != 2 for i in minted), (
+        f"minted ids {minted} revisited completed supplied id 2 (issue #3126)"
+    )
+
+
+@pytest.mark.anyio
+async def test_minted_ids_never_reuse_a_completed_numeric_string_supplied_id(pair_factory: PairFactory):
+    """`"2"` and `2` are one id in the correlation domain, so a completed
+    numeric-STRING supplied id must be skipped by the mint counter too (#3126)."""
+    async with running_pair(pair_factory) as (client, _server, _crec, srec):
+        with anyio.fail_after(5):
+            await client.send_raw_request("supplied", None, {"request_id": "2"})
+            await client.send_raw_request("minted-1", None)
+            await client.send_raw_request("minted-2", None)
+    wire_ids = [ctx.request_id for ctx in srec.contexts]
+    assert wire_ids[0] == "2"
+    minted = wire_ids[1:]
+    assert all(coerce_request_id(i) != 2 for i in minted), (
+        f"minted ids {minted} revisited completed supplied id '2' (issue #3126)"
+    )
+
+
+@pytest.mark.anyio
+async def test_supplying_a_used_id_yourself_is_still_allowed(pair_factory: PairFactory):
+    """Re-supplying an id the CALLER already used is an explicit API contract
+    (see `test_send_raw_request_with_in_flight_request_id_raises_and_frees_id_on_completion`)
+    and must keep working when the mint counter is taught to skip used ids (#3126)."""
+    async with running_pair(pair_factory) as (client, _server, _crec, srec):
+        with anyio.fail_after(5):
+            await client.send_raw_request("first", None, {"request_id": 5})
+            # Same caller re-supplies its own completed id: allowed on purpose.
+            await client.send_raw_request("second", None, {"request_id": 5})
+    assert [ctx.request_id for ctx in srec.contexts] == [5, 5]


### PR DESCRIPTION
Closes #3126

## Problem

When a caller supplies its own request id via `CallOptions["request_id"]`, the dispatcher accepts it but only guards the mint loop against the **in-flight** table. Once the supplied request completes and its entry is popped, the monotonic counter can land on the same value and put it on the wire again:

```text
supplied id 2, then three minted pings → wire ids [2, 1, 2]  # the third request reuses 2
```

The spec forbids this — _"The request ID MUST NOT have been previously used by the requestor within the same session"_ — and the SDK pins it as `protocol:request-id:unique` in `tests/interaction/_requirements.py`. A stateful peer is allowed to assume per-session id uniqueness, and the SDK's own Streamable HTTP server mishandles duplicate ids (#3060, response cross-wiring), so an innocent client that supplies a few small integer ids can hit that behavior through no fault of its own.

`DirectDispatcher` has the identical pattern with `_in_flight_ids` (discarded in the `finally`), so both dispatchers need the fix.

## Fix

When a **supplied** id is accepted, advance the mint counter past its coerced key (`_next_id = max(_next_id, pending_key)`), in both `JSONRPCDispatcher.send_raw_request` and `DirectDispatcher._dispatch_request`. Minted ids are ints, so only numeric keys can collide with the sequence — `"7"` and `7` share the coerced key and are both covered; string ids are unaffected, and the SDK-internal `listen-N` ids remain untouched. Caller re-supply of its own used id stays allowed, as asserted by the existing `test_send_raw_request_with_in_flight_request_id_raises_and_frees_id_on_completion`.

After the fix the same sequence yields `[2, 3, 4]` — no reuse.

## Tests

Six new regression tests in `tests/shared/test_dispatcher.py`, parameterized over both dispatchers via `pair_factory`:

- minted ids never revisit a **completed** supplied int id
- minted ids never revisit a **completed** supplied numeric-string id
- caller re-supply of its own used id is still allowed (guard against over-tightening the contract)

Plus one existing test updated — `test_minted_ids_skip_a_caller_supplied_id_still_in_flight` now expects minted sequence `[4, 5, 6]` instead of `[1, 2, 4]`: the counter clears the supplied id at acceptance rather than skipping only on collision. The never-collide contract it tests still holds; the docstring explains the change. Flagging this explicitly since it's a behavioral expectation change rather than a pure addition.

Local results (Python 3.14, venv):

```text
tests/shared/       905 passed
tests/client/       760 passed, 1 skipped, 1 xfailed
tests/interaction/  895 passed (incl. protocol:request-id:unique wire tests)
tests/server/       1335 passed, 1 pre-existing failure unrelated to this change
                     (test_modern_post_with_deeply_nested_body_is_parse_error_not_a_crash
                     fails identically on unmodified main in this environment)
```

## Notes

- The fix direction matches the one proposed in #3126 by the issue reporter; I verified the reproduction and root cause independently before implementing.
- No public API changes; `_next_id` is internal state on both dispatchers.

AI disclosure: I used an AI coding agent to help navigate the codebase and drive the work, and I verified the reproduction, root cause, fix, and full local test runs myself.