### PR TITLE
Deprecate constructing the pre-provisioned OAuth clients without an issuer

### DIFF
--- a/docs/client/oauth-clients.md
+++ b/docs/client/oauth-clients.md
@@ -112,7 +112,7 @@ A nightly job, a CI step, another service. There is no browser and nobody to cli
 What changed:
 
 * No `OAuthClientMetadata`, no handlers. You pass `client_id` and `client_secret`; the provider builds a minimal `client_credentials` registration around them and skips dynamic registration entirely.
-* `issuer` names the authorization server that issued those credentials; use the `issuer` value its `/.well-known/oauth-authorization-server` document returns. Discovery still runs as above, but token requests are only ever built from metadata for *that* issuer; if the MCP server points anywhere else, the flow stops with an `OAuthFlowError` instead. Leave it out and the provider uses whichever authorization server discovery finds, and says so with a `UserWarning` when it is constructed.
+* `issuer` names the authorization server that issued those credentials; use the `issuer` value its `/.well-known/oauth-authorization-server` document returns. Discovery still runs as above, but token requests are only ever built from metadata for *that* issuer; if the MCP server points anywhere else, the flow stops with an `OAuthFlowError` instead. Leaving it out is deprecated and it becomes required in 3.0 (see **[Deprecated features](../deprecated.md#deprecated-sdk-helpers)**); until then the provider warns and uses whichever authorization server discovery finds.
 * `scope` is a space-separated string, the OAuth wire format.
 * Everything downstream is identical: the same `TokenStorage`, the same `httpx2.AsyncClient(auth=...)`, the same `streamable_http_client`.
 

--- a/docs/client/oauth-clients.md
+++ b/docs/client/oauth-clients.md
@@ -112,7 +112,7 @@ A nightly job, a CI step, another service. There is no browser and nobody to cli
 What changed:
 
 * No `OAuthClientMetadata`, no handlers. You pass `client_id` and `client_secret`; the provider builds a minimal `client_credentials` registration around them and skips dynamic registration entirely.
-* `issuer` names the authorization server that issued those credentials; use the `issuer` value its `/.well-known/oauth-authorization-server` document returns. Discovery still runs as above, but token requests are only ever built from metadata for *that* issuer; if the MCP server points anywhere else, the flow stops with an `OAuthFlowError` instead. Leave it out and the provider uses whichever authorization server discovery finds.
+* `issuer` names the authorization server that issued those credentials; use the `issuer` value its `/.well-known/oauth-authorization-server` document returns. Discovery still runs as above, but token requests are only ever built from metadata for *that* issuer; if the MCP server points anywhere else, the flow stops with an `OAuthFlowError` instead. Leave it out and the provider uses whichever authorization server discovery finds, and says so with a `UserWarning` when it is constructed.
 * `scope` is a space-separated string, the OAuth wire format.
 * Everything downstream is identical: the same `TokenStorage`, the same `httpx2.AsyncClient(auth=...)`, the same `streamable_http_client`.
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,6 +1,6 @@
 # Deprecated features
 
-The 2026-07-28 spec retires five things. The SDK still implements every one of them, and every one of them now carries a **deprecation warning**. One SDK helper is deprecated on its own account and is listed [at the end](#deprecated-sdk-helpers).
+The 2026-07-28 spec retires five things. The SDK still implements every one of them, and every one of them now carries a **deprecation warning**. Two SDK-level deprecations stand on their own account and are listed [at the end](#deprecated-sdk-helpers).
 
 The table below names each deprecated feature, why it is going away, and the replacement to build on.
 
@@ -131,11 +131,12 @@ That is the whole API. There is no per-method switch, and you don't want one: th
 
 ## Deprecated SDK helpers
 
-These are not spec changes, only SDK internals with a better replacement. They warn with the same `MCPDeprecationWarning` and will be removed in 3.0.
+These are not spec changes, only SDK usage with a better replacement. They warn with the same `MCPDeprecationWarning`, and 3.0 removes the old form.
 
 | Deprecated | What you do instead |
 |---|---|
 | `FuncMetadata.call_fn_with_arg_validation()` | `FuncMetadata.validate_arguments()` and then `FuncMetadata.call_fn()`. Only code that drives `FuncMetadata` directly (a custom `Tool` subclass, say) ever called it. |
+| `ClientCredentialsOAuthProvider(...)` or `PrivateKeyJWTOAuthProvider(...)` without `issuer=` | Pass `issuer=` naming the authorization server that issued the credentials (see **[Writing OAuth clients](client/oauth-clients.md#machine-to-machine)**). Without it the MCP server decides which authorization server receives them; 3.0 makes the keyword required. |
 
 ## Recap
 
@@ -144,7 +145,7 @@ These are not spec changes, only SDK internals with a better replacement. They w
 * Deprecated is advisory: no wire changes, everything keeps working against pre-2026 sessions, and you get a visible `MCPDeprecationWarning` (a `UserWarning`, so it is on by default).
 * Sampling and roots additionally need a back-channel that a 2026-07-28 session does not have. On a modern connection they warn and then they raise.
 * `warnings.filterwarnings("ignore", category=MCPDeprecationWarning)` silences the whole category; `"error::mcp.MCPDeprecationWarning"` in pytest turns it into a test failure.
-* One SDK helper, `FuncMetadata.call_fn_with_arg_validation()`, is deprecated separately for removal in 3.0.
+* Two SDK-level deprecations ride along: `FuncMetadata.call_fn_with_arg_validation()` is removed in 3.0, and constructing `ClientCredentialsOAuthProvider` / `PrivateKeyJWTOAuthProvider` without `issuer=` stops being allowed in 3.0.
 * New code should not be built on any of these.
 
 Every other page in these docs teaches the current API.

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -1,6 +1,6 @@
 # Deprecated features
 
-The 2026-07-28 spec retires five things. The SDK still implements every one of them, and every one of them now carries a **deprecation warning**. Two SDK-level deprecations stand on their own account and are listed [at the end](#deprecated-sdk-helpers).
+The 2026-07-28 spec retires five things. The SDK still implements every one of them, and every one of them now carries a **deprecation warning**. A few SDK-level deprecations stand on their own account and are listed [at the end](#deprecated-sdk-helpers).
 
 The table below names each deprecated feature, why it is going away, and the replacement to build on.
 
@@ -145,7 +145,7 @@ These are not spec changes, only SDK usage with a better replacement. They warn 
 * Deprecated is advisory: no wire changes, everything keeps working against pre-2026 sessions, and you get a visible `MCPDeprecationWarning` (a `UserWarning`, so it is on by default).
 * Sampling and roots additionally need a back-channel that a 2026-07-28 session does not have. On a modern connection they warn and then they raise.
 * `warnings.filterwarnings("ignore", category=MCPDeprecationWarning)` silences the whole category; `"error::mcp.MCPDeprecationWarning"` in pytest turns it into a test failure.
-* Two SDK-level deprecations ride along: `FuncMetadata.call_fn_with_arg_validation()` is removed in 3.0, and constructing `ClientCredentialsOAuthProvider` / `PrivateKeyJWTOAuthProvider` without `issuer=` stops being allowed in 3.0.
+* The [SDK-level deprecations](#deprecated-sdk-helpers) follow the same rule: they warn now, and 3.0 drops the old form.
 * New code should not be built on any of these.
 
 Every other page in these docs teaches the current API.

--- a/examples/stories/oauth_client_credentials/README.md
+++ b/examples/stories/oauth_client_credentials/README.md
@@ -33,8 +33,8 @@ the client and server side.
 - `client.py` `main` — opens with `async with Client(target, mode=mode) as
   client:` and that's the whole program. `target` is a transport that already
   carries the OAuth `httpx2.Auth`; the body never touches a token.
-- `client.py` `build_auth` — five lines of `ClientCredentialsOAuthProvider`
-  config is all the caller writes; the SDK does RFC 9728 PRM →
+- `client.py` `build_auth` — a few lines of `ClientCredentialsOAuthProvider`
+  config (credentials plus `issuer=`) is all the caller writes; the SDK does RFC 9728 PRM →
   RFC 8414 AS-metadata discovery and token exchange on the first 401.
 - `server.py` `token_endpoint` — the *entire* AS for this grant: validate
   HTTP-Basic `client_id:client_secret`, mint a token, return RFC 6749 JSON.

--- a/examples/stories/oauth_client_credentials/client.py
+++ b/examples/stories/oauth_client_credentials/client.py
@@ -14,7 +14,7 @@ from .server import DEMO_CLIENT_ID, DEMO_CLIENT_SECRET, DEMO_SCOPE
 
 
 def build_auth(_http: httpx2.AsyncClient) -> httpx2.Auth:
-    """The ``httpx2.Auth`` for the ``client_credentials`` grant — six lines of provider config.
+    """The ``httpx2.Auth`` for the ``client_credentials`` grant — a few lines of provider config.
 
     The SDK then handles 401 → RFC 9728 PRM → RFC 8414 AS-metadata discovery → token POST →
     Bearer attachment automatically. ``Client(url)`` has no ``auth=`` passthrough yet, so the

--- a/examples/stories/oauth_client_credentials/client.py
+++ b/examples/stories/oauth_client_credentials/client.py
@@ -8,13 +8,13 @@ from stories._harness import Target, run_client
 
 # MCP_URL pins the resource to :8000, and the server side builds its PRM/AS metadata from
 # the same constant — run the server on 8000 or the discovery chain points at the wrong origin.
-from stories._shared.auth import MCP_URL, InMemoryTokenStorage
+from stories._shared.auth import BASE_URL, MCP_URL, InMemoryTokenStorage
 
 from .server import DEMO_CLIENT_ID, DEMO_CLIENT_SECRET, DEMO_SCOPE
 
 
 def build_auth(_http: httpx2.AsyncClient) -> httpx2.Auth:
-    """The ``httpx2.Auth`` for the ``client_credentials`` grant — five lines of provider config.
+    """The ``httpx2.Auth`` for the ``client_credentials`` grant — six lines of provider config.
 
     The SDK then handles 401 → RFC 9728 PRM → RFC 8414 AS-metadata discovery → token POST →
     Bearer attachment automatically. ``Client(url)`` has no ``auth=`` passthrough yet, so the
@@ -27,6 +27,7 @@ def build_auth(_http: httpx2.AsyncClient) -> httpx2.Auth:
         client_id=DEMO_CLIENT_ID,
         client_secret=DEMO_CLIENT_SECRET,
         scope=DEMO_SCOPE,
+        issuer=BASE_URL,
     )
 
 

--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -23,12 +23,11 @@ from mcp.client.auth.utils import issuers_match
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
 
 
-def _checked_issuer(issuer: str | None, provider: str, server_url: str) -> str | None:
+def _checked_issuer(issuer: str | None) -> str | None:
     if issuer is None:
         warnings.warn(
-            f"{provider} created without `issuer`: the client credentials will be sent to whichever "
-            f"authorization server {server_url} advertises. Pass issuer=<the issuer URL your authorization "
-            "server's metadata reports> so that token requests are only ever built for that server.",
+            "No `issuer` given: client credentials will be sent to whichever authorization server the MCP "
+            "server advertises. Pass issuer=<your authorization server's issuer URL> to send them only there.",
             stacklevel=3,
         )
         return None
@@ -117,7 +116,7 @@ class ClientCredentialsOAuthProvider(OAuthClientProvider):
             scope=scope,
         )
         super().__init__(server_url, client_metadata, storage, None, None)
-        self._issuer = _checked_issuer(issuer, type(self).__name__, server_url)
+        self._issuer = _checked_issuer(issuer)
         # Store client_info to be set during _initialize - no dynamic registration needed
         self._fixed_client_info = OAuthClientInformationFull(
             redirect_uris=None,
@@ -348,7 +347,7 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
         )
         super().__init__(server_url, client_metadata, storage, None, None)
         self._assertion_provider = assertion_provider
-        self._issuer = _checked_issuer(issuer, type(self).__name__, server_url)
+        self._issuer = _checked_issuer(issuer)
         # Store client_info to be set during _initialize - no dynamic registration needed
         self._fixed_client_info = OAuthClientInformationFull(
             redirect_uris=None,

--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -21,13 +21,16 @@ from mcp.client.auth import OAuthClientProvider, OAuthFlowError, TokenStorage
 from mcp.client.auth.oauth2 import OAuthContext
 from mcp.client.auth.utils import issuers_match
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
+from mcp.shared.exceptions import MCPDeprecationWarning
 
 
 def _checked_issuer(issuer: str | None) -> str | None:
     if issuer is None:
         warnings.warn(
-            "No `issuer` given: client credentials will be sent to whichever authorization server the MCP "
-            "server advertises. Pass issuer=<your authorization server's issuer URL> to send them only there.",
+            "Omitting `issuer` is deprecated and it will be required in 3.0. Without it, the MCP server "
+            "decides which authorization server receives this client's credentials; pass "
+            "issuer=<your authorization server's issuer URL> so they are only ever sent there.",
+            MCPDeprecationWarning,
             stacklevel=3,
         )
         return None
@@ -105,8 +108,9 @@ class ClientCredentialsOAuthProvider(OAuthClientProvider):
             issuer: The issuer identifier of the authorization server that issued
                 `client_id` and `client_secret`. When set, token requests are only built from
                 discovered authorization server metadata whose `issuer` is exactly this string;
-                otherwise the flow stops with `OAuthFlowError`. When omitted, whichever
-                authorization server discovery yields is used, and a `UserWarning` says so.
+                otherwise the flow stops with `OAuthFlowError`. Omitting it is deprecated
+                (`MCPDeprecationWarning`) and it will be required in 3.0; until then, whichever
+                authorization server discovery yields is used.
         """
         # Build minimal client_metadata for the base class
         client_metadata = OAuthClientMetadata(
@@ -335,8 +339,8 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
                 registered with. When set, an assertion is only minted, and token requests
                 are only built, once authorization server metadata whose `issuer` is exactly this
                 string has been discovered; otherwise the flow stops with `OAuthFlowError`.
-                When omitted, whichever authorization server discovery yields is used, and a
-                `UserWarning` says so.
+                Omitting it is deprecated (`MCPDeprecationWarning`) and it will be required in
+                3.0; until then, whichever authorization server discovery yields is used.
         """
         # Build minimal client_metadata for the base class
         client_metadata = OAuthClientMetadata(

--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -180,6 +180,7 @@ def static_assertion_provider(token: str) -> Callable[[str], Awaitable[str]]:
             storage=my_token_storage,
             client_id="my-client-id",
             assertion_provider=static_assertion_provider(my_prebuilt_jwt),
+            issuer="https://auth.example.com",
         )
         ```
 
@@ -214,6 +215,7 @@ class SignedJWTParameters(BaseModel):
             storage=my_token_storage,
             client_id="my-client-id",
             assertion_provider=jwt_params.create_assertion_provider(),
+            issuer="https://auth.example.com",
         )
         ```
     """
@@ -279,6 +281,7 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
             storage=my_token_storage,
             client_id="my-client-id",
             assertion_provider=get_workload_identity_token,
+            issuer="https://auth.example.com",
         )
         ```
 
@@ -292,6 +295,7 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
             storage=my_token_storage,
             client_id="my-client-id",
             assertion_provider=static_assertion_provider(my_prebuilt_jwt),
+            issuer="https://auth.example.com",
         )
         ```
 
@@ -310,6 +314,7 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
             storage=my_token_storage,
             client_id="my-client-id",
             assertion_provider=jwt_params.create_assertion_provider(),
+            issuer="https://auth.example.com",
         )
         ```
     """

--- a/src/mcp/client/auth/extensions/client_credentials.py
+++ b/src/mcp/client/auth/extensions/client_credentials.py
@@ -7,6 +7,7 @@ Provides OAuth providers for machine-to-machine authentication flows:
 """
 
 import time
+import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal
 from urllib.parse import urlparse
@@ -22,8 +23,16 @@ from mcp.client.auth.utils import issuers_match
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata
 
 
-def _checked_issuer(issuer: str | None) -> str | None:
-    if issuer is not None and urlparse(issuer).scheme not in ("http", "https"):
+def _checked_issuer(issuer: str | None, provider: str, server_url: str) -> str | None:
+    if issuer is None:
+        warnings.warn(
+            f"{provider} created without `issuer`: the client credentials will be sent to whichever "
+            f"authorization server {server_url} advertises. Pass issuer=<the issuer URL your authorization "
+            "server's metadata reports> so that token requests are only ever built for that server.",
+            stacklevel=3,
+        )
+        return None
+    if urlparse(issuer).scheme not in ("http", "https"):
         raise ValueError(f"issuer must be the authorization server's http(s) issuer URL, got {issuer!r}")
     return issuer
 
@@ -98,7 +107,7 @@ class ClientCredentialsOAuthProvider(OAuthClientProvider):
                 `client_id` and `client_secret`. When set, token requests are only built from
                 discovered authorization server metadata whose `issuer` is exactly this string;
                 otherwise the flow stops with `OAuthFlowError`. When omitted, whichever
-                authorization server discovery yields is used.
+                authorization server discovery yields is used, and a `UserWarning` says so.
         """
         # Build minimal client_metadata for the base class
         client_metadata = OAuthClientMetadata(
@@ -108,7 +117,7 @@ class ClientCredentialsOAuthProvider(OAuthClientProvider):
             scope=scope,
         )
         super().__init__(server_url, client_metadata, storage, None, None)
-        self._issuer = _checked_issuer(issuer)
+        self._issuer = _checked_issuer(issuer, type(self).__name__, server_url)
         # Store client_info to be set during _initialize - no dynamic registration needed
         self._fixed_client_info = OAuthClientInformationFull(
             redirect_uris=None,
@@ -327,7 +336,8 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
                 registered with. When set, an assertion is only minted, and token requests
                 are only built, once authorization server metadata whose `issuer` is exactly this
                 string has been discovered; otherwise the flow stops with `OAuthFlowError`.
-                When omitted, whichever authorization server discovery yields is used.
+                When omitted, whichever authorization server discovery yields is used, and a
+                `UserWarning` says so.
         """
         # Build minimal client_metadata for the base class
         client_metadata = OAuthClientMetadata(
@@ -338,7 +348,7 @@ class PrivateKeyJWTOAuthProvider(OAuthClientProvider):
         )
         super().__init__(server_url, client_metadata, storage, None, None)
         self._assertion_provider = assertion_provider
-        self._issuer = _checked_issuer(issuer)
+        self._issuer = _checked_issuer(issuer, type(self).__name__, server_url)
         # Store client_info to be set during _initialize - no dynamic registration needed
         self._fixed_client_info = OAuthClientInformationFull(
             redirect_uris=None,

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -57,6 +57,7 @@ class TestClientCredentialsOAuthProvider:
             storage=mock_storage,
             client_id="test-client-id",
             client_secret="test-client-secret",
+            issuer="https://api.example.com",
         )
 
         # client_info is set during _initialize
@@ -77,6 +78,7 @@ class TestClientCredentialsOAuthProvider:
             client_id="test-client-id",
             client_secret="test-client-secret",
             scope="read write",
+            issuer="https://api.example.com",
         )
 
         await provider._initialize()
@@ -92,6 +94,7 @@ class TestClientCredentialsOAuthProvider:
             client_id="test-client-id",
             client_secret="test-client-secret",
             token_endpoint_auth_method="client_secret_post",
+            issuer="https://api.example.com",
         )
 
         await provider._initialize()
@@ -107,6 +110,7 @@ class TestClientCredentialsOAuthProvider:
             client_id="test-client-id",
             client_secret="test-client-secret",
             scope="read write",
+            issuer="https://api.example.com",
         )
         provider.context.oauth_metadata = OAuthMetadata(
             issuer=AnyHttpUrl("https://api.example.com"),
@@ -135,6 +139,7 @@ class TestClientCredentialsOAuthProvider:
             client_secret="test-client-secret",
             token_endpoint_auth_method="client_secret_post",
             scope="read write",
+            issuer="https://api.example.com",
         )
         await provider._initialize()
         provider.context.oauth_metadata = OAuthMetadata(
@@ -161,6 +166,7 @@ class TestClientCredentialsOAuthProvider:
             storage=mock_storage,
             client_id="test-client-id",
             client_secret="test-client-secret",
+            issuer="https://api.example.com",
         )
         provider.context.oauth_metadata = OAuthMetadata(
             issuer=AnyHttpUrl("https://api.example.com"),
@@ -192,6 +198,7 @@ class TestPrivateKeyJWTOAuthProvider:
             storage=mock_storage,
             client_id="test-client-id",
             assertion_provider=mock_assertion_provider,
+            issuer="https://api.example.com",
         )
 
         # client_info is set during _initialize
@@ -215,6 +222,7 @@ class TestPrivateKeyJWTOAuthProvider:
             client_id="test-client-id",
             assertion_provider=mock_assertion_provider,
             scope="read write",
+            issuer="https://auth.example.com",
         )
         provider.context.oauth_metadata = OAuthMetadata(
             issuer=AnyHttpUrl("https://auth.example.com"),
@@ -246,6 +254,7 @@ class TestPrivateKeyJWTOAuthProvider:
             storage=mock_storage,
             client_id="test-client-id",
             assertion_provider=mock_assertion_provider,
+            issuer="https://auth.example.com",
         )
         provider.context.oauth_metadata = OAuthMetadata(
             issuer=AnyHttpUrl("https://auth.example.com"),
@@ -433,6 +442,68 @@ async def test_provider_picks_its_configured_issuer_among_several_advertised_ser
 
     assert provider.context.auth_server_url == _CONFIGURED_ISSUER
     assert str(token_request.url) == "https://auth.example.com/token"
+    await flow.aclose()
+
+
+@pytest.mark.parametrize("kind", ["secret", "jwt"])
+def test_constructing_without_issuer_warns_where_the_credentials_will_go(
+    mock_storage: MockTokenStorage, kind: str
+) -> None:
+    """SDK-defined: leaving `issuer` out is allowed, and the provider says at construction that
+    token requests will follow whichever authorization server the MCP server advertises."""
+
+    async def assertion_provider(audience: str) -> str:
+        raise NotImplementedError
+
+    with pytest.warns(UserWarning) as recorded:
+        if kind == "secret":
+            ClientCredentialsOAuthProvider(
+                server_url=_SERVER_URL, storage=mock_storage, client_id="c", client_secret="s"
+            )
+        else:
+            PrivateKeyJWTOAuthProvider(
+                server_url=_SERVER_URL, storage=mock_storage, client_id="c", assertion_provider=assertion_provider
+            )
+
+    [warning] = recorded
+    assert warning.filename == __file__
+    provider = "ClientCredentialsOAuthProvider" if kind == "secret" else "PrivateKeyJWTOAuthProvider"
+    assert str(warning.message) == (
+        f"{provider} created without `issuer`: the client credentials will be sent to whichever "
+        "authorization server https://api.example.com/v1/mcp advertises. Pass issuer=<the issuer URL your "
+        "authorization server's metadata reports> so that token requests are only ever built for that server."
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("kind", ["secret", "jwt"])
+async def test_without_issuer_the_exchange_follows_whichever_server_was_discovered(
+    mock_storage: MockTokenStorage, kind: str
+) -> None:
+    """SDK-defined: with no `issuer` configured the token request is built from whatever metadata
+    discovery produced, as before."""
+
+    async def assertion_provider(audience: str) -> str:
+        return "jwt"
+
+    with pytest.warns(UserWarning, match="created without `issuer`"):
+        if kind == "secret":
+            provider: OAuthClientProvider = ClientCredentialsOAuthProvider(
+                server_url=_SERVER_URL, storage=mock_storage, client_id="c", client_secret="s"
+            )
+        else:
+            provider = PrivateKeyJWTOAuthProvider(
+                server_url=_SERVER_URL, storage=mock_storage, client_id="c", assertion_provider=assertion_provider
+            )
+    flow = provider.async_auth_flow(httpx2.Request("POST", _SERVER_URL))
+
+    token_request = await _answer_discovery(
+        flow,
+        authorization_server="https://elsewhere.example.com",
+        metadata=_metadata_for("https://elsewhere.example.com"),
+    )
+
+    assert (token_request.method, str(token_request.url)) == ("POST", "https://elsewhere.example.com/token")
     await flow.aclose()
 
 

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -467,11 +467,9 @@ def test_constructing_without_issuer_warns_where_the_credentials_will_go(
 
     [warning] = recorded
     assert warning.filename == __file__
-    provider = "ClientCredentialsOAuthProvider" if kind == "secret" else "PrivateKeyJWTOAuthProvider"
     assert str(warning.message) == (
-        f"{provider} created without `issuer`: the client credentials will be sent to whichever "
-        "authorization server https://api.example.com/v1/mcp advertises. Pass issuer=<the issuer URL your "
-        "authorization server's metadata reports> so that token requests are only ever built for that server."
+        "No `issuer` given: client credentials will be sent to whichever authorization server the MCP "
+        "server advertises. Pass issuer=<your authorization server's issuer URL> to send them only there."
     )
 
 
@@ -486,7 +484,7 @@ async def test_without_issuer_the_exchange_follows_whichever_server_was_discover
     async def assertion_provider(audience: str) -> str:
         return "jwt"
 
-    with pytest.warns(UserWarning, match="created without `issuer`"):
+    with pytest.warns(UserWarning, match="No `issuer` given"):
         if kind == "secret":
             provider: OAuthClientProvider = ClientCredentialsOAuthProvider(
                 server_url=_SERVER_URL, storage=mock_storage, client_id="c", client_secret="s"

--- a/tests/client/auth/extensions/test_client_credentials.py
+++ b/tests/client/auth/extensions/test_client_credentials.py
@@ -7,6 +7,7 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import AnyHttpUrl
 
+from mcp import MCPDeprecationWarning
 from mcp.client.auth import OAuthClientProvider, OAuthFlowError
 from mcp.client.auth.extensions.client_credentials import (
     ClientCredentialsOAuthProvider,
@@ -446,16 +447,14 @@ async def test_provider_picks_its_configured_issuer_among_several_advertised_ser
 
 
 @pytest.mark.parametrize("kind", ["secret", "jwt"])
-def test_constructing_without_issuer_warns_where_the_credentials_will_go(
-    mock_storage: MockTokenStorage, kind: str
-) -> None:
+def test_constructing_without_issuer_is_deprecated(mock_storage: MockTokenStorage, kind: str) -> None:
     """SDK-defined: leaving `issuer` out is allowed, and the provider says at construction that
     token requests will follow whichever authorization server the MCP server advertises."""
 
     async def assertion_provider(audience: str) -> str:
         raise NotImplementedError
 
-    with pytest.warns(UserWarning) as recorded:
+    with pytest.warns(MCPDeprecationWarning) as recorded:
         if kind == "secret":
             ClientCredentialsOAuthProvider(
                 server_url=_SERVER_URL, storage=mock_storage, client_id="c", client_secret="s"
@@ -468,8 +467,9 @@ def test_constructing_without_issuer_warns_where_the_credentials_will_go(
     [warning] = recorded
     assert warning.filename == __file__
     assert str(warning.message) == (
-        "No `issuer` given: client credentials will be sent to whichever authorization server the MCP "
-        "server advertises. Pass issuer=<your authorization server's issuer URL> to send them only there."
+        "Omitting `issuer` is deprecated and it will be required in 3.0. Without it, the MCP server "
+        "decides which authorization server receives this client's credentials; pass "
+        "issuer=<your authorization server's issuer URL> so they are only ever sent there."
     )
 
 
@@ -484,7 +484,7 @@ async def test_without_issuer_the_exchange_follows_whichever_server_was_discover
     async def assertion_provider(audience: str) -> str:
         return "jwt"
 
-    with pytest.warns(UserWarning, match="No `issuer` given"):
+    with pytest.warns(MCPDeprecationWarning, match="Omitting `issuer` is deprecated"):
         if kind == "secret":
             provider: OAuthClientProvider = ClientCredentialsOAuthProvider(
                 server_url=_SERVER_URL, storage=mock_storage, client_id="c", client_secret="s"

--- a/tests/docs_src/test_oauth_clients.py
+++ b/tests/docs_src/test_oauth_clients.py
@@ -105,6 +105,7 @@ async def test_the_one_more_provider_is_private_key_jwt() -> None:
         storage=tutorial002.InMemoryTokenStorage(),
         client_id="reporting-agent",
         assertion_provider=static_assertion_provider("a.prebuilt.jwt"),
+        issuer="http://localhost:9000",
     )
     assert isinstance(provider, OAuthClientProvider)
     assert isinstance(provider, httpx2.Auth)

--- a/tests/interaction/auth/test_lifecycle.py
+++ b/tests/interaction/auth/test_lifecycle.py
@@ -373,6 +373,7 @@ async def test_client_credentials_provider_obtains_a_token_without_an_authorize_
         client_id="m2m-client",
         client_secret="m2m-secret",
         scope="mcp",
+        issuer=BASE_URL,
     )
 
     with anyio.fail_after(5):
@@ -424,6 +425,7 @@ async def test_private_key_jwt_provider_authenticates_the_token_request_with_an_
         client_id="m2m-jwt-client",
         assertion_provider=assertion_provider,
         scope="mcp",
+        issuer=BASE_URL,
     )
 
     with anyio.fail_after(5):


### PR DESCRIPTION
Constructing `ClientCredentialsOAuthProvider` or `PrivateKeyJWTOAuthProvider` without `issuer=` is deprecated: it keeps working in 2.x, warns with `MCPDeprecationWarning`, and the keyword becomes required in 3.0.

## Motivation and Context

#3398 added the optional `issuer=` keyword to the two pre-provisioned providers: with it, token requests are only ever built from metadata for that authorization server. Without it the provider follows whichever authorization server the MCP server advertises, which is the behaviour these providers have always had. For credentials that were issued by one specific authorization server, the second mode is rarely what anyone wants, and the operator always knows the value to pass, so 3.0 will require it. Until then the constructor says so:

```
MCPDeprecationWarning: Omitting `issuer` is deprecated and it will be required in 3.0. Without it, the MCP
server decides which authorization server receives this client's credentials; pass issuer=<your
authorization server's issuer URL> so they are only ever sent there.
```

`MCPDeprecationWarning` is the category the SDK already uses for its other deprecations (a `UserWarning`, so it is shown by default and filterable as one category). `stacklevel` points it at the caller's constructor line. Passing `issuer=` silences it, and there is no other change in behaviour.

## How Has This Been Tested?

`tests/client/auth/extensions/test_client_credentials.py`: a parametrised test asserts the category, the text, and that the warning is attributed to the calling file for both providers, and one test keeps exercising the no-issuer exchange path under `pytest.warns`. The older tests in that file, the interaction tests and the `PrivateKeyJWTOAuthProvider` docs test now pass `issuer=` matching the authorization server they already mock or run. The `oauth_client_credentials` example story passes `issuer=` too. `docs/deprecated.md` lists the deprecation next to the existing SDK-level one and `docs/client/oauth-clients.md` links to it.

## Breaking Changes

None in 2.x. Code that constructs either provider without `issuer=` keeps working and now sees one `MCPDeprecationWarning` per call site (test suites running with warnings as errors will want to pass `issuer=` or filter the category). 3.0 will make the keyword required.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The conformance client script constructs these providers from the harness's context, which does not carry an issuer yet, so the client-conformance job will print the warning; that is expected.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
