### PR TITLE
fix: prevent in-process callback failures from breaking calls

### DIFF
--- a/src/mcp/shared/direct_dispatcher.py
+++ b/src/mcp/shared/direct_dispatcher.py
@@ -90,7 +90,10 @@ class _DirectDispatchContext:
 
     async def progress(self, progress: float, total: float | None = None, message: str | None = None) -> None:
         if self._on_progress is not None:
-            await self._on_progress(progress, total, message)
+            try:
+                await self._on_progress(progress, total, message)
+            except Exception:
+                logger.exception("progress callback raised")
 
 
 class DirectDispatcher:
@@ -301,7 +304,10 @@ class DirectDispatcher:
             return
         assert self._on_notify is not None
         dctx = self._make_context()
-        await self._on_notify(dctx, method, params)
+        try:
+            await self._on_notify(dctx, method, params)
+        except Exception:
+            logger.exception("notification handler for %r raised", method)
 
 
 def create_direct_dispatcher_pair(

--- a/tests/shared/test_dispatcher.py
+++ b/tests/shared/test_dispatcher.py
@@ -217,6 +217,43 @@ async def test_ctx_progress_invokes_caller_on_progress_callback(pair_factory: Pa
 
 
 @pytest.mark.anyio
+async def test_progress_callback_exception_does_not_fail_request(
+    pair_factory: PairFactory, caplog: pytest.LogCaptureFixture
+) -> None:
+    async def on_progress(progress: float, total: float | None, message: str | None) -> None:
+        raise RuntimeError("progress callback failed")
+
+    async def server_on_request(
+        ctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None
+    ) -> dict[str, Any]:
+        await ctx.progress(0.5)
+        return {"ok": True}
+
+    async with running_pair(pair_factory, server_on_request=server_on_request) as (client, *_):
+        with anyio.fail_after(5):
+            result = await client.send_raw_request("tools/call", None, {"on_progress": on_progress})
+    assert result == {"ok": True}
+    assert "progress callback raised" in caplog.text
+
+
+@pytest.mark.anyio
+async def test_notification_handler_exception_does_not_reach_sender(
+    pair_factory: PairFactory, caplog: pytest.LogCaptureFixture
+) -> None:
+    called = anyio.Event()
+
+    async def on_notify(ctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None) -> None:
+        called.set()
+        raise RuntimeError("notification handler failed")
+
+    async with running_pair(pair_factory, server_on_notify=on_notify) as (client, *_):
+        with anyio.fail_after(5):
+            await client.notify("notifications/message", None)
+            await called.wait()
+    assert "notification handler for 'notifications/message' raised" in caplog.text
+
+
+@pytest.mark.anyio
 async def test_ctx_progress_is_noop_when_caller_supplied_no_callback(pair_factory: PairFactory):
     async def server_on_request(
         ctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None


### PR DESCRIPTION
Fixes https://github.com/modelcontextprotocol/python-sdk/issues/3434

With an in-process client, a progress callback exception turns a successful tool call into `UnexpectedToolError`. Notification handler exceptions also escape through `notify()`.

`DirectDispatcher` now logs and contains those failures, matching `JSONRPCDispatcher`.

## Motivation and Context

The transport should not let callback code change a protocol outcome. Request handler failures still become `MCPError`.

## How Has This Been Tested?

The contract tests fail on clean `origin/main` with only the tests applied, then pass with the fix.

<details><summary>Raw logs</summary>

```console
$ uv run --frozen pytest tests/shared/test_dispatcher.py \
    -k 'progress_callback_exception_does_not_fail_request or notification_handler_exception_does_not_reach_sender' -q
# clean origin/main with tests only
2 failed, 2 passed, 48 deselected

# with this fix
4 passed, 48 deselected

$ PYTHONWARNDEFAULTENCODING=1 uv run --frozen coverage run -m pytest tests/shared/test_dispatcher.py -q
52 passed
```

</details>

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- Not yet assigned, and the issue has no `help wanted` label.
- [x] I have disclosed any AI assistance and can explain the change in my own words.
- [x] I have read the relevant [MCP documentation](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress).
- [x] My code follows the repository's style guidelines.
- [x] New and existing dispatcher tests pass locally.
- [x] I have added appropriate error handling.
- [x] No documentation update is needed because this restores the existing contract.

## Additional context

I used GitHub Copilot CLI to inspect the dispatcher paths, write the patch and tests, and draft this pull request. I reviewed the change and verified the results.
