### PR TITLE
Keep following a relative redirect when the endpoint URL carries userinfo

### DIFF
--- a/src/mcp/shared/_httpx_utils.py
+++ b/src/mcp/shared/_httpx_utils.py
@@ -90,8 +90,10 @@ def next_request_within_origin(response: httpx2.Response) -> httpx2.Request | No
     GET: httpx2 turns a POST into a body-less GET for 301/302/303, which would
     drop the message), its URL stays within the origin of the request just sent
     (same scheme, host and port, or http to https on the same host with default
-    ports), and the Location carries no userinfo (which httpx2 would otherwise
-    send as Basic auth). None for anything else, including a non-redirect.
+    ports), and the Location does not bring userinfo of its own (which httpx2
+    would otherwise send as Basic auth; userinfo the configured URL already had
+    is kept by a relative Location and is fine). None for anything else,
+    including a non-redirect.
     """
     next_request = response.next_request
     if next_request is None:
@@ -99,7 +101,7 @@ def next_request_within_origin(response: httpx2.Response) -> httpx2.Request | No
     sent = response.request
     if (
         next_request.method != sent.method
-        or next_request.url.userinfo
+        or (next_request.url.userinfo and next_request.url.userinfo != sent.url.userinfo)
         or not _within_origin(sent.url, next_request.url)
     ):
         return None

--- a/tests/shared/test_httpx_utils.py
+++ b/tests/shared/test_httpx_utils.py
@@ -208,6 +208,20 @@ async def test_redirect_location_with_userinfo_is_not_followed():
     assert received == [f"POST {url}"]
 
 
+async def test_userinfo_of_the_configured_url_kept_by_a_relative_location_is_followed():
+    """Userinfo the caller put in the endpoint URL is carried over by a relative Location (URL join
+    keeps the authority); that is the caller's own credential for the same origin, so the redirect
+    is followed as httpx2 itself would (SDK-defined)."""
+    url = "http://user:secret@mcp.example/mcp"
+    client, received, _ = _recording_client({url: (307, "/mcp/")})
+
+    async with client, stream_within_origin(client, "POST", url, content=b"payload") as response:
+        await response.aread()
+
+    assert response.status_code == 200
+    assert received == [f"POST {url}", "POST http://user:secret@mcp.example/mcp/"]
+
+
 async def test_request_within_origin_returns_a_read_response():
     """The non-streaming form hands back a response whose body is already read."""
     url = "http://mcp.example/mcp"


### PR DESCRIPTION
Follow-up to #3397: an endpoint URL that carries userinfo (`http://user:pass@host/mcp`, which httpx2 turns into Basic auth) could no longer follow a redirect with a *relative* `Location`, because URL join keeps the base's userinfo and the transport refused any next request whose URL had userinfo. The check now refuses only userinfo the redirect itself introduces.

## Motivation and Context

#3397 stops the transports from following a `Location` that carries `user:pass@`, since re-sending would put that pair in an `Authorization` header. The check was broader than its purpose: for a relative `Location` (`/mcp/`), `next_request.url` inherits the authority of the URL the caller configured, userinfo included, so the ordinary same-origin trailing-slash redirect was handed back unfollowed for such an endpoint and the call failed with "Redirect to … not followed". An absolute `Location` was unaffected. Found in review of the v1.x backport (#3448), which carries the same change.

## How Has This Been Tested?

New helper test: a `307` with `Location: /mcp/` for `http://user:secret@mcp.example/mcp` is followed and the second request goes to `http://user:secret@mcp.example/mcp/`; it fails before the change. The existing test that a `Location` introducing userinfo is not followed still passes. Full suite, pyright and ruff pass.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
