### PR TITLE
fix(server): compare Host and Origin case-insensitively

### DIFF
--- a/src/mcp/server/transport_security.py
+++ b/src/mcp/server/transport_security.py
@@ -53,17 +53,24 @@ class TransportSecurityMiddleware:
             logger.warning("Missing Host header in request")
             return False
 
+        # RFC 9110: the host is case-insensitive. Clients built on WHATWG URL parsing
+        # (fetch, undici, browsers) lowercase it before sending, so an `allowed_hosts`
+        # entry derived from something uppercase - %COMPUTERNAME% on Windows always is -
+        # never matches, and the server 421s while configured exactly as intended.
+        # The header is compared folded; `host` is kept as sent for the log line.
+        folded = host.lower()
+
         # Check exact match first
-        if host in self.settings.allowed_hosts:
+        if folded in [allowed.lower() for allowed in self.settings.allowed_hosts]:
             return True
 
         # Check wildcard port patterns
         for allowed in self.settings.allowed_hosts:
             if allowed.endswith(":*"):
                 # Extract base host from pattern
-                base_host = allowed[:-2]
+                base_host = allowed[:-2].lower()
                 # Check if the actual host starts with base host and has a port
-                if host.startswith(base_host + ":"):
+                if folded.startswith(base_host + ":"):
                     return True
 
         logger.warning(f"Invalid Host header: {host}")
@@ -75,17 +82,21 @@ class TransportSecurityMiddleware:
         if not origin:
             return True
 
+        # Same rule, same reason: an origin is a scheme and a host, and RFC 9110 makes
+        # both case-insensitive. There is no path here to compare case-sensitively.
+        folded = origin.lower()
+
         # Check exact match first
-        if origin in self.settings.allowed_origins:
+        if folded in [allowed.lower() for allowed in self.settings.allowed_origins]:
             return True
 
         # Check wildcard port patterns
         for allowed in self.settings.allowed_origins:
             if allowed.endswith(":*"):
                 # Extract base origin from pattern
-                base_origin = allowed[:-2]
+                base_origin = allowed[:-2].lower()
                 # Check if the actual origin starts with base origin and has a port
-                if origin.startswith(base_origin + ":"):
+                if folded.startswith(base_origin + ":"):
                     return True
 
         logger.warning(f"Invalid Origin header: {origin}")

--- a/tests/server/test_transport_security.py
+++ b/tests/server/test_transport_security.py
@@ -45,6 +45,12 @@ SETTINGS = TransportSecuritySettings(
         pytest.param("good.example", "http://evil.example:9000", 403, id="origin-wildcard-base-mismatch"),
         pytest.param("good.example", "http://good.example", None, id="origin-exact"),
         pytest.param("good.example", "http://wild.example:9000", None, id="origin-wildcard-match"),
+        # RFC 9110: scheme and host are case-insensitive, and WHATWG-URL clients
+        # (fetch, undici, browsers) send them lowercased whatever was configured.
+        pytest.param("GOOD.EXAMPLE", None, None, id="host-exact-differing-case"),
+        pytest.param("WILD.EXAMPLE:9000", None, None, id="host-wildcard-differing-case"),
+        pytest.param("good.example", "http://GOOD.EXAMPLE", None, id="origin-exact-differing-case"),
+        pytest.param("good.example", "http://WILD.EXAMPLE:9000", None, id="origin-wildcard-differing-case"),
     ],
 )
 async def test_validate_request_checks_host_then_origin(
@@ -54,6 +60,41 @@ async def test_validate_request_checks_host_then_origin(
     middleware = TransportSecurityMiddleware(SETTINGS)
     response = await middleware.validate_request(_request(host, origin))
     assert (None if response is None else response.status_code) == expected
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("host", "origin"),
+    [
+        pytest.param("myhost", None, id="host-exact"),
+        pytest.param("myhost:8000", None, id="host-wildcard"),
+        pytest.param("myhost", "http://myhost", id="origin-exact"),
+        pytest.param("myhost", "http://myhost:8000", id="origin-wildcard"),
+    ],
+)
+async def test_an_uppercase_allowlist_still_matches_what_clients_send(host: str, origin: str | None) -> None:
+    """The reported path: %COMPUTERNAME% is always uppercase on Windows.
+
+    Deriving the allowlist from the machine name is the obvious thing to do and
+    yields entries like `MYHOST:*`; every fetch-based client then sends
+    `host: myhost:8000`, and the server 421s while configured exactly as intended.
+    """
+    settings = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=["MYHOST", "MYHOST:*"],
+        allowed_origins=["http://MYHOST", "http://MYHOST:*"],
+    )
+    middleware = TransportSecurityMiddleware(settings)
+    assert await middleware.validate_request(_request(host, origin)) is None
+
+
+@pytest.mark.anyio
+async def test_case_folding_does_not_widen_the_allowlist() -> None:
+    """Folding case must not make a host match that differs by more than case."""
+    middleware = TransportSecurityMiddleware(SETTINGS)
+    for host in ("EVIL.EXAMPLE", "good.example.evil.example", "GOOD.EXAMPLEX"):
+        response = await middleware.validate_request(_request(host, None))
+        assert response is not None and response.status_code == 421, host
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #3437

**Problem.** `TransportSecurityMiddleware._validate_host` compares the `Host` header against `allowed_hosts` byte for byte. RFC 9110 makes the host case-insensitive, and every WHATWG-URL client — `fetch`, undici, browsers, and therefore `mcp-remote` — lowercases it before sending.

On Windows this is the default path in, not an edge case: `%COMPUTERNAME%` is always uppercase, so deriving `allowed_hosts` from the machine name gives `MYHOST:*`, clients send `host: myhost:8000`, and the server returns 421 to everything while configured exactly as intended.

`_validate_origin` has the same comparison, as @UgaTheDev notes on the issue. An origin is a scheme and a host with no path, so both components fold under the same rule.

**Change.** Fold both sides of the comparison, in the exact-match and the `:*` wildcard branch, for host and origin. The header is kept as sent for the warning line, so logs still show what actually arrived.

**Verify.**

```
uv run pytest tests/server/test_transport_security.py
```

35 pass. The 8 added cases fail on `main` and pass here:

- 4 parametrised cases sending a differing-case host/origin against the existing lowercase allowlist;
- 4 for the reported `%COMPUTERNAME%` shape — an uppercase allowlist (`MYHOST`, `MYHOST:*`) against what a fetch client sends;
- one asserting folding does not *widen* the allowlist: `EVIL.EXAMPLE`, `good.example.evil.example` and `GOOD.EXAMPLEX` still 421.

`ruff check` and `ruff format --check` are clean on both files.