### PR TITLE
fix(dispatcher): preserve non-canonical numeric strings in coerce_request_id (#3432)

### DIFF
--- a/src/mcp/shared/dispatcher.py
+++ b/src/mcp/shared/dispatcher.py
@@ -61,7 +61,9 @@ def coerce_request_id(request_id: RequestId) -> RequestId:
     """
     if isinstance(request_id, str):
         try:
-            return int(request_id)
+            parsed = int(request_id)
+            if str(parsed) == request_id:
+                return parsed
         except ValueError:
             pass
     return request_id

--- a/tests/shared/test_jsonrpc_dispatcher.py
+++ b/tests/shared/test_jsonrpc_dispatcher.py
@@ -2011,6 +2011,13 @@ def test_coerce_request_id_passes_through_non_numeric_string_and_int():
     assert coerce_request_id(42) == 42
 
 
+def test_coerce_request_id_does_not_fold_non_canonical_numeric_strings():
+    for non_canonical in ("007", "+7", "1_000", " 7 ", "٧"):
+        assert coerce_request_id(non_canonical) == non_canonical
+    assert coerce_request_id("-3") == -3
+    assert coerce_request_id("0") == 0
+
+
 @pytest.mark.anyio
 async def test_jsonrpc_error_response_with_null_id_is_dropped():
     """Parse-error responses (id=null) have no waiter; they're dropped and the read loop stays healthy."""


### PR DESCRIPTION
### Summary

Fixes #3432.

`coerce_request_id()` in `src/mcp/shared/dispatcher.py` previously converted stringified IDs using a bare `int(request_id)`. Because Python's `int()` parses leading zeros (`"007"`), signs (`"+7"`), underscores (`"1_000"`), whitespace (`" 7 "`), and non-ASCII numerals (`"٧"`), distinct wire-level JSON-RPC IDs collapsed onto a single integer key.

This shared key backs `_pending` (response correlation), `_in_flight` (cancellation), and progress-token routing, creating unexpected cross-wiring when distinct string IDs share an integer representation.

### Changes

- In `src/mcp/shared/dispatcher.py`:
  - When parsing string request IDs, verify `str(parsed) == request_id` before folding to `int`. Canonical integer representations (`"7"`, `"-3"`, `"0"`) continue folding to `int` for peer interop, while non-canonical strings (`"007"`, `"+7"`, `"1_000"`, `" 7 "`, `"٧"`) are preserved verbatim as distinct strings.
- In `tests/shared/test_jsonrpc_dispatcher.py`:
  - Added `test_coerce_request_id_does_not_fold_non_canonical_numeric_strings` validating both preservation of non-canonical strings and folding of canonical integer strings.

### Verification

- Run `uv run pytest tests/shared/test_jsonrpc_dispatcher.py`: 80 passed in 1.13s.
- Checked with `uv run ruff check` and `uv run ruff format --check`: 100% clean.
