### PR TITLE
[v1.x] Preserve the exact OAuth resource indicator (backport #2925)

### DIFF
--- a/src/mcp/client/auth/oauth2.py
+++ b/src/mcp/client/auth/oauth2.py
@@ -155,7 +155,7 @@ class OAuthContext:
 
         # If PRM provides a resource that's a valid parent, use it
         if self.protected_resource_metadata and self.protected_resource_metadata.resource:
-            prm_resource = str(self.protected_resource_metadata.resource)
+            prm_resource = self.protected_resource_metadata.resource_str
             if check_resource_allowed(requested_resource=resource, configured_resource=prm_resource):
                 resource = prm_resource
 
@@ -280,7 +280,7 @@ class OAuthClientProvider(RedirectAwareAuth):
 
     async def _validate_resource_match(self, prm: ProtectedResourceMetadata) -> None:
         """Validate that PRM resource matches the server URL per RFC 8707."""
-        prm_resource = str(prm.resource) if prm.resource else None
+        prm_resource = prm.resource_str if prm.resource else None
         if not prm_resource:
             return  # pragma: no cover
         default_resource = resource_url_from_server_url(self.context.server_url)

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, field_validator
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator
 
 
 class OAuthToken(BaseModel):
@@ -40,6 +40,8 @@ class OAuthClientMetadata(BaseModel):
     See https://datatracker.ietf.org/doc/html/rfc7591#section-2
     for the full specification.
     """
+
+    model_config = ConfigDict(url_preserve_empty_path=True)
 
     redirect_uris: list[AnyUrl] | None = Field(..., min_length=1)
     # supported auth methods for the token endpoint
@@ -132,6 +134,8 @@ class OAuthMetadata(BaseModel):
     See https://datatracker.ietf.org/doc/html/rfc8414#section-2
     """
 
+    model_config = ConfigDict(url_preserve_empty_path=True)
+
     issuer: AnyHttpUrl
     authorization_endpoint: AnyHttpUrl
     token_endpoint: AnyHttpUrl
@@ -161,6 +165,8 @@ class ProtectedResourceMetadata(BaseModel):
     RFC 9728 OAuth 2.0 Protected Resource Metadata.
     See https://datatracker.ietf.org/doc/html/rfc9728#section-2
     """
+
+    model_config = ConfigDict(url_preserve_empty_path=True)
 
     resource: AnyHttpUrl
     authorization_servers: list[AnyHttpUrl] = Field(..., min_length=1)

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -1,6 +1,23 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, ConfigDict, Field, field_validator
+from pydantic import (
+    AnyHttpUrl,
+    AnyUrl,
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidatorFunctionWrapHandler,
+    field_validator,
+    model_validator,
+)
+
+# `url_preserve_empty_path` (pydantic >= 2.12) keeps a path-less URL from gaining a trailing slash when
+# parsed from the wire, so issuer/resource identifiers round-trip as transmitted (RFC 3986 §6.2.1 simple
+# string comparison). Older pydantic ignores unknown config keys at runtime; the cast keeps the 2.11 type
+# stubs (which do not know the key) quiet. See `ProtectedResourceMetadata.resource_str` for the
+# version-independent path used for the RFC 8707 `resource` parameter.
+_PRESERVE_EMPTY_PATH = cast(ConfigDict, {"url_preserve_empty_path": True})
 
 
 class OAuthToken(BaseModel):
@@ -41,7 +58,7 @@ class OAuthClientMetadata(BaseModel):
     for the full specification.
     """
 
-    model_config = ConfigDict(url_preserve_empty_path=True)
+    model_config = _PRESERVE_EMPTY_PATH
 
     redirect_uris: list[AnyUrl] | None = Field(..., min_length=1)
     # supported auth methods for the token endpoint
@@ -134,7 +151,7 @@ class OAuthMetadata(BaseModel):
     See https://datatracker.ietf.org/doc/html/rfc8414#section-2
     """
 
-    model_config = ConfigDict(url_preserve_empty_path=True)
+    model_config = _PRESERVE_EMPTY_PATH
 
     issuer: AnyHttpUrl
     authorization_endpoint: AnyHttpUrl
@@ -166,10 +183,31 @@ class ProtectedResourceMetadata(BaseModel):
     See https://datatracker.ietf.org/doc/html/rfc9728#section-2
     """
 
-    model_config = ConfigDict(url_preserve_empty_path=True)
+    model_config = _PRESERVE_EMPTY_PATH
 
     resource: AnyHttpUrl
     authorization_servers: list[AnyHttpUrl] = Field(..., min_length=1)
+    # The `resource` value exactly as received. `url_preserve_empty_path` only takes effect on
+    # pydantic >= 2.12; on older pydantic a path-less URL still renders with a trailing slash, which
+    # breaks the byte-exact RFC 8707 `resource` parameter. Kept alongside the parsed URL so callers
+    # can echo the server's identifier verbatim regardless of pydantic version.
+    _resource_raw: str | None = PrivateAttr(default=None)
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _capture_raw_resource(cls, data: Any, handler: ValidatorFunctionWrapHandler) -> "ProtectedResourceMetadata":
+        raw: Any = cast(dict[str, Any], data).get("resource") if isinstance(data, dict) else None
+        model = cast("ProtectedResourceMetadata", handler(data))
+        if isinstance(raw, str):
+            model._resource_raw = raw
+        return model
+
+    @property
+    def resource_str(self) -> str:
+        """The resource identifier as a string, exactly as the server published it when parsed from
+        JSON/dict input (RFC 8707 requires clients to send it byte-for-byte); otherwise the rendered URL."""
+        return self._resource_raw if self._resource_raw is not None else str(self.resource)
+
     jwks_uri: AnyHttpUrl | None = None
     scopes_supported: list[str] | None = None
     bearer_methods_supported: list[str] | None = Field(default=["header"])  # MCP only supports header method

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -522,10 +522,10 @@ class TestOAuthFallback:
         }"""
         response = httpx.Response(200, content=content)
 
-        # Should set metadata
+        # Should set metadata; the empty path is preserved (no trailing slash added)
         await oauth_provider._handle_oauth_metadata_response(response)
         assert oauth_provider.context.oauth_metadata is not None
-        assert str(oauth_provider.context.oauth_metadata.issuer) == "https://auth.example.com/"
+        assert str(oauth_provider.context.oauth_metadata.issuer) == "https://auth.example.com"
 
     @pytest.mark.anyio
     async def test_prioritize_www_auth_scope_over_prm(

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -522,10 +522,11 @@ class TestOAuthFallback:
         }"""
         response = httpx.Response(200, content=content)
 
-        # Should set metadata; the empty path is preserved (no trailing slash added)
+        # Should set metadata. On pydantic >= 2.12 the empty path is preserved (no trailing slash);
+        # older pydantic ignores `url_preserve_empty_path` and still normalises to ".../".
         await oauth_provider._handle_oauth_metadata_response(response)
         assert oauth_provider.context.oauth_metadata is not None
-        assert str(oauth_provider.context.oauth_metadata.issuer) == "https://auth.example.com"
+        assert str(oauth_provider.context.oauth_metadata.issuer).rstrip("/") == "https://auth.example.com"
 
     @pytest.mark.anyio
     async def test_prioritize_www_auth_scope_over_prm(
@@ -2210,6 +2211,28 @@ async def test_get_resource_url_falls_back_when_prm_mismatches(
 
     # get_resource_url should return the canonical server URL, not the PRM resource
     assert provider.context.get_resource_url() == "https://api.example.com/v1/mcp"
+
+
+@pytest.mark.anyio
+async def test_get_resource_url_echoes_pathless_prm_resource_verbatim(
+    client_metadata: OAuthClientMetadata, mock_storage: MockTokenStorage
+) -> None:
+    """RFC 8707: the `resource` parameter is the PRM `resource` byte-for-byte. A path-less identifier
+    parsed from the wire must not gain a trailing slash, on any supported pydantic version."""
+    provider = OAuthClientProvider(
+        server_url="https://api.example.com/mcp",
+        client_metadata=client_metadata,
+        storage=mock_storage,
+    )
+    provider._initialized = True
+
+    prm = ProtectedResourceMetadata.model_validate_json(
+        '{"resource": "https://api.example.com", "authorization_servers": ["https://auth.example.com"]}'
+    )
+    assert prm.resource_str == "https://api.example.com"
+    provider.context.protected_resource_metadata = prm
+
+    assert provider.context.get_resource_url() == "https://api.example.com"
 
 
 def _prepare_full_flow(provider: OAuthClientProvider, client_info: OAuthClientInformationFull | None) -> list[str]:


### PR DESCRIPTION
Backport of #2925 to the 1.x line, plus a small compat shim so the fix holds on pydantic < 2.12 (which 1.x still supports).

## Motivation and Context

RFC 8707's `resource` parameter must be the protected resource's identifier byte-for-byte. On 1.x a path-less `resource` from the server's Protected Resource Metadata (`http://host:port`) is parsed into `AnyHttpUrl` and re-serialised as `http://host:port/`, so the client sends a different identifier in the authorization and token requests (#2578). `main` fixed this in #2925 via `url_preserve_empty_path=True` on the OAuth metadata models; that was never backported.

This now matters for conformance: modelcontextprotocol/conformance#488 adds a `resource-parameter-matches-prm` check (FAILURE, RFC 8707 MUST) to the scored `auth/metadata-var2` client scenario, and the 1.x line fails it without this change while `main`, go, rust, csharp and the TS SDK pass.

## What's in here

1. Cherry-pick of #2925 (`url_preserve_empty_path=True` on `OAuthClientMetadata`, `OAuthMetadata`, `ProtectedResourceMetadata`; the v2 migration-guide hunk is dropped since that file doesn't exist on 1.x).
2. A compat commit for pydantic 2.11: the 1.x dependency range (and the `lowest-direct` CI leg) still resolves pydantic 2.11, where `url_preserve_empty_path` is silently ignored. `ProtectedResourceMetadata` now records the wire string (`resource_str`) and `OAuthContext.get_resource_url()` / `_validate_resource_match` use it, so the `resource` parameter is echoed verbatim on every supported pydantic version. The config is spelled as a cast dict so the 2.11 type stubs accept it, and the cherry-picked issuer assertion is made version-tolerant.

## How Has This Been Tested?

- `uv run --frozen pytest tests/client/test_auth.py` → 129 passed (new test `test_get_resource_url_echoes_pathless_prm_resource_verbatim`); ruff + pyright clean on the touched files; behaviour checked on pydantic 2.11.7 and 2.13.4.
- Conformance (modelcontextprotocol/conformance main + https://github.com/modelcontextprotocol/conformance/pull/488 ), `client --scenario auth/metadata-var2 --spec-version 2025-11-25` with `.github/actions/conformance/client.py`:
  - before (v1.x @ 8c2fa6e): `resource-parameter-matches-prm FAILURE` → scenario FAILED
  - after (this branch): `resource-parameter-matches-prm SUCCESS`, 18/18 checks, scenario PASSED; `auth/metadata-default` PASSED before and after.

## Breaking Changes

None intended. `str(prm.resource)` is unchanged on pydantic < 2.12 (still normalised); code that needs the exact identifier should use the new `ProtectedResourceMetadata.resource_str`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## AI Disclaimer

Prepared with Claude Code; reviewed the diff and the test/conformance output.
