### PR TITLE
fix(server): require a numeric port for Host/Origin :* allowlist entries

### DIFF
--- a/src/mcp/server/transport_security.py
+++ b/src/mcp/server/transport_security.py
@@ -16,6 +16,21 @@ DEFAULT_MAX_REQUEST_BODY_SIZE: Final = 4 * 1024 * 1024
 """Default maximum HTTP request body size in bytes (4 MiB)."""
 
 
+def _matches_wildcard_port(value: str, allowed: str) -> bool:
+    """Return True when ``allowed`` is ``base:*`` and ``value`` is ``base:<digits>``.
+
+    A prefix check alone accepts ``127.0.0.1:8080.evil`` for ``127.0.0.1:*``.
+    The port suffix must be digits so the wildcard cannot match a longer host
+    or origin.
+    """
+    if not allowed.endswith(":*"):
+        return False
+    prefix = allowed[:-1]  # "base:"
+    if not value.startswith(prefix):
+        return False
+    return value[len(prefix) :].isdigit()
+
+
 # TODO(Marcelo): We should flatten these settings. To be fair, I don't think we should even have this middleware.
 class TransportSecuritySettings(BaseModel):
     """Settings for MCP transport security features.
@@ -57,14 +72,10 @@ class TransportSecurityMiddleware:
         if host in self.settings.allowed_hosts:
             return True
 
-        # Check wildcard port patterns
+        # Check wildcard port patterns (base:* matches only base:<digits>)
         for allowed in self.settings.allowed_hosts:
-            if allowed.endswith(":*"):
-                # Extract base host from pattern
-                base_host = allowed[:-2]
-                # Check if the actual host starts with base host and has a port
-                if host.startswith(base_host + ":"):
-                    return True
+            if _matches_wildcard_port(host, allowed):
+                return True
 
         logger.warning(f"Invalid Host header: {host}")
         return False
@@ -79,14 +90,10 @@ class TransportSecurityMiddleware:
         if origin in self.settings.allowed_origins:
             return True
 
-        # Check wildcard port patterns
+        # Check wildcard port patterns (base:* matches only base:<digits>)
         for allowed in self.settings.allowed_origins:
-            if allowed.endswith(":*"):
-                # Extract base origin from pattern
-                base_origin = allowed[:-2]
-                # Check if the actual origin starts with base origin and has a port
-                if origin.startswith(base_origin + ":"):
-                    return True
+            if _matches_wildcard_port(origin, allowed):
+                return True
 
         logger.warning(f"Invalid Origin header: {origin}")
         return False

--- a/tests/server/test_transport_security.py
+++ b/tests/server/test_transport_security.py
@@ -41,10 +41,13 @@ SETTINGS = TransportSecuritySettings(
         pytest.param("evil.example:9000", None, 421, id="host-wildcard-base-mismatch"),
         pytest.param("good.example", None, None, id="host-exact-no-origin"),
         pytest.param("wild.example:9000", None, None, id="host-wildcard-match"),
+        pytest.param("wild.example:9000.evil", None, 421, id="host-wildcard-suffix-rejected"),
+        pytest.param("wild.example:", None, 421, id="host-wildcard-empty-port"),
         pytest.param("good.example", "http://evil.example", 403, id="origin-no-match"),
         pytest.param("good.example", "http://evil.example:9000", 403, id="origin-wildcard-base-mismatch"),
         pytest.param("good.example", "http://good.example", None, id="origin-exact"),
         pytest.param("good.example", "http://wild.example:9000", None, id="origin-wildcard-match"),
+        pytest.param("good.example", "http://wild.example:9000.evil", 403, id="origin-wildcard-suffix-rejected"),
     ],
 )
 async def test_validate_request_checks_host_then_origin(


### PR DESCRIPTION
Fixes #3463

## What

HTTP transports can enable DNS rebinding protection with `allowed_hosts` / `allowed_origins`. An entry that ends in `:*` is meant to allow any port on that host or origin.

The matcher was a prefix check:

```python
if host.startswith(base_host + ":"):
    return True
```

So `allowed_hosts=["wild.example:*"]` also accepted `wild.example:9000.evil`. The same form accepted Origin `http://wild.example:9000.evil` for `http://wild.example:*`.

Existing tests only used a numeric port (`wild.example:9000`). After the fix, the suffix after `base:` must be digits. `wild.example:9000` still passes. `wild.example:9000.evil` and an empty port do not.

## Why

I was reading `TransportSecurityMiddleware` next to `tests/server/test_transport_security.py`. The wildcard cases only cover `wild.example:9000`. I tried a Host that starts with that prefix and keeps going (`wild.example:9000.evil`) and `validate_request` returned `None`.

This matters when someone turns protection on and trusts `:*` to mean "this host, any port". A client that can set Host or Origin can satisfy the allowlist with a longer value.

## How

Share one helper: `base:*` matches only `base:<digits>`. Host and Origin both use it. No new settings.

## Testing

Added `host-wildcard-suffix-rejected`, `host-wildcard-empty-port`, and `origin-wildcard-suffix-rejected` to `test_validate_request_checks_host_then_origin`.

```
uv run pytest tests/server/test_transport_security.py -q
```

29 passed.

Written with AI assistance. I read the matcher, reproduced the suffix case, and kept the existing numeric-port tests.