### PR TITLE
fix: alias-normalize CallToolResult structuredContent after validate

### DIFF
--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -203,7 +203,15 @@ class FuncMetadata(BaseModel):
         output_model = self.output_model if self.output_schema is not None else None
         if isinstance(result, CallToolResult):
             if output_model is not None and not result.is_error:
-                self._output_adapter(output_model).validate_python(result.structured_content)
+                # Match the plain-return path: accept Python or alias keys, then emit
+                # wire keys (aliases) so structuredContent agrees with outputSchema.
+                adapter = self._output_adapter(output_model)
+                validated = adapter.validate_python(result.structured_content, by_alias=True, by_name=True)
+                if isinstance(validated, BaseModel):
+                    structured_content = validated.model_dump(mode="json", by_alias=True)
+                else:
+                    structured_content = adapter.dump_python(validated, mode="json", by_alias=True)
+                return result.model_copy(update={"structured_content": structured_content})
             return result
 
         unstructured_content = _convert_to_content(result)

--- a/tests/server/mcpserver/test_func_metadata.py
+++ b/tests/server/mcpserver/test_func_metadata.py
@@ -11,7 +11,7 @@ import annotated_types
 import pytest
 from dirty_equals import IsPartialDict
 from mcp_types import CallToolResult, ContentBlock, EmbeddedResource, InputRequiredResult, TextContent
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from typing_extensions import NotRequired, ReadOnly, Required
 
 from mcp import MCPDeprecationWarning
@@ -1320,6 +1320,34 @@ def test_structured_output_aliases():
     assert "field_second" not in structured_content_defaults
     assert structured_content_defaults["first"] is None
     assert structured_content_defaults["second"] is None
+
+
+def test_call_tool_result_structured_content_alias_normalized():
+    """CallToolResult.structured_content must be alias-normalized like plain returns."""
+
+    class ModelWithAliases(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+        field_first: str | None = Field(default=None, alias="first")
+        field_second: str | None = Field(default=None, alias="second")
+
+    def via_call_tool_result() -> Annotated[CallToolResult, ModelWithAliases]:
+        return CallToolResult(
+            content=[],
+            structured_content={"field_first": "hello", "field_second": "world"},
+        )
+
+    meta = func_metadata(via_call_tool_result)
+    assert meta.output_schema is not None
+    assert "first" in meta.output_schema["properties"]
+    assert "field_first" not in meta.output_schema["properties"]
+
+    converted = meta.convert_result(via_call_tool_result())
+    assert isinstance(converted, CallToolResult)
+    structured_content = converted.structured_content
+    assert structured_content is not None
+    assert structured_content == {"first": "hello", "second": "world"}
+    assert "field_first" not in structured_content
+    assert "field_second" not in structured_content
 
 
 def test_basemodel_reserved_names():


### PR DESCRIPTION
﻿Fixes #3467

## Summary
`FuncMetadata.convert_result` validates `CallToolResult.structured_content` but returns the result unchanged. Plain model returns validate then `model_dump`/`dump_python` with `by_alias=True`, so wire keys match `outputSchema`. The CallToolResult path skipped that dump, so Python field names that pass validation (`populate_by_name` / `by_name`) could be emitted while `outputSchema` advertises aliases.

## Motivation and Context
Clients validating `structuredContent` against the published `outputSchema` reject otherwise-valid tool results when aliases are used. This aligns the CallToolResult short-circuit with the plain-return path (#1073 / #1099). Distinct from #3100 / #3118 (schema generation mode).

## How Has This Been Tested?
- Added `test_call_tool_result_structured_content_alias_normalized`
- `py -3.12 -m pytest tests/server/mcpserver/test_func_metadata.py` — 59 passed
- Standalone repro from #3467: CallToolResult path now emits `{"first":...}` instead of `{"field_first":...}`

## Breaking Changes
None intended. Wire output for CallToolResult tools that previously leaked Python field names will now use aliases (matching schema / plain returns).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ ] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Smallest fix: after `validate_python(..., by_alias=True, by_name=True)` on CallToolResult.structured_content, dump with `by_alias=True` and `model_copy` the normalized dict — same serialization as the plain-return path.

## AI disclosure
This PR was prepared with AI assistance (Cursor / Grok): issue draft, repro, patch, and PR text. Changes were verified locally on current `main` (`08a3bc8`) with the new regression test and the full `test_func_metadata.py` file.
