### PR TITLE
fix(client): omit empty _meta on outbound requests

### DIFF
--- a/src/mcp/shared/jsonrpc_dispatcher.py
+++ b/src/mcp/shared/jsonrpc_dispatcher.py
@@ -359,7 +359,6 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
         if on_progress is not None:
             # The request id doubles as the progress token, so `_pending[token]` finds `on_progress` directly.
             out_meta["progressToken"] = request_id
-        out_params["_meta"] = out_meta
 
         # buffer=1: a close signal can arrive before the waiter parks in receive();
         # a WouldBlock later just means the waiter already has its one outcome.
@@ -386,8 +385,16 @@ class JSONRPCDispatcher(Dispatcher[TransportT]):
                 kind=SpanKind.CLIENT,
                 attributes={"mcp.method.name": method, "jsonrpc.request.id": str(request_id)},
             ):
-                # SEP-414: inject W3C trace context; `_meta` stays on the wire even with a no-op tracer.
+                # SEP-414: inject W3C trace context into `_meta`; the field only
+                # goes on the wire when it carries something (progress token,
+                # caller keys, or trace context) — an empty `_meta:{}` is
+                # rejected as invalid params by strict servers (e.g. Meta's
+                # hosted Ads MCP).
                 inject_trace_context(out_meta)
+                if out_meta:
+                    out_params["_meta"] = out_meta
+                elif "_meta" in out_params:
+                    del out_params["_meta"]
                 msg = JSONRPCRequest(jsonrpc="2.0", id=request_id, method=method, params=out_params)
                 # Surface a pre-existing cancellation while the request provably
                 # never started; past this point a cancelled write counts as issued.

--- a/tests/shared/test_jsonrpc_dispatcher.py
+++ b/tests/shared/test_jsonrpc_dispatcher.py
@@ -1501,9 +1501,10 @@ async def test_inline_methods_are_handled_before_next_message_is_dequeued():
 
 
 @pytest.mark.anyio
-async def test_send_raw_request_always_carries_meta_on_the_wire():
-    """Outbound requests always carry `params._meta` (otel injection per SEP-414); caller-supplied
-    keys are preserved and the progress token is merged in."""
+async def test_send_raw_request_carries_meta_only_when_non_empty():
+    """Outbound requests omit `params._meta` when it would be empty (strict servers
+    reject `_meta:{}` as invalid params); caller-supplied keys are preserved and
+    the progress token is merged in."""
     seen: list[Mapping[str, Any] | None] = []
 
     async def server_on_request(ctx: DCtx, method: str, params: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -1518,13 +1519,16 @@ async def test_send_raw_request_always_carries_meta_on_the_wire():
         with anyio.fail_after(5):
             await client.send_raw_request("a", None)
             await client.send_raw_request("b", {"x": 1, "_meta": {"k": "v"}}, opts)
+            await client.send_raw_request("c", {"x": 1, "_meta": {}})
     # `_meta` contents depend on the active otel tracer, so pin only what sits beyond the W3C keys.
     w3c = {"traceparent", "tracestate"}
-    assert seen[0] is not None and seen[0].keys() == {"_meta"}
-    assert set(seen[0]["_meta"].keys()) <= w3c
+    # No progress token, no caller keys, no-op tracer in tests: `_meta` is absent entirely.
+    assert seen[0] is not None and "_meta" not in seen[0]
     assert seen[1] is not None and seen[1]["x"] == 1
     assert set(seen[1]["_meta"].keys()) - w3c == {"k", "progressToken"}
     assert seen[1]["_meta"]["k"] == "v"
+    # A caller-supplied empty `_meta` must not go on the wire either.
+    assert seen[2] is not None and "_meta" not in seen[2]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

Fixes #3473.

`JSONRPCDispatcher.send_raw_request` attached `_meta` to `params` unconditionally, so with no progress callback and a no-op tracer every outbound request carried `_meta: {}` on the wire. Strict JSON-RPC servers reject that as invalid params — Meta's hosted Ads MCP server (`https://mcp.facebook.com/ads`) answers `-32602 "_meta for Request must be a dict or null"` with HTTP 400 on `initialize`, making it unreachable from any client built on this SDK (`_meta: null` is rejected identically; the field must be absent).

Reported downstream from Hermes Agent: NousResearch/hermes-agent#105637 (includes a curl repro against the real server: 400 with `_meta:{}}`, 200 without).

## Changes

- `src/mcp/shared/jsonrpc_dispatcher.py`: `_meta` is attached only when non-empty **after** `inject_trace_context` (so a real trace context still goes out per SEP-414); a caller-supplied empty `_meta` is dropped rather than forwarded. `out_meta` was already built before the otel span, so this only moves the wire decision to where its content is final.
- `tests/shared/test_jsonrpc_dispatcher.py`: the pinned behaviour test now asserts omission when `_meta` would be empty (both no-key and caller-supplied-empty cases), and still asserts preservation of caller keys + progress token.

This intentionally changes the behaviour pinned by `test_send_raw_request_always_carries_meta_on_the_wire` — the spec makes `_meta` optional, and an always-present empty object is rejected by real servers.

## Tests

```
tests/shared/test_jsonrpc_dispatcher.py ... 79 passed
tests/shared/ + tests/client/test_client.py . 974 passed
```

## Motivation

Any strict MCP server that rejects an empty `_meta` object is currently unreachable natively. Meta's hosted Ads MCP server is the first confirmed case.