### PR TITLE
fix(mcpserver): omit pydantic auto-derived titles on tool input schemas

### DIFF
--- a/src/mcp/server/mcpserver/tools/base.py
+++ b/src/mcp/server/mcpserver/tools/base.py
@@ -21,7 +21,7 @@ from mcp.server.mcpserver.resolve import (
     returns_input_required,
 )
 from mcp.server.mcpserver.utilities.context_injection import find_context_parameter
-from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, func_metadata
+from mcp.server.mcpserver.utilities.func_metadata import FuncMetadata, ToolInputJsonSchema, func_metadata
 from mcp.shared._callable_inspection import is_async_callable
 from mcp.shared.exceptions import MCPError
 from mcp.shared.tool_name_validation import validate_and_warn_tool_name
@@ -103,7 +103,10 @@ class Tool(BaseModel):
             skip_names=skip_names,
             structured_output=structured_output,
         )
-        parameters = func_arg_metadata.arg_model.model_json_schema(by_alias=True)
+        parameters = func_arg_metadata.arg_model.model_json_schema(
+            by_alias=True,
+            schema_generator=ToolInputJsonSchema,
+        )
 
         # Match `model_dump_one_level`'s kwarg keys (alias when present, else field name)
         # so a by-name resolver param resolves to a key that exists at call time.

--- a/src/mcp/server/mcpserver/utilities/func_metadata.py
+++ b/src/mcp/server/mcpserver/utilities/func_metadata.py
@@ -74,6 +74,18 @@ class StrictJsonSchema(GenerateJsonSchema):
         raise ValueError(f"JSON schema warning: {kind} - {detail}")
 
 
+class ToolInputJsonSchema(StrictJsonSchema):
+    """JSON schema for tool *input* parameters without pydantic auto-titles.
+
+    Auto-derived titles (Title Case of the field name) restate the property key and
+    waste context on every ``tools/list``. Explicit ``Field(title=...)`` / WithJsonSchema
+    titles still appear on the wire. See #3391.
+    """
+
+    def field_title_should_be_set(self, schema) -> bool:  # type: ignore[no-untyped-def]
+        return False
+
+
 _LOCAL_DEFS_PREFIX = "#/$defs/"
 
 

--- a/tests/server/mcpserver/tools/test_no_auto_titles.py
+++ b/tests/server/mcpserver/tools/test_no_auto_titles.py
@@ -1,0 +1,28 @@
+"""Regression: tool input schemas omit pydantic auto-derived property titles (#3391)."""
+
+from pydantic import Field
+
+from mcp.server.mcpserver.tools.base import Tool
+
+
+def test_tool_input_schema_omits_auto_derived_property_titles():
+    def log_set(exercise_id: str, reps: int) -> str:
+        """Log a set."""
+        return "ok"
+
+    tool = Tool.from_function(log_set)
+    props = tool.parameters["properties"]
+    assert "title" not in props["exercise_id"]
+    assert "title" not in props["reps"]
+    assert props["exercise_id"]["type"] == "string"
+    assert props["reps"]["type"] == "integer"
+
+
+def test_tool_input_schema_keeps_explicit_field_title():
+    def greet(name: str = Field(title="Preferred Name")) -> str:
+        """Greet someone."""
+        return f"hi {name}"
+
+    tool = Tool.from_function(greet)
+    props = tool.parameters["properties"]
+    assert props["name"]["title"] == "Preferred Name"


### PR DESCRIPTION
## Summary
- Add `ToolInputJsonSchema` that suppresses pydantic auto-derived field titles via `field_title_should_be_set`.
- Use it for `Tool.from_function` input `model_json_schema` generation.
- Keep explicit `Field(title=...)` / `WithJsonSchema` titles; leave output-schema generation unchanged for a smaller blast radius.

Fixes #3391

## Test plan
- [x] New unit tests: auto titles omitted; explicit `Field(title=...)` kept
- [ ] Existing mcpserver tool / docs snapshot tests — may need expectation updates where they asserted auto titles on input properties