### PR TITLE
feat(mcpserver): add prompt-level meta support to MCPServer.prompt and Prompt model

### DIFF
--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -92,6 +92,7 @@ class Prompt(BaseModel):
     arguments: list[PromptArgument] | None = Field(None, description="Arguments that can be passed to the prompt")
     fn: Callable[..., PromptResult | Awaitable[PromptResult]] = Field(exclude=True)
     icons: list[Icon] | None = Field(default=None, description="Optional list of icons for this prompt")
+    meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for this prompt")
     context_kwarg: str | None = Field(None, description="Name of the kwarg that should receive context", exclude=True)
 
     @classmethod
@@ -102,6 +103,7 @@ class Prompt(BaseModel):
         title: str | None = None,
         description: str | None = None,
         icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
         context_kwarg: str | None = None,
     ) -> Prompt:
         """Create a Prompt from a function.
@@ -152,6 +154,7 @@ class Prompt(BaseModel):
             arguments=arguments,
             fn=fn,
             icons=icons,
+            meta=meta,
             context_kwarg=context_kwarg,
         )
 

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -962,6 +962,7 @@ class MCPServer(Generic[LifespanResultT]):
         title: str | None = None,
         description: str | None = None,
         icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> Callable[[_CallableT], _CallableT]:
         """Decorator to register a prompt.
 
@@ -975,6 +976,7 @@ class MCPServer(Generic[LifespanResultT]):
             title: Optional human-readable title for the prompt
             description: Optional description of what the prompt does
             icons: Optional list of icons for the prompt
+            meta: Optional metadata dictionary for the prompt
 
         Example:
             ```python
@@ -1013,7 +1015,7 @@ class MCPServer(Generic[LifespanResultT]):
             )
 
         def decorator(func: _CallableT) -> _CallableT:
-            prompt = Prompt.from_function(func, name=name, title=title, description=description, icons=icons)
+            prompt = Prompt.from_function(func, name=name, title=title, description=description, icons=icons, meta=meta)
             self.add_prompt(prompt)
             return func
 
@@ -1326,6 +1328,7 @@ class MCPServer(Generic[LifespanResultT]):
                     for arg in (prompt.arguments or [])
                 ],
                 icons=prompt.icons,
+                _meta=prompt.meta,
             )
             for prompt in prompts
         ]

--- a/tests/server/mcpserver/prompts/test_base.py
+++ b/tests/server/mcpserver/prompts/test_base.py
@@ -50,6 +50,17 @@ class TestRenderPrompt:
         ]
 
     @pytest.mark.anyio
+    async def test_fn_with_meta(self):
+        def fn() -> str:
+            return "Hello, world!"
+
+        prompt = Prompt.from_function(fn, meta={"purpose": "testing", "version": 1})
+        assert prompt.meta == {"purpose": "testing", "version": 1}
+        assert await prompt.render(None, Context()) == [
+            UserMessage(content=TextContent(type="text", text="Hello, world!"))
+        ]
+
+    @pytest.mark.anyio
     async def test_fn_with_invalid_kwargs(self):
         async def fn(name: str, age: int = 30) -> str:  # pragma: no cover
             return f"Hello, {name}! You're {age} years old."

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -1403,6 +1403,22 @@ class TestServerPrompts:
         assert isinstance(content[0].content, TextContent)
         assert content[0].content.text == "Hello, world!"
 
+    async def test_prompt_decorator_with_meta(self):
+        """Test prompt decorator with custom meta."""
+        mcp = MCPServer()
+
+        @mcp.prompt(meta={"category": "tools", "priority": "high"})
+        def fn() -> str:
+            return "Hello, world!"
+
+        prompts = mcp._prompt_manager.list_prompts()
+        assert len(prompts) == 1
+        assert prompts[0].meta == {"category": "tools", "priority": "high"}
+        content = await prompts[0].render(None, Context())
+        assert not isinstance(content, InputRequiredResult)
+        assert isinstance(content[0].content, TextContent)
+        assert content[0].content.text == "Hello, world!"
+
     def test_prompt_decorator_error(self):
         """Test error when decorator is used incorrectly."""
         mcp = MCPServer()
@@ -1431,6 +1447,31 @@ class TestServerPrompts:
                                 PromptArgument(name="name", required=True),
                                 PromptArgument(name="optional", required=False),
                             ],
+                        )
+                    ],
+                )
+            )
+
+    async def test_list_prompts_with_meta(self):
+        """Test listing prompts with meta through MCP protocol."""
+        mcp = MCPServer()
+
+        @mcp.prompt(meta={"category": "tools", "priority": "high"})
+        def fn(name: str) -> str: ...  # pragma: no branch
+
+        async with Client(mcp) as client:
+            result = await client.list_prompts()
+            assert result == snapshot(
+                ListPromptsResult(
+                    _meta={"io.modelcontextprotocol/serverInfo": {"name": "mcp-server", "version": ""}},
+                    prompts=[
+                        Prompt(
+                            name="fn",
+                            description="",
+                            arguments=[
+                                PromptArgument(name="name", required=True),
+                            ],
+                            _meta={"category": "tools", "priority": "high"},
                         )
                     ],
                 )


### PR DESCRIPTION
### Summary
Adds prompt-level metadata support to `MCPServer.prompt()` decorator and the underlying `Prompt` model, aligning prompt metadata ergonomics with tools and resources.

### Problem
As reported in #3476, while MCP tools (`@server.tool(meta=...)`) and resources (`@server.resource(meta=...)`) allow attaching arbitrary metadata that gets populated onto the wire objects (`MCPTool._meta` and `MCPResource._meta`), `MCPServer.prompt()` lacked a `meta` parameter and `MCPServer.list_prompts()` did not forward `prompt.meta` to `MCPPrompt._meta`.

### Changes
1. **`src/mcp/server/mcpserver/prompts/base.py`**:
   - Added `meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for this prompt")` to `Prompt`.
   - Forwarded `meta` in `Prompt.from_function()`.
2. **`src/mcp/server/mcpserver/server.py`**:
   - Added `meta: dict[str, Any] | None = None` to `MCPServer.prompt()`.
   - Forwarded `meta=meta` in `decorator` to `Prompt.from_function()`.
   - Populated `_meta=prompt.meta` in `MCPServer.list_prompts()` when constructing `MCPPrompt`.
3. **Tests**:
   - Added `test_fn_with_meta` in `tests/server/mcpserver/prompts/test_base.py`.
   - Added `test_prompt_decorator_with_meta` and `test_list_prompts_with_meta` in `tests/server/mcpserver/test_server.py`.

### Verification
- `uv run ruff check .` passed cleanly (0 errors).
- `uv run ruff format --check .` passed cleanly (844 files already formatted).
- `uv run pytest tests/server/mcpserver` passed cleanly (633 passed, 1 skipped, 0 failures).

Fixes #3476
