### PR TITLE
Support meta on prompts, as tools and resources already do

### DIFF
--- a/src/mcp/server/mcpserver/prompts/base.py
+++ b/src/mcp/server/mcpserver/prompts/base.py
@@ -92,6 +92,7 @@ class Prompt(BaseModel):
     arguments: list[PromptArgument] | None = Field(None, description="Arguments that can be passed to the prompt")
     fn: Callable[..., PromptResult | Awaitable[PromptResult]] = Field(exclude=True)
     icons: list[Icon] | None = Field(default=None, description="Optional list of icons for this prompt")
+    meta: dict[str, Any] | None = Field(default=None, description="Optional metadata for this prompt")
     context_kwarg: str | None = Field(None, description="Name of the kwarg that should receive context", exclude=True)
 
     @classmethod
@@ -102,6 +103,7 @@ class Prompt(BaseModel):
         title: str | None = None,
         description: str | None = None,
         icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
         context_kwarg: str | None = None,
     ) -> Prompt:
         """Create a Prompt from a function.
@@ -152,6 +154,7 @@ class Prompt(BaseModel):
             arguments=arguments,
             fn=fn,
             icons=icons,
+            meta=meta,
             context_kwarg=context_kwarg,
         )
 

--- a/src/mcp/server/mcpserver/server.py
+++ b/src/mcp/server/mcpserver/server.py
@@ -962,6 +962,7 @@ class MCPServer(Generic[LifespanResultT]):
         title: str | None = None,
         description: str | None = None,
         icons: list[Icon] | None = None,
+        meta: dict[str, Any] | None = None,
     ) -> Callable[[_CallableT], _CallableT]:
         """Decorator to register a prompt.
 
@@ -975,6 +976,7 @@ class MCPServer(Generic[LifespanResultT]):
             title: Optional human-readable title for the prompt
             description: Optional description of what the prompt does
             icons: Optional list of icons for the prompt
+            meta: Optional metadata dictionary for the prompt
 
         Example:
             ```python
@@ -1013,7 +1015,7 @@ class MCPServer(Generic[LifespanResultT]):
             )
 
         def decorator(func: _CallableT) -> _CallableT:
-            prompt = Prompt.from_function(func, name=name, title=title, description=description, icons=icons)
+            prompt = Prompt.from_function(func, name=name, title=title, description=description, icons=icons, meta=meta)
             self.add_prompt(prompt)
             return func
 
@@ -1326,6 +1328,7 @@ class MCPServer(Generic[LifespanResultT]):
                     for arg in (prompt.arguments or [])
                 ],
                 icons=prompt.icons,
+                _meta=prompt.meta,
             )
             for prompt in prompts
         ]

--- a/tests/server/mcpserver/test_server.py
+++ b/tests/server/mcpserver/test_server.py
@@ -60,6 +60,7 @@ from mcp.server.mcpserver.exceptions import (
     UnexpectedToolError,
 )
 from mcp.server.mcpserver.prompts.base import Message, UserMessage
+from mcp.server.mcpserver.prompts.base import Prompt as MCPServerPrompt
 from mcp.server.mcpserver.resources import FileResource, FunctionResource
 from mcp.server.mcpserver.resources import Resource as MCPServerResource
 from mcp.server.mcpserver.utilities.types import Audio, Image
@@ -3186,3 +3187,58 @@ async def test_middleware_can_refuse_subscriptions_listen_before_the_ack() -> No
                 pass  # pragma: no cover - the refusal precedes the stream
     assert exc_info.value.error.code == INVALID_REQUEST
     assert exc_info.value.error.message == "not permitted to watch the requested resources"
+
+
+class TestServerPromptMetadata:
+    """Test MCPServer @prompt decorator meta parameter for list operations.
+
+    Meta flows: @prompt decorator -> Prompt.from_function -> Prompt.meta -> list_prompts.
+    """
+
+    async def test_prompt_decorator_with_metadata(self):
+        """Test that @prompt decorator accepts and passes meta parameter."""
+        mcp = MCPServer()
+
+        @mcp.prompt(name="code_review", title="Code Review", meta={"strictness": "high"})
+        def review_code(code: str) -> str:
+            """Review code with specific metadata rules."""
+            return f"Review this: {code}"  # pragma: no cover
+
+        prompts = await mcp.list_prompts()
+        assert prompts == snapshot(
+            [
+                Prompt(
+                    name="code_review",
+                    title="Code Review",
+                    description="Review code with specific metadata rules.",
+                    arguments=[PromptArgument(name="code", required=True)],
+                    meta={"strictness": "high"},  # type: ignore[reportCallIssue]
+                )
+            ]
+        )
+
+    async def test_prompt_without_metadata_has_no_meta(self):
+        """A prompt that declares no meta must not emit an empty _meta."""
+        mcp = MCPServer()
+
+        @mcp.prompt()
+        def plain(code: str) -> str:
+            """No metadata here."""
+            return code  # pragma: no cover
+
+        prompts = await mcp.list_prompts()
+        assert prompts[0].meta is None
+        assert "_meta" not in prompts[0].model_dump(by_alias=True, exclude_none=True)
+
+    async def test_add_prompt_preserves_metadata(self):
+        """Meta survives the non-decorator registration path too."""
+
+        def review_code(code: str) -> str:
+            """Review code."""
+            return code  # pragma: no cover
+
+        mcp = MCPServer()
+        mcp.add_prompt(MCPServerPrompt.from_function(review_code, meta={"strictness": "high"}))
+
+        prompts = await mcp.list_prompts()
+        assert prompts[0].meta == {"strictness": "high"}


### PR DESCRIPTION
Closes #3476.

## Problem

The 2026-07-28 specification puts an optional `_meta` on the Prompt schema, and `mcp_types.Prompt` already carries it — `Prompt(name="x", _meta={"a": 1}).model_dump(by_alias=True)` gives `{'name': 'x', '_meta': {'a': 1}}` on `main` today. Only the high-level layer was missing it:

- `@mcp.prompt(meta=...)` raised `TypeError: Prompt.from_function() got an unexpected keyword argument 'meta'`
- the high-level `Prompt` model had no `meta` field
- `MCPServer.list_prompts` never populated `_meta`

`@mcp.tool` and `@mcp.resource` both accept `meta` and surface it in their list operations, so prompts were the only one of the three left out.

## Fix

Wired through exactly the way tools and resources already do it:

- `meta: dict[str, Any] | None` field on `mcp.server.mcpserver.prompts.base.Prompt`
- `meta` argument on `Prompt.from_function`, passed to the model
- `meta` argument on the `@mcp.prompt` decorator, passed to `from_function`, documented in its `Args:` block alongside `icons`
- `_meta=prompt.meta` in `MCPServer.list_prompts`, matching the `_meta=info.meta` already in `list_tools`

Three source lines added, one changed. No new concepts — it closes a gap rather than introducing a mechanism.

**Deliberately out of scope:** `get_prompt` does not carry meta into the protocol response. That mirrors `read_resource`, which does not either (as `TestServerResourceMetadata`'s own docstring notes), and the issue asks only for `list_prompts`. Happy to extend if you'd rather have both.

## Tests

`TestServerPromptMetadata`, placed next to the existing `TestServerResourceMetadata` and following its shape:

- `test_prompt_decorator_with_metadata` — the issue's own example, asserting the full `Prompt` via `snapshot` so `_meta` is pinned alongside everything else the decorator produces.
- `test_prompt_without_metadata_has_no_meta` — a prompt declaring no meta must not emit an empty `_meta` on the wire. This one passes before the change too; it guards against the fix leaking a default.
- `test_add_prompt_preserves_metadata` — meta survives `Prompt.from_function` + `add_prompt`, not just the decorator.

The first and third fail on `main` with the `TypeError` above and pass with the fix.

## Verification

- `tests/server/mcpserver/`: **633 passed, 1 skipped**, no regressions.
- `ruff check` and `ruff format --check` clean on all three touched files.
- `pyright` on the two changed source files reports only the pre-existing `asynccontextmanager` deprecation at `server.py:149`, which is untouched by this change.

## AI disclosure

Written with AI assistance (Claude Code). I reproduced the `TypeError` on `main` @ `9972c21`, confirmed `mcp_types.Prompt` already round-trips `_meta`, and read the `@mcp.tool` / `@mcp.resource` meta paths before mirroring them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxphSQWkGcC4sgncbRU64C
