### PR TITLE
Ask cubic for a review when the intake gate lets a PR back in

### DIFF
--- a/.github/scripts/pr_intake_gate.js
+++ b/.github/scripts/pr_intake_gate.js
@@ -8,7 +8,8 @@
 // re-evaluates — and reopens — the PR when the description is edited or the
 // author is assigned to the issue. A triage+ user reopening the PR, removing
 // the label, or adding `bypass-issue-check` overrides it, and the override
-// sticks.
+// sticks. A PR that comes back this way also gets a comment asking the review
+// bot for a review, since it doesn't act on `reopened` by itself.
 //
 // Everything that writes goes through mutate(); when the workflow passes
 // ENFORCE=false (its kill switch) the run only logs what it would have done.
@@ -20,6 +21,10 @@ const OPEN_LABEL = 'help wanted'; // issue label that waives assignment
 const MARKER = '<!-- require-linked-issue -->';
 const BOT_LOGIN = 'github-actions[bot]';
 const MAX_ISSUES = 5;
+// cubic starts on `opened` and abandons the run when the gate closes the PR
+// seconds later; it ignores `reopened`, so a PR the gate lets back in would
+// otherwise wait for its next push to be reviewed.
+const REVIEW_REQUEST = '@cubic-dev-ai review this PR';
 
 module.exports = async function run({ github, context, core }) {
   const { owner, repo } = context.repo;
@@ -115,6 +120,8 @@ module.exports = async function run({ github, context, core }) {
       if (gated) {
         await removeLabel(prNumber, LABEL);
         await deleteGateComment(prNumber);
+        // Not for drafts: cubic picks those up itself on ready_for_review.
+        if (!pr.draft) await requestReview(prNumber);
       }
     }
 
@@ -296,6 +303,12 @@ module.exports = async function run({ github, context, core }) {
     } else if (existing.body !== body) {
       await mutate(`update the gate comment on PR #${prNumber}`, () => github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body }));
     }
+  }
+
+  // Runs once per return: the caller only gets here while the PR still counts
+  // as gate-closed, and it has just removed the label that says so.
+  async function requestReview(prNumber) {
+    await mutate(`request a review on PR #${prNumber}`, () => github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body: REVIEW_REQUEST }));
   }
 
   async function deleteGateComment(prNumber) {

--- a/.github/scripts/pr_intake_gate.test.js
+++ b/.github/scripts/pr_intake_gate.test.js
@@ -14,6 +14,7 @@ const gate = require('./pr_intake_gate.js');
 
 const LABEL = 'missing-issue-link';
 const BYPASS = 'bypass-issue-check';
+const REVIEW_REQUEST = '@cubic-dev-ai review this PR';
 const REPO = { owner: 'modelcontextprotocol', repo: 'python-sdk' };
 
 // People. Only the capability flags matter to the gate.
@@ -29,7 +30,8 @@ const PEOPLE = {
 // `prs` / `issues` describe the world before the event; `expect` describes each
 // PR afterwards: state, labels, and comment ('closed' = the "this PR has been
 // closed" comment, 'closed-draft' = its draft wording, 'cannot-reopen' = the
-// refused-reopen comment, null = none).
+// refused-reopen comment, null = none). `reviewRequested`, where given, is
+// whether the gate left its comment asking the review bot for a review.
 // `writes: 0` additionally asserts the gate touched nothing at all.
 
 const scenarios = [
@@ -78,7 +80,7 @@ const scenarios = [
     prs: [pr(3300, 'outsider', { state: 'closed', labels: [LABEL], body: 'Fixes #10', gateComment: true })],
     issues: [issue(10, { labels: ['help wanted'] })],
     event: edited(3300, 'outsider'),
-    expect: { 3300: { state: 'open', labels: [], comment: null } },
+    expect: { 3300: { state: 'open', labels: [], comment: null, reviewRequested: true } },
   },
   {
     name: 'gate-closed PR: maintainer assigns the author on the linked issue → reopened',
@@ -89,21 +91,21 @@ const scenarios = [
     issues: [issue(10, { assignees: ['outsider'] }), issue(99)],
     event: assigned(10, 'outsider', 'maintainer'),
     expect: {
-      3300: { state: 'open', labels: [], comment: null },
-      3301: { state: 'closed', labels: [LABEL], comment: 'closed' },
+      3300: { state: 'open', labels: [], comment: null, reviewRequested: true },
+      3301: { state: 'closed', labels: [LABEL], comment: 'closed', reviewRequested: false },
     },
   },
   {
     name: 'gate-closed PR: maintainer reopens it → stays open with the sticky bypass label',
     prs: [pr(3300, 'outsider', { state: 'open', labels: [LABEL], gateComment: true })], // payload arrives post-reopen
     event: reopened(3300, 'maintainer'),
-    expect: { 3300: { state: 'open', labels: [BYPASS], comment: null } },
+    expect: { 3300: { state: 'open', labels: [BYPASS], comment: null, reviewRequested: true } },
   },
   {
     name: 'gate-closed PR: triage-role user removes the label → reopened with the sticky bypass label',
     prs: [pr(3300, 'outsider', { state: 'closed', labels: [], gateComment: true })], // payload arrives post-unlabel
     event: unlabeled(3300, 'triager'),
-    expect: { 3300: { state: 'open', labels: [BYPASS], comment: null } },
+    expect: { 3300: { state: 'open', labels: [BYPASS], comment: null, reviewRequested: true } },
   },
   {
     name: 'gate-closed PR: some other bot strips the label → re-checked, label restored, still closed',
@@ -177,13 +179,20 @@ const scenarios = [
     prs: [pr(3300, 'outsider', { state: 'closed', labels: [LABEL], body: 'Fixes #10', gateComment: true, refuseReopen: true })],
     issues: [issue(10, { assignees: ['outsider'] })],
     event: edited(3300, 'outsider'),
-    expect: { 3300: { state: 'closed', labels: [LABEL], comment: 'cannot-reopen' } },
+    expect: { 3300: { state: 'closed', labels: [LABEL], comment: 'cannot-reopen', reviewRequested: false } },
   },
   {
     name: 'gate-closed PR: maintainer adds the bypass label → reopened, and the label sticks',
     prs: [pr(3300, 'outsider', { state: 'closed', labels: [LABEL, BYPASS], gateComment: true })], // payload arrives post-label
     event: labeled(3300, 'maintainer', BYPASS),
-    expect: { 3300: { state: 'open', labels: [BYPASS], comment: null } },
+    expect: { 3300: { state: 'open', labels: [BYPASS], comment: null, reviewRequested: true } },
+  },
+  {
+    name: 'gate-closed draft comes back → reopened, but no review is requested while it is a draft',
+    prs: [pr(3300, 'outsider', { state: 'closed', draft: true, labels: [LABEL], body: 'Fixes #10', gateComment: true })],
+    issues: [issue(10, { assignees: ['outsider'] })],
+    event: assigned(10, 'outsider', 'maintainer'),
+    expect: { 3300: { state: 'open', labels: [], comment: null, reviewRequested: false } },
   },
   {
     name: 'refused reopen after a label-removal override → both labels on, so the PR stays gate-managed',
@@ -303,6 +312,11 @@ function observe(world, expect) {
     const kind = !body ? null : body.includes("won't let it be reopened") ? 'cannot-reopen' : body.includes('still a draft') ? 'closed-draft' : 'closed';
     out[num] = { state: p.state, labels: [...p.labels].sort(), comment: kind };
     if ('foreignComments' in expect[num]) out[num].foreignComments = p.comments.length - gateComments.length;
+    if ('reviewRequested' in expect[num]) {
+      const requests = p.comments.filter((c) => c.user === 'github-actions[bot]' && c.body === REVIEW_REQUEST);
+      assert.ok(requests.length <= 1, `PR #${num} has ${requests.length} review requests`);
+      out[num].reviewRequested = requests.length === 1;
+    }
   }
   return out;
 }

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -6,7 +6,8 @@
 # otherwise it is labeled `missing-issue-link`, gets one comment, and is closed,
 # and it reopens automatically once the author is assigned. Drafts are gated
 # too; bots are skipped. A triage+ user reopening the PR, removing the label,
-# or adding `bypass-issue-check` overrides.
+# or adding `bypass-issue-check` overrides. A PR that comes back open gets a
+# comment asking cubic to review it, because cubic doesn't act on `reopened`.
 #
 # Operating it:
 #   - Live by default. To pause it without a revert, set the repository


### PR DESCRIPTION
When the intake gate lets a pull request back in, it now leaves one `@cubic-dev-ai review this PR` comment so cubic reviews it.

## Motivation and Context

cubic starts a review on `opened`, and the gate closes an unlinked external PR about 13 seconds later, at which point cubic abandons the run ("AI review cancelled"). cubic doesn't act on `reopened`, so when that PR later comes back (the author gets assigned to the issue, fixes the description, or a maintainer reopens it or adds `bypass-issue-check`) nothing triggers a review until the next push. #3413 is an example: closed by the gate one second after cubic started, reopened with the bypass label, head unchanged, and it never got a cubic review.

Every route back to open goes through `pass()` while the PR still carries `missing-issue-link`, and that label is removed right there, so it's the one place that runs exactly once per return. The request is posted from there. Drafts are skipped, since cubic reviews those by itself on `ready_for_review` and we don't want it reviewing drafts. The comment goes through `mutate()`, so the `PR_GATE_ENFORCE=false` kill switch covers it too.

## How Has This Been Tested?

`node --test '.github/scripts/*.test.js'`: the five existing "comes back open" scenarios now also assert that exactly one review request was left, and there are new assertions that none is left for a returning draft, for a PR GitHub refuses to reopen, or for a PR that stays closed. Those five scenarios fail against the old script and pass with the change.

One thing this can't test from here: whether cubic honours a `@cubic-dev-ai` mention written by `github-actions[bot]`. Their docs describe the mention as working for anyone commenting on the PR (an outside contributor's own summon worked on #3347) but say nothing about bot authors. The comment webhook does reach the cubic app regardless of who wrote it. If cubic turns out to ignore it, the fallback is a maintainer typing the same comment, and this can be reverted; the first PR that comes back after merge will show which.

## Breaking Changes

None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

A PR that returns because a maintainer manually reopened it also gets the comment, even if cubic had somehow finished a review before the gate closed it (only possible for PRs gated after the fact by a manual dispatch). A second review there seemed better than special-casing it.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
