### PR TITLE
Close the transport a rejected connect_to_server opened

### DIFF
--- a/src/mcp/client/session_group.py
+++ b/src/mcp/client/session_group.py
@@ -298,7 +298,16 @@ class ClientSessionGroup:
     ) -> mcp.ClientSession:
         """Connects to a single MCP server."""
         server_info, session = await self._establish_session(server_params, session_params or ClientSessionParameters())
-        return await self.connect_with_session(server_info, session)
+        try:
+            return await self.connect_with_session(server_info, session)
+        except Exception:
+            # Aggregation rejected the server. This transport is ours: the caller never
+            # received the session and so cannot close it. Close it here rather than
+            # leave it running until the whole group tears down.
+            session_stack = self._session_exit_stacks.pop(session, None)
+            if session_stack is not None:
+                await session_stack.aclose()
+            raise
 
     async def _establish_session(
         self,

--- a/tests/client/test_session_group.py
+++ b/tests/client/test_session_group.py
@@ -287,6 +287,60 @@ async def test_client_session_group_connect_to_server_duplicate_tool_raises_erro
 
 
 @pytest.mark.anyio
+async def test_client_session_group_connect_to_server_duplicate_closes_transport():
+    """A rejected connect_to_server closes the transport it opened.
+
+    The caller never receives the session, so if the group keeps it the connection is
+    unreachable until the whole group tears down. Locks in that the session's exit stack
+    is both closed and forgotten when aggregation raises.
+    """
+    existing_tool_name = "shared_tool"
+
+    # The new server offers a colliding tool, so aggregation will reject it.
+    mock_server_info = mock.Mock(spec=types.Implementation)
+    mock_server_info.name = "ServerWithDuplicate"
+    new_session = mock.AsyncMock(spec=mcp.ClientSession)
+    duplicate_tool = mock.Mock(spec=types.Tool)
+    duplicate_tool.name = existing_tool_name
+    new_session.list_tools.return_value = mock.AsyncMock(tools=[duplicate_tool])
+    new_session.list_resources.return_value = mock.AsyncMock(resources=[])
+    new_session.list_prompts.return_value = mock.AsyncMock(prompts=[])
+
+    # Stand in for the real transport: a callback on the session's own exit stack that
+    # records whether the stack was ever closed.
+    closed = False
+
+    def _on_close() -> None:
+        nonlocal closed
+        closed = True
+
+    async def _establish_session(*_args: object, **_kwargs: object):
+        """Register the stack exactly as the real _establish_session does."""
+        session_stack = contextlib.AsyncExitStack()
+        await session_stack.__aenter__()
+        session_stack.callback(_on_close)
+        group._session_exit_stacks[new_session] = session_stack
+        await group._exit_stack.enter_async_context(session_stack)
+        return mock_server_info, new_session
+
+    async with contextlib.AsyncExitStack() as stack:
+        group = ClientSessionGroup(exit_stack=stack)
+        group._tools[existing_tool_name] = mock.Mock(spec=types.Tool)
+        group._tools[existing_tool_name].name = existing_tool_name
+
+        with mock.patch.object(group, "_establish_session", side_effect=_establish_session):
+            with pytest.raises(MCPError) as excinfo:
+                await group.connect_to_server(StdioServerParameters(command="test"))
+
+        assert "already exist " in excinfo.value.error.message
+        # The transport is closed and no longer tracked, before the group tears down.
+        assert closed, "the rejected server's transport was left open"
+        assert new_session not in group._session_exit_stacks
+        assert new_session not in group._sessions
+        assert sorted(group._tools) == [existing_tool_name]
+
+
+@pytest.mark.anyio
 async def test_client_session_group_disconnect_non_existent_server():
     """Test disconnecting a server that isn't connected."""
     session = mock.Mock(spec=mcp.ClientSession)


### PR DESCRIPTION
Fixes #3490

`connect_to_server` opens the transport before the server's components are validated, so a server rejected for a duplicate name leaves its connection running with no way to reach it.

## Motivation and Context

`_establish_session` opens the transport, runs `initialize`, stores the session's stack in `self._session_exit_stacks[session]`, and enters it into `self._exit_stack`. `_aggregate_components` then raises `MCPError` when a component name collides with one already in the group — and `self._sessions[session] = component_names` is on the line *after* that raise.

So the connection stays live while being unreachable: `group.sessions` reads `self._sessions`, which the rejected server never reached, and `disconnect_from_server` needs the `ClientSession` object that `connect_to_server` raised instead of returning. It was released only when the whole group tore down — one live child process (stdio) or initialized session (streamable HTTP) per rejection.

This is the case the docs treat as ordinary: `docs/client/session-groups.md` says two servers you don't control "will collide eventually", and tells the reader to run exactly this and see the `MCPError`. The same page says the error is "raised before anything from the second server is registered", which held for the three component dicts but not for the connection opened to read them.

The fix closes the transport in `connect_to_server`, which is the only caller that owns one. `connect_with_session` is deliberately untouched: the caller owns that session and still holds it, and per the docs "the group never closes a session it didn't open". Putting the cleanup in `_aggregate_components` instead would close caller-owned sessions and break that contract.

It mirrors the existing precedent in this same file — `_establish_session` already does `except Exception:` → `aclose()` → `raise` for a failure during setup. This extends the same handling to a failure during aggregation.

## How Has This Been Tested?

`test_client_session_group_connect_to_server_duplicate_closes_transport` fails on `main` (`assert closed` → `AssertionError`) and passes with the change. The test registers the session's exit stack the way the real `_establish_session` does, so it observes the leak rather than a mock call.

The existing `test_client_session_group_connect_to_server_duplicate_tool_raises_error` mocks `_establish_session` and so never registers a stack — that is why it passes either way, and it now covers the `pop(...) is None` branch.

Locally against `9972c21a`:

- `pytest -n auto` — 5968 passed, 10 skipped (Windows-only), 1 xfailed
- `coverage report` — 100.00%, 0 missed statements, 0 partial branches
- `strict-no-cover` — clean, no pragma added
- `ruff format --check`, `ruff check`, `pyright` — clean on both touched files
- `uv lock --check`, README snippet check — clean; no dependency or lockfile changes

Also checked by hand with two real stdio servers both exposing a `search` tool: before the change each rejected `connect_to_server` left one more live child process behind (1, 2, 3 …) while `group.sessions` stayed at 1; after it, none.

## Breaking Changes

None. The `MCPError` and its message are unchanged, and callers that already catch it see the same exception — the connection behind it is simply closed now. Nothing that was reachable before becomes unreachable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I am assigned to the linked issue (or it is labeled `help wanted`, or I'm a maintainer)
- [x] I have disclosed any AI assistance and can explain the change in my own words
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

I used AI assistance to narrow this down and to build the reproduction; I ran it myself and can walk through the code path.

I reported #3490 and would like to fix it; I am not assigned yet, so the intake gate will close this until a maintainer decides. Opening it now so the fix is on the table rather than to jump the queue — happy for it to sit closed, and I will push any changes as new commits rather than force-pushing so it can reopen cleanly.

Not a duplicate of #3384. That one is the `KeyError` from `del self._session_exit_stacks[session]` in the empty-server branch, reached through `connect_with_session`. This is the duplicate-name branch reached through `connect_to_server`, which raises `MCPError` by design — the defect was what stayed running afterwards. I read the three PRs opened for #3384 (#3386, #3419, #3428); each removes only that one block, so none of them changes this path and this does not conflict with whichever you take.

Four things a reviewer might reasonably ask, answered up front:

- **Can this ever close a session the caller owns?** No. `_session_exit_stacks` has exactly one writer in the whole source tree — `_establish_session`, on a `ClientSession` it constructed itself — so the `pop` can only ever find a transport the group opened. `connect_with_session` is byte-identical to `main`.
- **Why `except Exception` and not `BaseException`?** Cancellation is deliberately excluded. `anyio.get_cancelled_exc_class()` is `CancelledError`, a `BaseException`; closing the stack under an active cancellation would need a shielded scope, which is a larger change. This matches the existing cleanup in `_establish_session`.
- **The closed stack stays registered in `_exit_stack` — is that a double close?** It is a no-op. `AsyncExitStack` has no unregister API, and re-closing a drained stack iterates an empty callback deque. `disconnect_from_server` has popped-and-closed this same way since it was written.
- **Behaviour change for callers who catch `MCPError` and retry:** the exception now arrives after transport teardown rather than before it, so there is bounded extra latency on stdio, and a rejected streamable-HTTP connection now terminates its session instead of leaving it registered. Both are the point of the change rather than side effects, but worth naming.

One nearby thing I deliberately did **not** touch: `_aggregate_components` un-tracks a component-less server's stack without closing it (the `del self._session_exit_stacks[session]` in its empty-server branch, further down the same call path rather than adjacent to this hunk). That is a sibling of this leak and is reachable from `disconnect_from_server`, and on the `connect_with_session` path it is the `KeyError` reported in #3384. It cannot interact with this fix — an empty component set makes every collision check vacuous, so the two paths are mutually exclusive — and expanding this diff into it would collide with whichever #3384 PR you take. Happy to follow up on it separately if useful.

No documentation change: `docs/client/session-groups.md` already states the intended behaviour ("raised before anything from the second server is registered"). This makes the code match it.
