### PR TITLE
fix(direct-dispatcher): contain callback failures

### DIFF
--- a/src/mcp/shared/direct_dispatcher.py
+++ b/src/mcp/shared/direct_dispatcher.py
@@ -30,6 +30,7 @@ from pydantic import ValidationError
 from mcp.shared._compat import resync_tracer
 from mcp.shared.dispatcher import (
     CallOptions,
+    DispatchContext,
     OnNotify,
     OnNotifyIntercept,
     OnRequest,
@@ -42,6 +43,30 @@ from mcp.shared.message import MessageMetadata
 from mcp.shared.transport_context import TransportContext
 
 logger = logging.getLogger(__name__)
+
+
+def _shielded_progress(fn: ProgressFnT) -> ProgressFnT:
+    """Wrap a progress callback so its failure does not fail the request."""
+
+    async def _wrapped(progress: float, total: float | None, message: str | None) -> None:
+        try:
+            await fn(progress, total, message)
+        except Exception:
+            logger.exception("progress callback raised")
+
+    return _wrapped
+
+
+def _contained_notify(fn: OnNotify) -> OnNotify:
+    """Wrap a notification handler so its failure does not reach the sender."""
+
+    async def _wrapped(dctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None) -> None:
+        try:
+            await fn(dctx, method, params)
+        except Exception:
+            logger.exception("notification handler for %r raised", method)
+
+    return _wrapped
 
 __all__ = ["DirectDispatcher", "create_direct_dispatcher_pair"]
 
@@ -206,7 +231,7 @@ class DirectDispatcher:
             _back_request=lambda m, p, o: peer._dispatch_request(m, p, o),
             _back_notify=lambda m, p: peer._dispatch_notify(m, p),
             request_id=request_id,
-            _on_progress=on_progress,
+            _on_progress=_shielded_progress(on_progress) if on_progress is not None else None,
         )
 
     async def _wait_ready(self) -> None:
@@ -301,7 +326,7 @@ class DirectDispatcher:
             return
         assert self._on_notify is not None
         dctx = self._make_context()
-        await self._on_notify(dctx, method, params)
+        await _contained_notify(self._on_notify)(dctx, method, params)
 
 
 def create_direct_dispatcher_pair(

--- a/tests/shared/test_dispatcher.py
+++ b/tests/shared/test_dispatcher.py
@@ -217,6 +217,35 @@ async def test_ctx_progress_invokes_caller_on_progress_callback(pair_factory: Pa
 
 
 @pytest.mark.anyio
+async def test_progress_callback_exception_does_not_fail_request(pair_factory: PairFactory):
+    async def server_on_request(
+        ctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None
+    ) -> dict[str, Any]:
+        await ctx.progress(0.5)
+        return {"ok": True}
+
+    async def on_progress(progress: float, total: float | None, message: str | None) -> None:
+        raise RuntimeError("consumer failed")
+
+    async with running_pair(pair_factory, server_on_request=server_on_request) as (client, *_):
+        with anyio.fail_after(5):
+            result = await client.send_raw_request("tools/call", None, {"on_progress": on_progress})
+    assert result == {"ok": True}
+
+
+@pytest.mark.anyio
+async def test_notification_handler_exception_does_not_reach_sender(pair_factory: PairFactory):
+    async def on_notify(
+        ctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None
+    ) -> None:
+        raise RuntimeError("handler failed")
+
+    async with running_pair(pair_factory, client_on_notify=on_notify) as (client, *_):
+        with anyio.fail_after(5):
+            await client.notify("notifications/message", None)
+
+
+@pytest.mark.anyio
 async def test_ctx_progress_is_noop_when_caller_supplied_no_callback(pair_factory: PairFactory):
     async def server_on_request(
         ctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None

--- a/tests/shared/test_dispatcher.py
+++ b/tests/shared/test_dispatcher.py
@@ -235,14 +235,18 @@ async def test_progress_callback_exception_does_not_fail_request(pair_factory: P
 
 @pytest.mark.anyio
 async def test_notification_handler_exception_does_not_reach_sender(pair_factory: PairFactory):
+    called = anyio.Event()
+
     async def on_notify(
         ctx: DispatchContext[TransportContext], method: str, params: Mapping[str, Any] | None
     ) -> None:
+        called.set()
         raise RuntimeError("handler failed")
 
-    async with running_pair(pair_factory, client_on_notify=on_notify) as (client, *_):
+    async with running_pair(pair_factory, server_on_notify=on_notify) as (client, *_):
         with anyio.fail_after(5):
             await client.notify("notifications/message", None)
+            await called.wait()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Contain progress callback failures in `DirectDispatcher`.
- Contain in-process notification handler failures.
- Add regression tests for both dispatcher implementations.

Fixes #3434

## Verification

- `python3 -m compileall -q src/mcp/shared/direct_dispatcher.py tests/shared/test_dispatcher.py`
- `git diff --check`

`uv run --frozen` checks were blocked because the installed uv version is 0.8.4 and this project requires uv >=0.9.5.